### PR TITLE
Phase 3 polish: wire-level HTTP contracts before Phase 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-/.claude/settings.local.json
+/.claude/
 /target
 /data/
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,9 @@
 # Roadmap
 
+Active work and planning happens in
+[GitHub Issues](https://github.com/TommyAmberson/verse-vault/issues). This file records what has
+shipped and points to the open work that's coming next.
+
 ## Phase 1: Core Algorithm ✅
 
 Edge-based memory graph with FSRS integration.
@@ -69,37 +73,34 @@ on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline
 
 ## Phase 4: Frontends
 
-Each sub-phase is its own mergeable workstream, comparable in scope to any of 3A–3E.
+Each sub-phase is its own mergeable workstream, comparable in scope to any of 3A–3E. Suggested order
+— 4A unlocks real usage, 4B is a parallel-track CLI, 4C and 4D layer on top of 4A.
 
-### Phase 4A: Vue web app (thin client)
+1. [#9 Phase 4A: Vue web app (thin client)](https://github.com/TommyAmberson/verse-vault/issues/9)
+2. [#10 Phase 4B: CLI](https://github.com/TommyAmberson/verse-vault/issues/10)
+3. [#11 Phase 4C: WASM offline in the web app](https://github.com/TommyAmberson/verse-vault/issues/11)
+   — blocked by #9, #15, #16
+4. [#12 Phase 4D: Tauri desktop](https://github.com/TommyAmberson/verse-vault/issues/12) — blocked
+   by #9, #11
 
-* [ ] `apps/web/` scaffold (Vue 3 + Vite + TypeScript)
-* [ ] Better Auth browser client (sign-in/sign-up, Google OAuth)
-* [ ] Materials list + enroll + status screens
-* [ ] Session screen (start / next / review / done)
-* [ ] Stats screen
-* [ ] Playwright smoke test
+## Known tech debt
 
-### Phase 4B: CLI
+Deferred items from Phase 3 — none block Phase 4 on day one, but each should land before real users
+exist.
 
-* [ ] `apps/cli/` terminal review tool consuming the server API
-
-### Phase 4C: WASM offline in the web app
-
-* [ ] IndexedDB cache of snapshot + edge/card state + pending events
-* [ ] WASM engine applied locally, synced via `/sync/:materialId/events`
-* [ ] 409 reconciliation on stale `snapshotVersion`
-
-### Phase 4D: Tauri desktop
-
-* [ ] `apps/desktop/` Tauri scaffold wrapping the web UI
-* [ ] Native Rust core (no WASM in the desktop build)
-* [ ] OS-keychain auth storage
+* [#13 EngineStore eviction (TTL/LRU + engine.free())](https://github.com/TommyAmberson/verse-vault/issues/13)
+* [#14 SessionStore eviction (idle reaper)](https://github.com/TommyAmberson/verse-vault/issues/14)
+* [#15 WASM delta export for edge/card state](https://github.com/TommyAmberson/verse-vault/issues/15)
+* [#16 Snapshot versioning + invalidation flow](https://github.com/TommyAmberson/verse-vault/issues/16)
+* [#17 Retention tuning knob (per-user desiredRetention)](https://github.com/TommyAmberson/verse-vault/issues/17)
+* [#18 Engine mutation before DB transaction in sync POST](https://github.com/TommyAmberson/verse-vault/issues/18)
 
 ## Future
 
-* [ ] Per-user FSRS parameter optimization (from review history)
-* [ ] Multiple translations (ESV, NIV — with licensing)
-* [ ] Team features for QuizMeet teams
-* [ ] Customizable learning flow
-* [ ] Import from Anki
+Long-horizon ideas; not filed as issues yet.
+
+* Per-user FSRS parameter optimization (from review history)
+* Multiple translations (ESV, NIV — with licensing)
+* Team features for QuizMeet teams
+* Customizable learning flow
+* Import from Anki

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Work with real Bible content.
 * [x] Club 150/300 verse list loading
 * [x] Heading data loading
 
-## Phase 3: Persistence + Server + Clients
+## Phase 3: Persistence + Server ✅
 
 Architecture established in `docs/architecture.md`. TS server wrapping the Rust core via WASM; Node
 on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline sync.
@@ -67,11 +67,34 @@ on a VPS; Better Auth; Drizzle + SQLite; event-sourced reviews for clean offline
 * [x] `GET /api/materials/:id/status`
 * [x] `GET /api/stats/:materialId`
 
-### Phase 3F: Frontends
+## Phase 4: Frontends
 
-* [ ] Vue web app
-* [ ] Tauri desktop app
-* [ ] CLI for terminal review
+Each sub-phase is its own mergeable workstream, comparable in scope to any of 3A–3E.
+
+### Phase 4A: Vue web app (thin client)
+
+* [ ] `apps/web/` scaffold (Vue 3 + Vite + TypeScript)
+* [ ] Better Auth browser client (sign-in/sign-up, Google OAuth)
+* [ ] Materials list + enroll + status screens
+* [ ] Session screen (start / next / review / done)
+* [ ] Stats screen
+* [ ] Playwright smoke test
+
+### Phase 4B: CLI
+
+* [ ] `apps/cli/` terminal review tool consuming the server API
+
+### Phase 4C: WASM offline in the web app
+
+* [ ] IndexedDB cache of snapshot + edge/card state + pending events
+* [ ] WASM engine applied locally, synced via `/sync/:materialId/events`
+* [ ] 409 reconciliation on stale `snapshotVersion`
+
+### Phase 4D: Tauri desktop
+
+* [ ] `apps/desktop/` Tauri scaffold wrapping the web UI
+* [ ] Native Rust core (no WASM in the desktop build)
+* [ ] OS-keychain auth storage
 
 ## Future
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,6 +95,19 @@ exist.
 * [#17 Retention tuning knob (per-user desiredRetention)](https://github.com/TommyAmberson/verse-vault/issues/17)
 * [#18 Engine mutation before DB transaction in sync POST](https://github.com/TommyAmberson/verse-vault/issues/18)
 
+## Before public launch
+
+Near-term operational work that should land before real users exist. Not filed as issues yet —
+promote to issues when a phase picks them up.
+
+* Content pipeline integration — wire the `tools/` Python scripts (Anki parsing, verse chunking)
+  into material enrollment so a new material produces a `graph_snapshots` row end-to-end
+* Observability — structured logging, request tracing, metrics (review throughput, engine load time,
+  cache hit rate)
+* Rate limiting + abuse controls — per-user/IP limits on review endpoints
+* Database backups + migration testing — file-based SQLite on a VPS needs a backup story
+  (litestream? periodic snapshots?) and a migration rehearsal process
+
 ## Future
 
 Long-horizon ideas; not filed as issues yet.

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -193,6 +193,10 @@ Side effects are a single transaction: append new events, upsert the union of ch
 every card's state. See [persistence.md](persistence.md#upload-flow--post-apisyncmaterialidevents)
 for replay semantics.
 
+`lastEventId` is the chronologically latest event (ordered by `timestampSecs` then `id`), the same
+value GET `/state` returns. Safe to use as a resume cursor — re-uploading an older batch does not
+rewind it.
+
 ## Materials — `/api/materials/*`
 
 Catalog of available materials + per-user enrollment. The catalog is a static manifest today; the

--- a/packages/api/src/lib/enrollment.test.ts
+++ b/packages/api/src/lib/enrollment.test.ts
@@ -1,24 +1,9 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import * as schema from '../db/schema.js';
-import { createTestDb } from '../test-utils.js';
+import { createTestDb, createTestUser } from '../test-utils.js';
 import { AlreadyEnrolledError, UnknownMaterialError, enrollUser } from './enrollment.js';
 
 const MATERIAL_ID = 'nkjv-1cor';
-
-function createUser(db: ReturnType<typeof createTestDb>['db'], userId: string): void {
-  const now = Math.floor(Date.now() / 1000);
-  db.insert(schema.user)
-    .values({
-      id: userId,
-      email: `${userId}@example.com`,
-      name: userId,
-      emailVerified: false,
-      createdAt: new Date(now * 1000),
-      updatedAt: new Date(now * 1000),
-    })
-    .run();
-}
 
 describe('enrollUser', () => {
   let cleanup: (() => void) | null = null;
@@ -30,7 +15,7 @@ describe('enrollUser', () => {
   it('enrolls a new user', () => {
     const test = createTestDb();
     cleanup = test.cleanup;
-    createUser(test.db, 'u1');
+    createTestUser(test.db, 'u1');
 
     const result = enrollUser({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
     expect(result.version).toBe(1);
@@ -40,7 +25,7 @@ describe('enrollUser', () => {
   it('throws UnknownMaterialError for unknown materials', () => {
     const test = createTestDb();
     cleanup = test.cleanup;
-    createUser(test.db, 'u1');
+    createTestUser(test.db, 'u1');
 
     expect(() =>
       enrollUser({ db: test.db, userId: 'u1', materialId: 'does-not-exist' }),
@@ -54,7 +39,7 @@ describe('enrollUser', () => {
     // 500.
     const test = createTestDb();
     cleanup = test.cleanup;
-    createUser(test.db, 'u1');
+    createTestUser(test.db, 'u1');
 
     enrollUser({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
 

--- a/packages/api/src/lib/enrollment.test.ts
+++ b/packages/api/src/lib/enrollment.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../db/schema.js';
+import { createTestDb } from '../test-utils.js';
+import { AlreadyEnrolledError, UnknownMaterialError, enrollUser } from './enrollment.js';
+
+const MATERIAL_ID = 'nkjv-1cor';
+
+function createUser(db: ReturnType<typeof createTestDb>['db'], userId: string): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.insert(schema.user)
+    .values({
+      id: userId,
+      email: `${userId}@example.com`,
+      name: userId,
+      emailVerified: false,
+      createdAt: new Date(now * 1000),
+      updatedAt: new Date(now * 1000),
+    })
+    .run();
+}
+
+describe('enrollUser', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('enrolls a new user', () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createUser(test.db, 'u1');
+
+    const result = enrollUser({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+    expect(result.version).toBe(1);
+    expect(result.snapshotId).toBeTruthy();
+  });
+
+  it('throws UnknownMaterialError for unknown materials', () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createUser(test.db, 'u1');
+
+    expect(() =>
+      enrollUser({ db: test.db, userId: 'u1', materialId: 'does-not-exist' }),
+    ).toThrow(UnknownMaterialError);
+  });
+
+  it('throws AlreadyEnrolledError when the PK constraint fires', () => {
+    // Simulates the concurrent-enroll race: another request already wrote the
+    // user_materials row between a would-be pre-check and this insert. The PK
+    // constraint is now the authoritative guard and must surface as 409, not
+    // 500.
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createUser(test.db, 'u1');
+
+    enrollUser({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+
+    expect(() => enrollUser({ db: test.db, userId: 'u1', materialId: MATERIAL_ID })).toThrow(
+      AlreadyEnrolledError,
+    );
+  });
+});

--- a/packages/api/src/lib/enrollment.ts
+++ b/packages/api/src/lib/enrollment.ts
@@ -8,6 +8,16 @@ import { NotEnrolledError } from './engine.js';
 import { type UserMaterial, jsonBlob } from './keys.js';
 import { type MaterialCard, buildMaterialTemplate, getMaterial } from './materials.js';
 
+/** better-sqlite3 surfaces constraint violations on `.code`. */
+function isUserMaterialsPkViolation(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: string }).code;
+  return (
+    (code === 'SQLITE_CONSTRAINT_PRIMARYKEY' || code === 'SQLITE_CONSTRAINT_UNIQUE') &&
+    err.message.includes('user_materials')
+  );
+}
+
 export interface EnrollArgs {
   db: DB;
   userId: string;
@@ -57,6 +67,10 @@ export function requireEnrollment(
  * Enrolls a user in a material. Inserts the `user_materials` row, the initial
  * `graph_snapshots` row from the material template, and seeds `card_states`
  * so status queries can hit a populated table even before the first review.
+ *
+ * The user_materials PK on (user_id, material_id) is the authoritative guard
+ * against duplicate enrollment — a concurrent double-enroll is mapped to
+ * AlreadyEnrolledError rather than bubbling up as a 500.
  */
 export function enrollUser(args: EnrollArgs): { snapshotId: string; version: number } {
   const { db, userId, materialId } = args;
@@ -65,59 +79,52 @@ export function enrollUser(args: EnrollArgs): { snapshotId: string; version: num
   const material = getMaterial(materialId);
   if (!material) throw new UnknownMaterialError(materialId);
 
-  const existing = db
-    .select()
-    .from(schema.userMaterials)
-    .where(
-      and(
-        eq(schema.userMaterials.userId, userId),
-        eq(schema.userMaterials.materialId, materialId),
-      ),
-    )
-    .get();
-  if (existing) throw new AlreadyEnrolledError(userId, materialId);
-
   const template = buildMaterialTemplate(materialId);
   const snapshotId = randomUUID();
   const createdAt = now();
 
-  db.transaction((tx) => {
-    tx.insert(schema.userMaterials)
-      .values({
-        userId,
-        materialId,
-        clubTier: args.clubTier ?? null,
-        createdAt,
-      })
-      .run();
-    tx.insert(schema.graphSnapshots)
-      .values({
-        id: snapshotId,
-        userId,
-        materialId,
-        version: 1,
-        graphData: jsonBlob(template.graph),
-        cardsData: jsonBlob(template.cards),
-        createdAt,
-      })
-      .run();
+  try {
+    db.transaction((tx) => {
+      tx.insert(schema.userMaterials)
+        .values({
+          userId,
+          materialId,
+          clubTier: args.clubTier ?? null,
+          createdAt,
+        })
+        .run();
+      tx.insert(schema.graphSnapshots)
+        .values({
+          id: snapshotId,
+          userId,
+          materialId,
+          version: 1,
+          graphData: jsonBlob(template.graph),
+          cardsData: jsonBlob(template.cards),
+          createdAt,
+        })
+        .run();
 
-    // MaterialCard.state stays PascalCase because that's what Rust's serde
-    // produces for the CardState enum on the WASM side; card_states on the
-    // DB is the lowercase union so we normalize on the way in.
-    const cardRows = template.cards.map((c: MaterialCard) => ({
-      userId,
-      materialId,
-      cardId: c.id,
-      state: c.state.toLowerCase() as Lowercase<MaterialCard['state']>,
-      dueR: null,
-      dueDateSecs: null,
-      priority: null,
-    }));
-    if (cardRows.length > 0) {
-      tx.insert(schema.cardStates).values(cardRows).run();
-    }
-  });
+      // MaterialCard.state stays PascalCase because that's what Rust's serde
+      // produces for the CardState enum on the WASM side; card_states on the
+      // DB is the lowercase union so we normalize on the way in.
+      const cardRows = template.cards.map((c: MaterialCard) => ({
+        userId,
+        materialId,
+        cardId: c.id,
+        state: c.state.toLowerCase() as Lowercase<MaterialCard['state']>,
+        dueR: null,
+        dueDateSecs: null,
+        priority: null,
+      }));
+      if (cardRows.length > 0) {
+        tx.insert(schema.cardStates).values(cardRows).run();
+      }
+    });
+  } catch (err) {
+    if (isUserMaterialsPkViolation(err)) throw new AlreadyEnrolledError(userId, materialId);
+    throw err;
+  }
 
   return { snapshotId, version: 1 };
 }

--- a/packages/api/src/routes/sessions.test.ts
+++ b/packages/api/src/routes/sessions.test.ts
@@ -49,6 +49,18 @@ describe('session routes', () => {
     expect(res.status).toBe(401);
   });
 
+  it('returns 404 when the caller is not enrolled', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const res = await test.app.request('/api/sessions/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ materialId: MATERIAL_ID }),
+    });
+    expect(res.status).toBe(404);
+  });
+
   it('runs a full session: start → review → done', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;

--- a/packages/api/src/routes/sessions.ts
+++ b/packages/api/src/routes/sessions.ts
@@ -1,7 +1,7 @@
 import { type Context, Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
-import { EngineStore } from '../lib/engine.js';
+import { EngineStore, NotEnrolledError } from '../lib/engine.js';
 import { type Grade, type ReviewOutcome, recordReview } from '../lib/review-log.js';
 import { SessionStore, type SessionCard, type SessionEntry } from '../lib/sessions.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
@@ -44,7 +44,13 @@ export function sessionRoutes(deps: SessionRoutesDeps) {
       return c.json({ error: 'materialId required' }, 400);
     }
     const user = getUser(c);
-    const loaded = await deps.engines.load({ userId: user.id, materialId: body.materialId });
+    let loaded;
+    try {
+      loaded = await deps.engines.load({ userId: user.id, materialId: body.materialId });
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
     const nowSecs = now();
     try {
       loaded.engine.start_session(

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -222,6 +222,37 @@ describe('sync routes', () => {
     expect(res.status).toBe(413);
   });
 
+  it('rejects non-finite or non-integer numeric fields with 400', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'alice@example.com');
+
+    const base = {
+      clientEventId: randomUUID(),
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2],
+      grades: [{ node_id: 2, grade: 3 as const }],
+    };
+    const bad = [
+      { ...base, timestampSecs: Number.NaN },
+      { ...base, timestampSecs: Number.POSITIVE_INFINITY },
+      { ...base, timestampSecs: 1.5 },
+      { ...base, timestampSecs: -1 },
+      { ...base, timestampSecs: 1_700_000_000, snapshotVersion: 0 },
+      { ...base, timestampSecs: 1_700_000_000, cardId: 1.5 },
+    ];
+    for (const event of bad) {
+      const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify({ events: [event] }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
   it('rejects a stale snapshot version with 409', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -200,6 +200,56 @@ describe('sync routes', () => {
     expect(afterSecond).toEqual(afterFirst);
   });
 
+  it('returns the chronologically latest lastEventId, even for older batches', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'alice@example.com');
+
+    const newer = {
+      clientEventId: randomUUID(),
+      timestampSecs: 2_000_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2],
+      grades: [{ node_id: 2, grade: 3 as const }],
+    };
+    const older = {
+      clientEventId: randomUUID(),
+      timestampSecs: 1_000_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+      shown: [0],
+      hidden: [2],
+      grades: [{ node_id: 2, grade: 3 as const }],
+    };
+
+    const firstRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [newer] }),
+    });
+    expect(firstRes.status).toBe(200);
+    const firstBody = (await firstRes.json()) as UploadResponse;
+    const newerId = firstBody.lastEventId;
+    expect(newerId).not.toBeNull();
+
+    const secondRes = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [older] }),
+    });
+    expect(secondRes.status).toBe(200);
+    const secondBody = (await secondRes.json()) as UploadResponse;
+    expect(secondBody.lastEventId).toBe(newerId);
+
+    const stateRes = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, {
+      headers: { cookie },
+    });
+    const stateBody = (await stateRes.json()) as StateResponse;
+    expect(stateBody.lastEventId).toBe(newerId);
+  });
+
   it('rejects batches larger than MAX_BATCH_SIZE with 413', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -232,9 +232,17 @@ function latestEventId(db: DB, userId: string, materialId: string): string | nul
 
 function validateUpload(e: ReviewEventUpload): string | null {
   if (typeof e.clientEventId !== 'string' || !e.clientEventId) return 'clientEventId required';
-  if (typeof e.timestampSecs !== 'number') return 'timestampSecs required';
-  if (typeof e.snapshotVersion !== 'number') return 'snapshotVersion required';
-  if (e.cardId !== null && typeof e.cardId !== 'number') return 'cardId must be number or null';
+  // NaN/Infinity/non-integer floats reach BigInt() at the engine boundary and
+  // throw RangeError → 500; reject them at the edge as 400 instead.
+  if (!Number.isInteger(e.timestampSecs) || e.timestampSecs < 0) {
+    return 'timestampSecs must be a non-negative integer';
+  }
+  if (!Number.isInteger(e.snapshotVersion) || e.snapshotVersion < 1) {
+    return 'snapshotVersion must be a positive integer';
+  }
+  if (e.cardId !== null && (!Number.isInteger(e.cardId) || e.cardId < 0)) {
+    return 'cardId must be a non-negative integer or null';
+  }
   if (!Array.isArray(e.shown)) return 'shown must be an array';
   if (!Array.isArray(e.hidden)) return 'hidden must be an array';
   if (!Array.isArray(e.grades)) return 'grades must be an array';

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -187,12 +187,15 @@ export function syncRoutes(deps: SyncRoutesDeps) {
 
     // Response carries the engine's full edge/card state so fat clients can
     // replace their local cache in one shot; DB writes are filtered above.
+    // `lastEventId` must agree with GET /state so clients can use it as a
+    // resume cursor — both report the chronologically latest event, not the
+    // last one in this batch (which may be older than pre-existing rows).
     return c.json({
       accepted: fresh.length,
       duplicates: events.length - fresh.length,
       edgeStates: allEdges,
       cardStates: allCards,
-      lastEventId: eventRows[eventRows.length - 1]!.id,
+      lastEventId: latestEventId(deps.db, user.id, materialId),
     });
   });
 

--- a/packages/api/src/test-fixtures.ts
+++ b/packages/api/src/test-fixtures.ts
@@ -1,6 +1,6 @@
 import type { DB } from './db/client.js';
-import * as schema from './db/schema.js';
 import { enrollUser } from './lib/enrollment.js';
+import { createTestUser } from './test-utils.js';
 
 export interface SeedOptions {
   db: DB;
@@ -19,18 +19,7 @@ export function seedUserWithFixture(opts: SeedOptions): { snapshotId: string; ve
   const { db, userId, materialId } = opts;
   const now = Math.floor(Date.now() / 1000);
 
-  if (opts.createUser ?? true) {
-    db.insert(schema.user)
-      .values({
-        id: userId,
-        email: `${userId}@example.com`,
-        name: userId,
-        emailVerified: false,
-        createdAt: new Date(now * 1000),
-        updatedAt: new Date(now * 1000),
-      })
-      .run();
-  }
+  if (opts.createUser ?? true) createTestUser(db, userId);
 
   return enrollUser({ db, userId, materialId, now: () => now });
 }

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -45,6 +45,21 @@ export function createTestApp() {
 
 export type TestApp = ReturnType<typeof createTestApp>;
 
+/** Inserts a bare user row for tests that don't need a Better Auth session. */
+export function createTestUser(db: DB, userId: string): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.insert(user)
+    .values({
+      id: userId,
+      email: `${userId}@example.com`,
+      name: userId,
+      emailVerified: false,
+      createdAt: new Date(now * 1000),
+      updatedAt: new Date(now * 1000),
+    })
+    .run();
+}
+
 /** Creates a user via Better Auth's email sign-up and returns the session cookie + user id. */
 export async function signUpTestUser(
   test: TestApp,


### PR DESCRIPTION
## Summary

Four wire-polish fixes that close out Phase 3 before frontends start on Phase 4. Each is a ~10-line fix with a focused test — the frontend would hit every one of these as a 500 where a 4xx belongs.

- **404 on unenrolled session start** — `/api/sessions/start` now matches the sync POST's `NotEnrolledError` → 404 pattern.
- **Tightened sync numeric validation** — `timestampSecs`, `snapshotVersion`, and `cardId` are now rejected at the edge (400) when not integers; `NaN`/`Infinity`/non-integer floats used to reach `BigInt()` and throw as 500.
- **Closed the enroll race** — `enrollUser` now relies on the `user_materials` PK as the authoritative guard (was SELECT-then-INSERT outside a transaction). Concurrent double-enroll now surfaces as 409, not 500.
- **`lastEventId` resume-cursor alignment** — POST `/events` now returns the chronologically latest event id, same as GET `/state`. Re-uploading an older batch no longer appears to rewind the cursor.

Bonus: `ROADMAP.md` promotes frontends from Phase 3F to Phase 4 (4A Vue thin → 4B CLI → 4C WASM offline → 4D Tauri), and `.gitignore` broadens to cover the full `.claude/` directory.

## Test plan

- [x] `pnpm --filter api test --run` — 41/41 pass (4 new tests, one per fix)
- [x] `pnpm --filter api build` — tsc clean
- [ ] Manual check via a frontend once 4A lands

🤖 Generated with [Claude Code](https://claude.ai/code)