### PR TITLE
Phase 3E: Materials + Stats endpoints

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,10 +60,12 @@ on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline
 * [x] Idempotent uploads via `client_event_id`
 * [x] Stale-snapshot rejection (409)
 
-### Phase 3E: Stats + Materials
+### Phase 3E: Stats + Materials ✅
 
-* [ ] Material enrollment
-* [ ] Progress stats
+* [x] `GET /api/materials` (static manifest)
+* [x] `POST /api/materials/enroll` (seeds graph + card_states)
+* [x] `GET /api/materials/:id/status`
+* [x] `GET /api/stats/:materialId`
 
 ### Phase 3F: Frontends
 

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -193,11 +193,83 @@ Side effects are a single transaction: append new events, upsert the union of ch
 every card's state. See [persistence.md](persistence.md#upload-flow--post-apisyncmaterialidevents)
 for replay semantics.
 
+## Materials — `/api/materials/*`
+
+Catalog of available materials + per-user enrollment. The catalog is a static manifest today; the
+content pipeline will eventually feed it.
+
+### `GET /api/materials`
+
+```json
+{
+  "materials": [
+    { "id": "nkjv-1cor", "title": "1 Corinthians (NKJV)", "description": "…" }
+  ]
+}
+```
+
+### `POST /api/materials/enroll`
+
+Enrolls the caller, inserts the initial graph snapshot, and seeds `card_states` so status queries
+work before any reviews. Re-enrolling returns 409.
+
+Request:
+
+```json
+{ "materialId": "nkjv-1cor", "clubTier": 150 }
+```
+
+`clubTier` is optional (`150`, `300`, or omitted for "full material").
+
+Response:
+
+```json
+{ "materialId": "nkjv-1cor", "snapshotId": "uuid", "version": 1 }
+```
+
+Errors: 404 for an unknown material, 409 for a duplicate enrollment.
+
+### `GET /api/materials/:id/status`
+
+```json
+{
+  "materialId": "nkjv-1cor",
+  "clubTier": 150,
+  "cardCounts": { "new": 1, "learning": 0, "review": 0, "relearning": 0 },
+  "nextDueSecs": null
+}
+```
+
+404 if the material is unknown or the caller isn't enrolled.
+
+## Stats — `/api/stats/:materialId`
+
+```json
+{
+  "materialId": "nkjv-1cor",
+  "versesLearned": 0,
+  "retentionRate": 0.92,
+  "totalGrades": 120,
+  "edgeDistribution": {
+    "weak": 0, "learning": 5, "familiar": 3, "strong": 2, "mastered": 1
+  }
+}
+```
+
+* `versesLearned`: cards currently in `review` state.
+* `retentionRate`: fraction of all grades in `review_events` that were a pass (3 or 4). `null` if no
+  reviews yet.
+* `totalGrades`: denominator for `retentionRate`, handy for displaying sample size.
+* `edgeDistribution`: edge counts bucketed by stability (days): `weak < 1`, `learning < 7`,
+  `familiar < 30`, `strong < 90`, `mastered ≥ 90`.
+
+404 on unknown material or non-enrolled caller.
+
 ## Errors
 
-| Status | Meaning                                                                                 |
-| ------ | --------------------------------------------------------------------------------------- |
-| 400    | Malformed body, missing field, or engine rejected input                                 |
-| 401    | No session cookie / expired session                                                     |
-| 404    | Session ID unknown / not owned by caller, or user not enrolled in the material          |
-| 409    | Session found but no card awaiting review, or sync batch uses a stale `snapshotVersion` |
+| Status | Meaning                                                                                                |
+| ------ | ------------------------------------------------------------------------------------------------------ |
+| 400    | Malformed body, missing field, or engine rejected input                                                |
+| 401    | No session cookie / expired session                                                                    |
+| 404    | Session ID unknown / not owned by caller, or user not enrolled in the material                         |
+| 409    | Session found but no card awaiting review, sync batch uses a stale `snapshotVersion`, or re-enrollment |

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -7,7 +7,9 @@ import { type AuthEnv, createAuth } from './lib/auth.js';
 import { EngineStore } from './lib/engine.js';
 import { SessionStore } from './lib/sessions.js';
 import { type SessionVariables, getUser, requireAuth, sessionMiddleware } from './middleware/session.js';
+import { materialsRoutes } from './routes/materials.js';
 import { sessionRoutes } from './routes/sessions.js';
+import { statsRoutes } from './routes/stats.js';
 import { syncRoutes } from './routes/sync.js';
 
 export interface AppDeps {
@@ -47,6 +49,8 @@ export function createApp(deps: AppDeps) {
 
   app.route('/api/sessions', sessionRoutes({ db: deps.db, engines, sessions, now: deps.now }));
   app.route('/api/sync', syncRoutes({ db: deps.db, engines, now: deps.now }));
+  app.route('/api/materials', materialsRoutes({ db: deps.db, now: deps.now }));
+  app.route('/api/stats', statsRoutes({ db: deps.db }));
 
   return app;
 }

--- a/packages/api/src/lib/enrollment.ts
+++ b/packages/api/src/lib/enrollment.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, eq } from 'drizzle-orm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import { jsonBlob } from './keys.js';
+import { type MaterialCard, buildMaterialTemplate, getMaterial } from './materials.js';
+
+export interface EnrollArgs {
+  db: DB;
+  userId: string;
+  materialId: string;
+  clubTier?: number | null;
+  now?: () => number;
+}
+
+export class UnknownMaterialError extends Error {
+  constructor(materialId: string) {
+    super(`Unknown material: ${materialId}`);
+    this.name = 'UnknownMaterialError';
+  }
+}
+
+export class AlreadyEnrolledError extends Error {
+  constructor(userId: string, materialId: string) {
+    super(`Already enrolled: user=${userId} material=${materialId}`);
+    this.name = 'AlreadyEnrolledError';
+  }
+}
+
+/**
+ * Enrolls a user in a material. Inserts the `user_materials` row, the initial
+ * `graph_snapshots` row from the material template, and seeds `card_states`
+ * so status queries can hit a populated table even before the first review.
+ */
+export function enrollUser(args: EnrollArgs): { snapshotId: string; version: number } {
+  const { db, userId, materialId } = args;
+  const now = args.now ?? (() => Math.floor(Date.now() / 1000));
+
+  const material = getMaterial(materialId);
+  if (!material) throw new UnknownMaterialError(materialId);
+
+  const existing = db
+    .select()
+    .from(schema.userMaterials)
+    .where(
+      and(
+        eq(schema.userMaterials.userId, userId),
+        eq(schema.userMaterials.materialId, materialId),
+      ),
+    )
+    .get();
+  if (existing) throw new AlreadyEnrolledError(userId, materialId);
+
+  const template = buildMaterialTemplate(materialId);
+  const snapshotId = randomUUID();
+  const createdAt = now();
+
+  db.transaction((tx) => {
+    tx.insert(schema.userMaterials)
+      .values({
+        userId,
+        materialId,
+        clubTier: args.clubTier ?? null,
+        createdAt,
+      })
+      .run();
+    tx.insert(schema.graphSnapshots)
+      .values({
+        id: snapshotId,
+        userId,
+        materialId,
+        version: 1,
+        graphData: jsonBlob(template.graph),
+        cardsData: jsonBlob(template.cards),
+        createdAt,
+      })
+      .run();
+
+    const cardRows = template.cards.map((c: MaterialCard) => ({
+      userId,
+      materialId,
+      cardId: c.id,
+      state: c.state.toLowerCase() as Lowercase<MaterialCard['state']>,
+      dueR: null,
+      dueDateSecs: null,
+      priority: null,
+    }));
+    if (cardRows.length > 0) {
+      tx.insert(schema.cardStates).values(cardRows).run();
+    }
+  });
+
+  return { snapshotId, version: 1 };
+}

--- a/packages/api/src/lib/enrollment.ts
+++ b/packages/api/src/lib/enrollment.ts
@@ -4,7 +4,8 @@ import { and, eq } from 'drizzle-orm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
-import { jsonBlob } from './keys.js';
+import { NotEnrolledError } from './engine.js';
+import { type UserMaterial, jsonBlob } from './keys.js';
 import { type MaterialCard, buildMaterialTemplate, getMaterial } from './materials.js';
 
 export interface EnrollArgs {
@@ -27,6 +28,29 @@ export class AlreadyEnrolledError extends Error {
     super(`Already enrolled: user=${userId} material=${materialId}`);
     this.name = 'AlreadyEnrolledError';
   }
+}
+
+/**
+ * Returns the user_materials row for the caller, or throws NotEnrolledError.
+ * Route handlers `try { … } catch (NotEnrolledError)` → 404, matching the
+ * sync-endpoint pattern.
+ */
+export function requireEnrollment(
+  db: DB,
+  key: UserMaterial,
+): typeof schema.userMaterials.$inferSelect {
+  const row = db
+    .select()
+    .from(schema.userMaterials)
+    .where(
+      and(
+        eq(schema.userMaterials.userId, key.userId),
+        eq(schema.userMaterials.materialId, key.materialId),
+      ),
+    )
+    .get();
+  if (!row) throw new NotEnrolledError(key);
+  return row;
 }
 
 /**
@@ -78,6 +102,9 @@ export function enrollUser(args: EnrollArgs): { snapshotId: string; version: num
       })
       .run();
 
+    // MaterialCard.state stays PascalCase because that's what Rust's serde
+    // produces for the CardState enum on the WASM side; card_states on the
+    // DB is the lowercase union so we normalize on the way in.
     const cardRows = template.cards.map((c: MaterialCard) => ({
       userId,
       materialId,

--- a/packages/api/src/lib/materials.ts
+++ b/packages/api/src/lib/materials.ts
@@ -1,0 +1,99 @@
+/**
+ * Material catalog. Today this is a static manifest; once the content
+ * pipeline lands, the templates will come from the pipeline's output and
+ * this file will read them off disk or a shared store.
+ */
+
+export interface Material {
+  id: string;
+  title: string;
+  description: string;
+}
+
+export const MATERIALS: readonly Material[] = [
+  {
+    id: 'nkjv-1cor',
+    title: '1 Corinthians (NKJV)',
+    description:
+      'Placeholder sample material — a single verse of 1 Corinthians until the content pipeline produces a full graph.',
+  },
+];
+
+export function getMaterial(id: string): Material | undefined {
+  return MATERIALS.find((m) => m.id === id);
+}
+
+export interface MaterialGraph {
+  nodes: Record<string, { id: number; kind: unknown }>;
+  edges: Record<string, MaterialEdge>;
+  outgoing: Record<string, number[]>;
+  incoming: Record<string, number[]>;
+  next_node_id: number;
+  next_edge_id: number;
+}
+
+interface MaterialEdge {
+  id: number;
+  kind: string;
+  source: number;
+  target: number;
+  state: { stability: number; difficulty: number; last_review_secs: number };
+}
+
+export interface MaterialCard {
+  id: number;
+  shown: number[];
+  hidden: number[];
+  state: 'New' | 'Learning' | 'Review' | 'Relearning';
+}
+
+export interface MaterialTemplate {
+  graph: MaterialGraph;
+  cards: MaterialCard[];
+}
+
+export function buildMaterialTemplate(id: string): MaterialTemplate {
+  if (id === 'nkjv-1cor') return buildSingleVerseTemplate();
+  throw new Error(`Unknown material: ${id}`);
+}
+
+/** Mirrors `crates/wasm/test-smoke.js` — minimum graph the engine accepts. */
+function buildSingleVerseTemplate(): MaterialTemplate {
+  const edgeState = { stability: 5.0, difficulty: 5.0, last_review_secs: 0 };
+  const graph: MaterialGraph = {
+    nodes: {
+      '0': { id: 0, kind: { Reference: { chapter: 3, verse: 16 } } },
+      '1': { id: 1, kind: { VerseGist: { chapter: 3, verse: 16 } } },
+      '2': { id: 2, kind: { Phrase: { text: 'phrase one', verse_id: 0, position: 0 } } },
+      '3': { id: 3, kind: { Phrase: { text: 'phrase two', verse_id: 0, position: 1 } } },
+      '4': { id: 4, kind: { Phrase: { text: 'phrase three', verse_id: 0, position: 2 } } },
+    },
+    edges: {},
+    outgoing: { '0': [], '1': [], '2': [], '3': [], '4': [] },
+    incoming: { '0': [], '1': [], '2': [], '3': [], '4': [] },
+    next_node_id: 5,
+    next_edge_id: 0,
+  };
+
+  const addBi = (kind: string, a: number, b: number) => {
+    const fwd = graph.next_edge_id++;
+    const bwd = graph.next_edge_id++;
+    graph.edges[String(fwd)] = { id: fwd, kind, source: a, target: b, state: edgeState };
+    graph.edges[String(bwd)] = { id: bwd, kind, source: b, target: a, state: edgeState };
+    graph.outgoing[String(a)]!.push(fwd);
+    graph.incoming[String(b)]!.push(fwd);
+    graph.outgoing[String(b)]!.push(bwd);
+    graph.incoming[String(a)]!.push(bwd);
+  };
+
+  addBi('VerseGistReference', 1, 0);
+  addBi('PhraseVerseGist', 2, 1);
+  addBi('PhraseVerseGist', 3, 1);
+  addBi('PhraseVerseGist', 4, 1);
+  addBi('PhrasePhrase', 2, 3);
+  addBi('PhrasePhrase', 3, 4);
+
+  const cards: MaterialCard[] = [{ id: 0, shown: [0], hidden: [2, 3, 4], state: 'New' }];
+
+  return { graph, cards };
+}

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -13,9 +13,9 @@ export interface Grade {
   grade: 1 | 2 | 3 | 4;
 }
 
-/** Mirrors the core's `Grade::is_pass` — Good (3) and Easy (4) are passes. */
+/** Mirrors the core's `Grade::is_pass` — only `Again` (1) is a fail. */
 export function isPass(g: Grade): boolean {
-  return g.grade >= 3;
+  return g.grade > 1;
 }
 
 export interface ReviewOutcome {

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -13,6 +13,11 @@ export interface Grade {
   grade: 1 | 2 | 3 | 4;
 }
 
+/** Mirrors the core's `Grade::is_pass` — Good (3) and Easy (4) are passes. */
+export function isPass(g: Grade): boolean {
+  return g.grade >= 3;
+}
+
 export interface ReviewOutcome {
   edge_updates: Array<{ edge_id: number; grade: number; weight: number }>;
   redrills_inserted: number;

--- a/packages/api/src/routes/materials.test.ts
+++ b/packages/api/src/routes/materials.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { userMaterials } from '../db/schema.js';
+import { createTestApp, signUpTestUser } from '../test-utils.js';
+
+const MATERIAL_ID = 'nkjv-1cor';
+
+interface ListResponse {
+  materials: Array<{ id: string; title: string; description: string }>;
+}
+
+interface StatusResponse {
+  materialId: string;
+  clubTier: number | null;
+  cardCounts: { new: number; learning: number; review: number; relearning: number };
+  nextDueSecs: number | null;
+}
+
+describe('materials routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('requires auth on every endpoint', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+
+    expect((await test.app.request('/api/materials')).status).toBe(401);
+    expect(
+      (
+        await test.app.request('/api/materials/enroll', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ materialId: MATERIAL_ID }),
+        })
+      ).status,
+    ).toBe(401);
+    expect((await test.app.request(`/api/materials/${MATERIAL_ID}/status`)).status).toBe(401);
+  });
+
+  it('lists the manifest', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+
+    const res = await test.app.request('/api/materials', { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ListResponse;
+    expect(body.materials.length).toBeGreaterThan(0);
+    expect(body.materials.some((m) => m.id === MATERIAL_ID)).toBe(true);
+  });
+
+  it('enrolls a user and rejects a second enrollment with 409', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await signUpTestUser(test, 'alice@example.com');
+
+    const res = await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID, clubTier: 150 }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { materialId: string; snapshotId: string; version: number };
+    expect(body.materialId).toBe(MATERIAL_ID);
+    expect(body.version).toBe(1);
+
+    const persisted = test.db
+      .select()
+      .from(userMaterials)
+      .all()
+      .find((r) => r.userId === userId && r.materialId === MATERIAL_ID);
+    expect(persisted?.clubTier).toBe(150);
+
+    const second = await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
+    });
+    expect(second.status).toBe(409);
+  });
+
+  it('rejects enrollment in an unknown material with 404', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+
+    const res = await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: 'does-not-exist' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 status for a caller that has not enrolled', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+
+    const res = await test.app.request(`/api/materials/${MATERIAL_ID}/status`, {
+      headers: { cookie },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('reports card counts after enrollment', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+
+    await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
+    });
+
+    const res = await test.app.request(`/api/materials/${MATERIAL_ID}/status`, {
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StatusResponse;
+    expect(body.materialId).toBe(MATERIAL_ID);
+    expect(body.cardCounts.new).toBeGreaterThan(0);
+    expect(body.cardCounts.review).toBe(0);
+    expect(body.nextDueSecs).toBeNull();
+  });
+});

--- a/packages/api/src/routes/materials.test.ts
+++ b/packages/api/src/routes/materials.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { userMaterials } from '../db/schema.js';
-import { createTestApp, signUpTestUser } from '../test-utils.js';
+import { createTestApp, enrollViaApi, signUpTestUser } from '../test-utils.js';
 
 const MATERIAL_ID = 'nkjv-1cor';
 
@@ -110,12 +110,7 @@ describe('materials routes', () => {
     const test = createTestApp();
     cleanup = test.cleanup;
     const { cookie } = await signUpTestUser(test, 'alice@example.com');
-
-    await test.app.request('/api/materials/enroll', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({ materialId: MATERIAL_ID }),
-    });
+    await enrollViaApi(test, cookie, MATERIAL_ID);
 
     const res = await test.app.request(`/api/materials/${MATERIAL_ID}/status`, {
       headers: { cookie },

--- a/packages/api/src/routes/materials.ts
+++ b/packages/api/src/routes/materials.ts
@@ -3,12 +3,14 @@ import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
+import { NotEnrolledError } from '../lib/engine.js';
 import {
   AlreadyEnrolledError,
   UnknownMaterialError,
   enrollUser,
+  requireEnrollment,
 } from '../lib/enrollment.js';
-import { MATERIALS, getMaterial } from '../lib/materials.js';
+import { MATERIALS } from '../lib/materials.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface MaterialsRoutesDeps {
@@ -64,20 +66,13 @@ export function materialsRoutes(deps: MaterialsRoutesDeps) {
   app.get('/:id/status', (c) => {
     const user = getUser(c);
     const materialId = c.req.param('id');
-    const material = getMaterial(materialId);
-    if (!material) return c.json({ error: 'Unknown material' }, 404);
-
-    const enrolled = deps.db
-      .select()
-      .from(schema.userMaterials)
-      .where(
-        and(
-          eq(schema.userMaterials.userId, user.id),
-          eq(schema.userMaterials.materialId, materialId),
-        ),
-      )
-      .get();
-    if (!enrolled) return c.json({ error: 'Not enrolled' }, 404);
+    let enrolled;
+    try {
+      enrolled = requireEnrollment(deps.db, { userId: user.id, materialId });
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
 
     const counts = deps.db
       .select({

--- a/packages/api/src/routes/materials.ts
+++ b/packages/api/src/routes/materials.ts
@@ -1,0 +1,123 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import {
+  AlreadyEnrolledError,
+  UnknownMaterialError,
+  enrollUser,
+} from '../lib/enrollment.js';
+import { MATERIALS, getMaterial } from '../lib/materials.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface MaterialsRoutesDeps {
+  db: DB;
+  now?: () => number;
+}
+
+interface EnrollBody {
+  materialId: string;
+  clubTier?: number | null;
+}
+
+export function materialsRoutes(deps: MaterialsRoutesDeps) {
+  const app = new Hono<{ Variables: SessionVariables }>();
+
+  app.use('*', requireAuth());
+
+  app.get('/', (c) => {
+    return c.json({ materials: MATERIALS });
+  });
+
+  app.post('/enroll', async (c) => {
+    const user = getUser(c);
+    let body: EnrollBody;
+    try {
+      body = await c.req.json<EnrollBody>();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (typeof body.materialId !== 'string') {
+      return c.json({ error: 'materialId required' }, 400);
+    }
+    if (body.clubTier != null && typeof body.clubTier !== 'number') {
+      return c.json({ error: 'clubTier must be a number or null' }, 400);
+    }
+
+    try {
+      const result = enrollUser({
+        db: deps.db,
+        userId: user.id,
+        materialId: body.materialId,
+        clubTier: body.clubTier ?? null,
+        now: deps.now,
+      });
+      return c.json({ materialId: body.materialId, snapshotId: result.snapshotId, version: result.version });
+    } catch (err) {
+      if (err instanceof UnknownMaterialError) return c.json({ error: err.message }, 404);
+      if (err instanceof AlreadyEnrolledError) return c.json({ error: 'Already enrolled' }, 409);
+      throw err;
+    }
+  });
+
+  app.get('/:id/status', (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('id');
+    const material = getMaterial(materialId);
+    if (!material) return c.json({ error: 'Unknown material' }, 404);
+
+    const enrolled = deps.db
+      .select()
+      .from(schema.userMaterials)
+      .where(
+        and(
+          eq(schema.userMaterials.userId, user.id),
+          eq(schema.userMaterials.materialId, materialId),
+        ),
+      )
+      .get();
+    if (!enrolled) return c.json({ error: 'Not enrolled' }, 404);
+
+    const counts = deps.db
+      .select({
+        state: schema.cardStates.state,
+        count: sql<number>`count(*)`.as('count'),
+      })
+      .from(schema.cardStates)
+      .where(
+        and(
+          eq(schema.cardStates.userId, user.id),
+          eq(schema.cardStates.materialId, materialId),
+        ),
+      )
+      .groupBy(schema.cardStates.state)
+      .all();
+
+    const byState = { new: 0, learning: 0, review: 0, relearning: 0 };
+    for (const row of counts) byState[row.state] = row.count;
+
+    const nextDue = deps.db
+      .select({ dueDateSecs: schema.cardStates.dueDateSecs })
+      .from(schema.cardStates)
+      .where(
+        and(
+          eq(schema.cardStates.userId, user.id),
+          eq(schema.cardStates.materialId, materialId),
+          sql`${schema.cardStates.dueDateSecs} IS NOT NULL`,
+        ),
+      )
+      .orderBy(schema.cardStates.dueDateSecs)
+      .limit(1)
+      .get();
+
+    return c.json({
+      materialId,
+      clubTier: enrolled.clubTier,
+      cardCounts: byState,
+      nextDueSecs: nextDue?.dueDateSecs ?? null,
+    });
+  });
+
+  return app;
+}

--- a/packages/api/src/routes/stats.test.ts
+++ b/packages/api/src/routes/stats.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createTestApp, signUpTestUser } from '../test-utils.js';
+
+const MATERIAL_ID = 'nkjv-1cor';
+
+interface StatsResponse {
+  materialId: string;
+  versesLearned: number;
+  retentionRate: number | null;
+  totalGrades: number;
+  edgeDistribution: Record<'weak' | 'learning' | 'familiar' | 'strong' | 'mastered', number>;
+}
+
+describe('stats routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('requires auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const res = await test.app.request(`/api/stats/${MATERIAL_ID}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 for an unknown material', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const res = await test.app.request('/api/stats/does-not-exist', { headers: { cookie } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 for a caller that has not enrolled', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const res = await test.app.request(`/api/stats/${MATERIAL_ID}`, { headers: { cookie } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns baseline zeros after enrollment, no reviews yet', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
+    });
+
+    const res = await test.app.request(`/api/stats/${MATERIAL_ID}`, { headers: { cookie } });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as StatsResponse;
+    expect(body.materialId).toBe(MATERIAL_ID);
+    expect(body.versesLearned).toBe(0);
+    expect(body.retentionRate).toBeNull();
+    expect(body.totalGrades).toBe(0);
+    for (const count of Object.values(body.edgeDistribution)) expect(count).toBe(0);
+  });
+
+  it('reflects review activity', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await test.app.request('/api/materials/enroll', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
+    });
+
+    const startRes = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        materialId: MATERIAL_ID,
+        newVerses: [{ verse_ref: 0, verse_phrases: [2, 3, 4] }],
+      }),
+    });
+    const start = (await startRes.json()) as {
+      sessionId: string;
+      card: { shown: number[]; hidden: number[]; is_reading: boolean };
+    };
+
+    let card = start.card;
+    let guard = 0;
+    while (card) {
+      const grades = card.is_reading
+        ? []
+        : card.hidden.map((node_id) => ({ node_id, grade: 3 as const }));
+      const reviewRes = await test.app.request(`/api/sessions/${start.sessionId}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify({ grades }),
+      });
+      const body = (await reviewRes.json()) as { done: boolean; card: typeof card | null };
+      if (body.done || !body.card) break;
+      card = body.card;
+      if (++guard > 30) throw new Error('loop guard');
+    }
+
+    const res = await test.app.request(`/api/stats/${MATERIAL_ID}`, { headers: { cookie } });
+    const body = (await res.json()) as StatsResponse;
+    expect(body.totalGrades).toBeGreaterThan(0);
+    expect(body.retentionRate).toBe(1); // all grades were 3 = pass
+    const edgeTotal = Object.values(body.edgeDistribution).reduce((a, b) => a + b, 0);
+    expect(edgeTotal).toBeGreaterThan(0);
+  });
+});

--- a/packages/api/src/routes/stats.test.ts
+++ b/packages/api/src/routes/stats.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { createTestApp, signUpTestUser } from '../test-utils.js';
+import { createTestApp, enrollViaApi, signUpTestUser } from '../test-utils.js';
 
 const MATERIAL_ID = 'nkjv-1cor';
 
@@ -46,11 +46,7 @@ describe('stats routes', () => {
     const test = createTestApp();
     cleanup = test.cleanup;
     const { cookie } = await signUpTestUser(test, 'alice@example.com');
-    await test.app.request('/api/materials/enroll', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({ materialId: MATERIAL_ID }),
-    });
+    await enrollViaApi(test, cookie, MATERIAL_ID);
 
     const res = await test.app.request(`/api/stats/${MATERIAL_ID}`, { headers: { cookie } });
     expect(res.status).toBe(200);
@@ -66,11 +62,7 @@ describe('stats routes', () => {
     const test = createTestApp();
     cleanup = test.cleanup;
     const { cookie } = await signUpTestUser(test, 'alice@example.com');
-    await test.app.request('/api/materials/enroll', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({ materialId: MATERIAL_ID }),
-    });
+    await enrollViaApi(test, cookie, MATERIAL_ID);
 
     const startRes = await test.app.request('/api/sessions/start', {
       method: 'POST',

--- a/packages/api/src/routes/stats.test.ts
+++ b/packages/api/src/routes/stats.test.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { createTestApp, enrollViaApi, signUpTestUser } from '../test-utils.js';
@@ -56,6 +58,40 @@ describe('stats routes', () => {
     expect(body.retentionRate).toBeNull();
     expect(body.totalGrades).toBe(0);
     for (const count of Object.values(body.edgeDistribution)) expect(count).toBe(0);
+  });
+
+  it('counts Hard (grade 2) as a pass, matching the core scheduler', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await enrollViaApi(test, cookie, MATERIAL_ID);
+
+    // Upload a synthetic event via sync so we control the exact grades.
+    const event = {
+      clientEventId: randomUUID(),
+      timestampSecs: 1_700_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2, 3, 4],
+      grades: [
+        { node_id: 2, grade: 2 as const },
+        { node_id: 3, grade: 3 as const },
+        { node_id: 4, grade: 4 as const },
+      ],
+    };
+    const uploadRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [event] }),
+    });
+    expect(uploadRes.status).toBe(200);
+
+    const res = await test.app.request(`/api/stats/${MATERIAL_ID}`, { headers: { cookie } });
+    const body = (await res.json()) as StatsResponse;
+    expect(body.totalGrades).toBe(3);
+    // Hard, Good, Easy all count as passes per crates/core/src/types.rs::is_pass.
+    expect(body.retentionRate).toBe(1);
   });
 
   it('reflects review activity', async () => {

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -1,0 +1,112 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import { getMaterial } from '../lib/materials.js';
+import type { Grade } from '../lib/review-log.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface StatsRoutesDeps {
+  db: DB;
+}
+
+/** Stability buckets in days, tuned roughly to "how long until you'd forget it". */
+const EDGE_BUCKETS = [
+  { label: 'weak', max: 1 },
+  { label: 'learning', max: 7 },
+  { label: 'familiar', max: 30 },
+  { label: 'strong', max: 90 },
+  { label: 'mastered', max: Infinity },
+] as const;
+
+type BucketLabel = (typeof EDGE_BUCKETS)[number]['label'];
+
+export function statsRoutes(deps: StatsRoutesDeps) {
+  const app = new Hono<{ Variables: SessionVariables }>();
+
+  app.use('*', requireAuth());
+
+  app.get('/:materialId', (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+    const material = getMaterial(materialId);
+    if (!material) return c.json({ error: 'Unknown material' }, 404);
+
+    const enrolled = deps.db
+      .select()
+      .from(schema.userMaterials)
+      .where(
+        and(
+          eq(schema.userMaterials.userId, user.id),
+          eq(schema.userMaterials.materialId, materialId),
+        ),
+      )
+      .get();
+    if (!enrolled) return c.json({ error: 'Not enrolled' }, 404);
+
+    const versesLearnedRow = deps.db
+      .select({ count: sql<number>`count(*)`.as('count') })
+      .from(schema.cardStates)
+      .where(
+        and(
+          eq(schema.cardStates.userId, user.id),
+          eq(schema.cardStates.materialId, materialId),
+          eq(schema.cardStates.state, 'review'),
+        ),
+      )
+      .get();
+
+    const events = deps.db
+      .select({ grades: schema.reviewEvents.grades })
+      .from(schema.reviewEvents)
+      .where(
+        and(
+          eq(schema.reviewEvents.userId, user.id),
+          eq(schema.reviewEvents.materialId, materialId),
+        ),
+      )
+      .all();
+    let gradeCount = 0;
+    let passCount = 0;
+    for (const row of events) {
+      const grades = JSON.parse(row.grades.toString('utf8')) as Grade[];
+      for (const g of grades) {
+        gradeCount += 1;
+        if (g.grade >= 3) passCount += 1;
+      }
+    }
+
+    const edges = deps.db
+      .select({ stability: schema.edgeStates.stability })
+      .from(schema.edgeStates)
+      .where(
+        and(
+          eq(schema.edgeStates.userId, user.id),
+          eq(schema.edgeStates.materialId, materialId),
+        ),
+      )
+      .all();
+    const edgeDistribution: Record<BucketLabel, number> = {
+      weak: 0,
+      learning: 0,
+      familiar: 0,
+      strong: 0,
+      mastered: 0,
+    };
+    for (const e of edges) {
+      const bucket = EDGE_BUCKETS.find((b) => e.stability < b.max)!;
+      edgeDistribution[bucket.label] += 1;
+    }
+
+    return c.json({
+      materialId,
+      versesLearned: versesLearnedRow?.count ?? 0,
+      retentionRate: gradeCount > 0 ? passCount / gradeCount : null,
+      totalGrades: gradeCount,
+      edgeDistribution,
+    });
+  });
+
+  return app;
+}

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -3,8 +3,9 @@ import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
-import { getMaterial } from '../lib/materials.js';
-import type { Grade } from '../lib/review-log.js';
+import { NotEnrolledError } from '../lib/engine.js';
+import { requireEnrollment } from '../lib/enrollment.js';
+import { type Grade, isPass } from '../lib/review-log.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface StatsRoutesDeps {
@@ -12,15 +13,7 @@ export interface StatsRoutesDeps {
 }
 
 /** Stability buckets in days, tuned roughly to "how long until you'd forget it". */
-const EDGE_BUCKETS = [
-  { label: 'weak', max: 1 },
-  { label: 'learning', max: 7 },
-  { label: 'familiar', max: 30 },
-  { label: 'strong', max: 90 },
-  { label: 'mastered', max: Infinity },
-] as const;
-
-type BucketLabel = (typeof EDGE_BUCKETS)[number]['label'];
+type BucketLabel = 'weak' | 'learning' | 'familiar' | 'strong' | 'mastered';
 
 export function statsRoutes(deps: StatsRoutesDeps) {
   const app = new Hono<{ Variables: SessionVariables }>();
@@ -30,20 +23,12 @@ export function statsRoutes(deps: StatsRoutesDeps) {
   app.get('/:materialId', (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
-    const material = getMaterial(materialId);
-    if (!material) return c.json({ error: 'Unknown material' }, 404);
-
-    const enrolled = deps.db
-      .select()
-      .from(schema.userMaterials)
-      .where(
-        and(
-          eq(schema.userMaterials.userId, user.id),
-          eq(schema.userMaterials.materialId, materialId),
-        ),
-      )
-      .get();
-    if (!enrolled) return c.json({ error: 'Not enrolled' }, 404);
+    try {
+      requireEnrollment(deps.db, { userId: user.id, materialId });
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
 
     const versesLearnedRow = deps.db
       .select({ count: sql<number>`count(*)`.as('count') })
@@ -73,12 +58,19 @@ export function statsRoutes(deps: StatsRoutesDeps) {
       const grades = JSON.parse(row.grades.toString('utf8')) as Grade[];
       for (const g of grades) {
         gradeCount += 1;
-        if (g.grade >= 3) passCount += 1;
+        if (isPass(g)) passCount += 1;
       }
     }
 
-    const edges = deps.db
-      .select({ stability: schema.edgeStates.stability })
+    const stability = schema.edgeStates.stability;
+    const histogram = deps.db
+      .select({
+        weak: sql<number>`coalesce(sum(case when ${stability} < 1 then 1 else 0 end), 0)`,
+        learning: sql<number>`coalesce(sum(case when ${stability} >= 1 and ${stability} < 7 then 1 else 0 end), 0)`,
+        familiar: sql<number>`coalesce(sum(case when ${stability} >= 7 and ${stability} < 30 then 1 else 0 end), 0)`,
+        strong: sql<number>`coalesce(sum(case when ${stability} >= 30 and ${stability} < 90 then 1 else 0 end), 0)`,
+        mastered: sql<number>`coalesce(sum(case when ${stability} >= 90 then 1 else 0 end), 0)`,
+      })
       .from(schema.edgeStates)
       .where(
         and(
@@ -86,18 +78,14 @@ export function statsRoutes(deps: StatsRoutesDeps) {
           eq(schema.edgeStates.materialId, materialId),
         ),
       )
-      .all();
-    const edgeDistribution: Record<BucketLabel, number> = {
+      .get();
+    const edgeDistribution: Record<BucketLabel, number> = histogram ?? {
       weak: 0,
       learning: 0,
       familiar: 0,
       strong: 0,
       mastered: 0,
     };
-    for (const e of edges) {
-      const bucket = EDGE_BUCKETS.find((b) => e.stability < b.max)!;
-      edgeDistribution[bucket.label] += 1;
-    }
 
     return c.json({
       materialId,

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -108,7 +108,10 @@ describe('sync routes', () => {
     expect(body.snapshot.graphData).toBeTruthy();
     expect(body.snapshot.cardsData).toBeTruthy();
     expect(body.edgeStates).toEqual([]);
-    expect(body.cardStates).toEqual([]);
+    // Enrollment seeds card_states with all cards in 'new' so the status
+    // endpoint can report accurate counts without a review happening first.
+    expect(body.cardStates.length).toBeGreaterThan(0);
+    expect(body.cardStates.every((c) => c.state === 'new')).toBe(true);
     expect(body.lastEventId).toBeNull();
   });
 

--- a/packages/api/src/test-fixtures.ts
+++ b/packages/api/src/test-fixtures.ts
@@ -1,87 +1,22 @@
-import { randomUUID } from 'node:crypto';
-
 import type { DB } from './db/client.js';
 import * as schema from './db/schema.js';
-import { jsonBlob } from './lib/keys.js';
-
-export interface FixtureGraph {
-  nodes: Record<string, { id: number; kind: unknown }>;
-  edges: Record<string, FixtureEdge>;
-  outgoing: Record<string, number[]>;
-  incoming: Record<string, number[]>;
-  next_node_id: number;
-  next_edge_id: number;
-}
-
-interface FixtureEdge {
-  id: number;
-  kind: string;
-  source: number;
-  target: number;
-  state: { stability: number; difficulty: number; last_review_secs: number };
-}
-
-export interface FixtureCard {
-  id: number;
-  shown: number[];
-  hidden: number[];
-  state: 'New' | 'Learning' | 'Review' | 'Relearning';
-}
-
-/** Mirrors `crates/wasm/test-smoke.js` — minimum shape the engine will accept. */
-export function buildSingleVerseFixture(): { graph: FixtureGraph; cards: FixtureCard[] } {
-  const edgeState = { stability: 5.0, difficulty: 5.0, last_review_secs: 0 };
-  const graph: FixtureGraph = {
-    nodes: {
-      '0': { id: 0, kind: { Reference: { chapter: 3, verse: 16 } } },
-      '1': { id: 1, kind: { VerseGist: { chapter: 3, verse: 16 } } },
-      '2': { id: 2, kind: { Phrase: { text: 'phrase one', verse_id: 0, position: 0 } } },
-      '3': { id: 3, kind: { Phrase: { text: 'phrase two', verse_id: 0, position: 1 } } },
-      '4': { id: 4, kind: { Phrase: { text: 'phrase three', verse_id: 0, position: 2 } } },
-    },
-    edges: {},
-    outgoing: { '0': [], '1': [], '2': [], '3': [], '4': [] },
-    incoming: { '0': [], '1': [], '2': [], '3': [], '4': [] },
-    next_node_id: 5,
-    next_edge_id: 0,
-  };
-
-  const addBi = (kind: string, a: number, b: number) => {
-    const fwd = graph.next_edge_id++;
-    const bwd = graph.next_edge_id++;
-    graph.edges[String(fwd)] = { id: fwd, kind, source: a, target: b, state: edgeState };
-    graph.edges[String(bwd)] = { id: bwd, kind, source: b, target: a, state: edgeState };
-    graph.outgoing[String(a)]!.push(fwd);
-    graph.incoming[String(b)]!.push(fwd);
-    graph.outgoing[String(b)]!.push(bwd);
-    graph.incoming[String(a)]!.push(bwd);
-  };
-
-  addBi('VerseGistReference', 1, 0);
-  addBi('PhraseVerseGist', 2, 1);
-  addBi('PhraseVerseGist', 3, 1);
-  addBi('PhraseVerseGist', 4, 1);
-  addBi('PhrasePhrase', 2, 3);
-  addBi('PhrasePhrase', 3, 4);
-
-  const cards: FixtureCard[] = [{ id: 0, shown: [0], hidden: [2, 3, 4], state: 'New' }];
-
-  return { graph, cards };
-}
+import { enrollUser } from './lib/enrollment.js';
 
 export interface SeedOptions {
   db: DB;
   userId: string;
   materialId: string;
-  version?: number;
   /** Off when the user already exists (e.g. created by Better Auth sign-up). */
   createUser?: boolean;
 }
 
+/**
+ * Test helper: enrolls a user in the placeholder `nkjv-1cor` material,
+ * optionally creating the user row first (for tests that don't sign up
+ * via Better Auth).
+ */
 export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; version: number } {
   const { db, userId, materialId } = opts;
-  const version = opts.version ?? 1;
-  const { graph, cards } = buildSingleVerseFixture();
   const now = Math.floor(Date.now() / 1000);
 
   if (opts.createUser ?? true) {
@@ -96,21 +31,6 @@ export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; ve
       })
       .run();
   }
-  db.insert(schema.userMaterials)
-    .values({ userId, materialId, clubTier: null, createdAt: now })
-    .run();
-  const snapshotId = randomUUID();
-  db.insert(schema.graphSnapshots)
-    .values({
-      id: snapshotId,
-      userId,
-      materialId,
-      version,
-      graphData: jsonBlob(graph),
-      cardsData: jsonBlob(cards),
-      createdAt: now,
-    })
-    .run();
 
-  return { snapshotId, version };
+  return enrollUser({ db, userId, materialId, now: () => now });
 }

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -66,3 +66,18 @@ export async function signUpTestUser(
   if (!row) throw new Error(`user not found: ${email}`);
   return { cookie, userId: row.id };
 }
+
+/** Hits POST /api/materials/enroll and asserts success. */
+export async function enrollViaApi(
+  test: TestApp,
+  cookie: string,
+  materialId: string,
+  clubTier: number | null = null,
+): Promise<void> {
+  const res = await test.app.request('/api/materials/enroll', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', cookie },
+    body: JSON.stringify({ materialId, clubTier }),
+  });
+  expect(res.status).toBe(200);
+}


### PR DESCRIPTION
## Summary

Completes Phase 3E: the materials catalog, enrollment, per-material status, and stats endpoints.

- `GET /api/materials` — static manifest (one placeholder material today; the content pipeline will feed it later)
- `POST /api/materials/enroll` — inserts `user_materials` + initial `graph_snapshots` + seeds `card_states` so status works pre-review; 404 for unknown material, 409 for duplicate enrollment
- `GET /api/materials/:id/status` — card-state counts + next-due time
- `GET /api/stats/:materialId` — `versesLearned`, `retentionRate`, `totalGrades`, `edgeDistribution` (stability buckets computed in SQL)

## Supporting changes

- `lib/materials.ts` — manifest + template builder (previously baked into `test-fixtures.ts` as `buildSingleVerseFixture`)
- `lib/enrollment.ts` — `enrollUser` shared between the HTTP route and the test fixture path; `requireEnrollment` helper used by materials/status and stats routes via the existing `NotEnrolledError`
- `lib/review-log.ts` — `isPass` helper mirroring the core's `Grade::is_pass` so the retention math isn't a magic number
- `test-utils.ts` — shared `enrollViaApi` helper so tests stop open-coding the enroll POST
- Docs: extends `docs/server-api.md` with all four endpoints + stability-bucket definition; marks 3E complete in ROADMAP

## Test plan

- [x] `pnpm test` — 34 tests pass (11 new across `materials.test.ts` + `stats.test.ts`)
- [x] `pnpm type-check`
- [x] `pnpm exec dprint check`
- [x] `cargo clippy --workspace` + `cargo fmt --check` (no Rust changes but kept clean)
- [ ] Manual smoke: register → enroll → start/review → stats via curl

## Known follow-ups (tracked in plan carry-overs)

- `retentionRate` still iterates `review_events` and JSON-parses grades in JS; denormalizing `pass_count`/`grade_count` onto `review_events` at write time is the right long-term fix but requires a migration and changes to both write paths — deferred.
- `buildMaterialTemplate` rebuilds the graph in JS on each enrollment; once real Bible templates land, cache the template blobs at module load.

🤖 Generated with [Claude Code](https://claude.ai/code)