### PR TITLE
Phase 3D: Sync API (state download + event replay)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,17 +46,19 @@ on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline
 * [x] Drizzle + SQLite + migrations
 * [x] Better Auth setup (email/password + Google OAuth)
 
-### Phase 3C: Engine integration
+### Phase 3C: Engine integration ✅
 
 * [x] Load graph from DB, construct WASM engine
 * [x] Session API endpoints (start/next/review/abort)
 * [x] Review event logging
 * [x] Edge/card state persistence
 
-### Phase 3D: Sync API
+### Phase 3D: Sync API ✅
 
-* [ ] State download endpoint
-* [ ] Event upload + merge (event replay)
+* [x] State download endpoint (`GET /api/sync/:materialId/state`)
+* [x] Event upload + replay (`POST /api/sync/:materialId/events`)
+* [x] Idempotent uploads via `client_event_id`
+* [x] Stale-snapshot rejection (409)
 
 ### Phase 3E: Stats + Materials
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -276,6 +276,52 @@ impl WasmEngine {
         }
     }
 
+    /// Replay a persisted review event without an active session. Runs
+    /// credit assignment + FSRS + schedule cascade on the given
+    /// shown/hidden/grades, same as an online `session_review`. Used by
+    /// the sync endpoint to apply offline events to the live engine.
+    pub fn replay_event(
+        &mut self,
+        shown_json: &str,
+        hidden_json: &str,
+        grades_json: &str,
+        now_secs: i64,
+    ) -> Result<String, JsError> {
+        let shown_raw: Vec<u32> = serde_json::from_str(shown_json)
+            .map_err(|e| JsError::new(&format!("shown parse: {e}")))?;
+        let hidden_raw: Vec<u32> = serde_json::from_str(hidden_json)
+            .map_err(|e| JsError::new(&format!("hidden parse: {e}")))?;
+        let grade_entries: Vec<GradeEntry> = if grades_json.is_empty() {
+            Vec::new()
+        } else {
+            serde_json::from_str(grades_json)
+                .map_err(|e| JsError::new(&format!("grades parse: {e}")))?
+        };
+
+        let shown: Vec<NodeId> = shown_raw.into_iter().map(NodeId).collect();
+        let hidden: Vec<NodeId> = hidden_raw.into_iter().map(NodeId).collect();
+        let mut grades: HashMap<NodeId, Grade> = HashMap::new();
+        for g in grade_entries {
+            grades.insert(NodeId(g.node_id), int_to_grade(g.grade)?);
+        }
+
+        let updates = self
+            .engine
+            .review_transient(&shown, &hidden, grades, now_secs);
+        let wire = ReviewOutcomeWire {
+            edge_updates: updates
+                .iter()
+                .map(|u| EdgeUpdateWire {
+                    edge_id: u.edge_id.0,
+                    grade: grade_to_int(u.grade),
+                    weight: u.weight,
+                })
+                .collect(),
+            redrills_inserted: 0,
+        };
+        serde_json::to_string(&wire).map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Whether the current session is done (empty queue).
     pub fn session_is_done(&self) -> bool {
         self.session.as_ref().is_none_or(|s| s.is_done())

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -242,31 +242,9 @@ impl WasmEngine {
             .as_mut()
             .ok_or_else(|| JsError::new("no active session"))?;
 
-        let grade_entries: Vec<GradeEntry> = if grades_json.is_empty() {
-            Vec::new()
-        } else {
-            serde_json::from_str(grades_json)
-                .map_err(|e| JsError::new(&format!("grades parse: {e}")))?
-        };
-        let mut grades: HashMap<NodeId, Grade> = HashMap::new();
-        for g in grade_entries {
-            grades.insert(NodeId(g.node_id), int_to_grade(g.grade)?);
-        }
-
+        let grades = parse_grades_json(grades_json)?;
         let outcome: ReviewOutcome = session.record_review(grades, &mut self.engine, now_secs);
-        let wire = ReviewOutcomeWire {
-            edge_updates: outcome
-                .edge_updates
-                .iter()
-                .map(|u| EdgeUpdateWire {
-                    edge_id: u.edge_id.0,
-                    grade: grade_to_int(u.grade),
-                    weight: u.weight,
-                })
-                .collect(),
-            redrills_inserted: outcome.redrills_inserted,
-        };
-        serde_json::to_string(&wire).map_err(|e| JsError::new(&e.to_string()))
+        serialize_outcome(&outcome.edge_updates, outcome.redrills_inserted)
     }
 
     /// Abort the current session.
@@ -287,39 +265,14 @@ impl WasmEngine {
         grades_json: &str,
         now_secs: i64,
     ) -> Result<String, JsError> {
-        let shown_raw: Vec<u32> = serde_json::from_str(shown_json)
-            .map_err(|e| JsError::new(&format!("shown parse: {e}")))?;
-        let hidden_raw: Vec<u32> = serde_json::from_str(hidden_json)
-            .map_err(|e| JsError::new(&format!("hidden parse: {e}")))?;
-        let grade_entries: Vec<GradeEntry> = if grades_json.is_empty() {
-            Vec::new()
-        } else {
-            serde_json::from_str(grades_json)
-                .map_err(|e| JsError::new(&format!("grades parse: {e}")))?
-        };
-
-        let shown: Vec<NodeId> = shown_raw.into_iter().map(NodeId).collect();
-        let hidden: Vec<NodeId> = hidden_raw.into_iter().map(NodeId).collect();
-        let mut grades: HashMap<NodeId, Grade> = HashMap::new();
-        for g in grade_entries {
-            grades.insert(NodeId(g.node_id), int_to_grade(g.grade)?);
-        }
+        let shown = parse_node_ids_json(shown_json, "shown")?;
+        let hidden = parse_node_ids_json(hidden_json, "hidden")?;
+        let grades = parse_grades_json(grades_json)?;
 
         let updates = self
             .engine
             .review_transient(&shown, &hidden, grades, now_secs);
-        let wire = ReviewOutcomeWire {
-            edge_updates: updates
-                .iter()
-                .map(|u| EdgeUpdateWire {
-                    edge_id: u.edge_id.0,
-                    grade: grade_to_int(u.grade),
-                    weight: u.weight,
-                })
-                .collect(),
-            redrills_inserted: 0,
-        };
-        serde_json::to_string(&wire).map_err(|e| JsError::new(&e.to_string()))
+        serialize_outcome(&updates, 0)
     }
 
     /// Whether the current session is done (empty queue).
@@ -395,6 +348,43 @@ fn parse_card_state(s: &str) -> Result<CardState, JsError> {
         "relearning" => Ok(CardState::Relearning),
         _ => Err(JsError::new(&format!("invalid card state: {s}"))),
     }
+}
+
+fn parse_node_ids_json(s: &str, field: &str) -> Result<Vec<NodeId>, JsError> {
+    let raw: Vec<u32> =
+        serde_json::from_str(s).map_err(|e| JsError::new(&format!("{field} parse: {e}")))?;
+    Ok(raw.into_iter().map(NodeId).collect())
+}
+
+fn parse_grades_json(s: &str) -> Result<HashMap<NodeId, Grade>, JsError> {
+    let entries: Vec<GradeEntry> = if s.is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str(s).map_err(|e| JsError::new(&format!("grades parse: {e}")))?
+    };
+    let mut grades = HashMap::with_capacity(entries.len());
+    for g in entries {
+        grades.insert(NodeId(g.node_id), int_to_grade(g.grade)?);
+    }
+    Ok(grades)
+}
+
+fn serialize_outcome(
+    updates: &[verse_vault_core::credit::EdgeUpdate],
+    redrills_inserted: usize,
+) -> Result<String, JsError> {
+    let wire = ReviewOutcomeWire {
+        edge_updates: updates
+            .iter()
+            .map(|u| EdgeUpdateWire {
+                edge_id: u.edge_id.0,
+                grade: grade_to_int(u.grade),
+                weight: u.weight,
+            })
+            .collect(),
+        redrills_inserted,
+    };
+    serde_json::to_string(&wire).map_err(|e| JsError::new(&e.to_string()))
 }
 
 fn int_to_grade(v: u8) -> Result<Grade, JsError> {

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -27,18 +27,25 @@ known-good snapshot even after the content pipeline regenerates the graph.
 
 ### `review_events` — source of truth
 
-Append-only log. Every call to `POST /api/sessions/:id/review` writes one row:
+Append-only log. Every drill review (online or uploaded offline) writes one row. Progressive-reveal
+reading cards are intentionally skipped — they don't change engine state, so logging them would make
+replay non-deterministic.
 
 | column             | notes                                                                 |
 | ------------------ | --------------------------------------------------------------------- |
-| `id`               | UUID, server-generated today; client-generated later for offline sync |
+| `id`               | server-generated UUID, stable row identity                            |
+| `client_event_id`  | idempotency key; server-generated UUID for online, client for offline |
 | `snapshot_version` | which graph snapshot this event applies to                            |
-| `card_id`          | source card, or null for re-drill / new-verse (progressive reveal)    |
+| `card_id`          | source card, or null for re-drill                                     |
 | `shown` / `hidden` | node IDs of the card as served to the user                            |
 | `grades`           | `[{ node_id, grade }]` — 1=Again, 2=Hard, 3=Good, 4=Easy              |
 
-Indexed by `(user_id, material_id, timestamp_secs)` because replay is always filtered by
-user+material and sorted by time.
+Two indexes:
+
+* `(user_id, material_id, timestamp_secs)` — replay is always filtered by user+material and sorted
+  by time.
+* Unique on `(user_id, material_id, client_event_id)` — re-uploading the same batch must not
+  double-apply events.
 
 ### `edge_states` — materialized
 
@@ -72,15 +79,41 @@ The engine loader (`EngineStore`, `packages/api/src/lib/engine.ts`) builds a `Wa
 Engines are cached in-process keyed by `(user_id, material_id)` — the Node process is long-running,
 so reloading per request would be wasteful.
 
-## Replay
+## Replay and sync
 
-Because the core algorithm is deterministic in `(current_state, grades, timestamp)`, any
-materialized state can be rebuilt by:
+Credit assignment and FSRS updates are pure functions of `(current_state, grades, timestamp)`, so
+the materialized state is recomputable. Phase 3D exposes this as a sync API for fat clients (Tauri,
+offline web):
 
-1. Starting a fresh `WasmEngine` from the snapshot (no edge/card overrides).
-2. Feeding `review_events` in timestamp order.
-3. Exporting the final `edge_states` + `card_states`.
+### Upload flow — `POST /api/sync/:materialId/events`
 
-This makes `edge_states` / `card_states` a cache, not a source of truth, and unlocks the Phase 3D
-sync flow: a fat client uploads offline events, the server merges by timestamp, replays, and returns
-the authoritative materialized state.
+1. Client sends a batch of events, each keyed by a client-generated `clientEventId` (UUID).
+2. Server rejects the batch (409) if any event's `snapshotVersion` doesn't match the current
+   snapshot — the client must re-pull `/state` before syncing.
+3. Server drops events whose `clientEventId` already exists for this (user, material). Remaining
+   events are sorted by `(timestampSecs, clientEventId)` for stable ordering.
+4. For each fresh event, the server calls `WasmEngine.replay_event(shown, hidden, grades, ts)` which
+   invokes the core's `review_transient` — same credit assignment + FSRS path as the online
+   `session_review`, but session-independent.
+5. In a single transaction the server appends the new events, upserts the union of changed edges,
+   and upserts `card_states` from the engine's full export.
+6. Response returns the engine's full edge/card state plus the new `lastEventId`, so the client can
+   replace its local cache in one shot.
+
+### Determinism contract
+
+Replaying a sequence of events through a fresh engine yields the same materialized state as applying
+them one-by-one through live sessions. The sync test `sync.test.ts` asserts parity between the
+online path and the sync path on an identical event.
+
+### Known limitations (Phase 3D)
+
+* **No snapshot-to-snapshot migration.** `graph_snapshots.version` is wired but nothing increments
+  it; when the content pipeline reissues a material we'll need to re-build edge/card state and
+  decide what to do with events tied to the old version.
+* **Live engine, not fresh replay.** Offline events are applied to the in-process cached engine, so
+  edge state reflects "server state before + offline events in timestamp order within the batch."
+  This is correct for single-device offline usage; truly concurrent multi-device edits are out of
+  scope.
+* **Reading cards aren't logged.** A client that lost its progressive-reveal progress will start
+  from the beginning on reconnect; only drill grades are preserved.

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -114,11 +114,90 @@ When `done: true`, the session is removed from the in-memory store; a later `/ne
 Aborts the session — any new-verse cards that were flipped to Learning roll back to New. Returns
 `{ "ok": true }`.
 
+## Sync — `/api/sync/*`
+
+Fat-client endpoints for offline review + catch-up. The client hydrates its local cache from
+`/state`, runs reviews offline, and uploads batches to `/events` when it reconnects.
+
+Shared shapes:
+
+```ts
+EdgeStateEntry = {
+  edge_id: number;
+  stability: number;
+  difficulty: number;
+  last_review_secs: number;
+}
+
+CardStateEntry = {
+  card_id: number;
+  state: 'new' | 'learning' | 'review' | 'relearning';
+  due_r: number | null;
+  due_date_secs: number | null;
+  priority: number | null;
+}
+
+ReviewEventUpload = {
+  clientEventId: string;          // client-generated UUID — idempotency key
+  timestampSecs: number;
+  snapshotVersion: number;
+  cardId: number | null;          // null for re-drills
+  shown: number[];
+  hidden: number[];
+  grades: Grade[];
+}
+```
+
+### `GET /api/sync/:materialId/state`
+
+Hydrate a fresh client. Returns the latest graph snapshot plus the user's materialized state.
+
+```json
+{
+  "snapshot": {
+    "version": 1,
+    "graphData": { ... },     // parsed graph JSON
+    "cardsData": [ ... ]      // parsed card catalog JSON
+  },
+  "edgeStates": EdgeStateEntry[],
+  "cardStates": CardStateEntry[],
+  "lastEventId": "uuid" | null
+}
+```
+
+404 if the caller isn't enrolled in the material.
+
+### `POST /api/sync/:materialId/events`
+
+Upload a batch of offline review events.
+
+Request:
+
+```json
+{ "events": ReviewEventUpload[] }
+```
+
+Response:
+
+```json
+{
+  "accepted": 3,                 // new events applied
+  "duplicates": 1,               // events skipped by clientEventId match
+  "edgeStates": EdgeStateEntry[], // engine's full state after replay
+  "cardStates": CardStateEntry[],
+  "lastEventId": "uuid" | null
+}
+```
+
+Side effects are a single transaction: append new events, upsert the union of changed edges, upsert
+every card's state. See [persistence.md](persistence.md#upload-flow--post-apisyncmaterialidevents)
+for replay semantics.
+
 ## Errors
 
-| Status | Meaning                                                 |
-| ------ | ------------------------------------------------------- |
-| 400    | Malformed body, missing field, or engine rejected input |
-| 401    | No session cookie / expired session                     |
-| 404    | Session ID unknown, or not owned by the caller          |
-| 409    | Session found but no card is currently awaiting review  |
+| Status | Meaning                                                                                 |
+| ------ | --------------------------------------------------------------------------------------- |
+| 400    | Malformed body, missing field, or engine rejected input                                 |
+| 401    | No session cookie / expired session                                                     |
+| 404    | Session ID unknown / not owned by caller, or user not enrolled in the material          |
+| 409    | Session found but no card awaiting review, or sync batch uses a stale `snapshotVersion` |

--- a/docs/wasm-api.md
+++ b/docs/wasm-api.md
@@ -47,7 +47,18 @@ reveal). Calling `session_abort` rolls them back to `New`.
 
 ```ts
 next_due_card(now_secs: bigint): number | undefined  // card_id of highest-priority due card
+
+replay_event(
+  shown_json: string,   // JSON number[]
+  hidden_json: string,  // JSON number[]
+  grades_json: string,  // JSON Grade[], or '' for []
+  now_secs: bigint,
+): string                // JSON ReviewOutcome
 ```
+
+`replay_event` runs the same credit assignment + FSRS + schedule cascade as `session_review`, but
+without requiring an active session. It's the primitive used by the server's sync endpoint to apply
+offline events.
 
 ### Export for persistence
 

--- a/packages/api/migrations/0004_nice_punisher.sql
+++ b/packages/api/migrations/0004_nice_punisher.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `review_events` ADD `client_event_id` text NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `uniq_review_events_user_material_client_event` ON `review_events` (`user_id`,`material_id`,`client_event_id`);

--- a/packages/api/migrations/meta/0004_snapshot.json
+++ b/packages/api/migrations/meta/0004_snapshot.json
@@ -1,0 +1,777 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "2d0b27cb-3080-448a-a818-3f645da100b0",
+  "prevId": "efc3c76c-8161-464c-b24f-47393298a649",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "card_states": {
+      "name": "card_states",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_r": {
+          "name": "due_r",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "due_date_secs": {
+          "name": "due_date_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "card_states_user_id_user_id_fk": {
+          "name": "card_states_user_id_user_id_fk",
+          "tableFrom": "card_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "card_states_user_id_material_id_card_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "card_id"
+          ],
+          "name": "card_states_user_id_material_id_card_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "edge_states": {
+      "name": "edge_states",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "edge_id": {
+          "name": "edge_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_review_secs": {
+          "name": "last_review_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "edge_states_user_id_user_id_fk": {
+          "name": "edge_states_user_id_user_id_fk",
+          "tableFrom": "edge_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "edge_states_user_id_material_id_edge_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "edge_id"
+          ],
+          "name": "edge_states_user_id_material_id_edge_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graph_snapshots": {
+      "name": "graph_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graph_data": {
+          "name": "graph_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cards_data": {
+          "name": "cards_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_graph_snapshots_user_material": {
+          "name": "idx_graph_snapshots_user_material",
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "graph_snapshots_user_id_user_id_fk": {
+          "name": "graph_snapshots_user_id_user_id_fk",
+          "tableFrom": "graph_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_events": {
+      "name": "review_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_version": {
+          "name": "snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_secs": {
+          "name": "timestamp_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_event_id": {
+          "name": "client_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown": {
+          "name": "shown",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grades": {
+          "name": "grades",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_review_events_user_material_time": {
+          "name": "idx_review_events_user_material_time",
+          "columns": [
+            "user_id",
+            "material_id",
+            "timestamp_secs"
+          ],
+          "isUnique": false
+        },
+        "uniq_review_events_user_material_client_event": {
+          "name": "uniq_review_events_user_material_client_event",
+          "columns": [
+            "user_id",
+            "material_id",
+            "client_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "review_events_user_id_user_id_fk": {
+          "name": "review_events_user_id_user_id_fk",
+          "tableFrom": "review_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_materials": {
+      "name": "user_materials",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_tier": {
+          "name": "club_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_materials_user_id_user_id_fk": {
+          "name": "user_materials_user_id_user_id_fk",
+          "tableFrom": "user_materials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_materials_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_materials_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776702485414,
       "tag": "0003_silky_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1776717638645,
+      "tag": "0004_nice_punisher",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -8,6 +8,7 @@ import { EngineStore } from './lib/engine.js';
 import { SessionStore } from './lib/sessions.js';
 import { type SessionVariables, getUser, requireAuth, sessionMiddleware } from './middleware/session.js';
 import { sessionRoutes } from './routes/sessions.js';
+import { syncRoutes } from './routes/sync.js';
 
 export interface AppDeps {
   db: DB;
@@ -45,6 +46,7 @@ export function createApp(deps: AppDeps) {
   app.get('/api/me', requireAuth(), (c) => c.json({ user: getUser(c) }));
 
   app.route('/api/sessions', sessionRoutes({ db: deps.db, engines, sessions, now: deps.now }));
+  app.route('/api/sync', syncRoutes({ db: deps.db, engines, now: deps.now }));
 
   return app;
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -1,4 +1,13 @@
-import { blob, index, integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import {
+  blob,
+  index,
+  integer,
+  primaryKey,
+  real,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
 
 // Better Auth tables — shape follows the Better Auth drizzle adapter's
 // expected schema. We own them here (rather than letting @better-auth/cli
@@ -118,18 +127,29 @@ export const reviewEvents = sqliteTable(
     snapshotVersion: integer('snapshot_version').notNull(),
     timestampSecs: integer('timestamp_secs').notNull(),
     cardId: integer('card_id'), // null for transient (re-drill / progressive reveal)
+    // Client-supplied ID that makes uploads idempotent across retries. For
+    // online reviews the server generates a UUID; for offline reviews the
+    // client sends its own UUID.
+    clientEventId: text('client_event_id').notNull(),
     shown: blob('shown', { mode: 'buffer' }).notNull(),
     hidden: blob('hidden', { mode: 'buffer' }).notNull(),
     grades: blob('grades', { mode: 'buffer' }).notNull(),
     createdAt: integer('created_at').notNull(),
   },
-  // Replay is always filtered by (user_id, material_id) and sorted by
-  // timestamp, so keep timestamp as the trailing key.
   (t) => ({
+    // Replay is always filtered by (user_id, material_id) and sorted by
+    // timestamp, so keep timestamp as the trailing key.
     replayIdx: index('idx_review_events_user_material_time').on(
       t.userId,
       t.materialId,
       t.timestampSecs,
+    ),
+    // Dedup on re-upload: a client may retry the same batch; accept the
+    // second POST without double-applying events.
+    clientEventIdx: uniqueIndex('uniq_review_events_user_material_client_event').on(
+      t.userId,
+      t.materialId,
+      t.clientEventId,
     ),
   }),
 );

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { seedUserWithFixture } from '../test-fixtures.js';
 import { createTestDb } from '../test-utils.js';
-import { EngineStore } from './engine.js';
+import { EngineStore, NotEnrolledError } from './engine.js';
 
 describe('EngineStore', () => {
   let cleanup: (() => void) | null = null;
@@ -30,8 +30,8 @@ describe('EngineStore', () => {
     cleanup = test.cleanup;
 
     const store = new EngineStore(test.db);
-    await expect(store.load({ userId: 'missing', materialId: 'x' })).rejects.toThrow(
-      /No graph snapshot/,
+    await expect(store.load({ userId: 'missing', materialId: 'x' })).rejects.toBeInstanceOf(
+      NotEnrolledError,
     );
   });
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -30,6 +30,39 @@ export interface CardStateEntry {
   priority: number | null;
 }
 
+export function readEdgeStateEntries(db: DB, key: EngineKey): EdgeStateEntry[] {
+  return db
+    .select()
+    .from(schema.edgeStates)
+    .where(
+      and(eq(schema.edgeStates.userId, key.userId), eq(schema.edgeStates.materialId, key.materialId)),
+    )
+    .all()
+    .map((e) => ({
+      edge_id: e.edgeId,
+      stability: e.stability,
+      difficulty: e.difficulty,
+      last_review_secs: e.lastReviewSecs,
+    }));
+}
+
+export function readCardStateEntries(db: DB, key: EngineKey): CardStateEntry[] {
+  return db
+    .select()
+    .from(schema.cardStates)
+    .where(
+      and(eq(schema.cardStates.userId, key.userId), eq(schema.cardStates.materialId, key.materialId)),
+    )
+    .all()
+    .map((c) => ({
+      card_id: c.cardId,
+      state: c.state,
+      due_r: c.dueR,
+      due_date_secs: c.dueDateSecs,
+      priority: c.priority,
+    }));
+}
+
 /** Long-running Node process, so engines live across requests; no eviction yet. */
 export class EngineStore {
   private readonly cache = new Map<string, LoadedEngine>();
@@ -59,40 +92,8 @@ export class EngineStore {
       throw new Error(`No graph snapshot for user=${key.userId} material=${key.materialId}`);
     }
 
-    const edges = this.db
-      .select()
-      .from(schema.edgeStates)
-      .where(
-        and(
-          eq(schema.edgeStates.userId, key.userId),
-          eq(schema.edgeStates.materialId, key.materialId),
-        ),
-      )
-      .all();
-    const cards = this.db
-      .select()
-      .from(schema.cardStates)
-      .where(
-        and(
-          eq(schema.cardStates.userId, key.userId),
-          eq(schema.cardStates.materialId, key.materialId),
-        ),
-      )
-      .all();
-
-    const edgeJson: EdgeStateEntry[] = edges.map((e) => ({
-      edge_id: e.edgeId,
-      stability: e.stability,
-      difficulty: e.difficulty,
-      last_review_secs: e.lastReviewSecs,
-    }));
-    const cardJson: CardStateEntry[] = cards.map((c) => ({
-      card_id: c.cardId,
-      state: c.state,
-      due_r: c.dueR,
-      due_date_secs: c.dueDateSecs,
-      priority: c.priority,
-    }));
+    const edgeJson = readEdgeStateEntries(this.db, key);
+    const cardJson = readCardStateEntries(this.db, key);
 
     const engine = new WasmEngine(
       snapshot.graphData.toString('utf8'),

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -14,6 +14,14 @@ export interface LoadedEngine {
   snapshotVersion: number;
 }
 
+/** Thrown by `EngineStore.load` when the caller isn't enrolled in the material. */
+export class NotEnrolledError extends Error {
+  constructor(key: EngineKey) {
+    super(`Not enrolled: user=${key.userId} material=${key.materialId}`);
+    this.name = 'NotEnrolledError';
+  }
+}
+
 /** Wire shapes must stay in sync with crates/wasm/src/lib.rs. */
 export interface EdgeStateEntry {
   edge_id: number;
@@ -89,7 +97,7 @@ export class EngineStore {
       .limit(1)
       .get();
     if (!snapshot) {
-      throw new Error(`No graph snapshot for user=${key.userId} material=${key.materialId}`);
+      throw new NotEnrolledError(key);
     }
 
     const edgeJson = readEdgeStateEntries(this.db, key);

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -55,14 +55,16 @@ export function recordReview(args: RecordReviewArgs): void {
   }));
 
   db.transaction((tx) => {
+    const eventId = randomUUID();
     tx.insert(schema.reviewEvents)
       .values({
-        id: randomUUID(),
+        id: eventId,
         userId,
         materialId,
         snapshotVersion: entry.snapshotVersion,
         timestampSecs,
         cardId: card.source_card_id,
+        clientEventId: eventId, // online review: server-generated IDs serve both roles
         shown: jsonBlob(card.shown),
         hidden: jsonBlob(card.hidden),
         grades: jsonBlob(grades),

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -27,78 +27,104 @@ export interface RecordReviewArgs {
   outcome: ReviewOutcome;
 }
 
-/** Transactional so the event log and the materialized state can't diverge. */
+type Tx = Parameters<Parameters<DB['transaction']>[0]>[0];
+
+export interface PersistEngineStateArgs {
+  userId: string;
+  materialId: string;
+  eventRows: (typeof schema.reviewEvents.$inferInsert)[];
+  changedEdges: EdgeStateEntry[];
+  allCards: CardStateEntry[];
+}
+
+/**
+ * Shared write path for the online session and the offline sync replay.
+ * Appending events + upserting materialized state in one transaction keeps
+ * the event log and the cache from drifting.
+ */
+export function persistEngineState(tx: Tx, args: PersistEngineStateArgs): void {
+  const { userId, materialId, eventRows, changedEdges, allCards } = args;
+
+  if (eventRows.length > 0) {
+    tx.insert(schema.reviewEvents).values(eventRows).run();
+  }
+
+  if (changedEdges.length > 0) {
+    tx.insert(schema.edgeStates)
+      .values(
+        changedEdges.map((e) => ({
+          userId,
+          materialId,
+          edgeId: e.edge_id,
+          stability: e.stability,
+          difficulty: e.difficulty,
+          lastReviewSecs: e.last_review_secs,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
+        set: {
+          stability: sql`excluded.stability`,
+          difficulty: sql`excluded.difficulty`,
+          lastReviewSecs: sql`excluded.last_review_secs`,
+        },
+      })
+      .run();
+  }
+
+  if (allCards.length > 0) {
+    tx.insert(schema.cardStates)
+      .values(
+        allCards.map((c) => ({
+          userId,
+          materialId,
+          cardId: c.card_id,
+          state: c.state,
+          dueR: c.due_r,
+          dueDateSecs: c.due_date_secs,
+          priority: c.priority,
+        })),
+      )
+      .onConflictDoUpdate({
+        target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
+        set: {
+          state: sql`excluded.state`,
+          dueR: sql`excluded.due_r`,
+          dueDateSecs: sql`excluded.due_date_secs`,
+          priority: sql`excluded.priority`,
+        },
+      })
+      .run();
+  }
+}
+
 export function recordReview(args: RecordReviewArgs): void {
   const { db, entry, timestampSecs, card, grades, outcome } = args;
   const { userId, materialId } = entry;
-  const edges = JSON.parse(entry.engine.export_edge_states()) as EdgeStateEntry[];
-  const cards = JSON.parse(entry.engine.export_card_states()) as CardStateEntry[];
+
+  const allEdges = JSON.parse(entry.engine.export_edge_states()) as EdgeStateEntry[];
+  const allCards = JSON.parse(entry.engine.export_card_states()) as CardStateEntry[];
   const changedEdgeIds = new Set(outcome.edge_updates.map((u) => u.edge_id));
-  const edgeRows = edges
-    .filter((e) => changedEdgeIds.has(e.edge_id))
-    .map((e) => ({
+  const changedEdges = allEdges.filter((e) => changedEdgeIds.has(e.edge_id));
+
+  const eventId = randomUUID();
+  const eventRows = [
+    {
+      id: eventId,
       userId,
       materialId,
-      edgeId: e.edge_id,
-      stability: e.stability,
-      difficulty: e.difficulty,
-      lastReviewSecs: e.last_review_secs,
-    }));
-  const cardRows = cards.map((c) => ({
-    userId,
-    materialId,
-    cardId: c.card_id,
-    state: c.state,
-    dueR: c.due_r,
-    dueDateSecs: c.due_date_secs,
-    priority: c.priority,
-  }));
+      snapshotVersion: entry.snapshotVersion,
+      timestampSecs,
+      cardId: card.source_card_id,
+      clientEventId: eventId, // online: server UUID serves as both row id and idempotency key
+      shown: jsonBlob(card.shown),
+      hidden: jsonBlob(card.hidden),
+      grades: jsonBlob(grades),
+      createdAt: timestampSecs,
+    },
+  ];
 
   db.transaction((tx) => {
-    const eventId = randomUUID();
-    tx.insert(schema.reviewEvents)
-      .values({
-        id: eventId,
-        userId,
-        materialId,
-        snapshotVersion: entry.snapshotVersion,
-        timestampSecs,
-        cardId: card.source_card_id,
-        clientEventId: eventId, // online review: server-generated IDs serve both roles
-        shown: jsonBlob(card.shown),
-        hidden: jsonBlob(card.hidden),
-        grades: jsonBlob(grades),
-        createdAt: timestampSecs,
-      })
-      .run();
-
-    if (edgeRows.length > 0) {
-      tx.insert(schema.edgeStates)
-        .values(edgeRows)
-        .onConflictDoUpdate({
-          target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
-          set: {
-            stability: sql`excluded.stability`,
-            difficulty: sql`excluded.difficulty`,
-            lastReviewSecs: sql`excluded.last_review_secs`,
-          },
-        })
-        .run();
-    }
-
-    if (cardRows.length > 0) {
-      tx.insert(schema.cardStates)
-        .values(cardRows)
-        .onConflictDoUpdate({
-          target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
-          set: {
-            state: sql`excluded.state`,
-            dueR: sql`excluded.due_r`,
-            dueDateSecs: sql`excluded.due_date_secs`,
-            priority: sql`excluded.priority`,
-          },
-        })
-        .run();
-    }
+    persistEngineState(tx, { userId, materialId, eventRows, changedEdges, allCards });
   });
 }

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -1,10 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { cardStates, edgeStates, reviewEvents, user } from '../db/schema.js';
+import { cardStates, edgeStates, reviewEvents } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
-import { createTestApp } from '../test-utils.js';
-
-type TestApp = ReturnType<typeof createTestApp>;
+import { type TestApp, createTestApp, signUpTestUser } from '../test-utils.js';
 
 interface StartResponse {
   sessionId: string;
@@ -18,25 +16,8 @@ interface ReviewResponse extends StartResponse {
 
 const MATERIAL_ID = 'nkjv-1cor';
 
-async function signUpAndGetUser(test: TestApp) {
-  const res = await test.app.request('/api/auth/sign-up/email', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      email: 'alice@example.com',
-      password: 'superSecret123!',
-      name: 'Alice',
-    }),
-  });
-  expect(res.status).toBe(200);
-  return {
-    cookie: res.headers.get('set-cookie')!,
-    userId: test.db.select().from(user).get()!.id,
-  };
-}
-
 async function startEnrolledSession(test: TestApp): Promise<{ cookie: string; userId: string; start: StartResponse }> {
-  const { cookie, userId } = await signUpAndGetUser(test);
+  const { cookie, userId } = await signUpTestUser(test, 'alice@example.com');
   seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
   const startRes = await test.app.request('/api/sessions/start', {
     method: 'POST',

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -107,8 +107,11 @@ describe('session routes', () => {
     });
     expect(nextRes.status).toBe(404);
 
+    // Progressive-reveal "reading" cards are skipped by the event log so
+    // the sync replay path stays deterministic — we get one event per drill.
     const loggedEvents = test.db.select().from(reviewEvents).all();
-    expect(loggedEvents.length).toBe(reviews);
+    expect(loggedEvents.length).toBeGreaterThan(0);
+    expect(loggedEvents.length).toBeLessThanOrEqual(reviews);
     expect(loggedEvents.every((e) => e.userId === userId)).toBe(true);
 
     const persistedEdges = test.db.select().from(edgeStates).all();

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -94,7 +94,13 @@ export function sessionRoutes(deps: SessionRoutesDeps) {
     } catch (err) {
       return c.json({ error: (err as Error).message }, 400);
     }
-    recordReview({ db: deps.db, entry, timestampSecs: nowSecs, card, grades: body.grades, outcome });
+    // Progressive-reveal "reading" cards don't run credit assignment inside
+    // the session, so they leave the engine unchanged. Skipping the event
+    // log here keeps the online path and the sync replay path symmetric —
+    // replaying these would wrongly trigger the exposure fallback.
+    if (!card.is_reading) {
+      recordReview({ db: deps.db, entry, timestampSecs: nowSecs, card, grades: body.grades, outcome });
+    }
     entry.currentCard = null;
     const next = advance(entry);
     if (next.done) deps.sessions.end(entry.id);

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -71,8 +71,29 @@ describe('sync routes', () => {
     cleanup = test.cleanup;
     const { cookie } = await signUpTestUser(test, 'nouser@example.com');
 
-    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, { headers: { cookie } });
-    expect(res.status).toBe(404);
+    const stateRes = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, {
+      headers: { cookie },
+    });
+    expect(stateRes.status).toBe(404);
+
+    const eventsRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        events: [
+          {
+            clientEventId: randomUUID(),
+            timestampSecs: 1_700_000_000,
+            snapshotVersion: 1,
+            cardId: 0,
+            shown: [0],
+            hidden: [2],
+            grades: [{ node_id: 2, grade: 3 }],
+          },
+        ],
+      }),
+    });
+    expect(eventsRes.status).toBe(404);
   });
 
   it('returns snapshot + empty state for a newly-enrolled user', async () => {

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -2,11 +2,9 @@ import { randomUUID } from 'node:crypto';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { cardStates, edgeStates, reviewEvents, user } from '../db/schema.js';
+import { cardStates, edgeStates, reviewEvents } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
-import { createTestApp } from '../test-utils.js';
-
-type TestApp = ReturnType<typeof createTestApp>;
+import { type TestApp, createTestApp, signUpTestUser } from '../test-utils.js';
 
 const MATERIAL_ID = 'nkjv-1cor';
 
@@ -37,24 +35,13 @@ interface UploadResponse {
   lastEventId: string | null;
 }
 
-async function signUp(
+async function enroll(
   test: TestApp,
   email: string,
 ): Promise<{ cookie: string; userId: string }> {
-  const res = await test.app.request('/api/auth/sign-up/email', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, password: 'superSecret123!', name: email }),
-  });
-  expect(res.status).toBe(200);
-  const cookie = res.headers.get('set-cookie')!;
-  const u = test.db
-    .select()
-    .from(user)
-    .all()
-    .find((r) => r.email === email);
-  if (!u) throw new Error(`user not found: ${email}`);
-  return { cookie, userId: u.id };
+  const { cookie, userId } = await signUpTestUser(test, email);
+  seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+  return { cookie, userId };
 }
 
 describe('sync routes', () => {
@@ -82,7 +69,7 @@ describe('sync routes', () => {
   it('returns 404 when the user is not enrolled', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie } = await signUp(test, 'nouser@example.com');
+    const { cookie } = await signUpTestUser(test, 'nouser@example.com');
 
     const res = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, { headers: { cookie } });
     expect(res.status).toBe(404);
@@ -91,8 +78,7 @@ describe('sync routes', () => {
   it('returns snapshot + empty state for a newly-enrolled user', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUp(test, 'alice@example.com');
-    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+    const { cookie } = await enroll(test, 'alice@example.com');
 
     const res = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, { headers: { cookie } });
     expect(res.status).toBe(200);
@@ -108,8 +94,7 @@ describe('sync routes', () => {
   it('accepts an offline event batch and persists merged state', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUp(test, 'alice@example.com');
-    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+    const { cookie } = await enroll(test, 'alice@example.com');
 
     const event = {
       clientEventId: randomUUID(),
@@ -151,8 +136,7 @@ describe('sync routes', () => {
   it('is idempotent on re-upload of the same client_event_id', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUp(test, 'alice@example.com');
-    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+    const { cookie } = await enroll(test, 'alice@example.com');
 
     const event = {
       clientEventId: randomUUID(),
@@ -192,11 +176,32 @@ describe('sync routes', () => {
     expect(afterSecond).toEqual(afterFirst);
   });
 
+  it('rejects batches larger than MAX_BATCH_SIZE with 413', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'alice@example.com');
+
+    const events = Array.from({ length: 501 }, () => ({
+      clientEventId: randomUUID(),
+      timestampSecs: 1_700_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2],
+      grades: [{ node_id: 2, grade: 3 as const }],
+    }));
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events }),
+    });
+    expect(res.status).toBe(413);
+  });
+
   it('rejects a stale snapshot version with 409', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;
-    const { cookie, userId } = await signUp(test, 'alice@example.com');
-    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+    const { cookie } = await enroll(test, 'alice@example.com');
 
     const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
       method: 'POST',
@@ -222,20 +227,8 @@ describe('sync routes', () => {
     const test = createTestApp();
     cleanup = test.cleanup;
 
-    const alice = await signUp(test, 'alice@example.com');
-    seedUserWithFixture({
-      db: test.db,
-      userId: alice.userId,
-      materialId: MATERIAL_ID,
-      createUser: false,
-    });
-    const bob = await signUp(test, 'bob@example.com');
-    seedUserWithFixture({
-      db: test.db,
-      userId: bob.userId,
-      materialId: MATERIAL_ID,
-      createUser: false,
-    });
+    const alice = await enroll(test, 'alice@example.com');
+    const bob = await enroll(test, 'bob@example.com');
 
     // Alice: review via live session — drive through reading stages until a
     // drill card produces a logged event.

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -1,0 +1,325 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { cardStates, edgeStates, reviewEvents, user } from '../db/schema.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestApp } from '../test-utils.js';
+
+type TestApp = ReturnType<typeof createTestApp>;
+
+const MATERIAL_ID = 'nkjv-1cor';
+
+interface EdgeEntry {
+  edge_id: number;
+  stability: number;
+  difficulty: number;
+  last_review_secs: number;
+}
+interface CardEntry {
+  card_id: number;
+  state: 'new' | 'learning' | 'review' | 'relearning';
+  due_r: number | null;
+  due_date_secs: number | null;
+  priority: number | null;
+}
+interface StateResponse {
+  snapshot: { version: number; graphData: unknown; cardsData: unknown };
+  edgeStates: EdgeEntry[];
+  cardStates: CardEntry[];
+  lastEventId: string | null;
+}
+interface UploadResponse {
+  accepted: number;
+  duplicates: number;
+  edgeStates: EdgeEntry[];
+  cardStates: CardEntry[];
+  lastEventId: string | null;
+}
+
+async function signUp(
+  test: TestApp,
+  email: string,
+): Promise<{ cookie: string; userId: string }> {
+  const res = await test.app.request('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password: 'superSecret123!', name: email }),
+  });
+  expect(res.status).toBe(200);
+  const cookie = res.headers.get('set-cookie')!;
+  const u = test.db
+    .select()
+    .from(user)
+    .all()
+    .find((r) => r.email === email);
+  if (!u) throw new Error(`user not found: ${email}`);
+  return { cookie, userId: u.id };
+}
+
+describe('sync routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('requires auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+
+    const stateRes = await test.app.request(`/api/sync/${MATERIAL_ID}/state`);
+    expect(stateRes.status).toBe(401);
+
+    const eventsRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ events: [] }),
+    });
+    expect(eventsRes.status).toBe(401);
+  });
+
+  it('returns 404 when the user is not enrolled', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUp(test, 'nouser@example.com');
+
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, { headers: { cookie } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns snapshot + empty state for a newly-enrolled user', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUp(test, 'alice@example.com');
+    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StateResponse;
+    expect(body.snapshot.version).toBe(1);
+    expect(body.snapshot.graphData).toBeTruthy();
+    expect(body.snapshot.cardsData).toBeTruthy();
+    expect(body.edgeStates).toEqual([]);
+    expect(body.cardStates).toEqual([]);
+    expect(body.lastEventId).toBeNull();
+  });
+
+  it('accepts an offline event batch and persists merged state', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUp(test, 'alice@example.com');
+    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+
+    const event = {
+      clientEventId: randomUUID(),
+      timestampSecs: 1_700_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2, 3, 4],
+      grades: [
+        { node_id: 2, grade: 3 as const },
+        { node_id: 3, grade: 3 as const },
+        { node_id: 4, grade: 3 as const },
+      ],
+    };
+
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [event] }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as UploadResponse;
+    expect(body.accepted).toBe(1);
+    expect(body.duplicates).toBe(0);
+    expect(body.edgeStates.length).toBeGreaterThan(0);
+    expect(body.cardStates.length).toBeGreaterThan(0);
+    expect(body.lastEventId).not.toBeNull();
+
+    const persistedEvents = test.db.select().from(reviewEvents).all();
+    expect(persistedEvents).toHaveLength(1);
+    expect(persistedEvents[0].clientEventId).toBe(event.clientEventId);
+
+    const persistedEdges = test.db.select().from(edgeStates).all();
+    expect(persistedEdges.length).toBeGreaterThan(0);
+    const persistedCards = test.db.select().from(cardStates).all();
+    expect(persistedCards.length).toBeGreaterThan(0);
+  });
+
+  it('is idempotent on re-upload of the same client_event_id', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUp(test, 'alice@example.com');
+    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+
+    const event = {
+      clientEventId: randomUUID(),
+      timestampSecs: 1_700_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2, 3, 4],
+      grades: [
+        { node_id: 2, grade: 3 as const },
+        { node_id: 3, grade: 3 as const },
+        { node_id: 4, grade: 3 as const },
+      ],
+    };
+
+    await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [event] }),
+    });
+
+    const afterFirst = test.db.select().from(edgeStates).all();
+
+    const second = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [event] }),
+    });
+    expect(second.status).toBe(200);
+    const body = (await second.json()) as UploadResponse;
+    expect(body.accepted).toBe(0);
+    expect(body.duplicates).toBe(1);
+
+    expect(test.db.select().from(reviewEvents).all()).toHaveLength(1);
+    // Engine state should be unchanged — no events were re-applied.
+    const afterSecond = test.db.select().from(edgeStates).all();
+    expect(afterSecond).toEqual(afterFirst);
+  });
+
+  it('rejects a stale snapshot version with 409', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUp(test, 'alice@example.com');
+    seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        events: [
+          {
+            clientEventId: randomUUID(),
+            timestampSecs: 1_700_000_000,
+            snapshotVersion: 99,
+            cardId: 0,
+            shown: [0],
+            hidden: [2],
+            grades: [{ node_id: 2, grade: 3 }],
+          },
+        ],
+      }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('reaches the same edge state whether a review is done online or via sync', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+
+    const alice = await signUp(test, 'alice@example.com');
+    seedUserWithFixture({
+      db: test.db,
+      userId: alice.userId,
+      materialId: MATERIAL_ID,
+      createUser: false,
+    });
+    const bob = await signUp(test, 'bob@example.com');
+    seedUserWithFixture({
+      db: test.db,
+      userId: bob.userId,
+      materialId: MATERIAL_ID,
+      createUser: false,
+    });
+
+    // Alice: review via live session — drive through reading stages until a
+    // drill card produces a logged event.
+    const startRes = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie: alice.cookie },
+      body: JSON.stringify({
+        materialId: MATERIAL_ID,
+        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+      }),
+    });
+    const start = (await startRes.json()) as {
+      sessionId: string;
+      card: { shown: number[]; hidden: number[]; is_reading: boolean };
+    };
+
+    let card = start.card;
+    let loops = 0;
+    while (test.db.select().from(reviewEvents).all().length === 0) {
+      const grades = card.is_reading
+        ? []
+        : card.hidden.map((node_id) => ({ node_id, grade: 3 as const }));
+      const reviewRes = await test.app.request(`/api/sessions/${start.sessionId}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', cookie: alice.cookie },
+        body: JSON.stringify({ grades }),
+      });
+      expect(reviewRes.status).toBe(200);
+      const body = (await reviewRes.json()) as {
+        card: typeof card | null;
+        done: boolean;
+      };
+      if (body.done || !body.card) break;
+      card = body.card;
+      if (++loops > 20) throw new Error('loop guard: no drill card emitted');
+    }
+
+    const aliceEvents = test.db.select().from(reviewEvents).all();
+    expect(aliceEvents.length).toBeGreaterThan(0);
+    const aliceEvent = aliceEvents[0];
+
+    const uploadRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie: bob.cookie },
+      body: JSON.stringify({
+        events: [
+          {
+            clientEventId: randomUUID(),
+            timestampSecs: aliceEvent.timestampSecs,
+            snapshotVersion: aliceEvent.snapshotVersion,
+            cardId: aliceEvent.cardId,
+            shown: JSON.parse(aliceEvent.shown.toString('utf8')),
+            hidden: JSON.parse(aliceEvent.hidden.toString('utf8')),
+            grades: JSON.parse(aliceEvent.grades.toString('utf8')),
+          },
+        ],
+      }),
+    });
+    expect(uploadRes.status).toBe(200);
+
+    const aliceEdges = sortEdges(
+      test.db
+        .select()
+        .from(edgeStates)
+        .all()
+        .filter((e) => e.userId === alice.userId),
+    );
+    const bobEdges = sortEdges(
+      test.db
+        .select()
+        .from(edgeStates)
+        .all()
+        .filter((e) => e.userId === bob.userId),
+    );
+    expect(bobEdges.length).toBe(aliceEdges.length);
+    for (let i = 0; i < bobEdges.length; i++) {
+      expect(bobEdges[i].edgeId).toBe(aliceEdges[i].edgeId);
+      expect(bobEdges[i].stability).toBeCloseTo(aliceEdges[i].stability, 4);
+      expect(bobEdges[i].difficulty).toBeCloseTo(aliceEdges[i].difficulty, 4);
+      expect(bobEdges[i].lastReviewSecs).toBe(aliceEdges[i].lastReviewSecs);
+    }
+  });
+});
+
+function sortEdges<T extends { edgeId: number }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => a.edgeId - b.edgeId);
+}

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -1,13 +1,19 @@
 import { randomUUID } from 'node:crypto';
 
-import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
-import { type CardStateEntry, type EdgeStateEntry, EngineStore } from '../lib/engine.js';
+import {
+  type CardStateEntry,
+  type EdgeStateEntry,
+  EngineStore,
+  readCardStateEntries,
+  readEdgeStateEntries,
+} from '../lib/engine.js';
 import { jsonBlob } from '../lib/keys.js';
-import type { Grade, ReviewOutcome } from '../lib/review-log.js';
+import { type Grade, type ReviewOutcome, persistEngineState } from '../lib/review-log.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface SyncRoutesDeps {
@@ -15,6 +21,9 @@ export interface SyncRoutesDeps {
   engines: EngineStore;
   now?: () => number;
 }
+
+/** Caps each upload so the `inArray` dedup stays under SQLite's 999-param limit. */
+const MAX_BATCH_SIZE = 500;
 
 interface ReviewEventUpload {
   clientEventId: string;
@@ -36,9 +45,11 @@ export function syncRoutes(deps: SyncRoutesDeps) {
 
   app.use('*', requireAuth());
 
-  app.get('/:materialId/state', async (c) => {
+  app.get('/:materialId/state', (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
+    const key = { userId: user.id, materialId };
+
     const snapshot = deps.db
       .select()
       .from(schema.graphSnapshots)
@@ -53,36 +64,22 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       .get();
     if (!snapshot) return c.json({ error: 'Not enrolled' }, 404);
 
-    const edges = readEdgeStates(deps.db, user.id, materialId);
-    const cards = readCardStates(deps.db, user.id, materialId);
-    const latest = deps.db
-      .select({ id: schema.reviewEvents.id })
-      .from(schema.reviewEvents)
-      .where(
-        and(
-          eq(schema.reviewEvents.userId, user.id),
-          eq(schema.reviewEvents.materialId, materialId),
-        ),
-      )
-      .orderBy(desc(schema.reviewEvents.timestampSecs), desc(schema.reviewEvents.id))
-      .limit(1)
-      .get();
-
     return c.json({
       snapshot: {
         version: snapshot.version,
         graphData: JSON.parse(snapshot.graphData.toString('utf8')) as unknown,
         cardsData: JSON.parse(snapshot.cardsData.toString('utf8')) as unknown,
       },
-      edgeStates: edges,
-      cardStates: cards,
-      lastEventId: latest?.id ?? null,
+      edgeStates: readEdgeStateEntries(deps.db, key),
+      cardStates: readCardStateEntries(deps.db, key),
+      lastEventId: latestEventId(deps.db, user.id, materialId),
     });
   });
 
   app.post('/:materialId/events', async (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
+    const key = { userId: user.id, materialId };
 
     let body: UploadBody;
     try {
@@ -92,43 +89,42 @@ export function syncRoutes(deps: SyncRoutesDeps) {
     }
     const events = body.events;
     if (!Array.isArray(events)) return c.json({ error: 'events required' }, 400);
+    if (events.length > MAX_BATCH_SIZE) {
+      return c.json({ error: `Batch too large — max ${MAX_BATCH_SIZE} events per request` }, 413);
+    }
     for (const e of events) {
       const problem = validateUpload(e);
       if (problem) return c.json({ error: problem }, 400);
     }
 
-    const loaded = await deps.engines.load({ userId: user.id, materialId });
+    if (events.length === 0) {
+      return c.json(unchangedResponse(deps.db, key, 0, 0));
+    }
+
+    const loaded = await deps.engines.load(key);
     for (const e of events) {
       if (e.snapshotVersion !== loaded.snapshotVersion) {
-        return c.json(
-          {
-            error: 'Snapshot version mismatch — re-fetch state before syncing',
-            expected: loaded.snapshotVersion,
-            got: e.snapshotVersion,
-          },
-          409,
-        );
+        return c.json({ error: 'Snapshot version mismatch — re-fetch state before syncing' }, 409);
       }
     }
 
-    const clientIds = events.map((e) => e.clientEventId);
-    const existing = clientIds.length
-      ? deps.db
-          .select({ clientEventId: schema.reviewEvents.clientEventId })
-          .from(schema.reviewEvents)
-          .where(
-            and(
-              eq(schema.reviewEvents.userId, user.id),
-              eq(schema.reviewEvents.materialId, materialId),
-              inArray(schema.reviewEvents.clientEventId, clientIds),
-            ),
-          )
-          .all()
-      : [];
+    const existing = deps.db
+      .select({ clientEventId: schema.reviewEvents.clientEventId })
+      .from(schema.reviewEvents)
+      .where(
+        and(
+          eq(schema.reviewEvents.userId, user.id),
+          eq(schema.reviewEvents.materialId, materialId),
+          inArray(
+            schema.reviewEvents.clientEventId,
+            events.map((e) => e.clientEventId),
+          ),
+        ),
+      )
+      .all();
     const seen = new Set(existing.map((r) => r.clientEventId));
 
-    // Apply events to the live engine in (timestamp, clientEventId) order so
-    // multi-device uploads stay deterministic regardless of arrival order.
+    // Sort so multi-device uploads stay deterministic regardless of arrival order.
     const fresh = events
       .filter((e) => !seen.has(e.clientEventId))
       .sort((a, b) =>
@@ -136,6 +132,10 @@ export function syncRoutes(deps: SyncRoutesDeps) {
           ? a.timestampSecs - b.timestampSecs
           : a.clientEventId.localeCompare(b.clientEventId),
       );
+
+    if (fresh.length === 0) {
+      return c.json(unchangedResponse(deps.db, key, 0, events.length));
+    }
 
     const changedEdgeIds = new Set<number>();
     for (const e of fresh) {
@@ -154,137 +154,73 @@ export function syncRoutes(deps: SyncRoutesDeps) {
     const changedEdges = allEdges.filter((e) => changedEdgeIds.has(e.edge_id));
     const allCards = JSON.parse(loaded.engine.export_card_states()) as CardStateEntry[];
     const createdAt = now();
+    const eventRows = fresh.map((e) => ({
+      id: randomUUID(),
+      userId: user.id,
+      materialId,
+      snapshotVersion: e.snapshotVersion,
+      timestampSecs: e.timestampSecs,
+      cardId: e.cardId,
+      clientEventId: e.clientEventId,
+      shown: jsonBlob(e.shown),
+      hidden: jsonBlob(e.hidden),
+      grades: jsonBlob(e.grades),
+      createdAt,
+    }));
 
-    let lastEventId: string | null = null;
     deps.db.transaction((tx) => {
-      if (fresh.length > 0) {
-        const rows = fresh.map((e) => {
-          const id = randomUUID();
-          lastEventId = id;
-          return {
-            id,
-            userId: user.id,
-            materialId,
-            snapshotVersion: e.snapshotVersion,
-            timestampSecs: e.timestampSecs,
-            cardId: e.cardId,
-            clientEventId: e.clientEventId,
-            shown: jsonBlob(e.shown),
-            hidden: jsonBlob(e.hidden),
-            grades: jsonBlob(e.grades),
-            createdAt,
-          };
-        });
-        tx.insert(schema.reviewEvents).values(rows).run();
-      }
-
-      if (changedEdges.length > 0) {
-        tx.insert(schema.edgeStates)
-          .values(
-            changedEdges.map((e) => ({
-              userId: user.id,
-              materialId,
-              edgeId: e.edge_id,
-              stability: e.stability,
-              difficulty: e.difficulty,
-              lastReviewSecs: e.last_review_secs,
-            })),
-          )
-          .onConflictDoUpdate({
-            target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
-            set: {
-              stability: sql`excluded.stability`,
-              difficulty: sql`excluded.difficulty`,
-              lastReviewSecs: sql`excluded.last_review_secs`,
-            },
-          })
-          .run();
-      }
-
-      if (allCards.length > 0) {
-        tx.insert(schema.cardStates)
-          .values(
-            allCards.map((c) => ({
-              userId: user.id,
-              materialId,
-              cardId: c.card_id,
-              state: c.state,
-              dueR: c.due_r,
-              dueDateSecs: c.due_date_secs,
-              priority: c.priority,
-            })),
-          )
-          .onConflictDoUpdate({
-            target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
-            set: {
-              state: sql`excluded.state`,
-              dueR: sql`excluded.due_r`,
-              dueDateSecs: sql`excluded.due_date_secs`,
-              priority: sql`excluded.priority`,
-            },
-          })
-          .run();
-      }
+      persistEngineState(tx, {
+        userId: user.id,
+        materialId,
+        eventRows,
+        changedEdges,
+        allCards,
+      });
     });
 
-    if (lastEventId === null) {
-      const latest = deps.db
-        .select({ id: schema.reviewEvents.id })
-        .from(schema.reviewEvents)
-        .where(
-          and(
-            eq(schema.reviewEvents.userId, user.id),
-            eq(schema.reviewEvents.materialId, materialId),
-          ),
-        )
-        .orderBy(desc(schema.reviewEvents.timestampSecs), desc(schema.reviewEvents.id))
-        .limit(1)
-        .get();
-      lastEventId = latest?.id ?? null;
-    }
-
-    // Response returns the engine's full edge/card state so fat clients can
-    // replace their local cache in one shot, rather than having to merge
-    // deltas. DB writes are filtered to the changed set as an optimization.
+    // Response carries the engine's full edge/card state so fat clients can
+    // replace their local cache in one shot; DB writes are filtered above.
     return c.json({
       accepted: fresh.length,
       duplicates: events.length - fresh.length,
       edgeStates: allEdges,
       cardStates: allCards,
-      lastEventId,
+      lastEventId: eventRows[eventRows.length - 1]!.id,
     });
   });
 
   return app;
 }
 
-function readEdgeStates(db: DB, userId: string, materialId: string): EdgeStateEntry[] {
-  return db
-    .select()
-    .from(schema.edgeStates)
-    .where(and(eq(schema.edgeStates.userId, userId), eq(schema.edgeStates.materialId, materialId)))
-    .all()
-    .map((e) => ({
-      edge_id: e.edgeId,
-      stability: e.stability,
-      difficulty: e.difficulty,
-      last_review_secs: e.lastReviewSecs,
-    }));
+function unchangedResponse(
+  db: DB,
+  key: { userId: string; materialId: string },
+  accepted: number,
+  duplicates: number,
+) {
+  return {
+    accepted,
+    duplicates,
+    edgeStates: readEdgeStateEntries(db, key),
+    cardStates: readCardStateEntries(db, key),
+    lastEventId: latestEventId(db, key.userId, key.materialId),
+  };
 }
 
-function readCardStates(db: DB, userId: string, materialId: string): CardStateEntry[] {
-  return db
-    .select()
-    .from(schema.cardStates)
-    .where(and(eq(schema.cardStates.userId, userId), eq(schema.cardStates.materialId, materialId)))
-    .all()
-    .map((c) => ({
-      card_id: c.cardId,
-      state: c.state,
-      due_r: c.dueR,
-      due_date_secs: c.dueDateSecs,
-      priority: c.priority,
-    }));
+function latestEventId(db: DB, userId: string, materialId: string): string | null {
+  const latest = db
+    .select({ id: schema.reviewEvents.id })
+    .from(schema.reviewEvents)
+    .where(
+      and(
+        eq(schema.reviewEvents.userId, userId),
+        eq(schema.reviewEvents.materialId, materialId),
+      ),
+    )
+    .orderBy(desc(schema.reviewEvents.timestampSecs), desc(schema.reviewEvents.id))
+    .limit(1)
+    .get();
+  return latest?.id ?? null;
 }
 
 function validateUpload(e: ReviewEventUpload): string | null {

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -1,0 +1,299 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, desc, eq, inArray, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import { type CardStateEntry, type EdgeStateEntry, EngineStore } from '../lib/engine.js';
+import { jsonBlob } from '../lib/keys.js';
+import type { Grade, ReviewOutcome } from '../lib/review-log.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface SyncRoutesDeps {
+  db: DB;
+  engines: EngineStore;
+  now?: () => number;
+}
+
+interface ReviewEventUpload {
+  clientEventId: string;
+  timestampSecs: number;
+  snapshotVersion: number;
+  cardId: number | null;
+  shown: number[];
+  hidden: number[];
+  grades: Grade[];
+}
+
+interface UploadBody {
+  events: ReviewEventUpload[];
+}
+
+export function syncRoutes(deps: SyncRoutesDeps) {
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
+  const app = new Hono<{ Variables: SessionVariables }>();
+
+  app.use('*', requireAuth());
+
+  app.get('/:materialId/state', async (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+    const snapshot = deps.db
+      .select()
+      .from(schema.graphSnapshots)
+      .where(
+        and(
+          eq(schema.graphSnapshots.userId, user.id),
+          eq(schema.graphSnapshots.materialId, materialId),
+        ),
+      )
+      .orderBy(desc(schema.graphSnapshots.version))
+      .limit(1)
+      .get();
+    if (!snapshot) return c.json({ error: 'Not enrolled' }, 404);
+
+    const edges = readEdgeStates(deps.db, user.id, materialId);
+    const cards = readCardStates(deps.db, user.id, materialId);
+    const latest = deps.db
+      .select({ id: schema.reviewEvents.id })
+      .from(schema.reviewEvents)
+      .where(
+        and(
+          eq(schema.reviewEvents.userId, user.id),
+          eq(schema.reviewEvents.materialId, materialId),
+        ),
+      )
+      .orderBy(desc(schema.reviewEvents.timestampSecs), desc(schema.reviewEvents.id))
+      .limit(1)
+      .get();
+
+    return c.json({
+      snapshot: {
+        version: snapshot.version,
+        graphData: JSON.parse(snapshot.graphData.toString('utf8')) as unknown,
+        cardsData: JSON.parse(snapshot.cardsData.toString('utf8')) as unknown,
+      },
+      edgeStates: edges,
+      cardStates: cards,
+      lastEventId: latest?.id ?? null,
+    });
+  });
+
+  app.post('/:materialId/events', async (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+
+    let body: UploadBody;
+    try {
+      body = await c.req.json<UploadBody>();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    const events = body.events;
+    if (!Array.isArray(events)) return c.json({ error: 'events required' }, 400);
+    for (const e of events) {
+      const problem = validateUpload(e);
+      if (problem) return c.json({ error: problem }, 400);
+    }
+
+    const loaded = await deps.engines.load({ userId: user.id, materialId });
+    for (const e of events) {
+      if (e.snapshotVersion !== loaded.snapshotVersion) {
+        return c.json(
+          {
+            error: 'Snapshot version mismatch — re-fetch state before syncing',
+            expected: loaded.snapshotVersion,
+            got: e.snapshotVersion,
+          },
+          409,
+        );
+      }
+    }
+
+    const clientIds = events.map((e) => e.clientEventId);
+    const existing = clientIds.length
+      ? deps.db
+          .select({ clientEventId: schema.reviewEvents.clientEventId })
+          .from(schema.reviewEvents)
+          .where(
+            and(
+              eq(schema.reviewEvents.userId, user.id),
+              eq(schema.reviewEvents.materialId, materialId),
+              inArray(schema.reviewEvents.clientEventId, clientIds),
+            ),
+          )
+          .all()
+      : [];
+    const seen = new Set(existing.map((r) => r.clientEventId));
+
+    // Apply events to the live engine in (timestamp, clientEventId) order so
+    // multi-device uploads stay deterministic regardless of arrival order.
+    const fresh = events
+      .filter((e) => !seen.has(e.clientEventId))
+      .sort((a, b) =>
+        a.timestampSecs !== b.timestampSecs
+          ? a.timestampSecs - b.timestampSecs
+          : a.clientEventId.localeCompare(b.clientEventId),
+      );
+
+    const changedEdgeIds = new Set<number>();
+    for (const e of fresh) {
+      const outcome = JSON.parse(
+        loaded.engine.replay_event(
+          JSON.stringify(e.shown),
+          JSON.stringify(e.hidden),
+          JSON.stringify(e.grades),
+          BigInt(e.timestampSecs),
+        ),
+      ) as ReviewOutcome;
+      for (const u of outcome.edge_updates) changedEdgeIds.add(u.edge_id);
+    }
+
+    const allEdges = JSON.parse(loaded.engine.export_edge_states()) as EdgeStateEntry[];
+    const changedEdges = allEdges.filter((e) => changedEdgeIds.has(e.edge_id));
+    const allCards = JSON.parse(loaded.engine.export_card_states()) as CardStateEntry[];
+    const createdAt = now();
+
+    let lastEventId: string | null = null;
+    deps.db.transaction((tx) => {
+      if (fresh.length > 0) {
+        const rows = fresh.map((e) => {
+          const id = randomUUID();
+          lastEventId = id;
+          return {
+            id,
+            userId: user.id,
+            materialId,
+            snapshotVersion: e.snapshotVersion,
+            timestampSecs: e.timestampSecs,
+            cardId: e.cardId,
+            clientEventId: e.clientEventId,
+            shown: jsonBlob(e.shown),
+            hidden: jsonBlob(e.hidden),
+            grades: jsonBlob(e.grades),
+            createdAt,
+          };
+        });
+        tx.insert(schema.reviewEvents).values(rows).run();
+      }
+
+      if (changedEdges.length > 0) {
+        tx.insert(schema.edgeStates)
+          .values(
+            changedEdges.map((e) => ({
+              userId: user.id,
+              materialId,
+              edgeId: e.edge_id,
+              stability: e.stability,
+              difficulty: e.difficulty,
+              lastReviewSecs: e.last_review_secs,
+            })),
+          )
+          .onConflictDoUpdate({
+            target: [schema.edgeStates.userId, schema.edgeStates.materialId, schema.edgeStates.edgeId],
+            set: {
+              stability: sql`excluded.stability`,
+              difficulty: sql`excluded.difficulty`,
+              lastReviewSecs: sql`excluded.last_review_secs`,
+            },
+          })
+          .run();
+      }
+
+      if (allCards.length > 0) {
+        tx.insert(schema.cardStates)
+          .values(
+            allCards.map((c) => ({
+              userId: user.id,
+              materialId,
+              cardId: c.card_id,
+              state: c.state,
+              dueR: c.due_r,
+              dueDateSecs: c.due_date_secs,
+              priority: c.priority,
+            })),
+          )
+          .onConflictDoUpdate({
+            target: [schema.cardStates.userId, schema.cardStates.materialId, schema.cardStates.cardId],
+            set: {
+              state: sql`excluded.state`,
+              dueR: sql`excluded.due_r`,
+              dueDateSecs: sql`excluded.due_date_secs`,
+              priority: sql`excluded.priority`,
+            },
+          })
+          .run();
+      }
+    });
+
+    if (lastEventId === null) {
+      const latest = deps.db
+        .select({ id: schema.reviewEvents.id })
+        .from(schema.reviewEvents)
+        .where(
+          and(
+            eq(schema.reviewEvents.userId, user.id),
+            eq(schema.reviewEvents.materialId, materialId),
+          ),
+        )
+        .orderBy(desc(schema.reviewEvents.timestampSecs), desc(schema.reviewEvents.id))
+        .limit(1)
+        .get();
+      lastEventId = latest?.id ?? null;
+    }
+
+    // Response returns the engine's full edge/card state so fat clients can
+    // replace their local cache in one shot, rather than having to merge
+    // deltas. DB writes are filtered to the changed set as an optimization.
+    return c.json({
+      accepted: fresh.length,
+      duplicates: events.length - fresh.length,
+      edgeStates: allEdges,
+      cardStates: allCards,
+      lastEventId,
+    });
+  });
+
+  return app;
+}
+
+function readEdgeStates(db: DB, userId: string, materialId: string): EdgeStateEntry[] {
+  return db
+    .select()
+    .from(schema.edgeStates)
+    .where(and(eq(schema.edgeStates.userId, userId), eq(schema.edgeStates.materialId, materialId)))
+    .all()
+    .map((e) => ({
+      edge_id: e.edgeId,
+      stability: e.stability,
+      difficulty: e.difficulty,
+      last_review_secs: e.lastReviewSecs,
+    }));
+}
+
+function readCardStates(db: DB, userId: string, materialId: string): CardStateEntry[] {
+  return db
+    .select()
+    .from(schema.cardStates)
+    .where(and(eq(schema.cardStates.userId, userId), eq(schema.cardStates.materialId, materialId)))
+    .all()
+    .map((c) => ({
+      card_id: c.cardId,
+      state: c.state,
+      due_r: c.dueR,
+      due_date_secs: c.dueDateSecs,
+      priority: c.priority,
+    }));
+}
+
+function validateUpload(e: ReviewEventUpload): string | null {
+  if (typeof e.clientEventId !== 'string' || !e.clientEventId) return 'clientEventId required';
+  if (typeof e.timestampSecs !== 'number') return 'timestampSecs required';
+  if (typeof e.snapshotVersion !== 'number') return 'snapshotVersion required';
+  if (e.cardId !== null && typeof e.cardId !== 'number') return 'cardId must be number or null';
+  if (!Array.isArray(e.shown)) return 'shown must be an array';
+  if (!Array.isArray(e.hidden)) return 'hidden must be an array';
+  if (!Array.isArray(e.grades)) return 'grades must be an array';
+  return null;
+}

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -9,6 +9,7 @@ import {
   type CardStateEntry,
   type EdgeStateEntry,
   EngineStore,
+  NotEnrolledError,
   readCardStateEntries,
   readEdgeStateEntries,
 } from '../lib/engine.js';
@@ -101,7 +102,13 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       return c.json(unchangedResponse(deps.db, key, 0, 0));
     }
 
-    const loaded = await deps.engines.load(key);
+    let loaded;
+    try {
+      loaded = await deps.engines.load(key);
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
     for (const e of events) {
       if (e.snapshotVersion !== loaded.snapshotVersion) {
         return c.json({ error: 'Snapshot version mismatch — re-fetch state before syncing' }, 409);

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -2,8 +2,11 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { expect } from 'vitest';
+
 import { createApp } from './app.js';
 import { type DB, createDb } from './db/client.js';
+import { user } from './db/schema.js';
 import { runMigrations } from './db/migrate.js';
 
 export const TEST_AUTH_ENV = {
@@ -38,4 +41,28 @@ export function createTestApp() {
   const test = createTestDb();
   const app = createApp({ db: test.db, authEnv: TEST_AUTH_ENV });
   return { app, ...test };
+}
+
+export type TestApp = ReturnType<typeof createTestApp>;
+
+/** Creates a user via Better Auth's email sign-up and returns the session cookie + user id. */
+export async function signUpTestUser(
+  test: TestApp,
+  email: string,
+  password = 'superSecret123!',
+): Promise<{ cookie: string; userId: string }> {
+  const res = await test.app.request('/api/auth/sign-up/email', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password, name: email }),
+  });
+  expect(res.status).toBe(200);
+  const cookie = res.headers.get('set-cookie')!;
+  const row = test.db
+    .select()
+    .from(user)
+    .all()
+    .find((r) => r.email === email);
+  if (!row) throw new Error(`user not found: ${email}`);
+  return { cookie, userId: row.id };
 }


### PR DESCRIPTION
## Summary

Adds the fat-client sync API so offline clients (Tauri, offline web) can hydrate a local cache, run reviews without network, and upload the batch on reconnect.

- `GET /api/sync/:materialId/state` — snapshot + materialized edge/card state + `lastEventId`
- `POST /api/sync/:materialId/events` — accepts offline batch, dedupes by `clientEventId`, replays via a new session-less WASM primitive, and persists the union of changed edges + full card state in a single transaction

## What's new

- WASM: `WasmEngine.replay_event` wraps `ReviewEngine::review_transient` so events can be applied without an active session
- Schema: `review_events.client_event_id` + unique `(user_id, material_id, client_event_id)` index for idempotent uploads
- Sessions: progressive-reveal reading cards are no longer logged — they don't change engine state, and logging them broke symmetry with replay
- Shared helpers: `persistEngineState`, `readEdgeStateEntries`, `readCardStateEntries`, `signUpTestUser`
- 500-event batch cap so the `inArray` dedup query stays under SQLite's 999-param limit
- Parity test asserting an online review and a sync-replayed event produce identical edge state
- Docs: `docs/persistence.md` replay/determinism/limitations section, `docs/server-api.md` sync endpoints, `docs/wasm-api.md` `replay_event`

## Test plan

- [x] `pnpm test` — 23 tests pass (7 new in `sync.test.ts` + parity test + 413 batch-cap test)
- [x] `pnpm type-check`
- [x] `cargo clippy --workspace` + `cargo fmt --check`
- [x] `pnpm exec dprint check`
- [x] `cargo test --workspace`
- [ ] Manual smoke: start server, register, sync flow via curl

## Known limitations (documented in `docs/persistence.md`)

- `graph_snapshots.version` isn't yet incremented by any code path; snapshot migration is future work.
- Offline events are applied to the in-process live engine (not replayed from zero), so edge state reflects server state before + batch in timestamp order. Correct for single-device offline; concurrent multi-device edits are out of scope.
- Reading cards are skipped from the log; progressive-reveal progress doesn't survive a device swap.

🤖 Generated with [Claude Code](https://claude.ai/code)