### PR TITLE
feat(core): wire new atoms + edges in builder, rewrite graph.md

### DIFF
--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -43,23 +43,109 @@ pub struct BuildResult {
     pub verse_atoms: Vec<VerseAtoms>,
 }
 
+// Internal aggregation types used while the builder stitches the club
+// hierarchy together. Pulled out to keep function signatures readable.
+type VerseClubMemberMap = HashMap<(ClubTier, String, u16, u16), NodeId>;
+type VerseMembersByChapter = HashMap<(ClubTier, String, u16), Vec<(u16, NodeId)>>;
+type VerseMembersByHeading = HashMap<(ClubTier, NodeId), Vec<((u16, u16), NodeId)>>;
+
+/// Tier-subset rule: in the Anki export a verse tagged "150" is
+/// implicitly a member of both club 150 and club 300. Expand a raw
+/// tier list (as written in `VerseData.clubs`) to the full set of
+/// tiers that should materialise VerseClubMember atoms.
+fn expand_tiers(raw: &[u16]) -> Vec<ClubTier> {
+    let mut tiers: Vec<ClubTier> = Vec::new();
+    let mut push = |t: ClubTier| {
+        if !tiers.contains(&t) {
+            tiers.push(t);
+        }
+    };
+    for &n in raw {
+        match n {
+            150 => {
+                push(ClubTier::Club150);
+                push(ClubTier::Club300);
+            }
+            300 => push(ClubTier::Club300),
+            _ => {}
+        }
+    }
+    tiers
+}
+
 /// Build a graph and card catalog from content data and card type definitions.
 /// `now_secs` is used to set initial edge last_review to `now - 365 days`.
 pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -> BuildResult {
     let mut graph = Graph::new();
     let state = initial_state(now_secs);
 
-    // Chapter gist + ref nodes
+    // --- Book layer ---
+    let mut book_gists: HashMap<String, NodeId> = HashMap::new();
+    let mut book_refs: HashMap<String, NodeId> = HashMap::new();
+    for book in &data.books {
+        let bg = graph.add_node(NodeKind::BookGist { book: book.clone() });
+        let br = graph.add_node(NodeKind::BookRef { book: book.clone() });
+        graph.add_bi_edge_with_state(EdgeKind::BookGistBookRef, bg, br, state);
+        book_gists.insert(book.clone(), bg);
+        book_refs.insert(book.clone(), br);
+    }
+    // Book-consecutive chain follows `data.books` order.
+    for i in 1..data.books.len() {
+        if let (Some(&prev), Some(&curr)) = (
+            book_gists.get(&data.books[i - 1]),
+            book_gists.get(&data.books[i]),
+        ) {
+            graph.add_bi_edge_with_state(EdgeKind::BookGistBookGist, prev, curr, state);
+        }
+    }
+
+    // --- Chapter layer ---
     let mut chapter_gists: HashMap<(String, u16), NodeId> = HashMap::new();
+    let mut chapter_refs: HashMap<(String, u16), NodeId> = HashMap::new();
+    let mut chapters_by_book: HashMap<String, Vec<(u16, NodeId)>> = HashMap::new();
 
     for ch in &data.chapters {
         let gist = graph.add_node(NodeKind::ChapterGist { chapter: ch.number });
         let cref = graph.add_node(NodeKind::ChapterRef { chapter: ch.number });
         graph.add_bi_edge_with_state(EdgeKind::ChapterGistChapterRef, gist, cref, state);
+
+        // chapter_gist → book_gist (uni)
+        if let Some(&bg) = book_gists.get(&ch.book) {
+            graph.add_edge_with_state(EdgeKind::ChapterGistBookGist, gist, bg, state);
+        }
+        // chapter_ref → book_ref (uni)
+        if let Some(&br) = book_refs.get(&ch.book) {
+            graph.add_edge_with_state(EdgeKind::ChapterRefBookRef, cref, br, state);
+        }
+
         chapter_gists.insert((ch.book.clone(), ch.number), gist);
+        chapter_refs.insert((ch.book.clone(), ch.number), cref);
+        chapters_by_book
+            .entry(ch.book.clone())
+            .or_default()
+            .push((ch.number, gist));
     }
 
-    // Heading nodes
+    // Chapter-consecutive chain and book→first/last chapter endpoints
+    for (book, chapters) in &mut chapters_by_book {
+        chapters.sort_by_key(|(num, _)| *num);
+        for i in 1..chapters.len() {
+            graph.add_bi_edge_with_state(
+                EdgeKind::ChapterGistChapterGist,
+                chapters[i - 1].1,
+                chapters[i].1,
+                state,
+            );
+        }
+        if let Some(&bg) = book_gists.get(book)
+            && let (Some(first), Some(last)) = (chapters.first(), chapters.last())
+        {
+            graph.add_edge_with_state(EdgeKind::BookGistFirstChapterGist, bg, first.1, state);
+            graph.add_edge_with_state(EdgeKind::BookGistLastChapterGist, bg, last.1, state);
+        }
+    }
+
+    // --- Heading nodes + chain ---
     let mut heading_nodes: Vec<(NodeId, &crate::content::HeadingData)> = Vec::new();
     for h in &data.headings {
         let hid = graph.add_node(NodeKind::Heading {
@@ -71,28 +157,29 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         });
         heading_nodes.push((hid, h));
     }
-
-    // Heading ↔ heading chain (bidirectional)
+    // Heading ↔ heading chain (bidirectional, within-book only)
     for i in 1..heading_nodes.len() {
         let (prev_id, prev_h) = &heading_nodes[i - 1];
         let (curr_id, curr_h) = &heading_nodes[i];
-        // Only chain headings within the same book
         if prev_h.book == curr_h.book {
             graph.add_bi_edge_with_state(EdgeKind::HeadingHeading, *prev_id, *curr_id, state);
         }
     }
-
     // Build heading lookup: (book, chapter, verse) -> heading node
     let heading_lookup = build_heading_lookup(&heading_nodes);
 
-    // Verse nodes
+    // --- Verse layer ---
     let mut verse_atoms_list: Vec<VerseAtoms> = Vec::new();
     let mut prev_verse_gist: Option<NodeId> = None;
     let mut prev_verse_book: Option<String> = None;
 
-    // Club entry tracking
-    let mut club150_entries: Vec<(NodeId, String, u16)> = Vec::new(); // (entry_id, book, verse)
-    let mut club300_entries: Vec<(NodeId, String, u16)> = Vec::new();
+    // Track verses per chapter for endpoint wiring after all verses exist.
+    let mut verses_by_chapter: HashMap<(String, u16), Vec<(u16, NodeId)>> = HashMap::new();
+
+    // Track per-verse club membership for club-hierarchy wiring later.
+    let mut verse_club_members: VerseClubMemberMap = HashMap::new();
+    let mut verse_members_by_chapter_tier: VerseMembersByChapter = HashMap::new();
+    let mut verse_members_by_heading_tier: VerseMembersByHeading = HashMap::new();
 
     for verse_data in data.verses_with_text() {
         let ref_node = graph.add_node(NodeKind::VerseRef {
@@ -104,12 +191,16 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             verse: verse_data.verse,
         });
 
-        // verse gist ↔ reference (bi)
+        // verse gist ↔ verse ref (bi)
         graph.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, verse_gist, ref_node, state);
 
         // verse gist → chapter gist (uni)
         if let Some(&ch_gist) = chapter_gists.get(&(verse_data.book.clone(), verse_data.chapter)) {
             graph.add_edge_with_state(EdgeKind::VerseGistChapterGist, verse_gist, ch_gist, state);
+        }
+        // verse ref → chapter ref (uni)
+        if let Some(&ch_ref) = chapter_refs.get(&(verse_data.book.clone(), verse_data.chapter)) {
+            graph.add_edge_with_state(EdgeKind::VerseRefChapterRef, ref_node, ch_ref, state);
         }
 
         // Phrase nodes
@@ -120,11 +211,9 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
                 verse_id: verse_data.verse as u32,
                 position: pos as u16,
             });
-            // phrase ↔ verse gist (bi)
             graph.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, pid, verse_gist, state);
             phrase_nodes.push(pid);
         }
-
         // Phrase ↔ phrase chain (bi)
         for i in 1..phrase_nodes.len() {
             graph.add_bi_edge_with_state(
@@ -135,7 +224,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             );
         }
 
-        // FTV node (optional, ≤ 5 words)
+        // FTV node (optional, ≤ FTV_MAX_WORDS)
         let ftv_node = if !verse_data.ftv.is_empty()
             && verse_data.ftv.split_whitespace().count() <= FTV_MAX_WORDS
             && !phrase_nodes.is_empty()
@@ -143,9 +232,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             let ftv = graph.add_node(NodeKind::Ftv {
                 text: verse_data.ftv.clone(),
             });
-            // ftv → first phrase (uni)
             graph.add_edge_with_state(EdgeKind::FtvPhrase, ftv, phrase_nodes[0], state);
-            // ftv → verse gist (uni)
             graph.add_edge_with_state(EdgeKind::FtvVerseGist, ftv, verse_gist, state);
             Some(ftv)
         } else {
@@ -178,32 +265,42 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             graph.add_edge_with_state(EdgeKind::VerseGistHeading, verse_gist, hid, state);
         }
 
-        // Club entries
-        for &club in &verse_data.clubs {
-            let tier = match club {
-                150 => ClubTier::Club150,
-                300 => ClubTier::Club300,
-                _ => continue,
-            };
-            let entry = graph.add_node(NodeKind::VerseClubMember {
+        // Club membership (verse layer). Tier expansion materialises both
+        // 150 and 300 for verses tagged "150" per the Anki export.
+        for tier in expand_tiers(&verse_data.clubs) {
+            let member = graph.add_node(NodeKind::VerseClubMember {
                 tier,
                 chapter: verse_data.chapter,
                 verse: verse_data.verse,
             });
-            // ref ↔ club entry (bi)
-            graph.add_bi_edge_with_state(EdgeKind::VerseRefVerseClubMember, ref_node, entry, state);
-
-            match tier {
-                ClubTier::Club150 => {
-                    club150_entries.push((entry, verse_data.book.clone(), verse_data.verse));
-                }
-                ClubTier::Club300 => {
-                    club300_entries.push((entry, verse_data.book.clone(), verse_data.verse));
-                }
+            graph.add_bi_edge_with_state(
+                EdgeKind::VerseRefVerseClubMember,
+                ref_node,
+                member,
+                state,
+            );
+            verse_club_members.insert(
+                (
+                    tier,
+                    verse_data.book.clone(),
+                    verse_data.chapter,
+                    verse_data.verse,
+                ),
+                member,
+            );
+            verse_members_by_chapter_tier
+                .entry((tier, verse_data.book.clone(), verse_data.chapter))
+                .or_default()
+                .push((verse_data.verse, member));
+            if let Some(hid) = heading_node {
+                verse_members_by_heading_tier
+                    .entry((tier, hid))
+                    .or_default()
+                    .push(((verse_data.chapter, verse_data.verse), member));
             }
         }
 
-        // Find adjacent headings for card generation
+        // Heading context for card generation (lookup adjacent headings)
         let heading_idx =
             heading_node.and_then(|hid| heading_nodes.iter().position(|(id, _)| *id == hid));
         let next_heading = heading_idx.and_then(|i| heading_nodes.get(i + 1).map(|(id, _)| *id));
@@ -212,6 +309,11 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
                 .and_then(|j| heading_nodes.get(j))
                 .map(|(id, _)| *id)
         });
+
+        verses_by_chapter
+            .entry((verse_data.book.clone(), verse_data.chapter))
+            .or_default()
+            .push((verse_data.verse, verse_gist));
 
         verse_atoms_list.push(VerseAtoms {
             ref_node,
@@ -224,11 +326,50 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         });
     }
 
-    // Club entry chains (uni)
-    chain_club_entries(&mut graph, &club150_entries, state);
-    chain_club_entries(&mut graph, &club300_entries, state);
+    // Chapter → first/last verse endpoints (needs full verse map)
+    for ((book, chapter_num), mut verses) in verses_by_chapter {
+        verses.sort_by_key(|(num, _)| *num);
+        if let Some(&ch_gist) = chapter_gists.get(&(book.clone(), chapter_num))
+            && let (Some(first), Some(last)) = (verses.first(), verses.last())
+        {
+            graph.add_edge_with_state(EdgeKind::ChapterGistFirstVerseGist, ch_gist, first.1, state);
+            graph.add_edge_with_state(EdgeKind::ChapterGistLastVerseGist, ch_gist, last.1, state);
+        }
+    }
 
-    // Generate cards from card type definitions
+    // Heading → first/last verse endpoints (by range, sorted by chapter/verse)
+    for (hid, hdata) in &heading_nodes {
+        let mut verses_in_range: Vec<((u16, u16), NodeId)> = Vec::new();
+        // Look at verses in the chapter range; filter by the heading's start/end
+        for atoms in &verse_atoms_list {
+            if let Some(NodeKind::VerseGist { chapter, verse }) =
+                graph.node_kind(atoms.verse_gist).cloned()
+            {
+                let in_range = verse_in_heading(chapter, verse, hdata);
+                if in_range {
+                    verses_in_range.push(((chapter, verse), atoms.verse_gist));
+                }
+            }
+        }
+        verses_in_range.sort_by_key(|(k, _)| *k);
+        if let (Some(first), Some(last)) = (verses_in_range.first(), verses_in_range.last()) {
+            graph.add_edge_with_state(EdgeKind::HeadingFirstVerseGist, *hid, first.1, state);
+            graph.add_edge_with_state(EdgeKind::HeadingLastVerseGist, *hid, last.1, state);
+        }
+    }
+
+    // --- Club hierarchy ---
+    build_club_hierarchy(
+        &mut graph,
+        state,
+        &verse_club_members,
+        &verse_members_by_chapter_tier,
+        &verse_members_by_heading_tier,
+        &chapter_refs,
+        &heading_nodes,
+    );
+
+    // --- Cards ---
     let cards = generate_cards(card_types, &verse_atoms_list);
 
     BuildResult {
@@ -238,24 +379,220 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     }
 }
 
-fn chain_club_entries(graph: &mut Graph, entries: &[(NodeId, String, u16)], state: EdgeState) {
-    // Group by book, then chain within each book
-    let mut by_book: HashMap<&str, Vec<(NodeId, u16)>> = HashMap::new();
-    for (id, book, verse) in entries {
-        by_book
-            .entry(book.as_str())
-            .or_default()
-            .push((*id, *verse));
+fn verse_in_heading(chapter: u16, verse: u16, h: &crate::content::HeadingData) -> bool {
+    if chapter < h.start_chapter || chapter > h.end_chapter {
+        return false;
     }
-    for (_, mut verses) in by_book {
-        verses.sort_by_key(|(_, v)| *v);
-        for i in 1..verses.len() {
+    if chapter == h.start_chapter && verse < h.start_verse {
+        return false;
+    }
+    if chapter == h.end_chapter && verse > h.end_verse {
+        return false;
+    }
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_club_hierarchy(
+    graph: &mut Graph,
+    state: EdgeState,
+    verse_club_members: &VerseClubMemberMap,
+    verse_members_by_chapter_tier: &VerseMembersByChapter,
+    verse_members_by_heading_tier: &VerseMembersByHeading,
+    chapter_refs: &HashMap<(String, u16), NodeId>,
+    heading_nodes: &[(NodeId, &crate::content::HeadingData)],
+) {
+    // Set of tiers that actually appear in the material.
+    let mut tiers: Vec<ClubTier> = Vec::new();
+    for (tier, _, _, _) in verse_club_members.keys() {
+        if !tiers.contains(tier) {
+            tiers.push(*tier);
+        }
+    }
+    tiers.sort_by_key(|t| match t {
+        ClubTier::Club150 => 0,
+        ClubTier::Club300 => 1,
+    });
+
+    // ClubGist per tier.
+    let mut club_gists: HashMap<ClubTier, NodeId> = HashMap::new();
+    for &tier in &tiers {
+        let cg = graph.add_node(NodeKind::ClubGist { tier });
+        club_gists.insert(tier, cg);
+    }
+
+    // Per-chapter club member atoms + per-heading club member atoms, plus
+    // all downward/upward edges. Also collects sorted lists for later
+    // per-tier endpoint wiring.
+    let mut chapter_cm_by_tier: HashMap<ClubTier, Vec<(String, u16, NodeId)>> = HashMap::new();
+    let mut heading_cm_by_tier: HashMap<ClubTier, Vec<(usize, NodeId)>> = HashMap::new();
+
+    // Chapter club members
+    for ((tier, book, chapter), members) in verse_members_by_chapter_tier {
+        let cref = match chapter_refs.get(&(book.clone(), *chapter)) {
+            Some(&r) => r,
+            None => continue,
+        };
+        let ccm = graph.add_node(NodeKind::ChapterClubMember {
+            tier: *tier,
+            chapter: *chapter,
+        });
+        graph.add_bi_edge_with_state(EdgeKind::ChapterRefChapterClubMember, cref, ccm, state);
+        if let Some(&cg) = club_gists.get(tier) {
+            graph.add_edge_with_state(EdgeKind::ChapterClubMemberClubGist, ccm, cg, state);
+        }
+
+        let mut sorted = members.clone();
+        sorted.sort_by_key(|(v, _)| *v);
+        if let (Some(first), Some(last)) = (sorted.first(), sorted.last()) {
             graph.add_edge_with_state(
-                EdgeKind::VerseClubMemberVerseClubMember,
-                verses[i - 1].0,
-                verses[i].0,
+                EdgeKind::ChapterClubMemberFirstVerseClubMember,
+                ccm,
+                first.1,
                 state,
             );
+            graph.add_edge_with_state(
+                EdgeKind::ChapterClubMemberLastVerseClubMember,
+                ccm,
+                last.1,
+                state,
+            );
+        }
+        // Upward verse_cm → chapter_cm
+        for (_, vcm) in &sorted {
+            graph.add_edge_with_state(EdgeKind::VerseClubMemberChapterClubMember, *vcm, ccm, state);
+        }
+
+        chapter_cm_by_tier
+            .entry(*tier)
+            .or_default()
+            .push((book.clone(), *chapter, ccm));
+    }
+
+    // Chapter club-member chain (bi, within tier, global chapter order
+    // across books mirrors `data.books` order via chapter_refs insertion).
+    for (tier, chapters) in chapter_cm_by_tier.iter_mut() {
+        chapters.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+        for i in 1..chapters.len() {
+            graph.add_bi_edge_with_state(
+                EdgeKind::ChapterClubMemberChapterClubMember,
+                chapters[i - 1].2,
+                chapters[i].2,
+                state,
+            );
+        }
+        // Club gist → first/last chapter_cm endpoints
+        if let Some(&cg) = club_gists.get(tier)
+            && let (Some(first), Some(last)) = (chapters.first(), chapters.last())
+        {
+            graph.add_edge_with_state(EdgeKind::ClubGistFirstChapterClubMember, cg, first.2, state);
+            graph.add_edge_with_state(EdgeKind::ClubGistLastChapterClubMember, cg, last.2, state);
+        }
+    }
+
+    // Heading club members
+    let heading_index: HashMap<NodeId, usize> = heading_nodes
+        .iter()
+        .enumerate()
+        .map(|(i, (id, _))| (*id, i))
+        .collect();
+
+    for ((tier, hid), members) in verse_members_by_heading_tier {
+        let hdata = match heading_nodes.iter().find(|(id, _)| id == hid) {
+            Some((_, h)) => *h,
+            None => continue,
+        };
+        let hcm = graph.add_node(NodeKind::HeadingClubMember {
+            tier: *tier,
+            start_chapter: hdata.start_chapter,
+            start_verse: hdata.start_verse,
+        });
+        graph.add_bi_edge_with_state(EdgeKind::HeadingHeadingClubMember, *hid, hcm, state);
+        if let Some(&cg) = club_gists.get(tier) {
+            graph.add_edge_with_state(EdgeKind::HeadingClubMemberClubGist, hcm, cg, state);
+        }
+
+        let mut sorted = members.clone();
+        sorted.sort_by_key(|(k, _)| *k);
+        if let (Some(first), Some(last)) = (sorted.first(), sorted.last()) {
+            graph.add_edge_with_state(
+                EdgeKind::HeadingClubMemberFirstVerseClubMember,
+                hcm,
+                first.1,
+                state,
+            );
+            graph.add_edge_with_state(
+                EdgeKind::HeadingClubMemberLastVerseClubMember,
+                hcm,
+                last.1,
+                state,
+            );
+        }
+        // Upward verse_cm → heading_cm
+        for (_, vcm) in &sorted {
+            graph.add_edge_with_state(EdgeKind::VerseClubMemberHeadingClubMember, *vcm, hcm, state);
+        }
+
+        if let Some(&idx) = heading_index.get(hid) {
+            heading_cm_by_tier
+                .entry(*tier)
+                .or_default()
+                .push((idx, hcm));
+        }
+    }
+
+    // Heading club-member chain (bi, within tier, sorted by heading_nodes order)
+    for (tier, headings) in heading_cm_by_tier.iter_mut() {
+        headings.sort_by_key(|(idx, _)| *idx);
+        for i in 1..headings.len() {
+            graph.add_bi_edge_with_state(
+                EdgeKind::HeadingClubMemberHeadingClubMember,
+                headings[i - 1].1,
+                headings[i].1,
+                state,
+            );
+        }
+        if let Some(&cg) = club_gists.get(tier)
+            && let (Some(first), Some(last)) = (headings.first(), headings.last())
+        {
+            graph.add_edge_with_state(EdgeKind::ClubGistFirstHeadingClubMember, cg, first.1, state);
+            graph.add_edge_with_state(EdgeKind::ClubGistLastHeadingClubMember, cg, last.1, state);
+        }
+    }
+
+    // --- Verse-member chain (bi, within tier) + ClubGist verse endpoints ---
+    type VerseMembersByTier = HashMap<ClubTier, Vec<((String, u16, u16), NodeId)>>;
+    let mut verse_members_by_tier: VerseMembersByTier = HashMap::new();
+    for ((tier, book, chapter, verse), vcm) in verse_club_members {
+        verse_members_by_tier
+            .entry(*tier)
+            .or_default()
+            .push(((book.clone(), *chapter, *verse), *vcm));
+    }
+    for (tier, verses) in verse_members_by_tier.iter_mut() {
+        verses.sort_by(|a, b| a.0.cmp(&b.0));
+        for i in 1..verses.len() {
+            graph.add_bi_edge_with_state(
+                EdgeKind::VerseClubMemberVerseClubMember,
+                verses[i - 1].1,
+                verses[i].1,
+                state,
+            );
+        }
+        // verse_cm → club_gist
+        if let Some(&cg) = club_gists.get(tier) {
+            for (_, vcm) in verses.iter() {
+                graph.add_edge_with_state(EdgeKind::VerseClubMemberClubGist, *vcm, cg, state);
+            }
+            if let (Some(first), Some(last)) = (verses.first(), verses.last()) {
+                graph.add_edge_with_state(
+                    EdgeKind::ClubGistFirstVerseClubMember,
+                    cg,
+                    first.1,
+                    state,
+                );
+                graph.add_edge_with_state(EdgeKind::ClubGistLastVerseClubMember, cg, last.1, state);
+            }
         }
     }
 }
@@ -265,13 +602,11 @@ fn build_heading_lookup(
 ) -> HashMap<(String, u16, u16), NodeId> {
     let mut lookup = HashMap::new();
     for (hid, h) in heading_nodes {
-        // Map every verse in the heading's range to this heading
         if h.start_chapter == h.end_chapter {
             for v in h.start_verse..=h.end_verse {
                 lookup.insert((h.book.clone(), h.start_chapter, v), *hid);
             }
         } else {
-            // Cross-chapter heading: map all chapters in range
             for ch in h.start_chapter..=h.end_chapter {
                 let start_v = if ch == h.start_chapter {
                     h.start_verse
@@ -298,7 +633,6 @@ fn generate_cards(card_types: &CardTypesConfig, verse_atoms: &[VerseAtoms]) -> V
 
     for atoms in verse_atoms {
         for card_type in &card_types.card_types {
-            // Check requires
             if let Some(req) = &card_type.requires {
                 let has_it = match req.as_str() {
                     "ftv" => atoms.ftv.is_some(),
@@ -314,7 +648,6 @@ fn generate_cards(card_types: &CardTypesConfig, verse_atoms: &[VerseAtoms]) -> V
 
             if let Some(iterate) = &card_type.iterate {
                 if iterate == "phrases" {
-                    // Generate one card per phrase
                     for (idx, _) in atoms.phrases.iter().enumerate() {
                         if let Some(card) = resolve_card(card_type, atoms, Some(idx), &mut next_id)
                         {
@@ -390,7 +723,7 @@ fn resolve_roles(
             AtomRole::NextHeading => nodes.push(atoms.next_heading?),
             AtomRole::PrevHeading => nodes.push(atoms.prev_heading?),
             AtomRole::ChapterGist | AtomRole::ClubRefs => {
-                // These need chapter-level context, handled separately
+                // These need chapter-level context, handled separately.
             }
         }
     }
@@ -414,7 +747,7 @@ mod tests {
                     "text": "Paul called to be an apostle",
                     "phrases": ["Paul called", "to be an apostle"],
                     "ftv": "Paul called",
-                    "clubs": [150, 300]
+                    "clubs": [150]
                 },
                 {
                     "book": "1 Corinthians", "chapter": 1, "verse": 2,
@@ -454,14 +787,15 @@ mod tests {
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
 
-        // 3 verses × (ref + gist + 2 phrases) + chapter gist + chapter ref + heading + FTV nodes + club entries
+        // The new topology adds book + chapter endpoints + club hierarchy,
+        // so the graph is much denser than before.
         assert!(
-            result.graph.node_count() > 15,
+            result.graph.node_count() > 20,
             "should have many nodes: {}",
             result.graph.node_count()
         );
         assert!(
-            result.graph.edge_count() > 20,
+            result.graph.edge_count() > 40,
             "should have many edges: {}",
             result.graph.edge_count()
         );
@@ -472,16 +806,7 @@ mod tests {
         let data = test_data();
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
-
-        // Each verse with 2 phrases should get: full_recitation, 2x fill_in_blank,
-        // first_phrase_to_rest, verse_to_ref = 5 cards. Plus FTV, heading cards.
-        assert!(
-            result.cards.len() >= 10,
-            "should generate cards: {}",
-            result.cards.len()
-        );
-
-        // Verify a full_recitation card exists
+        assert!(result.cards.len() >= 10, "cards: {}", result.cards.len());
         let full_recit = result
             .cards
             .iter()
@@ -494,7 +819,6 @@ mod tests {
         let data = test_data();
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
-
         let atoms = &result.verse_atoms[0];
         let (ref_id, phrases) = result.graph.verse_context(atoms.phrases[0]).unwrap();
         assert_eq!(ref_id, atoms.ref_node);
@@ -502,27 +826,45 @@ mod tests {
     }
 
     #[test]
-    fn club_entries_created() {
+    fn tier_subset_rule_expands_150_to_300() {
         let data = test_data();
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
-
-        // Verse 1 is in club 150 and 300
-        let club_nodes: Vec<_> = result
+        // Verse 1 has clubs=[150] but should get BOTH Club150 and Club300 members.
+        let club_members: Vec<_> = result
             .graph
             .node_ids()
-            .filter(|&id| {
-                matches!(
-                    result.graph.node_kind(id),
-                    Some(NodeKind::VerseClubMember { .. })
-                )
+            .filter_map(|id| match result.graph.node_kind(id) {
+                Some(NodeKind::VerseClubMember {
+                    tier,
+                    chapter,
+                    verse,
+                }) => Some((*tier, *chapter, *verse)),
+                _ => None,
             })
             .collect();
+        let verse1_150 = club_members
+            .iter()
+            .any(|(t, c, v)| *t == ClubTier::Club150 && *c == 1 && *v == 1);
+        let verse1_300 = club_members
+            .iter()
+            .any(|(t, c, v)| *t == ClubTier::Club300 && *c == 1 && *v == 1);
+        let verse2_150 = club_members
+            .iter()
+            .any(|(t, c, v)| *t == ClubTier::Club150 && *c == 1 && *v == 2);
+        let verse2_300 = club_members
+            .iter()
+            .any(|(t, c, v)| *t == ClubTier::Club300 && *c == 1 && *v == 2);
+        assert!(verse1_150, "verse 1 should be a Club150 member");
         assert!(
-            club_nodes.len() >= 3,
-            "should have club entries: {}",
-            club_nodes.len()
+            verse1_300,
+            "verse 1 should ALSO be a Club300 member (subset rule)"
         );
+        assert!(
+            !verse2_150,
+            "verse 2 clubs=[300] should NOT be a Club150 member"
+        );
+        assert!(verse2_300, "verse 2 should be a Club300 member");
     }
 
     #[test]
@@ -530,13 +872,11 @@ mod tests {
         let data = test_data();
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
-
         let ftv_nodes: Vec<_> = result
             .graph
             .node_ids()
             .filter(|&id| matches!(result.graph.node_kind(id), Some(NodeKind::Ftv { .. })))
             .collect();
-        // Verse 1 and 2 have FTV (≤5 words), verse 3 has empty FTV
         assert_eq!(ftv_nodes.len(), 2, "should have 2 FTV nodes");
     }
 
@@ -545,8 +885,6 @@ mod tests {
         let data = test_data();
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
-
-        // All 3 verses should have verse_gist → heading edges
         let heading_edges: Vec<_> = result
             .graph
             .edge_ids()
@@ -557,10 +895,73 @@ mod tests {
                     .is_some_and(|e| matches!(e.kind, EdgeKind::VerseGistHeading))
             })
             .collect();
-        assert_eq!(
-            heading_edges.len(),
-            3,
-            "all 3 verses should link to heading"
-        );
+        assert_eq!(heading_edges.len(), 3);
+    }
+
+    #[test]
+    fn book_layer_wired() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+        let book_gists: Vec<_> = result
+            .graph
+            .node_ids()
+            .filter(|&id| matches!(result.graph.node_kind(id), Some(NodeKind::BookGist { .. })))
+            .collect();
+        let book_refs: Vec<_> = result
+            .graph
+            .node_ids()
+            .filter(|&id| matches!(result.graph.node_kind(id), Some(NodeKind::BookRef { .. })))
+            .collect();
+        assert_eq!(book_gists.len(), 1, "one BookGist for 1 Corinthians");
+        assert_eq!(book_refs.len(), 1, "one BookRef for 1 Corinthians");
+    }
+
+    #[test]
+    fn chapter_endpoints_wired() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+        let first_count = result
+            .graph
+            .edge_ids()
+            .filter(|&id| {
+                result
+                    .graph
+                    .edge(id)
+                    .is_some_and(|e| matches!(e.kind, EdgeKind::ChapterGistFirstVerseGist))
+            })
+            .count();
+        let last_count = result
+            .graph
+            .edge_ids()
+            .filter(|&id| {
+                result
+                    .graph
+                    .edge(id)
+                    .is_some_and(|e| matches!(e.kind, EdgeKind::ChapterGistLastVerseGist))
+            })
+            .count();
+        assert_eq!(first_count, 1);
+        assert_eq!(last_count, 1);
+    }
+
+    #[test]
+    fn chapter_club_member_per_tier_per_chapter() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+        let ccm_tiers: Vec<_> = result
+            .graph
+            .node_ids()
+            .filter_map(|id| match result.graph.node_kind(id) {
+                Some(NodeKind::ChapterClubMember { tier, chapter }) => Some((*tier, *chapter)),
+                _ => None,
+            })
+            .collect();
+        // Chapter 1 has 150 + 300 presence (verse 1 is 150 → expanded to both; verse 2 is 300).
+        assert!(ccm_tiers.contains(&(ClubTier::Club150, 1)));
+        assert!(ccm_tiers.contains(&(ClubTier::Club300, 1)));
+        assert_eq!(ccm_tiers.len(), 2);
     }
 }

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -5,8 +5,26 @@ memory**. The core insight: memory is not about knowing isolated facts — it is
 between pieces of information. "Given cue X, I can produce Y" is one edge, tracked with its own
 spaced-repetition state.
 
-Each learnable edge stores Stability (S), Difficulty (D), and last_review_time. Retrievability is
-computed on demand: `R = (1 + t / (9 · S))^(-1)`.
+Each edge stores Stability (S), Difficulty (D), and last_review_time. Retrievability is computed on
+demand from the FSRS-6 forgetting curve (see [review.md](review.md) and
+`crates/core/src/fsrs_bridge.rs`).
+
+## Retrieval-edge framing
+
+An edge is a **testable retrieval proposition**. When deciding whether an edge should exist between
+two atoms X and Y, ask:
+
+> If I'm thinking about X, is "produce Y" a retrieval with a unique, gradable answer?
+
+If the answer is a definite unique Y, the edge is valid. If Y is ambiguous, non-existent, or a list
+of many items, the edge does not exist — the relationship is either expressed via a proper atom that
+lets the listing become a sequence of single retrievals (see `ChapterClubMember`), or not modeled in
+the graph at all.
+
+**Every edge is learnable.** There are no structural edges — each edge carries FSRS state. This was
+not always true: the original design had one `ChapterGistClubEntry` structural edge to support club
+listings from a chapter, but that role was replaced by proper `ChapterClubMember` atoms when the
+club hierarchy was fleshed out.
 
 ## Theoretical grounding
 
@@ -15,224 +33,308 @@ computed on demand: `R = (1 + t / (9 · S))^(-1)`.
   items as single cards have stability collapsing toward zero. Decomposition into smaller
   cue→response pairs is theoretically required.
 
-## Node types
+## Atoms (node types)
 
-| Node type        | Testable?                         | Example                       |
-| ---------------- | --------------------------------- | ----------------------------- |
-| **Phrase**       | Yes                               | "For God so loved the world," |
-| **Verse gist**   | No — latent, updated via coupling | [gist of Acts 2:3]            |
-| **Reference**    | Yes                               | "Acts 2:3"                    |
-| **Club entry**   | Indirectly                        | "Acts 2:1 is in club 150"     |
-| **Heading**      | Yes                               | "All to the Glory of God"     |
-| **Chapter gist** | No — structural source node       | [gist of Acts 2]              |
-| **Chapter ref**  | Yes                               | "Acts 2"                      |
-| **FTV**          | No — cue only, never recalled     | "Paul, called"                |
+| Atom                  | Testable?                         | Purpose                               |
+| --------------------- | --------------------------------- | ------------------------------------- |
+| **Phrase**            | yes                               | "For God so loved the world,"         |
+| **VerseGist**         | no — latent, updated via coupling | [meaning of Acts 2:3]                 |
+| **VerseRef**          | yes                               | "verse 3 within the chapter"          |
+| **ChapterGist**       | no — chapter-level hub            | [meaning of Acts 2]                   |
+| **ChapterRef**        | yes                               | "chapter 2"                           |
+| **BookGist**          | no — book-level hub               | [meaning of Acts]                     |
+| **BookRef**           | yes                               | "Acts"                                |
+| **Heading**           | yes                               | "All to the Glory of God"             |
+| **ClubGist**          | no — per-tier hub                 | concept of "club 150" / "club 300"    |
+| **VerseClubMember**   | indirectly                        | "verse X is a member of club N"       |
+| **ChapterClubMember** | indirectly                        | "chapter C has club-N presence"       |
+| **HeadingClubMember** | indirectly                        | "section H has club-N presence"       |
+| **Ftv**               | no — cue only, never recalled     | first few words that identify a verse |
 
-**Verse gist**: non-testable hub connecting reference, phrases, and chapter. Separates gist memory
-("what this verse is about") from verbatim memory ("the exact words"). No direct edges between
-references and phrases — all paths route through the verse gist.
+**VerseRef carries the verse-number fact only.** The struct keeps `chapter` and `verse` fields for
+atom uniqueness, but the retrieval the atom represents is "which verse within the chapter." The
+chapter part is a separate atom (`ChapterRef`), and the book is yet another (`BookRef`). See the
+per-component grading section below.
 
-**Chapter gist**: structural source node for listing cards. Receives incoming edges from verse
-gists, has outgoing edges to club entries and a bidirectional edge to the chapter ref. Cannot be
-traversed into from club entries — prevents shortcut paths. Does not need FSRS state.
+**Gist atoms are routing hubs.** They are never the visible answer on a card, but participate in
+credit-assignment paths. A `VerseGist`'s edges get updated whenever reviews involve atoms that
+connect through it.
 
-**FTV** (Finish This Verse): the unique first words that identify a verse for quiz purposes.
+**`*ClubMember` atoms represent membership at a given layer.** The atom's existence is the fact.
+There is one `VerseClubMember` per (tier, verse) pair where the verse is in the tier, one
+`ChapterClubMember` per (tier, chapter) where the chapter contains any member of that tier, and
+similarly for headings. Deleting a member atom is how you'd remove club membership.
+
+**`Ftv` (Finish This Verse)** is the unique first words that identify a verse for quiz purposes.
 Optional — only created when the FTV text is ≤ 5 words. A pure cue node with unidirectional edges
 outward only (ftv → first phrase, ftv → verse gist). You never recall the FTV; it's given as a
-prompt to trigger verse recall.
+prompt.
 
-## Edge types
+## The layered pattern
 
-All learnable edges are tracked by FSRS. There are no hardcoded R=1.0 edges.
+Every containment layer (book → chapter → verse, and the parallel club-membership hierarchies) has
+the same five-edge shape:
 
-| Edge                                          | Direction | Learnable?      |
-| --------------------------------------------- | --------- | --------------- |
-| phrase ↔ phrase (sequential)                  | bi        | yes             |
-| phrase ↔ verse gist (hub)                     | bi        | yes             |
-| verse gist ↔ reference                        | bi        | yes             |
-| verse gist ↔ verse gist (chapter-consecutive) | bi        | yes             |
-| reference ↔ club entry                        | bi        | yes             |
-| chapter gist ↔ chapter ref                    | bi        | yes             |
-| verse gist → chapter gist                     | uni       | yes             |
-| chapter gist → club entry                     | uni       | no (structural) |
-| club entry → club entry (chain)               | uni       | yes             |
-| verse gist → heading                          | uni       | yes             |
-| heading ↔ heading (chain)                     | bi        | yes             |
-| ftv → first phrase                            | uni       | yes             |
-| ftv → verse gist                              | uni       | yes             |
+| Pattern                        | Direction | Example                                |
+| ------------------------------ | --------- | -------------------------------------- |
+| gist ↔ ref                     | bi        | `ChapterGistChapterRef`                |
+| child_gist → parent_gist       | uni       | `VerseGistChapterGist`                 |
+| parent_gist → first_child_gist | uni       | `ChapterGistFirstVerseGist`            |
+| parent_gist → last_child_gist  | uni       | `ChapterGistLastVerseGist`             |
+| parent-consecutive gist ↔ gist | bi        | `ChapterGistChapterGist` (within book) |
+| child_ref → parent_ref         | uni       | `VerseRefChapterRef`                   |
 
-### Directionality rationale
+Child→parent is always a unique retrieval ("which chapter is this verse in?"). Parent→child is only
+unique via the endpoint edges ("what's the first verse of this chapter?") — there's no
+`ChapterGist → some_verse_gist` for arbitrary verses because it's non-unique.
 
-* **verse gist → chapter gist** (not reverse): given a verse, you recall its chapter. The reverse
-  would let the chapter gist reach all verses, creating shortcuts between club entries and arbitrary
-  verses.
+## Edge inventory (43 kinds)
 
-* **chapter gist → club entry** (not reverse): needed for listing cards ("which 150 verses in Acts
-  2?"). The reverse is unnecessary — club_entry → ref → verse_gist → chapter_gist already exists as
-  a path.
+### Phrase / verse layer
 
-* **club entry → club entry** (forward only): the chain represents "what's the next 150 verse."
-  Reverse traversal could be added later if needed.
+| Edge                 | Shape | Role                                   |
+| -------------------- | ----- | -------------------------------------- |
+| `PhrasePhrase`       | bi    | sequential phrase chain within a verse |
+| `PhraseVerseGist`    | bi    | hub between phrase and verse gist      |
+| `VerseGistVerseRef`  | bi    | verse gist ↔ verse ref                 |
+| `VerseGistVerseGist` | bi    | chapter-consecutive verse chain        |
 
-* **verse gist → heading** (not reverse): given a verse, you recall which section it belongs to. The
-  reverse (heading → verses) isn't needed — the primary cards show verses and ask for the heading,
-  never the other way around. If "show heading, list verses" cards are needed later, heading → verse
-  edges can be added.
+### Chapter layer
 
-* **ftv → first phrase, ftv → verse gist** (outward only): the FTV is a cue given to the learner to
-  trigger verse recall. You never recall FTV text — it's always shown. No incoming edges needed.
+| Edge                        | Shape | Role                           |
+| --------------------------- | ----- | ------------------------------ |
+| `ChapterGistChapterRef`     | bi    | chapter gist ↔ ref             |
+| `VerseGistChapterGist`      | uni   | verse knows its chapter        |
+| `ChapterGistFirstVerseGist` | uni   | first verse of this chapter    |
+| `ChapterGistLastVerseGist`  | uni   | last verse of this chapter     |
+| `VerseRefChapterRef`        | uni   | "Acts 2:3" → "Acts 2"          |
+| `ChapterGistChapterGist`    | bi    | book-consecutive chapter chain |
 
-* **heading ↔ heading** (bidirectional): sequential section ordering. Supports both "what section
-  comes next?" and "what section came before?" No shortcut risk because headings have no outgoing
-  edges to verses — they're sink nodes in the verse→heading direction.
+### Book layer
 
-## Graph structure
+| Edge                       | Shape | Role                            |
+| -------------------------- | ----- | ------------------------------- |
+| `BookGistBookRef`          | bi    | book gist ↔ ref                 |
+| `ChapterGistBookGist`      | uni   | chapter knows its book          |
+| `BookGistFirstChapterGist` | uni   | first chapter of this book      |
+| `BookGistLastChapterGist`  | uni   | last chapter of this book       |
+| `ChapterRefBookRef`        | uni   | "Acts 2" → "Acts"               |
+| `BookGistBookGist`         | bi    | material-consecutive book chain |
 
-Two consecutive verses with club 150 membership:
+### Heading layer
+
+| Edge                    | Shape | Role                                        |
+| ----------------------- | ----- | ------------------------------------------- |
+| `VerseGistHeading`      | uni   | verse knows its section                     |
+| `HeadingHeading`        | bi    | section-to-section chain (within-book only) |
+| `HeadingFirstVerseGist` | uni   | first verse in section's range              |
+| `HeadingLastVerseGist`  | uni   | last verse in section's range               |
+
+Heading layer routes **through verses** to reach chapter/book
+(`heading → first_verse_gist → chapter_gist → book_gist`). There are no direct
+`heading → chapter_gist` or `heading → book_gist` edges. This keeps the graph narrow; book-scoping
+is a graph-building invariant rather than an edge.
+
+### Club hierarchy (verse + chapter)
+
+| Edge                                    | Shape | Role                                  |
+| --------------------------------------- | ----- | ------------------------------------- |
+| `VerseRefVerseClubMember`               | bi    | "is this verse in club N?"            |
+| `VerseClubMemberVerseClubMember`        | bi    | prev/next verse in same tier          |
+| `VerseClubMemberClubGist`               | uni   | which club is this member in          |
+| `VerseClubMemberChapterClubMember`      | uni   | which chapter-membership am I part of |
+| `ChapterRefChapterClubMember`           | bi    | chapter ↔ its club-presence atom      |
+| `ChapterClubMemberChapterClubMember`    | bi    | prev/next chapter with club presence  |
+| `ChapterClubMemberClubGist`             | uni   | which club                            |
+| `ChapterClubMemberFirstVerseClubMember` | uni   | first verse-member in this chapter    |
+| `ChapterClubMemberLastVerseClubMember`  | uni   | last verse-member in this chapter     |
+| `ClubGistFirstVerseClubMember`          | uni   | first verse of whole club             |
+| `ClubGistLastVerseClubMember`           | uni   | last verse of whole club              |
+| `ClubGistFirstChapterClubMember`        | uni   | first chapter with club presence      |
+| `ClubGistLastChapterClubMember`         | uni   | last chapter with club presence       |
+
+### Heading-club hierarchy
+
+Same shape as chapter-club, applied at the section level.
+
+| Edge                                    | Shape | Role                                    |
+| --------------------------------------- | ----- | --------------------------------------- |
+| `HeadingHeadingClubMember`              | bi    | section ↔ its club-presence atom        |
+| `HeadingClubMemberHeadingClubMember`    | bi    | prev/next section with club presence    |
+| `HeadingClubMemberClubGist`             | uni   | which club                              |
+| `VerseClubMemberHeadingClubMember`      | uni   | verse-member → section-level membership |
+| `HeadingClubMemberFirstVerseClubMember` | uni   | first verse-member in section           |
+| `HeadingClubMemberLastVerseClubMember`  | uni   | last verse-member in section            |
+| `ClubGistFirstHeadingClubMember`        | uni   | first section with club presence        |
+| `ClubGistLastHeadingClubMember`         | uni   | last section with club presence         |
+
+**Why section-level atoms matter.** In long chapters (Luke 1, ~80 verses across many sections),
+quizzers don't hold "the club-150 verses in Luke 1" as a single flat list. They mentally bucket by
+section ("these are my 150s in the Annunciation; these are mine in the Visitation; …").
+`HeadingClubMember` makes that section-scoped navigation an explicit retrieval the graph can test
+and reinforce.
+
+### FTV
+
+| Edge           | Shape | Role                   |
+| -------------- | ----- | ---------------------- |
+| `FtvPhrase`    | uni   | FTV cue → first phrase |
+| `FtvVerseGist` | uni   | FTV cue → verse gist   |
+
+## Card coupling (design intent)
+
+When card generation code lands, it should enforce these co-presence rules so grading and credit
+assignment have the right source atoms:
+
+* **Ref-chain coupling**: whenever a `VerseRef` is in `shown` or `hidden`, add its `ChapterRef`.
+  Whenever `ChapterRef` is present, add its `BookRef`. Transitively, any `VerseRef` pulls all three
+  refs together.
+* **Club-gist coupling**: whenever any `*ClubMember` atom is in `shown` or `hidden`, add its
+  `ClubGist`. Listing cards that hide verse-members are automatically sourced from the club tier.
+* Do **not** auto-add chapter/heading `*ClubMember` atoms when a verse-member appears — those are
+  hub atoms, not transitively present.
+
+These rules are not yet implemented in code; they're documented here as the design contract for the
+eventual card generator.
+
+## Per-component grading (design intent)
+
+Verse references are graded per-component, not as a single string:
+
+| Typed (for "Acts 2:3") | book_ref | chapter_ref | verse_ref | Interpretation                    |
+| ---------------------- | -------- | ----------- | --------- | --------------------------------- |
+| "Acts 2:3"             | Pass     | Pass        | Pass      | clean recall                      |
+| "Acts 2:4"             | Pass     | Pass        | Again     | right chapter, wrong verse number |
+| "Acts 3:3"             | Pass     | Again       | Pass      | right verse fact, wrong chapter   |
+| "John 2:3"             | Again    | Pass        | Pass      | wrong book, position facts held   |
+| "Matthew 5:16"         | Again    | Again       | Again     | lost everything                   |
+
+The "John 2:3" row is where the decomposition earns its keep: the learner's
+`phrase → verse_gist → verse_ref` and `phrase → verse_gist → chapter_gist → chapter_ref` chains
+produced the right numeric facts — they just lost book context. The graph tracks this as three
+independent signals rather than collapsing to a single pass/fail.
+
+This grading decomposition happens at the app layer (client-side typed-answer parser). It's not
+implemented today; documented here for when the frontend lands.
+
+## Tier-subset rule (Anki import)
+
+The Anki export tags quiz verses with a single tier: a verse is marked "150" or "300". Because club
+150 is a subset of club 300, a verse tagged "150" implicitly belongs to both tiers.
+
+The builder enforces this via `expand_tiers()` in `crates/core/src/builder.rs`: a raw `clubs: [150]`
+expands to `[Club150, Club300]` and emits `VerseClubMember` atoms for both tiers. Verses tagged only
+"300" stay single-tier.
+
+The same rule applies transitively to `ChapterClubMember` and `HeadingClubMember` — a chapter with
+any 150-tagged verse has both a `ChapterClubMember(tier=150)` and a `ChapterClubMember(tier=300)`.
+
+## Graph structure (worked example)
+
+Two consecutive verses in Acts 2, verse 1 is a 150-member:
 
 ```
-                        CHAPTER LEVEL
-                        ─────────────
-              chapter_ref("Acts 2") ←──bi──→ chapter_gist
-                                                  │
-                                          uni ────┘└──── uni
-                                          │              │
-                                          ▼              ▼
-                                   club_entry(2:1) ─→ club_entry(2:4)
-                                        │  (uni chain)    │
-                                    bi ─┘                 └─ bi
-                                        │                    │
-                        VERSE LEVEL     ▼                    ▼
-                        ───────────
-        verse1 ──bi── verse2       ref(2:1)             ref(2:4)
-         /│\           /│\            │                     │
-        / │ \         / │ \       bi ─┘                     └─ bi
-       /  │  \       /  │  \          │                        │
-      p1─p2─p3     p4─p5─p6      verse1                   verse2
-       (bi)          (bi)
+  BOOK LAYER
+  ──────────
+            BookGist(Acts) ↔ BookRef(Acts)
 
-                verse1 ──uni──→ chapter_gist
-                verse2 ──uni──→ chapter_gist
+  CHAPTER LAYER
+  ─────────────
+          ChapterGist(2) ↔ ChapterRef(2)
+              ↑                ↑
+       uni from         uni from
+       verse gist       verse ref
+
+  VERSE LAYER
+  ───────────
+        VerseGist(2:1) ─bi─ VerseGist(2:2)
+            ↕                    ↕
+      VerseRef(2:1)         VerseRef(2:2)
+         (uni → ChapterRef)    (uni → ChapterRef)
+         ↕                    ↕
+      VerseClubMember         (no member)
+        (tier=150)
+      VerseClubMember
+        (tier=300)
+
+  PHRASE LAYER
+  ────────────
+     p1─p2─p3─p4              p1─p2─p3─p4
+     (bi chain)                (bi chain)
+     each ↔ VerseGist          each ↔ VerseGist
 ```
 
-The diagram is split into levels for clarity. Key connections:
+Plus:
 
-* **Phrases ↔ verse gist**: bidirectional hub (each phrase connects to its verse)
-* **Phrase ↔ phrase**: bidirectional sequential chain
-* **Verse gist ↔ ref**: bidirectional (shown as vertical bi edges above)
-* **Verse gist ↔ verse gist**: bidirectional chapter-consecutive
-* **Verse gist → chapter gist**: unidirectional
-* **Ref ↔ club entry**: bidirectional
-* **Chapter gist → club entry**: unidirectional (structural)
-* **Club entry → club entry**: unidirectional chain
+* `ChapterGist(2) → first/last VerseGist(chapter 2)` (endpoint edges)
+* `BookGist → first/last ChapterGist` (endpoint edges)
+* `ChapterGist(2) ↔ ChapterGist(3)` if the book has more chapters
+* Club hierarchy: `ClubGist(150)`, `ChapterClubMember(150, 2)`, plus all the "first/last member"
+  endpoints and the verse/chapter chains
+* FTV nodes for verses whose FTV text is ≤ 5 words
+* Heading associations when a verse falls in a section
 
-## Reference model
+## Edge inventory per verse
 
-A verse's reference = chapter + verse number. The verse number can be recalled two ways:
+Rough counts to sanity-check memory usage. Per verse with N phrases:
 
-**Direct recall**: verse_gist → ref is strong. "I just know this is Acts 2:3."
+| Edge                              | Directed count    |
+| --------------------------------- | ----------------- |
+| phrase ↔ phrase (sequential)      | 2(N-1)            |
+| phrase ↔ verse gist (hub)         | 2N                |
+| verse gist ↔ verse ref            | 2                 |
+| verse gist → chapter gist         | 1                 |
+| verse ref → chapter ref           | 1                 |
+| verse gist ↔ next verse (chapter) | 2                 |
+| verse gist → heading              | 1 (if in section) |
+| **verse total**                   | **≈ 4N + 7**      |
 
-**Anchor-derived**: count the chapter-consecutive chain distance from a verse with a known
-reference, then apply arithmetic. Any reachable verse→ref edge serves as an anchor.
+Plus per-tier-member additions:
 
-```
-Direct:      verse(2:3) → ref(2:3)                              just know it
-Via anchor:  verse(2:3) → verse(2:2) → verse(2:1) → ref(2:1)   2 hops from anchor
-             "Acts 2:1" + 2 = "Acts 2:3"                        arithmetic (free)
-```
+* `ref ↔ club_member` (2 directed)
+* verse member chain (2 directed) + upward to chapter/heading cm (1–2)
+* club gist hub (1)
+* ≈ 6–8 extra directed edges per (verse, tier) pair.
 
-Every verse has a ref atom and a verse→ref edge. The edge may start weak — nearby anchors provide
-backup. Over time, the direct edge strengthens and the learner transitions from counting to instant
-recall. See anchor transfer in [review.md](review.md).
+At the material level, add:
 
-**Counting requires full-material knowledge**: a club-150 quizzer using club entries (entry(2:1) →
-entry(2:4), 1 hop) doesn't know the chapter-distance is 3. Counting from ref(2:1) to ref(2:4)
-requires the chapter-consecutive verse chain (3 hops through verses 2:2, 2:3). If those edges are
-weak (unreviewed), the anchor path is naturally weak.
+* ~6 book-level edges (gist↔ref, endpoints, consecutive chain)
+* ~6–8 edges per chapter (gist↔ref, endpoints, parent-linkage, consecutive chain)
+* Club hierarchy: chapter-cm + heading-cm add bounded overhead per populated chapter / section.
 
-## Club structure
+A full 1 Corinthians (553 verses, single book, ~16 chapters, 150 + 300 club members) builds to ~4k
+nodes and ~14.6k directed edges. Every edge has FSRS state — on the order of 250 KB of raw state,
+trivially tractable.
 
-QuizMeet tiers: **full material** (all verses), **club 300** (specific 300), **club 150** (specific
-150, subset of 300). Most chapters have 3–7 club-150 and 6–14 club-300 verses.
+## Reference model (anchor transfer)
 
-### Per-verse club entries
+A verse's full reference = book + chapter + verse number. The verse number can be recalled two ways:
 
-```
-chapter_gist ──→ club_150_entry(2:1) ──→ club_150_entry(2:4) ──→ club_150_entry(2:7)
-                       ↕                        ↕                        ↕
-                    ref(2:1)                 ref(2:4)                 ref(2:7)
-```
+**Direct recall**: `verse_gist → verse_ref` is strong. "I just know this is verse 3."
 
-Each club entry connects to its reference (bi) and chains to the next entry (uni). The chapter gist
-points to entries (uni) for listing cards.
-
-**Why separate atoms** (not verse↔verse edges):
-
-* Avoids verse-chain shortcuts that give false anchor transfer credit
-* Club sequence is meta-knowledge about the list, not content flow
-* Keeps verse↔verse edges clean: only chapter-consecutive content flow
-
-**Membership** is implicit: a verse with a club entry is in the club.
-
-Club 300 entries include all 300 verses. A club-150 verse has both a club_150_entry and a
-club_300_entry.
-
-## Headings
-
-Bible section headings (e.g., "All to the Glory of God" covering 1 Cor 10:23–11:1) provide
-contextual grouping that crosses chapter boundaries. The heading text is both the name and the gist
-— unlike verse references, heading names describe what the section is about.
-
-Headings vary by translation (and even by print edition) — both the text and the verse ranges
-differ. Heading atoms are per-translation.
+**Anchor-derived**: count the chapter-consecutive chain distance from a verse whose reference is
+already known, then apply arithmetic. Any reachable `verse_gist → verse_ref` edge serves as an
+anchor, with decay based on chain distance (see [review.md](review.md) anchor transfer).
 
 ```
-heading("All to the Glory of God") ↔ heading("Do Not Cause Others to Stumble")
-       ↑      ↑      ↑      ↑
-  v(10:23) v(10:24) v(10:25) ... v(11:1)
+Direct:      verse(2:3) → verse_ref(2:3)                       just know it
+Via anchor:  verse(2:3) → verse(2:2) → verse(2:1) → ref(2:1)   2 hops + arithmetic
 ```
 
-* **verse gist → heading** (uni): every verse in the heading's range knows its heading
-* **heading ↔ heading** (bi): sequential section ordering — supports "what comes next?" and "what
-  came before?"
-* **No heading → verse edges**: the primary use is verse → heading ("what section is this verse
-  in?"), not heading → verses. Start/end verse numbers are metadata on the heading atom for the app
-  to know the range — not graph structure the learner memorizes.
-
-**Cards** (heading is always hidden):
-
-* Show all phrases of a verse → ask for heading
-* Show one verse reference → ask for heading
-* Show a reference range (e.g., "10:23–11:1") → ask for heading
-* Show a reference → ask for heading
-* Show a heading → ask for next heading
-* Show a heading → ask for previous heading
-
-## Edge inventory
-
-Per verse with N phrases:
-
-| Edge                              | Directed count |
-| --------------------------------- | -------------- |
-| phrase ↔ phrase (sequential)      | 2(N-1)         |
-| phrase ↔ verse gist (hub)         | 2N             |
-| verse gist ↔ ref                  | 2              |
-| verse gist ↔ next verse (chapter) | 2              |
-| verse gist → chapter gist         | 1              |
-| verse gist → heading              | 1              |
-| **Base total**                    | **4N + 4**     |
-
-Per club-member verse, add: ref ↔ club_entry (2–4) + club_entry → next (1–2) + chapter_gist → entry
-(1–2) = up to 8.
-
-Per heading, add: heading ↔ next heading (2).
-
-For N=4: 20 base + up to 8 club = ~28 directed edges per verse. 500-verse season: ~12,000 directed
-edges. Each learnable edge stores 3 values. Trivially tractable.
+**Counting requires full-material knowledge**: anchor transfer works via the verse-gist chain; if
+that chain is weak the anchor path is weak.
 
 ## Open questions
 
-* **Chapter section boundaries**: material may not start at verse 1. Represent as properties on the
-  chapter gist, or edges to specific boundary verses?
-* **Reverse club chain**: add backward club_entry edges for "what was the previous 150 verse?"
-* **Phrase boundaries for non-KJV**: transfer across translations or chunk each independently?
+* **Generalised edge-kind enum.** The book/chapter/verse/heading/club-member layers all follow the
+  same five-edge containment shape (gist↔ref, child→parent, parent→first/last child,
+  parent-consecutive chain, child_ref→parent_ref). A future cleanup could collapse `EdgeKind` to
+  generic variants parameterised by a layer discriminator (`ContainsStart`, `ContainsEnd`,
+  `ParentRef`, …). Kept explicit for now while the schema is still iterating.
+* **Cross-book anchor transfer.** `BookGistBookGist` exists in the schema but isn't exercised in
+  card generation today. Once multi-book materials land, the anchor-transfer algorithm may want to
+  use book-level chains for cross-book references.
+* **Reverse club_entry chain.** The `VerseClubMemberVerseClubMember` edge is now bi (previous + next
+  verse in tier). Earlier versions had it uni.
+* **Phrase boundaries for non-KJV.** Unresolved: do phrase atoms transfer across translations or
+  chunk each translation independently?


### PR DESCRIPTION
## Summary

Second PR in the graph schema redesign. PR #19 added the atom/edge vocabulary; this PR makes the builder actually emit the new topology and rewrites \`docs/graph.md\` to reflect it.

## Commits

1. **\`feat(core): wire new atoms and edges in builder\`**
   Replaces the old builder with one that emits:
   - Book layer (BookGist, BookRef, chapter→book linkages, first/last-chapter endpoints, book-consecutive chain).
   - Chapter endpoints (ChapterGist → first/last VerseGist, chapter-consecutive bi-chain within book, VerseRef → ChapterRef).
   - Heading endpoints (Heading → first/last VerseGist in range).
   - Club hierarchy (ClubGist per tier, ChapterClubMember + HeadingClubMember atoms, full set of member↔gist and chain edges, endpoint edges at every level).
   - **Anki tier-subset rule**: verses tagged "150" are materialised as members of BOTH tier 150 and tier 300 via \`expand_tiers()\`, matching the export semantic where club 150 is a subset of club 300.
   - VerseClubMember chain upgraded from uni to bi.
   Adds tests covering book layer, chapter endpoints, tier-subset expansion, and per-tier-per-chapter member atoms. The \`real_data\` test against 1 Corinthians (553 verses) builds a 3972-node / 14622-edge graph cleanly.

2. **\`docs: rewrite graph.md for the new schema\`**
   New writeup aligned with the retrieval-edge framing, 12 atom kinds, 43 edge kinds grouped by layer, card-coupling rules, per-component grading design intent, Anki tier-subset rule, HeadingClubMember motivation (long chapters like Luke 1), and open questions.

## What's **not** in this PR

- Card coupling code — no card generator yet; rules documented as design intent.
- Per-component grading parser — app/frontend-layer, lands with Phase 4A.
- Multi-book materials — \`BookGistBookGist\` is in the schema but single-book materials don't exercise it.
- Generic edge-kind enum cleanup — tracked as an open question.

## Test plan

- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --workspace -- -D warnings\` — clean (new type aliases silence type-complexity warnings)
- [x] \`cargo test --workspace\` — 70 core + 1 real-data + 4 sim + 1 wasm roundtrip, green
- [x] \`wasm-pack build crates/wasm --target nodejs --out-dir pkg && node crates/wasm/test-smoke.js\` — passes
- [x] \`pnpm --filter @verse-vault/api test\` — 41 tests pass
- [x] \`dprint check\` — clean