### PR TITLE
phase 3c: engine integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,19 +39,19 @@ on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline
 * [x] Expose ReviewEngine + Session to JS
 * [x] Node smoke test verifies the full session flow
 
-### Phase 3B: Server foundation
+### Phase 3B: Server foundation ✅
 
-* [ ] pnpm monorepo setup (`packages/api/`)
-* [ ] Hono server with health check
-* [ ] Drizzle + SQLite + migrations
-* [ ] Better Auth setup (email/password + Google OAuth)
+* [x] pnpm monorepo setup (`packages/api/`)
+* [x] Hono server with health check
+* [x] Drizzle + SQLite + migrations
+* [x] Better Auth setup (email/password + Google OAuth)
 
 ### Phase 3C: Engine integration
 
-* [ ] Load graph from DB, construct WASM engine
-* [ ] Session API endpoints (start/next/review/abort)
-* [ ] Review event logging
-* [ ] Edge/card state persistence
+* [x] Load graph from DB, construct WASM engine
+* [x] Session API endpoints (start/next/review/abort)
+* [x] Review event logging
+* [x] Edge/card state persistence
 
 ### Phase 3D: Sync API
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,86 @@
+# Persistence
+
+How user progress is stored, updated, and recomputed. The server is authoritative for the event log;
+materialized state is a cache that can be rebuilt at any time.
+
+## Storage layer
+
+SQLite via [Drizzle](https://orm.drizzle.team) + `better-sqlite3`. Schema lives in
+`packages/api/src/db/schema.ts`. WAL mode is on; foreign keys are enforced.
+
+## Tables
+
+### Auth (Better Auth)
+
+`user`, `session`, `account`, `verification` are owned by Better Auth. We keep them in the Drizzle
+schema so FK constraints from domain tables can reference `user.id`.
+
+### `user_materials`
+
+Which materials a user has enrolled in. `club_tier` is `150 | 300 | null` (null = full material).
+
+### `graph_snapshots`
+
+The memory graph plus card catalog for a (user, material, version) triple. Stored as JSON blobs
+matching the [WASM wire format](wasm-api.md). Versioned so existing events can be replayed against a
+known-good snapshot even after the content pipeline regenerates the graph.
+
+### `review_events` — source of truth
+
+Append-only log. Every call to `POST /api/sessions/:id/review` writes one row:
+
+| column             | notes                                                                 |
+| ------------------ | --------------------------------------------------------------------- |
+| `id`               | UUID, server-generated today; client-generated later for offline sync |
+| `snapshot_version` | which graph snapshot this event applies to                            |
+| `card_id`          | source card, or null for re-drill / new-verse (progressive reveal)    |
+| `shown` / `hidden` | node IDs of the card as served to the user                            |
+| `grades`           | `[{ node_id, grade }]` — 1=Again, 2=Hard, 3=Good, 4=Easy              |
+
+Indexed by `(user_id, material_id, timestamp_secs)` because replay is always filtered by
+user+material and sorted by time.
+
+### `edge_states` — materialized
+
+Per-edge FSRS state: `stability`, `difficulty`, `last_review_secs`. Primary key is
+`(user_id, material_id, edge_id)`. Recomputable from `review_events` by replaying the engine.
+
+### `card_states` — materialized
+
+Per-card state machine + schedule: `state`, `due_r`, `due_date_secs`, `priority`. Same primary key
+shape. Also recomputable.
+
+## Write path
+
+`recordReview` (`packages/api/src/lib/review-log.ts`) runs in a single transaction:
+
+1. Append the event to `review_events`.
+2. Upsert the edges returned in `ReviewOutcome.edge_updates`.
+3. Upsert every card from `engine.export_card_states()` — cheap and avoids having to track which
+   cards moved.
+
+Either everything lands or nothing does, so the log and the cache never drift.
+
+## Read path
+
+The engine loader (`EngineStore`, `packages/api/src/lib/engine.ts`) builds a `WasmEngine` from:
+
+1. The latest `graph_snapshots` row for (user, material).
+2. All `edge_states` rows for (user, material).
+3. All `card_states` rows for (user, material).
+
+Engines are cached in-process keyed by `(user_id, material_id)` — the Node process is long-running,
+so reloading per request would be wasteful.
+
+## Replay
+
+Because the core algorithm is deterministic in `(current_state, grades, timestamp)`, any
+materialized state can be rebuilt by:
+
+1. Starting a fresh `WasmEngine` from the snapshot (no edge/card overrides).
+2. Feeding `review_events` in timestamp order.
+3. Exporting the final `edge_states` + `card_states`.
+
+This makes `edge_states` / `card_states` a cache, not a source of truth, and unlocks the Phase 3D
+sync flow: a fat client uploads offline events, the server merges by timestamp, replays, and returns
+the authoritative materialized state.

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -1,0 +1,124 @@
+# Server API
+
+HTTP contract exposed by `@verse-vault/api`. JSON in, JSON out; cookie-based sessions via
+[Better Auth](https://www.better-auth.com). Unless noted, all non-auth endpoints require a valid
+session cookie (401 otherwise).
+
+## Auth — `/api/auth/*`
+
+Handled by Better Auth directly. See the [Better Auth docs](https://www.better-auth.com/docs) for
+the full surface; the ones we rely on today:
+
+| Method | Path                        | Purpose                      |
+| ------ | --------------------------- | ---------------------------- |
+| POST   | `/api/auth/sign-up/email`   | register with email+password |
+| POST   | `/api/auth/sign-in/email`   | log in                       |
+| POST   | `/api/auth/sign-out`        | log out                      |
+| GET    | `/api/auth/session`         | current session or null      |
+| GET    | `/api/auth/sign-in/social`  | start Google OAuth redirect  |
+| GET    | `/api/auth/callback/google` | OAuth callback               |
+
+### `GET /api/me`
+
+Echoes the authenticated user. Useful smoke test.
+
+```json
+{ "user": { "id": "...", "email": "alice@example.com", "name": "Alice" } }
+```
+
+## Sessions — `/api/sessions/*`
+
+The server owns the review engine: a session is an in-memory handle on the user's `WasmEngine`. Only
+one active session per (user, material) — starting a new one aborts the previous one.
+
+Shared shapes:
+
+```ts
+SessionCard = {
+  shown: number[];             // node IDs the user can see
+  hidden: number[];             // node IDs they must recall (grade these)
+  is_reading: boolean;          // if true, it's a reading-stage card — send grades: []
+  source_kind: 'scheduled' | 'redrill' | 'new_verse';
+  source_card_id: number | null;
+}
+
+Grade = { node_id: number; grade: 1 | 2 | 3 | 4 }   // 1=Again … 4=Easy
+
+ReviewOutcome = {
+  edge_updates: Array<{ edge_id: number; grade: number; weight: number }>;
+  redrills_inserted: number;
+}
+```
+
+### `POST /api/sessions/start`
+
+Request:
+
+```json
+{
+  "materialId": "nkjv-1cor",
+  "newVerses": [{ "verse_ref": 0, "verse_phrases": [2, 3, 4] }]
+}
+```
+
+`newVerses` is optional; omit to only review scheduled cards.
+
+Response:
+
+```json
+{ "sessionId": "uuid", "card": SessionCard | null, "done": boolean }
+```
+
+`done: true` with `card: null` means there was nothing to review.
+
+### `GET /api/sessions/:id/next`
+
+Returns the card awaiting review, or `done: true` if the session is exhausted. Idempotent — it peeks
+at the same card until a review lands.
+
+```json
+{ "sessionId": "uuid", "card": SessionCard | null, "done": boolean }
+```
+
+### `POST /api/sessions/:id/review`
+
+Request:
+
+```json
+{ "grades": [{ "node_id": 2, "grade": 3 }] }
+```
+
+For reading-stage cards (`is_reading: true`), send `{ "grades": [] }`.
+
+Response — outcome plus the next card (or `done: true`):
+
+```json
+{
+  "outcome": ReviewOutcome,
+  "sessionId": "uuid",
+  "card": SessionCard | null,
+  "done": boolean
+}
+```
+
+Side effects (atomic, one transaction):
+
+* Appends a row to `review_events`.
+* Upserts the changed edges into `edge_states`.
+* Upserts `card_states` for every card in the catalog.
+
+When `done: true`, the session is removed from the in-memory store; a later `/next` returns 404.
+
+### `POST /api/sessions/:id/abort`
+
+Aborts the session — any new-verse cards that were flipped to Learning roll back to New. Returns
+`{ "ok": true }`.
+
+## Errors
+
+| Status | Meaning                                                 |
+| ------ | ------------------------------------------------------- |
+| 400    | Malformed body, missing field, or engine rejected input |
+| 401    | No session cookie / expired session                     |
+| 404    | Session ID unknown, or not owned by the caller          |
+| 409    | Session found but no card is currently awaiting review  |

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,8 @@
     "better-auth": "^1.2.0",
     "better-sqlite3": "^11.0.0",
     "drizzle-orm": "^0.44.0",
-    "hono": "^4.7.0"
+    "hono": "^4.7.0",
+    "verse-vault-wasm": "workspace:*"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.0.0",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -4,15 +4,21 @@ import { logger } from 'hono/logger';
 
 import type { DB } from './db/client.js';
 import { type AuthEnv, createAuth } from './lib/auth.js';
+import { EngineStore } from './lib/engine.js';
+import { SessionStore } from './lib/sessions.js';
 import { type SessionVariables, getUser, requireAuth, sessionMiddleware } from './middleware/session.js';
+import { sessionRoutes } from './routes/sessions.js';
 
 export interface AppDeps {
   db: DB;
   authEnv: AuthEnv;
+  now?: () => number;
 }
 
 export function createApp(deps: AppDeps) {
   const auth = createAuth(deps.db, deps.authEnv);
+  const engines = new EngineStore(deps.db);
+  const sessions = new SessionStore();
   const app = new Hono<{ Variables: SessionVariables }>();
 
   app.use('*', logger());
@@ -37,6 +43,8 @@ export function createApp(deps: AppDeps) {
   app.get('/health', (c) => c.json({ status: 'ok' }));
 
   app.get('/api/me', requireAuth(), (c) => c.json({ user: getUser(c) }));
+
+  app.route('/api/sessions', sessionRoutes({ db: deps.db, engines, sessions, now: deps.now }));
 
   return app;
 }

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb } from '../test-utils.js';
+import { EngineStore } from './engine.js';
+
+describe('EngineStore', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('loads an engine from a seeded snapshot', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: 'nkjv-1cor' });
+
+    const store = new EngineStore(test.db);
+    const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-1cor' });
+
+    expect(loaded.snapshotVersion).toBe(1);
+    const edgeStates = JSON.parse(loaded.engine.export_edge_states()) as Array<{ edge_id: number }>;
+    expect(edgeStates.length).toBeGreaterThan(0);
+    store.clear();
+  });
+
+  it('throws when no snapshot exists', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+
+    const store = new EngineStore(test.db);
+    await expect(store.load({ userId: 'missing', materialId: 'x' })).rejects.toThrow(
+      /No graph snapshot/,
+    );
+  });
+
+  it('caches engines across calls', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: 'nkjv-1cor' });
+
+    const store = new EngineStore(test.db);
+    const a = await store.load({ userId: 'u1', materialId: 'nkjv-1cor' });
+    const b = await store.load({ userId: 'u1', materialId: 'nkjv-1cor' });
+    expect(a.engine).toBe(b.engine);
+    store.clear();
+  });
+});

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -30,10 +30,7 @@ export interface CardStateEntry {
   priority: number | null;
 }
 
-/**
- * Caches per-(user, material) WASM engines across requests — the Node process
- * is long-running so reloading the graph per session action would be wasteful.
- */
+/** Long-running Node process, so engines live across requests; no eviction yet. */
 export class EngineStore {
   private readonly cache = new Map<string, LoadedEngine>();
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -1,0 +1,131 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { WasmEngine } from 'verse-vault-wasm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+
+const DEFAULT_DESIRED_RETENTION = 0.9;
+
+export interface EngineKey {
+  userId: string;
+  materialId: string;
+}
+
+export interface LoadedEngine {
+  engine: WasmEngine;
+  snapshotVersion: number;
+}
+
+/** Wire shapes for persisted state — must match the WASM boundary contract. */
+export interface EdgeStateEntry {
+  edge_id: number;
+  stability: number;
+  difficulty: number;
+  last_review_secs: number;
+}
+
+export interface CardStateEntry {
+  card_id: number;
+  state: 'new' | 'learning' | 'review' | 'relearning';
+  due_r: number | null;
+  due_date_secs: number | null;
+  priority: number | null;
+}
+
+/**
+ * Loads and caches per-(user, material) WASM engines. The Node process is
+ * long-running so engines stay in memory between requests — much faster than
+ * reloading the graph on every session action.
+ */
+export class EngineStore {
+  private readonly cache = new Map<string, LoadedEngine>();
+
+  constructor(
+    private readonly db: DB,
+    private readonly desiredRetention: number = DEFAULT_DESIRED_RETENTION,
+  ) {}
+
+  async load(key: EngineKey): Promise<LoadedEngine> {
+    const cached = this.cache.get(cacheKey(key));
+    if (cached) return cached;
+
+    const snapshot = this.db
+      .select()
+      .from(schema.graphSnapshots)
+      .where(
+        and(
+          eq(schema.graphSnapshots.userId, key.userId),
+          eq(schema.graphSnapshots.materialId, key.materialId),
+        ),
+      )
+      .orderBy(desc(schema.graphSnapshots.version))
+      .limit(1)
+      .get();
+    if (!snapshot) {
+      throw new Error(`No graph snapshot for user=${key.userId} material=${key.materialId}`);
+    }
+
+    const edges = this.db
+      .select()
+      .from(schema.edgeStates)
+      .where(
+        and(
+          eq(schema.edgeStates.userId, key.userId),
+          eq(schema.edgeStates.materialId, key.materialId),
+        ),
+      )
+      .all();
+    const cards = this.db
+      .select()
+      .from(schema.cardStates)
+      .where(
+        and(
+          eq(schema.cardStates.userId, key.userId),
+          eq(schema.cardStates.materialId, key.materialId),
+        ),
+      )
+      .all();
+
+    const edgeJson: EdgeStateEntry[] = edges.map((e) => ({
+      edge_id: e.edgeId,
+      stability: e.stability,
+      difficulty: e.difficulty,
+      last_review_secs: e.lastReviewSecs,
+    }));
+    const cardJson: CardStateEntry[] = cards.map((c) => ({
+      card_id: c.cardId,
+      state: c.state,
+      due_r: c.dueR,
+      due_date_secs: c.dueDateSecs,
+      priority: c.priority,
+    }));
+
+    const engine = new WasmEngine(
+      snapshot.graphData.toString('utf8'),
+      snapshot.cardsData.toString('utf8'),
+      JSON.stringify(edgeJson),
+      JSON.stringify(cardJson),
+      this.desiredRetention,
+    );
+
+    const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
+    this.cache.set(cacheKey(key), loaded);
+    return loaded;
+  }
+
+  invalidate(key: EngineKey): void {
+    const k = cacheKey(key);
+    const existing = this.cache.get(k);
+    existing?.engine.free();
+    this.cache.delete(k);
+  }
+
+  clear(): void {
+    for (const loaded of this.cache.values()) loaded.engine.free();
+    this.cache.clear();
+  }
+}
+
+function cacheKey(k: EngineKey): string {
+  return `${k.userId}:${k.materialId}`;
+}

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -3,20 +3,18 @@ import { WasmEngine } from 'verse-vault-wasm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
+import { type UserMaterial, userMaterialKey } from './keys.js';
 
 const DEFAULT_DESIRED_RETENTION = 0.9;
 
-export interface EngineKey {
-  userId: string;
-  materialId: string;
-}
+export type EngineKey = UserMaterial;
 
 export interface LoadedEngine {
   engine: WasmEngine;
   snapshotVersion: number;
 }
 
-/** Wire shapes for persisted state — must match the WASM boundary contract. */
+/** Wire shapes must stay in sync with crates/wasm/src/lib.rs. */
 export interface EdgeStateEntry {
   edge_id: number;
   stability: number;
@@ -33,9 +31,8 @@ export interface CardStateEntry {
 }
 
 /**
- * Loads and caches per-(user, material) WASM engines. The Node process is
- * long-running so engines stay in memory between requests — much faster than
- * reloading the graph on every session action.
+ * Caches per-(user, material) WASM engines across requests — the Node process
+ * is long-running so reloading the graph per session action would be wasteful.
  */
 export class EngineStore {
   private readonly cache = new Map<string, LoadedEngine>();
@@ -46,7 +43,7 @@ export class EngineStore {
   ) {}
 
   async load(key: EngineKey): Promise<LoadedEngine> {
-    const cached = this.cache.get(cacheKey(key));
+    const cached = this.cache.get(userMaterialKey(key));
     if (cached) return cached;
 
     const snapshot = this.db
@@ -109,14 +106,13 @@ export class EngineStore {
     );
 
     const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
-    this.cache.set(cacheKey(key), loaded);
+    this.cache.set(userMaterialKey(key), loaded);
     return loaded;
   }
 
   invalidate(key: EngineKey): void {
-    const k = cacheKey(key);
-    const existing = this.cache.get(k);
-    existing?.engine.free();
+    const k = userMaterialKey(key);
+    this.cache.get(k)?.engine.free();
     this.cache.delete(k);
   }
 
@@ -124,8 +120,4 @@ export class EngineStore {
     for (const loaded of this.cache.values()) loaded.engine.free();
     this.cache.clear();
   }
-}
-
-function cacheKey(k: EngineKey): string {
-  return `${k.userId}:${k.materialId}`;
 }

--- a/packages/api/src/lib/keys.ts
+++ b/packages/api/src/lib/keys.ts
@@ -1,0 +1,12 @@
+export interface UserMaterial {
+  userId: string;
+  materialId: string;
+}
+
+export function userMaterialKey(x: UserMaterial): string {
+  return `${x.userId}:${x.materialId}`;
+}
+
+export function jsonBlob(value: unknown): Buffer {
+  return Buffer.from(JSON.stringify(value), 'utf8');
+}

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from 'node:crypto';
+
+import type { WasmEngine } from 'verse-vault-wasm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import type { CardStateEntry, EdgeStateEntry } from './engine.js';
+import type { SessionCard } from './sessions.js';
+
+export interface Grade {
+  node_id: number;
+  grade: 1 | 2 | 3 | 4;
+}
+
+export interface ReviewOutcome {
+  edge_updates: Array<{ edge_id: number; grade: number; weight: number }>;
+  redrills_inserted: number;
+}
+
+export interface RecordReviewArgs {
+  db: DB;
+  engine: WasmEngine;
+  userId: string;
+  materialId: string;
+  snapshotVersion: number;
+  timestampSecs: number;
+  card: SessionCard;
+  grades: Grade[];
+  outcome: ReviewOutcome;
+}
+
+/**
+ * Appends a review event and upserts the resulting edge/card states. Runs in a
+ * transaction so the log and the materialized state stay consistent.
+ */
+export function recordReview(args: RecordReviewArgs): void {
+  const edges = JSON.parse(args.engine.export_edge_states()) as EdgeStateEntry[];
+  const cards = JSON.parse(args.engine.export_card_states()) as CardStateEntry[];
+  const changedEdgeIds = new Set(args.outcome.edge_updates.map((u) => u.edge_id));
+  const edgeRows = edges
+    .filter((e) => changedEdgeIds.has(e.edge_id))
+    .map((e) => ({
+      userId: args.userId,
+      materialId: args.materialId,
+      edgeId: e.edge_id,
+      stability: e.stability,
+      difficulty: e.difficulty,
+      lastReviewSecs: e.last_review_secs,
+    }));
+  const cardRows = cards.map((c) => ({
+    userId: args.userId,
+    materialId: args.materialId,
+    cardId: c.card_id,
+    state: c.state,
+    dueR: c.due_r,
+    dueDateSecs: c.due_date_secs,
+    priority: c.priority,
+  }));
+
+  args.db.transaction((tx) => {
+    tx.insert(schema.reviewEvents)
+      .values({
+        id: randomUUID(),
+        userId: args.userId,
+        materialId: args.materialId,
+        snapshotVersion: args.snapshotVersion,
+        timestampSecs: args.timestampSecs,
+        cardId: args.card.source_card_id,
+        shown: Buffer.from(JSON.stringify(args.card.shown), 'utf8'),
+        hidden: Buffer.from(JSON.stringify(args.card.hidden), 'utf8'),
+        grades: Buffer.from(JSON.stringify(args.grades), 'utf8'),
+        createdAt: args.timestampSecs,
+      })
+      .run();
+
+    for (const row of edgeRows) {
+      tx.insert(schema.edgeStates)
+        .values(row)
+        .onConflictDoUpdate({
+          target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
+          set: {
+            stability: row.stability,
+            difficulty: row.difficulty,
+            lastReviewSecs: row.lastReviewSecs,
+          },
+        })
+        .run();
+    }
+
+    for (const row of cardRows) {
+      tx.insert(schema.cardStates)
+        .values(row)
+        .onConflictDoUpdate({
+          target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
+          set: {
+            state: row.state,
+            dueR: row.dueR,
+            dueDateSecs: row.dueDateSecs,
+            priority: row.priority,
+          },
+        })
+        .run();
+    }
+  });
+}

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
+import { sql } from 'drizzle-orm';
 import type { WasmEngine } from 'verse-vault-wasm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
 import type { CardStateEntry, EdgeStateEntry } from './engine.js';
+import { jsonBlob } from './keys.js';
 import type { SessionCard } from './sessions.js';
 
 export interface Grade {
@@ -29,10 +31,7 @@ export interface RecordReviewArgs {
   outcome: ReviewOutcome;
 }
 
-/**
- * Appends a review event and upserts the resulting edge/card states. Runs in a
- * transaction so the log and the materialized state stay consistent.
- */
+/** Transactional so the event log and the materialized state can't diverge. */
 export function recordReview(args: RecordReviewArgs): void {
   const edges = JSON.parse(args.engine.export_edge_states()) as EdgeStateEntry[];
   const cards = JSON.parse(args.engine.export_card_states()) as CardStateEntry[];
@@ -66,37 +65,37 @@ export function recordReview(args: RecordReviewArgs): void {
         snapshotVersion: args.snapshotVersion,
         timestampSecs: args.timestampSecs,
         cardId: args.card.source_card_id,
-        shown: Buffer.from(JSON.stringify(args.card.shown), 'utf8'),
-        hidden: Buffer.from(JSON.stringify(args.card.hidden), 'utf8'),
-        grades: Buffer.from(JSON.stringify(args.grades), 'utf8'),
+        shown: jsonBlob(args.card.shown),
+        hidden: jsonBlob(args.card.hidden),
+        grades: jsonBlob(args.grades),
         createdAt: args.timestampSecs,
       })
       .run();
 
-    for (const row of edgeRows) {
+    if (edgeRows.length > 0) {
       tx.insert(schema.edgeStates)
-        .values(row)
+        .values(edgeRows)
         .onConflictDoUpdate({
           target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
           set: {
-            stability: row.stability,
-            difficulty: row.difficulty,
-            lastReviewSecs: row.lastReviewSecs,
+            stability: sql`excluded.stability`,
+            difficulty: sql`excluded.difficulty`,
+            lastReviewSecs: sql`excluded.last_review_secs`,
           },
         })
         .run();
     }
 
-    for (const row of cardRows) {
+    if (cardRows.length > 0) {
       tx.insert(schema.cardStates)
-        .values(row)
+        .values(cardRows)
         .onConflictDoUpdate({
           target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
           set: {
-            state: row.state,
-            dueR: row.dueR,
-            dueDateSecs: row.dueDateSecs,
-            priority: row.priority,
+            state: sql`excluded.state`,
+            dueR: sql`excluded.due_r`,
+            dueDateSecs: sql`excluded.due_date_secs`,
+            priority: sql`excluded.priority`,
           },
         })
         .run();

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -1,13 +1,12 @@
 import { randomUUID } from 'node:crypto';
 
 import { sql } from 'drizzle-orm';
-import type { WasmEngine } from 'verse-vault-wasm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
 import type { CardStateEntry, EdgeStateEntry } from './engine.js';
 import { jsonBlob } from './keys.js';
-import type { SessionCard } from './sessions.js';
+import type { SessionCard, SessionEntry } from './sessions.js';
 
 export interface Grade {
   node_id: number;
@@ -21,10 +20,7 @@ export interface ReviewOutcome {
 
 export interface RecordReviewArgs {
   db: DB;
-  engine: WasmEngine;
-  userId: string;
-  materialId: string;
-  snapshotVersion: number;
+  entry: SessionEntry;
   timestampSecs: number;
   card: SessionCard;
   grades: Grade[];
@@ -33,22 +29,24 @@ export interface RecordReviewArgs {
 
 /** Transactional so the event log and the materialized state can't diverge. */
 export function recordReview(args: RecordReviewArgs): void {
-  const edges = JSON.parse(args.engine.export_edge_states()) as EdgeStateEntry[];
-  const cards = JSON.parse(args.engine.export_card_states()) as CardStateEntry[];
-  const changedEdgeIds = new Set(args.outcome.edge_updates.map((u) => u.edge_id));
+  const { db, entry, timestampSecs, card, grades, outcome } = args;
+  const { userId, materialId } = entry;
+  const edges = JSON.parse(entry.engine.export_edge_states()) as EdgeStateEntry[];
+  const cards = JSON.parse(entry.engine.export_card_states()) as CardStateEntry[];
+  const changedEdgeIds = new Set(outcome.edge_updates.map((u) => u.edge_id));
   const edgeRows = edges
     .filter((e) => changedEdgeIds.has(e.edge_id))
     .map((e) => ({
-      userId: args.userId,
-      materialId: args.materialId,
+      userId,
+      materialId,
       edgeId: e.edge_id,
       stability: e.stability,
       difficulty: e.difficulty,
       lastReviewSecs: e.last_review_secs,
     }));
   const cardRows = cards.map((c) => ({
-    userId: args.userId,
-    materialId: args.materialId,
+    userId,
+    materialId,
     cardId: c.card_id,
     state: c.state,
     dueR: c.due_r,
@@ -56,19 +54,19 @@ export function recordReview(args: RecordReviewArgs): void {
     priority: c.priority,
   }));
 
-  args.db.transaction((tx) => {
+  db.transaction((tx) => {
     tx.insert(schema.reviewEvents)
       .values({
         id: randomUUID(),
-        userId: args.userId,
-        materialId: args.materialId,
-        snapshotVersion: args.snapshotVersion,
-        timestampSecs: args.timestampSecs,
-        cardId: args.card.source_card_id,
-        shown: jsonBlob(args.card.shown),
-        hidden: jsonBlob(args.card.hidden),
-        grades: jsonBlob(args.grades),
-        createdAt: args.timestampSecs,
+        userId,
+        materialId,
+        snapshotVersion: entry.snapshotVersion,
+        timestampSecs,
+        cardId: card.source_card_id,
+        shown: jsonBlob(card.shown),
+        hidden: jsonBlob(card.hidden),
+        grades: jsonBlob(grades),
+        createdAt: timestampSecs,
       })
       .run();
 

--- a/packages/api/src/lib/sessions.ts
+++ b/packages/api/src/lib/sessions.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'node:crypto';
+
+import type { WasmEngine } from 'verse-vault-wasm';
+
+export interface SessionCard {
+  shown: number[];
+  hidden: number[];
+  is_reading: boolean;
+  source_kind: 'scheduled' | 'redrill' | 'new_verse';
+  source_card_id: number | null;
+}
+
+export interface SessionEntry {
+  id: string;
+  userId: string;
+  materialId: string;
+  snapshotVersion: number;
+  engine: WasmEngine;
+  createdAtSecs: number;
+  /** Card currently awaiting a review. Populated by `advance()`, consumed by review. */
+  currentCard: SessionCard | null;
+}
+
+/**
+ * In-memory registry of active sessions. A WasmEngine can hold at most one
+ * session at a time, so we also track the current session per (user, material)
+ * and abort it when a new one is started.
+ */
+export class SessionStore {
+  private readonly sessions = new Map<string, SessionEntry>();
+  private readonly activeByUserMaterial = new Map<string, string>();
+
+  create(args: {
+    userId: string;
+    materialId: string;
+    snapshotVersion: number;
+    engine: WasmEngine;
+    nowSecs: number;
+  }): SessionEntry {
+    const prevId = this.activeByUserMaterial.get(userMaterialKey(args));
+    if (prevId) this.end(prevId);
+
+    const id = randomUUID();
+    const entry: SessionEntry = {
+      id,
+      userId: args.userId,
+      materialId: args.materialId,
+      snapshotVersion: args.snapshotVersion,
+      engine: args.engine,
+      createdAtSecs: args.nowSecs,
+      currentCard: null,
+    };
+    this.sessions.set(id, entry);
+    this.activeByUserMaterial.set(userMaterialKey(args), id);
+    return entry;
+  }
+
+  get(id: string): SessionEntry | undefined {
+    return this.sessions.get(id);
+  }
+
+  end(id: string): void {
+    const entry = this.sessions.get(id);
+    if (!entry) return;
+    this.sessions.delete(id);
+    const key = userMaterialKey(entry);
+    if (this.activeByUserMaterial.get(key) === id) {
+      this.activeByUserMaterial.delete(key);
+    }
+  }
+}
+
+function userMaterialKey(x: { userId: string; materialId: string }): string {
+  return `${x.userId}:${x.materialId}`;
+}

--- a/packages/api/src/lib/sessions.ts
+++ b/packages/api/src/lib/sessions.ts
@@ -2,6 +2,8 @@ import { randomUUID } from 'node:crypto';
 
 import type { WasmEngine } from 'verse-vault-wasm';
 
+import { userMaterialKey } from './keys.js';
+
 export interface SessionCard {
   shown: number[];
   hidden: number[];
@@ -17,14 +19,12 @@ export interface SessionEntry {
   snapshotVersion: number;
   engine: WasmEngine;
   createdAtSecs: number;
-  /** Card currently awaiting a review. Populated by `advance()`, consumed by review. */
   currentCard: SessionCard | null;
 }
 
 /**
- * In-memory registry of active sessions. A WasmEngine can hold at most one
- * session at a time, so we also track the current session per (user, material)
- * and abort it when a new one is started.
+ * A WasmEngine can hold at most one `Session` at a time, so we abort the
+ * previous session for a (user, material) pair when a new one is started.
  */
 export class SessionStore {
   private readonly sessions = new Map<string, SessionEntry>();
@@ -68,8 +68,4 @@ export class SessionStore {
       this.activeByUserMaterial.delete(key);
     }
   }
-}
-
-function userMaterialKey(x: { userId: string; materialId: string }): string {
-  return `${x.userId}:${x.materialId}`;
 }

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { cardStates, edgeStates, reviewEvents, user } from '../db/schema.js';
-import { buildSingleVerseFixture, seedUserWithFixture } from '../test-fixtures.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
 import { createTestApp } from '../test-utils.js';
+
+type TestApp = ReturnType<typeof createTestApp>;
 
 interface StartResponse {
   sessionId: string;
@@ -14,8 +16,10 @@ interface ReviewResponse extends StartResponse {
   outcome: { edge_updates: Array<{ edge_id: number }>; redrills_inserted: number };
 }
 
-async function signUpAndGetUser(app: ReturnType<typeof createTestApp>['app'], db: ReturnType<typeof createTestApp>['db']) {
-  const res = await app.request('/api/auth/sign-up/email', {
+const MATERIAL_ID = 'nkjv-1cor';
+
+async function signUpAndGetUser(test: TestApp) {
+  const res = await test.app.request('/api/auth/sign-up/email', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -25,9 +29,25 @@ async function signUpAndGetUser(app: ReturnType<typeof createTestApp>['app'], db
     }),
   });
   expect(res.status).toBe(200);
-  const cookie = res.headers.get('set-cookie')!;
-  const row = db.select().from(user).get()!;
-  return { cookie, userId: row.id };
+  return {
+    cookie: res.headers.get('set-cookie')!,
+    userId: test.db.select().from(user).get()!.id,
+  };
+}
+
+async function startEnrolledSession(test: TestApp): Promise<{ cookie: string; userId: string; start: StartResponse }> {
+  const { cookie, userId } = await signUpAndGetUser(test);
+  seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+  const startRes = await test.app.request('/api/sessions/start', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', cookie },
+    body: JSON.stringify({
+      materialId: MATERIAL_ID,
+      newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+    }),
+  });
+  expect(startRes.status).toBe(200);
+  return { cookie, userId, start: (await startRes.json()) as StartResponse };
 }
 
 describe('session routes', () => {
@@ -43,7 +63,7 @@ describe('session routes', () => {
     const res = await test.app.request('/api/sessions/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ materialId: 'nkjv-1cor' }),
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
     });
     expect(res.status).toBe(401);
   });
@@ -51,25 +71,12 @@ describe('session routes', () => {
   it('runs a full session: start → review → done', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
-    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
-
-    const { graph: _g } = buildSingleVerseFixture();
-    const startRes = await test.app.request('/api/sessions/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({
-        materialId: 'nkjv-1cor',
-        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
-      }),
-    });
-    expect(startRes.status).toBe(200);
-    const start = (await startRes.json()) as StartResponse;
+    const { cookie, userId, start } = await startEnrolledSession(test);
     expect(start.done).toBe(false);
     expect(start.card).not.toBeNull();
     expect(start.sessionId).toBeTruthy();
 
-    let sessionId = start.sessionId;
+    const sessionId = start.sessionId;
     let card = start.card!;
     let reviews = 0;
     while (card) {
@@ -115,44 +122,24 @@ describe('session routes', () => {
   it('rejects access to other users sessions', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
-    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
-    const startRes = await test.app.request('/api/sessions/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({
-        materialId: 'nkjv-1cor',
-        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
-      }),
-    });
-    const { sessionId } = (await startRes.json()) as StartResponse;
+    const { start } = await startEnrolledSession(test);
 
-    const res = await test.app.request(`/api/sessions/${sessionId}/next`);
+    const res = await test.app.request(`/api/sessions/${start.sessionId}/next`);
     expect(res.status).toBe(401);
   });
 
   it('aborts a session', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
-    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
-    const startRes = await test.app.request('/api/sessions/start', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({
-        materialId: 'nkjv-1cor',
-        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
-      }),
-    });
-    const { sessionId } = (await startRes.json()) as StartResponse;
+    const { cookie, start } = await startEnrolledSession(test);
 
-    const abortRes = await test.app.request(`/api/sessions/${sessionId}/abort`, {
+    const abortRes = await test.app.request(`/api/sessions/${start.sessionId}/abort`, {
       method: 'POST',
       headers: { cookie },
     });
     expect(abortRes.status).toBe(200);
 
-    const nextRes = await test.app.request(`/api/sessions/${sessionId}/next`, {
+    const nextRes = await test.app.request(`/api/sessions/${start.sessionId}/next`, {
       headers: { cookie },
     });
     expect(nextRes.status).toBe(404);

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { cardStates, edgeStates, reviewEvents, user } from '../db/schema.js';
+import { buildSingleVerseFixture, seedUserWithFixture } from '../test-fixtures.js';
+import { createTestApp } from '../test-utils.js';
+
+interface StartResponse {
+  sessionId: string;
+  card: { shown: number[]; hidden: number[]; is_reading: boolean } | null;
+  done: boolean;
+}
+
+interface ReviewResponse extends StartResponse {
+  outcome: { edge_updates: Array<{ edge_id: number }>; redrills_inserted: number };
+}
+
+async function signUpAndGetUser(app: ReturnType<typeof createTestApp>['app'], db: ReturnType<typeof createTestApp>['db']) {
+  const res = await app.request('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: 'alice@example.com',
+      password: 'superSecret123!',
+      name: 'Alice',
+    }),
+  });
+  expect(res.status).toBe(200);
+  const cookie = res.headers.get('set-cookie')!;
+  const row = db.select().from(user).get()!;
+  return { cookie, userId: row.id };
+}
+
+describe('session routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('requires auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const res = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ materialId: 'nkjv-1cor' }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('runs a full session: start → review → done', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
+    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
+
+    const { graph: _g } = buildSingleVerseFixture();
+    const startRes = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        materialId: 'nkjv-1cor',
+        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+      }),
+    });
+    expect(startRes.status).toBe(200);
+    const start = (await startRes.json()) as StartResponse;
+    expect(start.done).toBe(false);
+    expect(start.card).not.toBeNull();
+    expect(start.sessionId).toBeTruthy();
+
+    let sessionId = start.sessionId;
+    let card = start.card!;
+    let reviews = 0;
+    while (card) {
+      const grades = card.is_reading
+        ? []
+        : card.hidden.map((node_id) => ({ node_id, grade: 3 }));
+      const res = await test.app.request(`/api/sessions/${sessionId}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify({ grades }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as ReviewResponse;
+      reviews += 1;
+      if (body.done) {
+        card = null as unknown as typeof card;
+        break;
+      }
+      card = body.card!;
+      expect(card).not.toBeNull();
+      if (reviews > 30) throw new Error('loop guard');
+    }
+
+    expect(reviews).toBeGreaterThan(0);
+
+    const nextRes = await test.app.request(`/api/sessions/${sessionId}/next`, {
+      headers: { cookie },
+    });
+    expect(nextRes.status).toBe(404);
+
+    const loggedEvents = test.db.select().from(reviewEvents).all();
+    expect(loggedEvents.length).toBe(reviews);
+    expect(loggedEvents.every((e) => e.userId === userId)).toBe(true);
+
+    const persistedEdges = test.db.select().from(edgeStates).all();
+    expect(persistedEdges.length).toBeGreaterThan(0);
+
+    const persistedCards = test.db.select().from(cardStates).all();
+    expect(persistedCards.length).toBeGreaterThan(0);
+    expect(persistedCards.some((c) => c.state === 'review')).toBe(true);
+  });
+
+  it('rejects access to other users sessions', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
+    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
+    const startRes = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        materialId: 'nkjv-1cor',
+        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+      }),
+    });
+    const { sessionId } = (await startRes.json()) as StartResponse;
+
+    const res = await test.app.request(`/api/sessions/${sessionId}/next`);
+    expect(res.status).toBe(401);
+  });
+
+  it('aborts a session', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUpAndGetUser(test.app, test.db);
+    seedUserWithFixture({ db: test.db, userId, materialId: 'nkjv-1cor', createUser: false });
+    const startRes = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        materialId: 'nkjv-1cor',
+        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+      }),
+    });
+    const { sessionId } = (await startRes.json()) as StartResponse;
+
+    const abortRes = await test.app.request(`/api/sessions/${sessionId}/abort`, {
+      method: 'POST',
+      headers: { cookie },
+    });
+    expect(abortRes.status).toBe(200);
+
+    const nextRes = await test.app.request(`/api/sessions/${sessionId}/next`, {
+      headers: { cookie },
+    });
+    expect(nextRes.status).toBe(404);
+  });
+});

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -10,7 +10,6 @@ export interface SessionRoutesDeps {
   db: DB;
   engines: EngineStore;
   sessions: SessionStore;
-  /** Seconds-precision clock. Injectable for tests. */
   now?: () => number;
 }
 

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -34,8 +34,13 @@ export function sessionRoutes(deps: SessionRoutesDeps) {
   app.use('*', requireAuth());
 
   app.post('/start', async (c) => {
-    const body = await parseJson<StartBody>(c.req.raw);
-    if (!body || typeof body.materialId !== 'string') {
+    let body: StartBody;
+    try {
+      body = await c.req.json<StartBody>();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (typeof body.materialId !== 'string') {
       return c.json({ error: 'materialId required' }, 400);
     }
     const user = getUser(c);
@@ -71,8 +76,13 @@ export function sessionRoutes(deps: SessionRoutesDeps) {
     if (!entry) return c.json({ error: 'Session not found' }, 404);
     const card = entry.currentCard;
     if (!card) return c.json({ error: 'No card awaiting review' }, 409);
-    const body = await parseJson<ReviewBody>(c.req.raw);
-    if (!body || !Array.isArray(body.grades)) {
+    let body: ReviewBody;
+    try {
+      body = await c.req.json<ReviewBody>();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (!Array.isArray(body.grades)) {
       return c.json({ error: 'grades required' }, 400);
     }
     const nowSecs = now();
@@ -84,17 +94,7 @@ export function sessionRoutes(deps: SessionRoutesDeps) {
     } catch (err) {
       return c.json({ error: (err as Error).message }, 400);
     }
-    recordReview({
-      db: deps.db,
-      engine: entry.engine,
-      userId: entry.userId,
-      materialId: entry.materialId,
-      snapshotVersion: entry.snapshotVersion,
-      timestampSecs: nowSecs,
-      card,
-      grades: body.grades,
-      outcome,
-    });
+    recordReview({ db: deps.db, entry, timestampSecs: nowSecs, card, grades: body.grades, outcome });
     entry.currentCard = null;
     const next = advance(entry);
     if (next.done) deps.sessions.end(entry.id);
@@ -134,10 +134,3 @@ function authorizedSession(
   return entry;
 }
 
-async function parseJson<T>(req: Request): Promise<T | null> {
-  try {
-    return (await req.json()) as T;
-  } catch {
-    return null;
-  }
-}

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1,0 +1,144 @@
+import { type Context, Hono } from 'hono';
+
+import type { DB } from '../db/client.js';
+import { EngineStore } from '../lib/engine.js';
+import { type Grade, type ReviewOutcome, recordReview } from '../lib/review-log.js';
+import { SessionStore, type SessionCard, type SessionEntry } from '../lib/sessions.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface SessionRoutesDeps {
+  db: DB;
+  engines: EngineStore;
+  sessions: SessionStore;
+  /** Seconds-precision clock. Injectable for tests. */
+  now?: () => number;
+}
+
+interface NewVerseInfo {
+  verse_ref: number;
+  verse_phrases: number[];
+}
+
+interface StartBody {
+  materialId: string;
+  newVerses?: NewVerseInfo[];
+}
+
+interface ReviewBody {
+  grades: Grade[];
+}
+
+export function sessionRoutes(deps: SessionRoutesDeps) {
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
+  const app = new Hono<{ Variables: SessionVariables }>();
+
+  app.use('*', requireAuth());
+
+  app.post('/start', async (c) => {
+    const body = await parseJson<StartBody>(c.req.raw);
+    if (!body || typeof body.materialId !== 'string') {
+      return c.json({ error: 'materialId required' }, 400);
+    }
+    const user = getUser(c);
+    const loaded = await deps.engines.load({ userId: user.id, materialId: body.materialId });
+    const nowSecs = now();
+    try {
+      loaded.engine.start_session(
+        BigInt(nowSecs),
+        JSON.stringify(body.newVerses ?? []),
+        '',
+      );
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+    const entry = deps.sessions.create({
+      userId: user.id,
+      materialId: body.materialId,
+      snapshotVersion: loaded.snapshotVersion,
+      engine: loaded.engine,
+      nowSecs,
+    });
+    return c.json(advance(entry));
+  });
+
+  app.get('/:id/next', (c) => {
+    const entry = authorizedSession(c, deps.sessions);
+    if (!entry) return c.json({ error: 'Session not found' }, 404);
+    return c.json(advance(entry));
+  });
+
+  app.post('/:id/review', async (c) => {
+    const entry = authorizedSession(c, deps.sessions);
+    if (!entry) return c.json({ error: 'Session not found' }, 404);
+    const card = entry.currentCard;
+    if (!card) return c.json({ error: 'No card awaiting review' }, 409);
+    const body = await parseJson<ReviewBody>(c.req.raw);
+    if (!body || !Array.isArray(body.grades)) {
+      return c.json({ error: 'grades required' }, 400);
+    }
+    const nowSecs = now();
+    let outcome: ReviewOutcome;
+    try {
+      outcome = JSON.parse(
+        entry.engine.session_review(JSON.stringify(body.grades), BigInt(nowSecs)),
+      ) as ReviewOutcome;
+    } catch (err) {
+      return c.json({ error: (err as Error).message }, 400);
+    }
+    recordReview({
+      db: deps.db,
+      engine: entry.engine,
+      userId: entry.userId,
+      materialId: entry.materialId,
+      snapshotVersion: entry.snapshotVersion,
+      timestampSecs: nowSecs,
+      card,
+      grades: body.grades,
+      outcome,
+    });
+    entry.currentCard = null;
+    const next = advance(entry);
+    if (next.done) deps.sessions.end(entry.id);
+    return c.json({ outcome, ...next });
+  });
+
+  app.post('/:id/abort', (c) => {
+    const entry = authorizedSession(c, deps.sessions);
+    if (!entry) return c.json({ error: 'Session not found' }, 404);
+    entry.engine.session_abort();
+    deps.sessions.end(entry.id);
+    return c.json({ ok: true });
+  });
+
+  return app;
+}
+
+function advance(entry: SessionEntry): { sessionId: string; card: SessionCard | null; done: boolean } {
+  const raw = entry.engine.session_next();
+  if (raw === undefined) {
+    entry.currentCard = null;
+    return { sessionId: entry.id, card: null, done: true };
+  }
+  const card = JSON.parse(raw) as SessionCard;
+  entry.currentCard = card;
+  return { sessionId: entry.id, card, done: false };
+}
+
+function authorizedSession(
+  c: Context<{ Variables: SessionVariables }>,
+  sessions: SessionStore,
+): SessionEntry | null {
+  const entry = sessions.get(c.req.param('id')!);
+  if (!entry) return null;
+  const user = getUser(c);
+  if (entry.userId !== user.id) return null;
+  return entry;
+}
+
+async function parseJson<T>(req: Request): Promise<T | null> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return null;
+  }
+}

--- a/packages/api/src/test-fixtures.ts
+++ b/packages/api/src/test-fixtures.ts
@@ -2,8 +2,8 @@ import { randomUUID } from 'node:crypto';
 
 import type { DB } from './db/client.js';
 import * as schema from './db/schema.js';
+import { jsonBlob } from './lib/keys.js';
 
-/** Minimal graph shape matching the WASM wire format. */
 export interface FixtureGraph {
   nodes: Record<string, { id: number; kind: unknown }>;
   edges: Record<string, FixtureEdge>;
@@ -28,10 +28,7 @@ export interface FixtureCard {
   state: 'New' | 'Learning' | 'Review' | 'Relearning';
 }
 
-/**
- * Builds a minimal three-phrase verse graph: one verse reference, one gist, three phrases.
- * Matches the shape used in `crates/wasm/test-smoke.js` so the engine will accept it.
- */
+/** Mirrors `crates/wasm/test-smoke.js` — minimum shape the engine will accept. */
 export function buildSingleVerseFixture(): { graph: FixtureGraph; cards: FixtureCard[] } {
   const edgeState = { stability: 5.0, difficulty: 5.0, last_review_secs: 0 };
   const graph: FixtureGraph = {
@@ -77,11 +74,10 @@ export interface SeedOptions {
   userId: string;
   materialId: string;
   version?: number;
-  /** If true, also inserts a user row. Off when the user already exists (e.g. after sign-up). */
+  /** Off when the user already exists (e.g. created by Better Auth sign-up). */
   createUser?: boolean;
 }
 
-/** Inserts enrollment + graph snapshot (and optionally the user) — enough to load an engine. */
 export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; version: number } {
   const { db, userId, materialId } = opts;
   const version = opts.version ?? 1;
@@ -110,8 +106,8 @@ export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; ve
       userId,
       materialId,
       version,
-      graphData: Buffer.from(JSON.stringify(graph), 'utf8'),
-      cardsData: Buffer.from(JSON.stringify(cards), 'utf8'),
+      graphData: jsonBlob(graph),
+      cardsData: jsonBlob(cards),
       createdAt: now,
     })
     .run();

--- a/packages/api/src/test-fixtures.ts
+++ b/packages/api/src/test-fixtures.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from 'node:crypto';
+
+import type { DB } from './db/client.js';
+import * as schema from './db/schema.js';
+
+/** Minimal graph shape matching the WASM wire format. */
+export interface FixtureGraph {
+  nodes: Record<string, { id: number; kind: unknown }>;
+  edges: Record<string, FixtureEdge>;
+  outgoing: Record<string, number[]>;
+  incoming: Record<string, number[]>;
+  next_node_id: number;
+  next_edge_id: number;
+}
+
+interface FixtureEdge {
+  id: number;
+  kind: string;
+  source: number;
+  target: number;
+  state: { stability: number; difficulty: number; last_review_secs: number };
+}
+
+export interface FixtureCard {
+  id: number;
+  shown: number[];
+  hidden: number[];
+  state: 'New' | 'Learning' | 'Review' | 'Relearning';
+}
+
+/**
+ * Builds a minimal three-phrase verse graph: one verse reference, one gist, three phrases.
+ * Matches the shape used in `crates/wasm/test-smoke.js` so the engine will accept it.
+ */
+export function buildSingleVerseFixture(): { graph: FixtureGraph; cards: FixtureCard[] } {
+  const edgeState = { stability: 5.0, difficulty: 5.0, last_review_secs: 0 };
+  const graph: FixtureGraph = {
+    nodes: {
+      '0': { id: 0, kind: { Reference: { chapter: 3, verse: 16 } } },
+      '1': { id: 1, kind: { VerseGist: { chapter: 3, verse: 16 } } },
+      '2': { id: 2, kind: { Phrase: { text: 'phrase one', verse_id: 0, position: 0 } } },
+      '3': { id: 3, kind: { Phrase: { text: 'phrase two', verse_id: 0, position: 1 } } },
+      '4': { id: 4, kind: { Phrase: { text: 'phrase three', verse_id: 0, position: 2 } } },
+    },
+    edges: {},
+    outgoing: { '0': [], '1': [], '2': [], '3': [], '4': [] },
+    incoming: { '0': [], '1': [], '2': [], '3': [], '4': [] },
+    next_node_id: 5,
+    next_edge_id: 0,
+  };
+
+  const addBi = (kind: string, a: number, b: number) => {
+    const fwd = graph.next_edge_id++;
+    const bwd = graph.next_edge_id++;
+    graph.edges[String(fwd)] = { id: fwd, kind, source: a, target: b, state: edgeState };
+    graph.edges[String(bwd)] = { id: bwd, kind, source: b, target: a, state: edgeState };
+    graph.outgoing[String(a)]!.push(fwd);
+    graph.incoming[String(b)]!.push(fwd);
+    graph.outgoing[String(b)]!.push(bwd);
+    graph.incoming[String(a)]!.push(bwd);
+  };
+
+  addBi('VerseGistReference', 1, 0);
+  addBi('PhraseVerseGist', 2, 1);
+  addBi('PhraseVerseGist', 3, 1);
+  addBi('PhraseVerseGist', 4, 1);
+  addBi('PhrasePhrase', 2, 3);
+  addBi('PhrasePhrase', 3, 4);
+
+  const cards: FixtureCard[] = [{ id: 0, shown: [0], hidden: [2, 3, 4], state: 'New' }];
+
+  return { graph, cards };
+}
+
+export interface SeedOptions {
+  db: DB;
+  userId: string;
+  materialId: string;
+  version?: number;
+}
+
+/** Inserts a user, enrollment, and graph snapshot — enough to load an engine. */
+export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; version: number } {
+  const { db, userId, materialId } = opts;
+  const version = opts.version ?? 1;
+  const { graph, cards } = buildSingleVerseFixture();
+  const now = Math.floor(Date.now() / 1000);
+
+  db.insert(schema.user)
+    .values({
+      id: userId,
+      email: `${userId}@example.com`,
+      name: userId,
+      emailVerified: false,
+      createdAt: new Date(now * 1000),
+      updatedAt: new Date(now * 1000),
+    })
+    .run();
+  db.insert(schema.userMaterials)
+    .values({ userId, materialId, clubTier: null, createdAt: now })
+    .run();
+  const snapshotId = randomUUID();
+  db.insert(schema.graphSnapshots)
+    .values({
+      id: snapshotId,
+      userId,
+      materialId,
+      version,
+      graphData: Buffer.from(JSON.stringify(graph), 'utf8'),
+      cardsData: Buffer.from(JSON.stringify(cards), 'utf8'),
+      createdAt: now,
+    })
+    .run();
+
+  return { snapshotId, version };
+}

--- a/packages/api/src/test-fixtures.ts
+++ b/packages/api/src/test-fixtures.ts
@@ -77,25 +77,29 @@ export interface SeedOptions {
   userId: string;
   materialId: string;
   version?: number;
+  /** If true, also inserts a user row. Off when the user already exists (e.g. after sign-up). */
+  createUser?: boolean;
 }
 
-/** Inserts a user, enrollment, and graph snapshot — enough to load an engine. */
+/** Inserts enrollment + graph snapshot (and optionally the user) — enough to load an engine. */
 export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; version: number } {
   const { db, userId, materialId } = opts;
   const version = opts.version ?? 1;
   const { graph, cards } = buildSingleVerseFixture();
   const now = Math.floor(Date.now() / 1000);
 
-  db.insert(schema.user)
-    .values({
-      id: userId,
-      email: `${userId}@example.com`,
-      name: userId,
-      emailVerified: false,
-      createdAt: new Date(now * 1000),
-      updatedAt: new Date(now * 1000),
-    })
-    .run();
+  if (opts.createUser ?? true) {
+    db.insert(schema.user)
+      .values({
+        id: userId,
+        email: `${userId}@example.com`,
+        name: userId,
+        emailVerified: false,
+        createdAt: new Date(now * 1000),
+        updatedAt: new Date(now * 1000),
+      })
+      .run();
+  }
   db.insert(schema.userMaterials)
     .values({ userId, materialId, clubTier: null, createdAt: now })
     .run();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,8 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  crates/wasm/pkg: {}
+
   packages/api:
     dependencies:
       '@hono/node-server':
@@ -47,6 +49,9 @@ importers:
       hono:
         specifier: ^4.7.0
         version: 4.12.14
+      verse-vault-wasm:
+        specifier: workspace:*
+        version: link:../../crates/wasm/pkg
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "packages/*"
   - "apps/*"
+  - "crates/wasm/pkg"


### PR DESCRIPTION
## Summary

Wires the WASM engine into the server. Closes Phase 3C of the persistence + server plan.

- `EngineStore` loads a `WasmEngine` per `(user, material)` from the latest `graph_snapshot` plus any materialized `edge_states` / `card_states`, and caches it in-process.
- `SessionStore` tracks active sessions. A new session for the same (user, material) aborts the previous one, matching the WASM invariant of one `Session` per engine.
- Session routes: `POST /api/sessions/start`, `GET /api/sessions/:id/next`, `POST /api/sessions/:id/review`, `POST /api/sessions/:id/abort`.
- Each review lands atomically: append to `review_events`, upsert changed edges + all cards in one transaction.
- Docs: `docs/persistence.md` and `docs/server-api.md` added; ROADMAP marks 3B + 3C done.

## Test plan

- [x] `cargo test` (76 pass)
- [x] `pnpm --filter @verse-vault/api test` (15 pass, including full start → review → done flow and review-event persistence assertions)
- [x] `pnpm -w exec dprint check`
- [x] `typos`
- [x] `cargo fmt --check`
- [ ] Manual curl: register → enroll → start session → review cards → verify rows in `review_events` / `edge_states` / `card_states`

## Known follow-ups (not in this PR)

- Engine + session caches are unbounded — add TTL / LRU eviction before multi-tenant use.
- `export_card_states()` serializes the full catalog per review. Worth exposing a delta export on the WASM side once profiles show it.