### PR TITLE
refactor(core): drop EdgeKind + align card catalog to ref triple

### DIFF
--- a/crates/core/card_types.toml
+++ b/crates/core/card_types.toml
@@ -36,9 +36,3 @@ name = "heading_to_next"
 show = ["heading"]
 hide = ["next_heading"]
 requires = "next_heading"
-
-[[card_types]]
-name = "heading_to_prev"
-show = ["heading"]
-hide = ["prev_heading"]
-requires = "prev_heading"

--- a/crates/core/card_types.toml
+++ b/crates/core/card_types.toml
@@ -38,6 +38,11 @@ hide = ["next_heading"]
 requires = "next_heading"
 
 [[card_types]]
+name = "verse_to_club"
+show = ["ref"]
+hide = ["club_gist"]
+
+[[card_types]]
 name = "club_chapter_listing"
 scope = "chapter_club"
 show = ["club_gist", "book_ref", "chapter_ref"]

--- a/crates/core/card_types.toml
+++ b/crates/core/card_types.toml
@@ -36,3 +36,15 @@ name = "heading_to_next"
 show = ["heading"]
 hide = ["next_heading"]
 requires = "next_heading"
+
+[[card_types]]
+name = "club_chapter_listing"
+scope = "chapter_club"
+show = ["club_gist", "book_ref", "chapter_ref"]
+hide = ["chapter_club_verse_refs"]
+
+[[card_types]]
+name = "verses_to_heading"
+scope = "heading"
+show = ["heading_verse_refs"]
+hide = ["heading"]

--- a/crates/core/src/anchor.rs
+++ b/crates/core/src/anchor.rs
@@ -84,7 +84,6 @@ pub fn enumerate_paths_with_anchor_transfer(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::EdgeKind;
     use crate::node::NodeKind;
 
     fn two_verse_graph() -> (Graph, NodeId, NodeId, NodeId, NodeId) {
@@ -106,9 +105,9 @@ mod tests {
             verse: 2,
         });
 
-        g.add_bi_edge(EdgeKind::VerseGistVerseRef, v1, r1);
-        g.add_bi_edge(EdgeKind::VerseGistVerseRef, v2, r2);
-        g.add_bi_edge(EdgeKind::VerseGistVerseGist, v1, v2);
+        g.add_bi_edge(v1, r1);
+        g.add_bi_edge(v2, r2);
+        g.add_bi_edge(v1, v2);
 
         (g, v1, r1, v2, r2)
     }
@@ -163,9 +162,9 @@ mod tests {
                 chapter: 1,
                 verse: i,
             });
-            g.add_bi_edge(EdgeKind::VerseGistVerseRef, v, r);
+            g.add_bi_edge(v, r);
             if let Some(&prev_v) = verses.last() {
-                g.add_bi_edge(EdgeKind::VerseGistVerseGist, prev_v, v);
+                g.add_bi_edge(prev_v, v);
             }
             verses.push(v);
             refs.push(r);
@@ -221,9 +220,9 @@ mod tests {
             chapter: 2,
             verse: 1,
         });
-        g.add_bi_edge(EdgeKind::VerseGistVerseRef, v1, r1);
-        g.add_bi_edge(EdgeKind::VerseGistVerseRef, v2, r2);
-        g.add_bi_edge(EdgeKind::VerseGistVerseGist, v1, v2);
+        g.add_bi_edge(v1, r1);
+        g.add_bi_edge(v2, r2);
+        g.add_bi_edge(v1, v2);
 
         let sources = HashSet::from([v1]);
         let paths = enumerate_paths_with_anchor_transfer(&g, &sources, r2, 5, DEFAULT_DECAY_FACTOR);

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -35,6 +35,11 @@ pub struct VerseAtoms {
     pub heading: Option<NodeId>,
     pub next_heading: Option<NodeId>,
     pub prev_heading: Option<NodeId>,
+    /// `ClubGist` of the most-specific tier this verse belongs to: Club150
+    /// if tagged 150 (which by the subset rule also lives in 300), else
+    /// Club300 if tagged 300, else None for full-material-only verses.
+    /// Resolves the `club_gist` role on verse-scope cards.
+    pub most_specific_club_gist: Option<NodeId>,
 }
 
 /// Per-(book, chapter, tier) context for chapter-club-scoped card types.
@@ -189,6 +194,10 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
 
     // --- Verse layer ---
     let mut verse_atoms_list: Vec<VerseAtoms> = Vec::new();
+    // Parallel to verse_atoms_list: most-specific club tier per verse, or
+    // None for full-material-only verses. Resolved to a ClubGist NodeId
+    // after `build_club_hierarchy` returns the per-tier gist map.
+    let mut verse_most_specific_tier: Vec<Option<ClubTier>> = Vec::new();
     let mut prev_verse_gist: Option<NodeId> = None;
     let mut prev_verse_book: Option<String> = None;
 
@@ -351,6 +360,16 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             .get(&verse_data.book)
             .expect("book_ref was inserted during book layer");
 
+        // Most-specific tier this verse belongs to (filled in below once
+        // ClubGist NodeIds are known). 150 wins over 300 because 150 ⊂ 300.
+        let most_specific_tier =
+            expand_tiers(&verse_data.clubs)
+                .into_iter()
+                .min_by_key(|t| match t {
+                    ClubTier::Club150 => 0,
+                    ClubTier::Club300 => 1,
+                });
+
         verse_atoms_list.push(VerseAtoms {
             ref_node,
             chapter_ref,
@@ -361,7 +380,11 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             heading: heading_node,
             next_heading,
             prev_heading,
+            // Filled in after build_club_hierarchy — store the tier in
+            // a parallel vec so we don't carry it on the public struct.
+            most_specific_club_gist: None,
         });
+        verse_most_specific_tier.push(most_specific_tier);
     }
 
     // Chapter → first/last verse endpoints (needs full verse map)
@@ -406,6 +429,15 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         &chapter_refs,
         &heading_nodes,
     );
+
+    // Resolve each verse's most-specific ClubGist NodeId now that the
+    // gist map exists.
+    for (atoms, tier) in verse_atoms_list
+        .iter_mut()
+        .zip(verse_most_specific_tier.iter())
+    {
+        atoms.most_specific_club_gist = tier.and_then(|t| club_gists.get(&t).copied());
+    }
 
     // --- Chapter-club atom bundles ---
     let mut chapter_club_atoms_list: Vec<ChapterClubAtoms> = Vec::new();
@@ -881,14 +913,18 @@ fn resolve_roles(
             AtomRole::ChapterGist | AtomRole::ClubRefs => {
                 // These need chapter-level context, handled separately.
             }
-            AtomRole::ClubGist
-            | AtomRole::BookRef
-            | AtomRole::ChapterRef
-            | AtomRole::ChapterClubVerseRefs
-            | AtomRole::HeadingVerseRefs => {
-                // Roles for chapter-club / heading scopes — not applicable
-                // to verse-scoped cards. A verse-scoped card that names
-                // one of these is a malformed definition; return None.
+            // Verse-scope resolution for roles that name a single parent
+            // atom of the verse: book_ref, chapter_ref, and the
+            // most-specific club_gist (if the verse is in any tier).
+            AtomRole::BookRef => nodes.push(atoms.book_ref),
+            AtomRole::ChapterRef => nodes.push(atoms.chapter_ref),
+            AtomRole::ClubGist => {
+                // Skip the card entirely for full-material-only verses.
+                nodes.push(atoms.most_specific_club_gist?);
+            }
+            // Genuine cross-scope roles that don't map to a single verse-
+            // scoped answer.
+            AtomRole::ChapterClubVerseRefs | AtomRole::HeadingVerseRefs => {
                 return None;
             }
         }
@@ -1144,6 +1180,68 @@ mod tests {
         assert!(ccm_tiers.contains(&(ClubTier::Club150, 1)));
         assert!(ccm_tiers.contains(&(ClubTier::Club300, 1)));
         assert_eq!(ccm_tiers.len(), 2);
+    }
+
+    #[test]
+    fn verse_to_club_picks_most_specific_tier() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+
+        // Test data: verse 1 tagged 150 (→ both 150 and 300; most specific
+        // = 150), verse 2 tagged 300 only (most specific = 300), verse 3
+        // untagged (no card).
+        let club_gist_150 = result
+            .graph
+            .node_ids()
+            .find(|&id| {
+                matches!(
+                    result.graph.node_kind(id),
+                    Some(NodeKind::ClubGist {
+                        tier: ClubTier::Club150
+                    })
+                )
+            })
+            .unwrap();
+        let club_gist_300 = result
+            .graph
+            .node_ids()
+            .find(|&id| {
+                matches!(
+                    result.graph.node_kind(id),
+                    Some(NodeKind::ClubGist {
+                        tier: ClubTier::Club300
+                    })
+                )
+            })
+            .unwrap();
+
+        let verse_to_club_cards: Vec<_> = result
+            .cards
+            .iter()
+            .filter(|c| {
+                c.hidden.len() == 1
+                    && (c.hidden[0] == club_gist_150 || c.hidden[0] == club_gist_300)
+            })
+            .collect();
+        assert_eq!(
+            verse_to_club_cards.len(),
+            2,
+            "verse_to_club should be generated only for verses 1 and 2"
+        );
+
+        let v1 = &result.verse_atoms[0];
+        let v2 = &result.verse_atoms[1];
+        let v1_card = verse_to_club_cards
+            .iter()
+            .find(|c| c.shown.contains(&v1.ref_node))
+            .expect("verse 1 card");
+        let v2_card = verse_to_club_cards
+            .iter()
+            .find(|c| c.shown.contains(&v2.ref_node))
+            .expect("verse 2 card");
+        assert_eq!(v1_card.hidden, vec![club_gist_150], "verse 1 → Club150");
+        assert_eq!(v2_card.hidden, vec![club_gist_300], "verse 2 → Club300");
     }
 
     #[test]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::card::{Card, CardState};
-use crate::card_types::{AtomRole, CardTypeDef, CardTypesConfig, parse_role};
+use crate::card_types::{AtomRole, CardScope, CardTypeDef, CardTypesConfig, parse_role};
 use crate::content::MaterialData;
 use crate::edge::{EdgeRole, EdgeState};
 use crate::graph::Graph;
@@ -35,6 +35,28 @@ pub struct VerseAtoms {
     pub heading: Option<NodeId>,
     pub next_heading: Option<NodeId>,
     pub prev_heading: Option<NodeId>,
+}
+
+/// Per-(book, chapter, tier) context for chapter-club-scoped card types.
+/// Produced for every (chapter, tier) pair that has at least one member.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ChapterClubAtoms {
+    pub club_gist: NodeId,
+    pub book_ref: NodeId,
+    pub chapter_ref: NodeId,
+    /// VerseRef atoms for members of this chapter in this tier,
+    /// sorted by verse number.
+    pub verse_refs: Vec<NodeId>,
+}
+
+/// Per-heading context for heading-scoped card types. Produced for every
+/// heading that covers at least one verse with text.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct HeadingAtoms {
+    pub heading: NodeId,
+    /// VerseRef atoms for every verse inside the heading's range,
+    /// sorted by (chapter, verse).
+    pub verse_refs: Vec<NodeId>,
 }
 
 /// Build result from content data.
@@ -178,6 +200,16 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     let mut verse_members_by_chapter_tier: VerseMembersByChapter = HashMap::new();
     let mut verse_members_by_heading_tier: VerseMembersByHeading = HashMap::new();
 
+    // Track VerseRef NodeIds for chapter-club and heading listing cards.
+    // Parallel to verse_members_by_chapter_tier but stores verse_ref (the
+    // displayed atom) rather than the VerseClubMember (internal atom).
+    type VerseRefsByChapterTier = HashMap<(ClubTier, String, u16), Vec<(u16, NodeId)>>;
+    type VerseRefsByHeading = HashMap<NodeId, Vec<((u16, u16), NodeId)>>;
+    let mut verse_refs_by_chapter_tier: VerseRefsByChapterTier = HashMap::new();
+    // (heading_id) -> list of ((chapter, verse), verse_ref) for verses in
+    // that heading's range (regardless of club membership).
+    let mut verse_refs_by_heading: VerseRefsByHeading = HashMap::new();
+
     for verse_data in data.verses_with_text() {
         let ref_node = graph.add_node(NodeKind::VerseRef {
             chapter: verse_data.chapter,
@@ -274,12 +306,26 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
                 .entry((tier, verse_data.book.clone(), verse_data.chapter))
                 .or_default()
                 .push((verse_data.verse, member));
+            verse_refs_by_chapter_tier
+                .entry((tier, verse_data.book.clone(), verse_data.chapter))
+                .or_default()
+                .push((verse_data.verse, ref_node));
             if let Some(hid) = heading_node {
                 verse_members_by_heading_tier
                     .entry((tier, hid))
                     .or_default()
                     .push(((verse_data.chapter, verse_data.verse), member));
             }
+        }
+
+        // Heading-scope tracking: every verse with a heading contributes
+        // its verse_ref to the heading's card scope (independent of club
+        // membership).
+        if let Some(hid) = heading_node {
+            verse_refs_by_heading
+                .entry(hid)
+                .or_default()
+                .push(((verse_data.chapter, verse_data.verse), ref_node));
         }
 
         // Heading context for card generation (lookup adjacent headings)
@@ -351,7 +397,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     }
 
     // --- Club hierarchy ---
-    build_club_hierarchy(
+    let club_gists = build_club_hierarchy(
         &mut graph,
         state,
         &verse_club_members,
@@ -361,8 +407,44 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         &heading_nodes,
     );
 
+    // --- Chapter-club atom bundles ---
+    let mut chapter_club_atoms_list: Vec<ChapterClubAtoms> = Vec::new();
+    for ((tier, book, chapter), verse_refs) in &verse_refs_by_chapter_tier {
+        let mut sorted = verse_refs.clone();
+        sorted.sort_by_key(|(v, _)| *v);
+        let (Some(&club_gist), Some(&book_ref), Some(&chapter_ref)) = (
+            club_gists.get(tier),
+            book_refs.get(book),
+            chapter_refs.get(&(book.clone(), *chapter)),
+        ) else {
+            continue;
+        };
+        chapter_club_atoms_list.push(ChapterClubAtoms {
+            club_gist,
+            book_ref,
+            chapter_ref,
+            verse_refs: sorted.into_iter().map(|(_, vref)| vref).collect(),
+        });
+    }
+
+    // --- Heading atom bundles ---
+    let mut heading_atoms_list: Vec<HeadingAtoms> = Vec::new();
+    for (hid, entries) in &verse_refs_by_heading {
+        let mut sorted = entries.clone();
+        sorted.sort_by_key(|(k, _)| *k);
+        heading_atoms_list.push(HeadingAtoms {
+            heading: *hid,
+            verse_refs: sorted.into_iter().map(|(_, vref)| vref).collect(),
+        });
+    }
+
     // --- Cards ---
-    let cards = generate_cards(card_types, &verse_atoms_list);
+    let cards = generate_cards(
+        card_types,
+        &verse_atoms_list,
+        &chapter_club_atoms_list,
+        &heading_atoms_list,
+    );
 
     BuildResult {
         graph,
@@ -393,7 +475,7 @@ fn build_club_hierarchy(
     verse_members_by_heading_tier: &VerseMembersByHeading,
     chapter_refs: &HashMap<(String, u16), NodeId>,
     heading_nodes: &[(NodeId, &crate::content::HeadingData)],
-) {
+) -> HashMap<ClubTier, NodeId> {
     // Set of tiers that actually appear in the material.
     let mut tiers: Vec<ClubTier> = Vec::new();
     for (tier, _, _, _) in verse_club_members.keys() {
@@ -547,6 +629,8 @@ fn build_club_hierarchy(
             }
         }
     }
+
+    club_gists
 }
 
 fn build_heading_lookup(
@@ -579,41 +663,154 @@ fn build_heading_lookup(
     lookup
 }
 
-fn generate_cards(card_types: &CardTypesConfig, verse_atoms: &[VerseAtoms]) -> Vec<Card> {
+fn generate_cards(
+    card_types: &CardTypesConfig,
+    verse_atoms: &[VerseAtoms],
+    chapter_club_atoms: &[ChapterClubAtoms],
+    heading_atoms: &[HeadingAtoms],
+) -> Vec<Card> {
     let mut cards = Vec::new();
     let mut next_id = 0u32;
 
-    for atoms in verse_atoms {
-        for card_type in &card_types.card_types {
-            if let Some(req) = &card_type.requires {
-                let has_it = match req.as_str() {
-                    "ftv" => atoms.ftv.is_some(),
-                    "heading" => atoms.heading.is_some(),
-                    "next_heading" => atoms.next_heading.is_some(),
-                    "prev_heading" => atoms.prev_heading.is_some(),
-                    _ => true,
-                };
-                if !has_it {
-                    continue;
-                }
+    for card_type in &card_types.card_types {
+        match card_type.scope {
+            CardScope::Verse => {
+                generate_verse_cards(card_type, verse_atoms, &mut cards, &mut next_id);
             }
-
-            if let Some(iterate) = &card_type.iterate {
-                if iterate == "phrases" {
-                    for (idx, _) in atoms.phrases.iter().enumerate() {
-                        if let Some(card) = resolve_card(card_type, atoms, Some(idx), &mut next_id)
-                        {
-                            cards.push(card);
-                        }
-                    }
-                }
-            } else if let Some(card) = resolve_card(card_type, atoms, None, &mut next_id) {
-                cards.push(card);
+            CardScope::ChapterClub => {
+                generate_chapter_club_cards(
+                    card_type,
+                    chapter_club_atoms,
+                    &mut cards,
+                    &mut next_id,
+                );
+            }
+            CardScope::Heading => {
+                generate_heading_cards(card_type, heading_atoms, &mut cards, &mut next_id);
             }
         }
     }
 
     cards
+}
+
+fn generate_verse_cards(
+    card_type: &CardTypeDef,
+    verse_atoms: &[VerseAtoms],
+    cards: &mut Vec<Card>,
+    next_id: &mut u32,
+) {
+    for atoms in verse_atoms {
+        if let Some(req) = &card_type.requires {
+            let has_it = match req.as_str() {
+                "ftv" => atoms.ftv.is_some(),
+                "heading" => atoms.heading.is_some(),
+                "next_heading" => atoms.next_heading.is_some(),
+                "prev_heading" => atoms.prev_heading.is_some(),
+                _ => true,
+            };
+            if !has_it {
+                continue;
+            }
+        }
+
+        if let Some(iterate) = &card_type.iterate {
+            if iterate == "phrases" {
+                for (idx, _) in atoms.phrases.iter().enumerate() {
+                    if let Some(card) = resolve_card(card_type, atoms, Some(idx), next_id) {
+                        cards.push(card);
+                    }
+                }
+            }
+        } else if let Some(card) = resolve_card(card_type, atoms, None, next_id) {
+            cards.push(card);
+        }
+    }
+}
+
+fn generate_chapter_club_cards(
+    card_type: &CardTypeDef,
+    chapter_club_atoms: &[ChapterClubAtoms],
+    cards: &mut Vec<Card>,
+    next_id: &mut u32,
+) {
+    for atoms in chapter_club_atoms {
+        if atoms.verse_refs.is_empty() {
+            continue;
+        }
+        let shown = resolve_chapter_club_roles(&card_type.show, atoms);
+        let hidden = resolve_chapter_club_roles(&card_type.hide, atoms);
+        let (Some(shown), Some(hidden)) = (shown, hidden) else {
+            continue;
+        };
+        if shown.is_empty() || hidden.is_empty() {
+            continue;
+        }
+        let id = CardId(*next_id);
+        *next_id += 1;
+        cards.push(Card {
+            id,
+            shown,
+            hidden,
+            state: CardState::New,
+        });
+    }
+}
+
+fn generate_heading_cards(
+    card_type: &CardTypeDef,
+    heading_atoms: &[HeadingAtoms],
+    cards: &mut Vec<Card>,
+    next_id: &mut u32,
+) {
+    for atoms in heading_atoms {
+        if atoms.verse_refs.is_empty() {
+            continue;
+        }
+        let shown = resolve_heading_roles(&card_type.show, atoms);
+        let hidden = resolve_heading_roles(&card_type.hide, atoms);
+        let (Some(shown), Some(hidden)) = (shown, hidden) else {
+            continue;
+        };
+        if shown.is_empty() || hidden.is_empty() {
+            continue;
+        }
+        let id = CardId(*next_id);
+        *next_id += 1;
+        cards.push(Card {
+            id,
+            shown,
+            hidden,
+            state: CardState::New,
+        });
+    }
+}
+
+fn resolve_chapter_club_roles(roles: &[String], atoms: &ChapterClubAtoms) -> Option<Vec<NodeId>> {
+    let mut nodes = Vec::new();
+    for role_str in roles {
+        match parse_role(role_str)? {
+            AtomRole::ClubGist => nodes.push(atoms.club_gist),
+            AtomRole::BookRef => nodes.push(atoms.book_ref),
+            AtomRole::ChapterRef => nodes.push(atoms.chapter_ref),
+            AtomRole::ChapterClubVerseRefs => nodes.extend_from_slice(&atoms.verse_refs),
+            // Roles outside the chapter-club scope aren't resolvable here.
+            _ => return None,
+        }
+    }
+    Some(nodes)
+}
+
+fn resolve_heading_roles(roles: &[String], atoms: &HeadingAtoms) -> Option<Vec<NodeId>> {
+    let mut nodes = Vec::new();
+    for role_str in roles {
+        match parse_role(role_str)? {
+            AtomRole::Heading => nodes.push(atoms.heading),
+            AtomRole::HeadingVerseRefs => nodes.extend_from_slice(&atoms.verse_refs),
+            _ => return None,
+        }
+    }
+    Some(nodes)
 }
 
 fn resolve_card(
@@ -788,36 +985,6 @@ mod tests {
     }
 
     #[test]
-    fn ref_role_expands_to_book_chapter_verse() {
-        let data = test_data();
-        let card_types = test_card_types();
-        let result = build(&data, &card_types, 0);
-
-        // A card containing a given verse's VerseRef must also contain the
-        // matching chapter_ref and book_ref (in the same slot).
-        let mut saw_ref_card = false;
-        for card in &result.cards {
-            for atoms in &result.verse_atoms {
-                for (slot_name, slot) in [("shown", &card.shown), ("hidden", &card.hidden)] {
-                    if !slot.contains(&atoms.ref_node) {
-                        continue;
-                    }
-                    saw_ref_card = true;
-                    assert!(
-                        slot.contains(&atoms.chapter_ref),
-                        "card {slot_name} has verse_ref but missing chapter_ref: {slot:?}"
-                    );
-                    assert!(
-                        slot.contains(&atoms.book_ref),
-                        "card {slot_name} has verse_ref but missing book_ref: {slot:?}"
-                    );
-                }
-            }
-        }
-        assert!(saw_ref_card, "expected at least one ref-bearing card");
-    }
-
-    #[test]
     fn verse_context_works_on_built_graph() {
         let data = test_data();
         let card_types = test_card_types();
@@ -977,5 +1144,101 @@ mod tests {
         assert!(ccm_tiers.contains(&(ClubTier::Club150, 1)));
         assert!(ccm_tiers.contains(&(ClubTier::Club300, 1)));
         assert_eq!(ccm_tiers.len(), 2);
+    }
+
+    #[test]
+    fn club_chapter_listing_cards_generated() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+
+        // Test data: chapter 1 has verse 1 tagged 150 (→ both 150 and 300)
+        // and verse 2 tagged 300. So we expect TWO listing cards:
+        // - Club150 / chapter 1 with 1 verse (verse 1).
+        // - Club300 / chapter 1 with 2 verses (verse 1 + verse 2).
+        let book_ref = result
+            .graph
+            .node_ids()
+            .find(|&id| matches!(result.graph.node_kind(id), Some(NodeKind::BookRef { .. })))
+            .unwrap();
+        let chapter_ref = result
+            .graph
+            .node_ids()
+            .find(|&id| {
+                matches!(
+                    result.graph.node_kind(id),
+                    Some(NodeKind::ChapterRef { .. })
+                )
+            })
+            .unwrap();
+
+        let listing_cards: Vec<_> = result
+            .cards
+            .iter()
+            .filter(|c| c.shown.len() == 3 && c.shown[1] == book_ref && c.shown[2] == chapter_ref)
+            .collect();
+        assert_eq!(
+            listing_cards.len(),
+            2,
+            "expected 2 listing cards (Club150 + Club300), got {}",
+            listing_cards.len()
+        );
+
+        let card_150 = listing_cards
+            .iter()
+            .find(|c| {
+                matches!(
+                    result.graph.node_kind(c.shown[0]),
+                    Some(NodeKind::ClubGist {
+                        tier: ClubTier::Club150
+                    })
+                )
+            })
+            .expect("should have a Club150 listing card");
+        assert_eq!(card_150.hidden.len(), 1, "Club150 ch 1: just verse 1");
+
+        let card_300 = listing_cards
+            .iter()
+            .find(|c| {
+                matches!(
+                    result.graph.node_kind(c.shown[0]),
+                    Some(NodeKind::ClubGist {
+                        tier: ClubTier::Club300
+                    })
+                )
+            })
+            .expect("should have a Club300 listing card");
+        assert_eq!(card_300.hidden.len(), 2, "Club300 ch 1: verses 1 and 2");
+    }
+
+    #[test]
+    fn verses_to_heading_card_generated() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+
+        // Test data has one heading ("Greeting") covering verses 1-3.
+        // The card hides that heading and shows all three verse refs.
+        let heading = result
+            .graph
+            .node_ids()
+            .find(|&id| matches!(result.graph.node_kind(id), Some(NodeKind::Heading { .. })))
+            .unwrap();
+
+        // verses_to_heading hides the heading and shows the full range of
+        // verse refs. Distinguish from verse_to_heading (which also hides
+        // the heading but shows [book_ref, chapter_ref, verse_ref]) by
+        // requiring every shown atom to be a VerseRef.
+        let card = result
+            .cards
+            .iter()
+            .find(|c| {
+                c.hidden == vec![heading]
+                    && c.shown.iter().all(|&n| {
+                        matches!(result.graph.node_kind(n), Some(NodeKind::VerseRef { .. }))
+                    })
+            })
+            .expect("verses_to_heading card should exist");
+        assert_eq!(card.shown.len(), 3, "three verses in the heading range");
     }
 }

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -684,6 +684,16 @@ fn resolve_roles(
             AtomRole::ChapterGist | AtomRole::ClubRefs => {
                 // These need chapter-level context, handled separately.
             }
+            AtomRole::ClubGist
+            | AtomRole::BookRef
+            | AtomRole::ChapterRef
+            | AtomRole::ChapterClubVerseRefs
+            | AtomRole::HeadingVerseRefs => {
+                // Roles for chapter-club / heading scopes — not applicable
+                // to verse-scoped cards. A verse-scoped card that names
+                // one of these is a malformed definition; return None.
+                return None;
+            }
         }
     }
 

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::card::{Card, CardState};
 use crate::card_types::{AtomRole, CardTypeDef, CardTypesConfig, parse_role};
 use crate::content::MaterialData;
-use crate::edge::{EdgeKind, EdgeState};
+use crate::edge::{EdgeRole, EdgeState};
 use crate::graph::Graph;
 use crate::node::{ClubTier, NodeKind};
 use crate::types::{CardId, NodeId};
@@ -85,7 +85,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     for book in &data.books {
         let bg = graph.add_node(NodeKind::BookGist { book: book.clone() });
         let br = graph.add_node(NodeKind::BookRef { book: book.clone() });
-        graph.add_bi_edge_with_state(EdgeKind::BookGistBookRef, bg, br, state);
+        graph.add_bi_edge_with_state(bg, br, state);
         book_gists.insert(book.clone(), bg);
         book_refs.insert(book.clone(), br);
     }
@@ -95,7 +95,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             book_gists.get(&data.books[i - 1]),
             book_gists.get(&data.books[i]),
         ) {
-            graph.add_bi_edge_with_state(EdgeKind::BookGistBookGist, prev, curr, state);
+            graph.add_bi_edge_with_state(prev, curr, state);
         }
     }
 
@@ -107,15 +107,15 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     for ch in &data.chapters {
         let gist = graph.add_node(NodeKind::ChapterGist { chapter: ch.number });
         let cref = graph.add_node(NodeKind::ChapterRef { chapter: ch.number });
-        graph.add_bi_edge_with_state(EdgeKind::ChapterGistChapterRef, gist, cref, state);
+        graph.add_bi_edge_with_state(gist, cref, state);
 
         // chapter_gist → book_gist (uni)
         if let Some(&bg) = book_gists.get(&ch.book) {
-            graph.add_edge_with_state(EdgeKind::ChapterGistBookGist, gist, bg, state);
+            graph.add_edge_with_state(gist, bg, state);
         }
         // chapter_ref → book_ref (uni)
         if let Some(&br) = book_refs.get(&ch.book) {
-            graph.add_edge_with_state(EdgeKind::ChapterRefBookRef, cref, br, state);
+            graph.add_edge_with_state(cref, br, state);
         }
 
         chapter_gists.insert((ch.book.clone(), ch.number), gist);
@@ -130,18 +130,13 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
     for (book, chapters) in &mut chapters_by_book {
         chapters.sort_by_key(|(num, _)| *num);
         for i in 1..chapters.len() {
-            graph.add_bi_edge_with_state(
-                EdgeKind::ChapterGistChapterGist,
-                chapters[i - 1].1,
-                chapters[i].1,
-                state,
-            );
+            graph.add_bi_edge_with_state(chapters[i - 1].1, chapters[i].1, state);
         }
         if let Some(&bg) = book_gists.get(book)
             && let (Some(first), Some(last)) = (chapters.first(), chapters.last())
         {
-            graph.add_edge_with_state(EdgeKind::BookGistFirstChapterGist, bg, first.1, state);
-            graph.add_edge_with_state(EdgeKind::BookGistLastChapterGist, bg, last.1, state);
+            graph.add_edge_with_role(bg, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(bg, last.1, EdgeRole::LastChild, state);
         }
     }
 
@@ -162,7 +157,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         let (prev_id, prev_h) = &heading_nodes[i - 1];
         let (curr_id, curr_h) = &heading_nodes[i];
         if prev_h.book == curr_h.book {
-            graph.add_bi_edge_with_state(EdgeKind::HeadingHeading, *prev_id, *curr_id, state);
+            graph.add_bi_edge_with_state(*prev_id, *curr_id, state);
         }
     }
     // Build heading lookup: (book, chapter, verse) -> heading node
@@ -192,15 +187,15 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         });
 
         // verse gist ↔ verse ref (bi)
-        graph.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, verse_gist, ref_node, state);
+        graph.add_bi_edge_with_state(verse_gist, ref_node, state);
 
         // verse gist → chapter gist (uni)
         if let Some(&ch_gist) = chapter_gists.get(&(verse_data.book.clone(), verse_data.chapter)) {
-            graph.add_edge_with_state(EdgeKind::VerseGistChapterGist, verse_gist, ch_gist, state);
+            graph.add_edge_with_state(verse_gist, ch_gist, state);
         }
         // verse ref → chapter ref (uni)
         if let Some(&ch_ref) = chapter_refs.get(&(verse_data.book.clone(), verse_data.chapter)) {
-            graph.add_edge_with_state(EdgeKind::VerseRefChapterRef, ref_node, ch_ref, state);
+            graph.add_edge_with_state(ref_node, ch_ref, state);
         }
 
         // Phrase nodes
@@ -211,17 +206,12 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
                 verse_id: verse_data.verse as u32,
                 position: pos as u16,
             });
-            graph.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, pid, verse_gist, state);
+            graph.add_bi_edge_with_state(pid, verse_gist, state);
             phrase_nodes.push(pid);
         }
         // Phrase ↔ phrase chain (bi)
         for i in 1..phrase_nodes.len() {
-            graph.add_bi_edge_with_state(
-                EdgeKind::PhrasePhrase,
-                phrase_nodes[i - 1],
-                phrase_nodes[i],
-                state,
-            );
+            graph.add_bi_edge_with_state(phrase_nodes[i - 1], phrase_nodes[i], state);
         }
 
         // FTV node (optional, ≤ FTV_MAX_WORDS)
@@ -232,8 +222,8 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             let ftv = graph.add_node(NodeKind::Ftv {
                 text: verse_data.ftv.clone(),
             });
-            graph.add_edge_with_state(EdgeKind::FtvPhrase, ftv, phrase_nodes[0], state);
-            graph.add_edge_with_state(EdgeKind::FtvVerseGist, ftv, verse_gist, state);
+            graph.add_edge_with_state(ftv, phrase_nodes[0], state);
+            graph.add_edge_with_state(ftv, verse_gist, state);
             Some(ftv)
         } else {
             None
@@ -243,12 +233,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         if let Some(prev_gist) = prev_verse_gist
             && prev_verse_book.as_deref() == Some(&verse_data.book)
         {
-            graph.add_bi_edge_with_state(
-                EdgeKind::VerseGistVerseGist,
-                prev_gist,
-                verse_gist,
-                state,
-            );
+            graph.add_bi_edge_with_state(prev_gist, verse_gist, state);
         }
         prev_verse_gist = Some(verse_gist);
         prev_verse_book = Some(verse_data.book.clone());
@@ -262,7 +247,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             ))
             .copied();
         if let Some(hid) = heading_node {
-            graph.add_edge_with_state(EdgeKind::VerseGistHeading, verse_gist, hid, state);
+            graph.add_edge_with_state(verse_gist, hid, state);
         }
 
         // Club membership (verse layer). Tier expansion materialises both
@@ -273,12 +258,7 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
                 chapter: verse_data.chapter,
                 verse: verse_data.verse,
             });
-            graph.add_bi_edge_with_state(
-                EdgeKind::VerseRefVerseClubMember,
-                ref_node,
-                member,
-                state,
-            );
+            graph.add_bi_edge_with_state(ref_node, member, state);
             verse_club_members.insert(
                 (
                     tier,
@@ -332,8 +312,8 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         if let Some(&ch_gist) = chapter_gists.get(&(book.clone(), chapter_num))
             && let (Some(first), Some(last)) = (verses.first(), verses.last())
         {
-            graph.add_edge_with_state(EdgeKind::ChapterGistFirstVerseGist, ch_gist, first.1, state);
-            graph.add_edge_with_state(EdgeKind::ChapterGistLastVerseGist, ch_gist, last.1, state);
+            graph.add_edge_with_role(ch_gist, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(ch_gist, last.1, EdgeRole::LastChild, state);
         }
     }
 
@@ -353,8 +333,8 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
         }
         verses_in_range.sort_by_key(|(k, _)| *k);
         if let (Some(first), Some(last)) = (verses_in_range.first(), verses_in_range.last()) {
-            graph.add_edge_with_state(EdgeKind::HeadingFirstVerseGist, *hid, first.1, state);
-            graph.add_edge_with_state(EdgeKind::HeadingLastVerseGist, *hid, last.1, state);
+            graph.add_edge_with_role(*hid, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(*hid, last.1, EdgeRole::LastChild, state);
         }
     }
 
@@ -437,30 +417,20 @@ fn build_club_hierarchy(
             tier: *tier,
             chapter: *chapter,
         });
-        graph.add_bi_edge_with_state(EdgeKind::ChapterRefChapterClubMember, cref, ccm, state);
+        graph.add_bi_edge_with_state(cref, ccm, state);
         if let Some(&cg) = club_gists.get(tier) {
-            graph.add_edge_with_state(EdgeKind::ChapterClubMemberClubGist, ccm, cg, state);
+            graph.add_edge_with_state(ccm, cg, state);
         }
 
         let mut sorted = members.clone();
         sorted.sort_by_key(|(v, _)| *v);
         if let (Some(first), Some(last)) = (sorted.first(), sorted.last()) {
-            graph.add_edge_with_state(
-                EdgeKind::ChapterClubMemberFirstVerseClubMember,
-                ccm,
-                first.1,
-                state,
-            );
-            graph.add_edge_with_state(
-                EdgeKind::ChapterClubMemberLastVerseClubMember,
-                ccm,
-                last.1,
-                state,
-            );
+            graph.add_edge_with_role(ccm, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(ccm, last.1, EdgeRole::LastChild, state);
         }
         // Upward verse_cm → chapter_cm
         for (_, vcm) in &sorted {
-            graph.add_edge_with_state(EdgeKind::VerseClubMemberChapterClubMember, *vcm, ccm, state);
+            graph.add_edge_with_state(*vcm, ccm, state);
         }
 
         chapter_cm_by_tier
@@ -474,19 +444,14 @@ fn build_club_hierarchy(
     for (tier, chapters) in chapter_cm_by_tier.iter_mut() {
         chapters.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
         for i in 1..chapters.len() {
-            graph.add_bi_edge_with_state(
-                EdgeKind::ChapterClubMemberChapterClubMember,
-                chapters[i - 1].2,
-                chapters[i].2,
-                state,
-            );
+            graph.add_bi_edge_with_state(chapters[i - 1].2, chapters[i].2, state);
         }
         // Club gist → first/last chapter_cm endpoints
         if let Some(&cg) = club_gists.get(tier)
             && let (Some(first), Some(last)) = (chapters.first(), chapters.last())
         {
-            graph.add_edge_with_state(EdgeKind::ClubGistFirstChapterClubMember, cg, first.2, state);
-            graph.add_edge_with_state(EdgeKind::ClubGistLastChapterClubMember, cg, last.2, state);
+            graph.add_edge_with_role(cg, first.2, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(cg, last.2, EdgeRole::LastChild, state);
         }
     }
 
@@ -507,30 +472,20 @@ fn build_club_hierarchy(
             start_chapter: hdata.start_chapter,
             start_verse: hdata.start_verse,
         });
-        graph.add_bi_edge_with_state(EdgeKind::HeadingHeadingClubMember, *hid, hcm, state);
+        graph.add_bi_edge_with_state(*hid, hcm, state);
         if let Some(&cg) = club_gists.get(tier) {
-            graph.add_edge_with_state(EdgeKind::HeadingClubMemberClubGist, hcm, cg, state);
+            graph.add_edge_with_state(hcm, cg, state);
         }
 
         let mut sorted = members.clone();
         sorted.sort_by_key(|(k, _)| *k);
         if let (Some(first), Some(last)) = (sorted.first(), sorted.last()) {
-            graph.add_edge_with_state(
-                EdgeKind::HeadingClubMemberFirstVerseClubMember,
-                hcm,
-                first.1,
-                state,
-            );
-            graph.add_edge_with_state(
-                EdgeKind::HeadingClubMemberLastVerseClubMember,
-                hcm,
-                last.1,
-                state,
-            );
+            graph.add_edge_with_role(hcm, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(hcm, last.1, EdgeRole::LastChild, state);
         }
         // Upward verse_cm → heading_cm
         for (_, vcm) in &sorted {
-            graph.add_edge_with_state(EdgeKind::VerseClubMemberHeadingClubMember, *vcm, hcm, state);
+            graph.add_edge_with_state(*vcm, hcm, state);
         }
 
         if let Some(&idx) = heading_index.get(hid) {
@@ -545,18 +500,13 @@ fn build_club_hierarchy(
     for (tier, headings) in heading_cm_by_tier.iter_mut() {
         headings.sort_by_key(|(idx, _)| *idx);
         for i in 1..headings.len() {
-            graph.add_bi_edge_with_state(
-                EdgeKind::HeadingClubMemberHeadingClubMember,
-                headings[i - 1].1,
-                headings[i].1,
-                state,
-            );
+            graph.add_bi_edge_with_state(headings[i - 1].1, headings[i].1, state);
         }
         if let Some(&cg) = club_gists.get(tier)
             && let (Some(first), Some(last)) = (headings.first(), headings.last())
         {
-            graph.add_edge_with_state(EdgeKind::ClubGistFirstHeadingClubMember, cg, first.1, state);
-            graph.add_edge_with_state(EdgeKind::ClubGistLastHeadingClubMember, cg, last.1, state);
+            graph.add_edge_with_role(cg, first.1, EdgeRole::FirstChild, state);
+            graph.add_edge_with_role(cg, last.1, EdgeRole::LastChild, state);
         }
     }
 
@@ -572,26 +522,16 @@ fn build_club_hierarchy(
     for (tier, verses) in verse_members_by_tier.iter_mut() {
         verses.sort_by(|a, b| a.0.cmp(&b.0));
         for i in 1..verses.len() {
-            graph.add_bi_edge_with_state(
-                EdgeKind::VerseClubMemberVerseClubMember,
-                verses[i - 1].1,
-                verses[i].1,
-                state,
-            );
+            graph.add_bi_edge_with_state(verses[i - 1].1, verses[i].1, state);
         }
         // verse_cm → club_gist
         if let Some(&cg) = club_gists.get(tier) {
             for (_, vcm) in verses.iter() {
-                graph.add_edge_with_state(EdgeKind::VerseClubMemberClubGist, *vcm, cg, state);
+                graph.add_edge_with_state(*vcm, cg, state);
             }
             if let (Some(first), Some(last)) = (verses.first(), verses.last()) {
-                graph.add_edge_with_state(
-                    EdgeKind::ClubGistFirstVerseClubMember,
-                    cg,
-                    first.1,
-                    state,
-                );
-                graph.add_edge_with_state(EdgeKind::ClubGistLastVerseClubMember, cg, last.1, state);
+                graph.add_edge_with_role(cg, first.1, EdgeRole::FirstChild, state);
+                graph.add_edge_with_role(cg, last.1, EdgeRole::LastChild, state);
             }
         }
     }
@@ -889,10 +829,13 @@ mod tests {
             .graph
             .edge_ids()
             .filter(|&id| {
-                result
-                    .graph
-                    .edge(id)
-                    .is_some_and(|e| matches!(e.kind, EdgeKind::VerseGistHeading))
+                result.graph.edge(id).is_some_and(|e| {
+                    result.graph.edge_connects(
+                        e,
+                        |k| matches!(k, NodeKind::VerseGist { .. }),
+                        |k| matches!(k, NodeKind::Heading { .. }),
+                    )
+                })
             })
             .collect();
         assert_eq!(heading_edges.len(), 3);
@@ -926,20 +869,28 @@ mod tests {
             .graph
             .edge_ids()
             .filter(|&id| {
-                result
-                    .graph
-                    .edge(id)
-                    .is_some_and(|e| matches!(e.kind, EdgeKind::ChapterGistFirstVerseGist))
+                result.graph.edge(id).is_some_and(|e| {
+                    e.role == Some(EdgeRole::FirstChild)
+                        && result.graph.edge_connects(
+                            e,
+                            |k| matches!(k, NodeKind::ChapterGist { .. }),
+                            |k| matches!(k, NodeKind::VerseGist { .. }),
+                        )
+                })
             })
             .count();
         let last_count = result
             .graph
             .edge_ids()
             .filter(|&id| {
-                result
-                    .graph
-                    .edge(id)
-                    .is_some_and(|e| matches!(e.kind, EdgeKind::ChapterGistLastVerseGist))
+                result.graph.edge(id).is_some_and(|e| {
+                    e.role == Some(EdgeRole::LastChild)
+                        && result.graph.edge_connects(
+                            e,
+                            |k| matches!(k, NodeKind::ChapterGist { .. }),
+                            |k| matches!(k, NodeKind::VerseGist { .. }),
+                        )
+                })
             })
             .count();
         assert_eq!(first_count, 1);

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -27,6 +27,8 @@ fn initial_state(now_secs: i64) -> EdgeState {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct VerseAtoms {
     pub ref_node: NodeId,
+    pub chapter_ref: NodeId,
+    pub book_ref: NodeId,
     pub verse_gist: NodeId,
     pub phrases: Vec<NodeId>,
     pub ftv: Option<NodeId>,
@@ -295,8 +297,18 @@ pub fn build(data: &MaterialData, card_types: &CardTypesConfig, now_secs: i64) -
             .or_default()
             .push((verse_data.verse, verse_gist));
 
+        let chapter_ref = chapter_refs
+            .get(&(verse_data.book.clone(), verse_data.chapter))
+            .copied()
+            .expect("chapter_ref was inserted during chapter layer");
+        let book_ref = *book_refs
+            .get(&verse_data.book)
+            .expect("book_ref was inserted during book layer");
+
         verse_atoms_list.push(VerseAtoms {
             ref_node,
+            chapter_ref,
+            book_ref,
             verse_gist,
             phrases: phrase_nodes,
             ftv: ftv_node,

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -648,7 +648,14 @@ fn resolve_roles(
 
     for role_str in roles {
         match parse_role(role_str)? {
-            AtomRole::Ref => nodes.push(atoms.ref_node),
+            // `ref` expands to the full book/chapter/verse triple so every
+            // reference-bearing card carries the three atoms that grade
+            // independently (see card-coupling design in docs/graph.md).
+            AtomRole::Ref => {
+                nodes.push(atoms.book_ref);
+                nodes.push(atoms.chapter_ref);
+                nodes.push(atoms.ref_node);
+            }
             AtomRole::Phrases => nodes.extend_from_slice(&atoms.phrases),
             AtomRole::FirstPhrase => {
                 nodes.push(*atoms.phrases.first()?);
@@ -759,11 +766,45 @@ mod tests {
         let card_types = test_card_types();
         let result = build(&data, &card_types, 0);
         assert!(result.cards.len() >= 10, "cards: {}", result.cards.len());
-        let full_recit = result
-            .cards
-            .iter()
-            .find(|c| c.shown.len() == 1 && c.hidden.len() == 2);
+
+        // Full-recitation: shown = [book_ref, chapter_ref, verse_ref] (3)
+        // and hidden = all phrases (2 in test data).
+        let atoms0 = &result.verse_atoms[0];
+        let full_recit = result.cards.iter().find(|c| {
+            c.shown == vec![atoms0.book_ref, atoms0.chapter_ref, atoms0.ref_node]
+                && c.hidden == atoms0.phrases
+        });
         assert!(full_recit.is_some(), "should have a full recitation card");
+    }
+
+    #[test]
+    fn ref_role_expands_to_book_chapter_verse() {
+        let data = test_data();
+        let card_types = test_card_types();
+        let result = build(&data, &card_types, 0);
+
+        // A card containing a given verse's VerseRef must also contain the
+        // matching chapter_ref and book_ref (in the same slot).
+        let mut saw_ref_card = false;
+        for card in &result.cards {
+            for atoms in &result.verse_atoms {
+                for (slot_name, slot) in [("shown", &card.shown), ("hidden", &card.hidden)] {
+                    if !slot.contains(&atoms.ref_node) {
+                        continue;
+                    }
+                    saw_ref_card = true;
+                    assert!(
+                        slot.contains(&atoms.chapter_ref),
+                        "card {slot_name} has verse_ref but missing chapter_ref: {slot:?}"
+                    );
+                    assert!(
+                        slot.contains(&atoms.book_ref),
+                        "card {slot_name} has verse_ref but missing book_ref: {slot:?}"
+                    );
+                }
+            }
+        }
+        assert!(saw_ref_card, "expected at least one ref-bearing card");
     }
 
     #[test]

--- a/crates/core/src/card_types.rs
+++ b/crates/core/src/card_types.rs
@@ -34,9 +34,94 @@ pub struct CardTypeDef {
     pub scope: CardScope,
 }
 
+/// Errors surfaced by `CardTypesConfig::from_toml`: either bad TOML or a
+/// schema-valid TOML whose semantics don't fit the card-types model
+/// (wrong scope for a role, `iterate`/`requires` on a non-verse card, …).
+#[derive(Debug)]
+pub enum CardTypesError {
+    Toml(toml::de::Error),
+    Invalid { card: String, reason: String },
+}
+
+impl std::fmt::Display for CardTypesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CardTypesError::Toml(e) => write!(f, "card_types TOML parse error: {e}"),
+            CardTypesError::Invalid { card, reason } => {
+                write!(f, "invalid card type `{card}`: {reason}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CardTypesError {}
+
 impl CardTypesConfig {
-    pub fn from_toml(toml_str: &str) -> Result<Self, toml::de::Error> {
-        toml::from_str(toml_str)
+    pub fn from_toml(toml_str: &str) -> Result<Self, CardTypesError> {
+        let config: Self = toml::from_str(toml_str).map_err(CardTypesError::Toml)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), CardTypesError> {
+        for ct in &self.card_types {
+            // `iterate` and `requires` only mean something on the verse
+            // path — `generate_chapter_club_cards` and
+            // `generate_heading_cards` don't honour them. Reject up front
+            // rather than silently ignoring.
+            if ct.scope != CardScope::Verse && (ct.iterate.is_some() || ct.requires.is_some()) {
+                return Err(CardTypesError::Invalid {
+                    card: ct.name.clone(),
+                    reason: format!(
+                        "`iterate` / `requires` are only valid on `scope = \"verse\"` (got {:?})",
+                        ct.scope
+                    ),
+                });
+            }
+            // Every role in show/hide must be valid AND fit the card's scope.
+            for role_str in ct.show.iter().chain(ct.hide.iter()) {
+                let role = parse_role(role_str).ok_or_else(|| CardTypesError::Invalid {
+                    card: ct.name.clone(),
+                    reason: format!("unknown role `{role_str}`"),
+                })?;
+                let allowed = allowed_scopes(&role);
+                if !allowed.contains(&ct.scope) {
+                    return Err(CardTypesError::Invalid {
+                        card: ct.name.clone(),
+                        reason: format!(
+                            "role `{role_str}` is not valid in scope `{:?}` (allowed: {:?})",
+                            ct.scope, allowed
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Which `CardScope`s an atom role can be resolved within. Used by
+/// `CardTypesConfig::validate` to reject mismatched configurations at
+/// parse time so the runtime never silently drops a misconfigured card.
+fn allowed_scopes(role: &AtomRole) -> &'static [CardScope] {
+    match role {
+        AtomRole::Ref
+        | AtomRole::Phrases
+        | AtomRole::FirstPhrase
+        | AtomRole::RemainingPhrases
+        | AtomRole::Current
+        | AtomRole::PhrasesExceptCurrent
+        | AtomRole::Ftv
+        | AtomRole::NextHeading
+        | AtomRole::PrevHeading
+        | AtomRole::ChapterGist
+        | AtomRole::ClubRefs => &[CardScope::Verse],
+        AtomRole::Heading => &[CardScope::Verse, CardScope::Heading],
+        AtomRole::BookRef | AtomRole::ChapterRef | AtomRole::ClubGist => {
+            &[CardScope::Verse, CardScope::ChapterClub]
+        }
+        AtomRole::ChapterClubVerseRefs => &[CardScope::ChapterClub],
+        AtomRole::HeadingVerseRefs => &[CardScope::Heading],
     }
 }
 
@@ -181,5 +266,67 @@ mod tests {
         assert_eq!(config.card_types[0].scope, CardScope::Verse);
         assert_eq!(config.card_types[1].scope, CardScope::ChapterClub);
         assert_eq!(config.card_types[2].scope, CardScope::Heading);
+    }
+
+    #[test]
+    fn rejects_iterate_on_non_verse_scope() {
+        let toml = r#"
+            [[card_types]]
+            name = "bad"
+            scope = "chapter_club"
+            iterate = "phrases"
+            show = ["club_gist"]
+            hide = ["chapter_club_verse_refs"]
+        "#;
+        let err = CardTypesConfig::from_toml(toml).unwrap_err();
+        match err {
+            CardTypesError::Invalid { card, reason } => {
+                assert_eq!(card, "bad");
+                assert!(reason.contains("`iterate`"), "got: {reason}");
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_requires_on_non_verse_scope() {
+        let toml = r#"
+            [[card_types]]
+            name = "bad"
+            scope = "heading"
+            requires = "ftv"
+            show = ["heading_verse_refs"]
+            hide = ["heading"]
+        "#;
+        let err = CardTypesConfig::from_toml(toml).unwrap_err();
+        assert!(matches!(err, CardTypesError::Invalid { .. }));
+    }
+
+    #[test]
+    fn rejects_role_outside_its_scope() {
+        let toml = r#"
+            [[card_types]]
+            name = "wrong_role"
+            show = ["chapter_club_verse_refs"]
+            hide = ["phrases"]
+        "#;
+        let err = CardTypesConfig::from_toml(toml).unwrap_err();
+        match err {
+            CardTypesError::Invalid { reason, .. } => {
+                assert!(reason.contains("chapter_club_verse_refs"), "got: {reason}");
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepts_book_chapter_club_in_verse_scope() {
+        let toml = r#"
+            [[card_types]]
+            name = "verse_to_club"
+            show = ["ref"]
+            hide = ["club_gist"]
+        "#;
+        CardTypesConfig::from_toml(toml).expect("club_gist allowed in verse scope");
     }
 }

--- a/crates/core/src/card_types.rs
+++ b/crates/core/src/card_types.rs
@@ -7,6 +7,20 @@ pub struct CardTypesConfig {
     pub card_types: Vec<CardTypeDef>,
 }
 
+/// Which iteration axis a card definition runs over.
+///
+/// `Verse` is the default: one card per `VerseAtoms`. Listing-style cards
+/// that operate at a coarser granularity use a different scope and iterate
+/// over matching context bundles (e.g. `ChapterClubAtoms`).
+#[derive(Debug, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CardScope {
+    #[default]
+    Verse,
+    ChapterClub,
+    Heading,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct CardTypeDef {
     pub name: String,
@@ -16,6 +30,8 @@ pub struct CardTypeDef {
     pub iterate: Option<String>,
     #[serde(default)]
     pub requires: Option<String>,
+    #[serde(default)]
+    pub scope: CardScope,
 }
 
 impl CardTypesConfig {
@@ -28,6 +44,9 @@ impl CardTypesConfig {
 /// The graph builder resolves these to actual NodeIds.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AtomRole {
+    // --- Verse-scope roles ---
+    /// Shorthand that expands to the full `[book_ref, chapter_ref, verse_ref]`
+    /// triple in the verse scope (see card-coupling design in docs/graph.md).
     Ref,
     Phrases,
     FirstPhrase,
@@ -42,6 +61,18 @@ pub enum AtomRole {
     PrevHeading,
     ChapterGist,
     ClubRefs,
+
+    // --- Chapter-club scope roles ---
+    /// The `ClubGist` atom for the card's tier.
+    ClubGist,
+    /// The `BookRef` atom only (no triple coupling).
+    BookRef,
+    /// The `ChapterRef` atom only (no triple coupling).
+    ChapterRef,
+    /// Every `VerseRef` atom for verses in the card's (chapter, tier).
+    ChapterClubVerseRefs,
+    /// Every `VerseRef` atom for verses in the card's heading range.
+    HeadingVerseRefs,
 }
 
 pub fn parse_role(s: &str) -> Option<AtomRole> {
@@ -56,6 +87,11 @@ pub fn parse_role(s: &str) -> Option<AtomRole> {
         "prev_heading" => Some(AtomRole::PrevHeading),
         "chapter_gist" => Some(AtomRole::ChapterGist),
         "club_refs" => Some(AtomRole::ClubRefs),
+        "club_gist" => Some(AtomRole::ClubGist),
+        "book_ref" => Some(AtomRole::BookRef),
+        "chapter_ref" => Some(AtomRole::ChapterRef),
+        "chapter_club_verse_refs" => Some(AtomRole::ChapterClubVerseRefs),
+        "heading_verse_refs" => Some(AtomRole::HeadingVerseRefs),
         "$" => Some(AtomRole::Current),
         _ if s.starts_with("phrases - $") => Some(AtomRole::PhrasesExceptCurrent),
         _ => None,
@@ -106,5 +142,44 @@ mod tests {
         assert_eq!(parse_role("$"), Some(AtomRole::Current));
         assert!(parse_role("phrases - $").is_some());
         assert!(parse_role("unknown").is_none());
+
+        // Chapter-club + heading scope roles
+        assert_eq!(parse_role("club_gist"), Some(AtomRole::ClubGist));
+        assert_eq!(parse_role("book_ref"), Some(AtomRole::BookRef));
+        assert_eq!(parse_role("chapter_ref"), Some(AtomRole::ChapterRef));
+        assert_eq!(
+            parse_role("chapter_club_verse_refs"),
+            Some(AtomRole::ChapterClubVerseRefs)
+        );
+        assert_eq!(
+            parse_role("heading_verse_refs"),
+            Some(AtomRole::HeadingVerseRefs)
+        );
+    }
+
+    #[test]
+    fn card_scope_defaults_to_verse() {
+        let toml = r#"
+            [[card_types]]
+            name = "full_recitation"
+            show = ["ref"]
+            hide = ["phrases"]
+
+            [[card_types]]
+            name = "club_chapter_listing"
+            scope = "chapter_club"
+            show = ["club_gist", "book_ref", "chapter_ref"]
+            hide = ["chapter_club_verse_refs"]
+
+            [[card_types]]
+            name = "verses_to_heading"
+            scope = "heading"
+            show = ["heading_verse_refs"]
+            hide = ["heading"]
+        "#;
+        let config = CardTypesConfig::from_toml(toml).unwrap();
+        assert_eq!(config.card_types[0].scope, CardScope::Verse);
+        assert_eq!(config.card_types[1].scope, CardScope::ChapterClub);
+        assert_eq!(config.card_types[2].scope, CardScope::Heading);
     }
 }

--- a/crates/core/src/cascade.rs
+++ b/crates/core/src/cascade.rs
@@ -111,7 +111,7 @@ fn collect_card_edges(graph: &Graph, card: &Card, params: &ScheduleParams) -> Ve
 mod tests {
     use super::*;
     use crate::card::CardState;
-    use crate::edge::{EdgeKind, EdgeState};
+    use crate::edge::EdgeState;
     use crate::node::NodeKind;
 
     fn make_test_graph_and_cards() -> (Graph, Vec<Card>) {
@@ -140,10 +140,10 @@ mod tests {
             difficulty: 5.0,
             last_review_secs: 0,
         };
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p1, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p2, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p1, p2, state);
+        g.add_bi_edge_with_state(v, r, state);
+        g.add_bi_edge_with_state(p1, v, state);
+        g.add_bi_edge_with_state(p2, v, state);
+        g.add_bi_edge_with_state(p1, p2, state);
 
         let full_recitation = Card {
             id: CardId(0),
@@ -178,7 +178,11 @@ mod tests {
             .edge_ids()
             .filter(|&eid| {
                 let e = g.edge(eid).unwrap();
-                matches!(e.kind, EdgeKind::PhraseVerseGist)
+                g.edge_connects(
+                    e,
+                    |k| matches!(k, NodeKind::Phrase { .. }),
+                    |k| matches!(k, NodeKind::VerseGist { .. }),
+                )
             })
             .collect();
 

--- a/crates/core/src/credit.rs
+++ b/crates/core/src/credit.rs
@@ -305,9 +305,7 @@ fn apply_reverse_reinforcement(
             Some(e) => e,
             None => continue,
         };
-        // Find reverse edge: target → source with the same role. Since we
-        // iterate outgoing_edges(edge.target) the source matches by
-        // construction; we only need to check the far end.
+        // Reverse edge: target → source with the same role.
         for &reverse_candidate in graph.outgoing_edges(edge.target) {
             let rev = match graph.edge(reverse_candidate) {
                 Some(e) => e,

--- a/crates/core/src/credit.rs
+++ b/crates/core/src/credit.rs
@@ -305,13 +305,15 @@ fn apply_reverse_reinforcement(
             Some(e) => e,
             None => continue,
         };
-        // Find reverse edge (same kind, target->source)
+        // Find reverse edge: target → source with the same role. Since we
+        // iterate outgoing_edges(edge.target) the source matches by
+        // construction; we only need to check the far end.
         for &reverse_candidate in graph.outgoing_edges(edge.target) {
             let rev = match graph.edge(reverse_candidate) {
                 Some(e) => e,
                 None => continue,
             };
-            if rev.target != edge.source || rev.kind != edge.kind {
+            if rev.target != edge.source || rev.role != edge.role {
                 continue;
             }
             if primary_edge_ids.contains(&reverse_candidate)
@@ -345,7 +347,7 @@ fn path_probability(graph: &Graph, edges: &[EdgeId], fsrs: &FsrsBridge, now_secs
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::{EdgeKind, EdgeState};
+    use crate::edge::EdgeState;
     use crate::node::NodeKind;
 
     fn make_verse_graph() -> (Graph, NodeId, NodeId, NodeId, NodeId, NodeId) {
@@ -381,12 +383,12 @@ mod tests {
             last_review_secs: 0,
         };
 
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p1, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p2, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p3, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p1, p2, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p2, p3, state);
+        g.add_bi_edge_with_state(v, r, state);
+        g.add_bi_edge_with_state(p1, v, state);
+        g.add_bi_edge_with_state(p2, v, state);
+        g.add_bi_edge_with_state(p3, v, state);
+        g.add_bi_edge_with_state(p1, p2, state);
+        g.add_bi_edge_with_state(p2, p3, state);
 
         (g, r, v, p1, p2, p3)
     }
@@ -451,7 +453,7 @@ mod tests {
             .iter()
             .filter(|&&eid| {
                 let e = g.edge(eid).unwrap();
-                e.target == p2 && matches!(e.kind, EdgeKind::PhrasePhrase)
+                e.target == p2
             })
             .collect();
         assert!(!p1_to_p2_edges.is_empty());
@@ -484,7 +486,7 @@ mod tests {
             .copied()
             .filter(|&eid| {
                 let e = g.edge(eid).unwrap();
-                e.target == p3 && matches!(e.kind, EdgeKind::PhrasePhrase)
+                e.target == p3
             })
             .collect();
 
@@ -537,7 +539,7 @@ mod tests {
             .copied()
             .filter(|&eid| {
                 let e = g.edge(eid).unwrap();
-                e.target == p2 && matches!(e.kind, EdgeKind::PhrasePhrase)
+                e.target == p2
             })
             .collect();
 
@@ -573,7 +575,7 @@ mod tests {
             .copied()
             .filter(|&eid| {
                 let e = g.edge(eid).unwrap();
-                e.target == p2 && matches!(e.kind, EdgeKind::PhrasePhrase)
+                e.target == p2
             })
             .collect();
 

--- a/crates/core/src/edge.rs
+++ b/crates/core/src/edge.rs
@@ -2,76 +2,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{EdgeId, NodeId};
 
-/// Directed edge kinds in the memory graph.
-///
-/// Each variant represents a specific retrieval proposition: "given I am
-/// thinking about X, can I produce Y?" Every edge carries FSRS state.
-///
-/// The enum duplicates the same containment pattern (gist↔ref,
-/// parent→first/last child, parent-consecutive chain, child_ref→parent_ref)
-/// across the book/chapter/verse/heading/club layers. A future cleanup
-/// could collapse these to generic variants parameterised by a layer
-/// discriminator (`ContainsStart`, `ContainsEnd`, `ParentRef`, …); kept
-/// explicit for now while the schema is still iterating. See
-/// `docs/graph.md` for the design rationale.
+/// Disambiguates edges that share the same `(source.kind, target.kind)`
+/// pair. Presently just parent → first/last child endpoint edges — for
+/// a one-child parent those would otherwise be indistinguishable. Every
+/// other edge has `role: None` and gets its identity from its endpoint
+/// node kinds alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum EdgeKind {
-    // --- Phrase / verse layer ---
-    PhrasePhrase,
-    PhraseVerseGist,
-    VerseGistVerseRef,
-    VerseGistVerseGist,
-
-    // --- Chapter layer ---
-    ChapterGistChapterRef,
-    VerseGistChapterGist,
-    ChapterGistFirstVerseGist,
-    ChapterGistLastVerseGist,
-    VerseRefChapterRef,
-    ChapterGistChapterGist,
-
-    // --- Book layer ---
-    BookGistBookRef,
-    ChapterGistBookGist,
-    BookGistFirstChapterGist,
-    BookGistLastChapterGist,
-    ChapterRefBookRef,
-    BookGistBookGist,
-
-    // --- Heading layer ---
-    VerseGistHeading,
-    HeadingHeading,
-    HeadingFirstVerseGist,
-    HeadingLastVerseGist,
-
-    // --- Club hierarchy (verse + chapter) ---
-    VerseRefVerseClubMember,
-    VerseClubMemberVerseClubMember,
-    VerseClubMemberClubGist,
-    VerseClubMemberChapterClubMember,
-    ChapterRefChapterClubMember,
-    ChapterClubMemberChapterClubMember,
-    ChapterClubMemberClubGist,
-    ChapterClubMemberFirstVerseClubMember,
-    ChapterClubMemberLastVerseClubMember,
-    ClubGistFirstVerseClubMember,
-    ClubGistLastVerseClubMember,
-    ClubGistFirstChapterClubMember,
-    ClubGistLastChapterClubMember,
-
-    // --- Heading-club hierarchy ---
-    HeadingHeadingClubMember,
-    HeadingClubMemberHeadingClubMember,
-    HeadingClubMemberClubGist,
-    VerseClubMemberHeadingClubMember,
-    HeadingClubMemberFirstVerseClubMember,
-    HeadingClubMemberLastVerseClubMember,
-    ClubGistFirstHeadingClubMember,
-    ClubGistLastHeadingClubMember,
-
-    // --- FTV ---
-    FtvPhrase,
-    FtvVerseGist,
+pub enum EdgeRole {
+    FirstChild,
+    LastChild,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -84,8 +23,9 @@ pub struct EdgeState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Edge {
     pub id: EdgeId,
-    pub kind: EdgeKind,
     pub source: NodeId,
     pub target: NodeId,
     pub state: EdgeState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<EdgeRole>,
 }

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -175,7 +175,7 @@ impl ReviewEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::{EdgeKind, EdgeState};
+    use crate::edge::EdgeState;
     use crate::node::NodeKind;
 
     const DAY: i64 = 86400;
@@ -211,12 +211,12 @@ mod tests {
             difficulty: 5.0,
             last_review_secs: 0,
         };
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p1, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p2, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p3, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p1, p2, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p2, p3, state);
+        g.add_bi_edge_with_state(v, r, state);
+        g.add_bi_edge_with_state(p1, v, state);
+        g.add_bi_edge_with_state(p2, v, state);
+        g.add_bi_edge_with_state(p3, v, state);
+        g.add_bi_edge_with_state(p1, p2, state);
+        g.add_bi_edge_with_state(p2, p3, state);
 
         let full = Card {
             id: CardId(0),
@@ -302,7 +302,7 @@ mod tests {
             .copied()
             .find(|&eid| {
                 let e = engine.graph.edge(eid).unwrap();
-                e.target == p2 && matches!(e.kind, EdgeKind::PhrasePhrase)
+                e.target == p2
             })
             .unwrap();
 

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::edge::{Edge, EdgeKind, EdgeState};
+use crate::edge::{Edge, EdgeRole, EdgeState};
 use crate::node::{Node, NodeKind};
 use crate::types::{EdgeId, NodeId};
 
@@ -15,6 +15,12 @@ pub struct Graph {
     next_node_id: u32,
     next_edge_id: u32,
 }
+
+const DEFAULT_EDGE_STATE: EdgeState = EdgeState {
+    stability: 0.0,
+    difficulty: 5.0,
+    last_review_secs: 0,
+};
 
 impl Graph {
     pub fn new() -> Self {
@@ -30,21 +36,54 @@ impl Graph {
         id
     }
 
-    pub fn add_edge(&mut self, kind: EdgeKind, source: NodeId, target: NodeId) -> EdgeId {
-        let state = EdgeState {
-            stability: 0.0,
-            difficulty: 5.0,
-            last_review_secs: 0,
-        };
-        self.add_edge_with_state(kind, source, target, state)
+    pub fn add_edge(&mut self, source: NodeId, target: NodeId) -> EdgeId {
+        self.insert_edge(source, target, DEFAULT_EDGE_STATE, None)
     }
 
     pub fn add_edge_with_state(
         &mut self,
-        kind: EdgeKind,
         source: NodeId,
         target: NodeId,
         state: EdgeState,
+    ) -> EdgeId {
+        self.insert_edge(source, target, state, None)
+    }
+
+    pub fn add_edge_with_role(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        role: EdgeRole,
+        state: EdgeState,
+    ) -> EdgeId {
+        self.insert_edge(source, target, state, Some(role))
+    }
+
+    /// Add a bidirectional edge pair (two directed edges with independent state).
+    pub fn add_bi_edge(&mut self, a: NodeId, b: NodeId) -> (EdgeId, EdgeId) {
+        let forward = self.add_edge(a, b);
+        let backward = self.add_edge(b, a);
+        (forward, backward)
+    }
+
+    /// Add a bidirectional edge pair with explicit initial state.
+    pub fn add_bi_edge_with_state(
+        &mut self,
+        a: NodeId,
+        b: NodeId,
+        state: EdgeState,
+    ) -> (EdgeId, EdgeId) {
+        let forward = self.add_edge_with_state(a, b, state);
+        let backward = self.add_edge_with_state(b, a, state);
+        (forward, backward)
+    }
+
+    fn insert_edge(
+        &mut self,
+        source: NodeId,
+        target: NodeId,
+        state: EdgeState,
+        role: Option<EdgeRole>,
     ) -> EdgeId {
         let id = EdgeId(self.next_edge_id);
         self.next_edge_id += 1;
@@ -52,35 +91,15 @@ impl Graph {
             id,
             Edge {
                 id,
-                kind,
                 source,
                 target,
                 state,
+                role,
             },
         );
         self.outgoing.entry(source).or_default().push(id);
         self.incoming.entry(target).or_default().push(id);
         id
-    }
-
-    /// Add a bidirectional edge pair (two directed edges with independent state).
-    pub fn add_bi_edge(&mut self, kind: EdgeKind, a: NodeId, b: NodeId) -> (EdgeId, EdgeId) {
-        let forward = self.add_edge(kind, a, b);
-        let backward = self.add_edge(kind, b, a);
-        (forward, backward)
-    }
-
-    /// Add a bidirectional edge pair with explicit initial state.
-    pub fn add_bi_edge_with_state(
-        &mut self,
-        kind: EdgeKind,
-        a: NodeId,
-        b: NodeId,
-        state: EdgeState,
-    ) -> (EdgeId, EdgeId) {
-        let forward = self.add_edge_with_state(kind, a, b, state);
-        let backward = self.add_edge_with_state(kind, b, a, state);
-        (forward, backward)
     }
 
     pub fn node(&self, id: NodeId) -> Option<&Node> {
@@ -127,45 +146,45 @@ impl Graph {
         self.edges.values()
     }
 
+    /// True when `edge` connects a node matching `src` to a node matching
+    /// `dst`. Use with `matches!` against `NodeKind` variants when the
+    /// caller cares about the specific source→target shape.
+    pub fn edge_connects<P, Q>(&self, edge: &Edge, src: P, dst: Q) -> bool
+    where
+        P: FnOnce(&NodeKind) -> bool,
+        Q: FnOnce(&NodeKind) -> bool,
+    {
+        self.node_kind(edge.source).is_some_and(src) && self.node_kind(edge.target).is_some_and(dst)
+    }
+
     /// Find the verse context for a given atom: (verse-ref NodeId, sorted phrase NodeIds).
-    /// Traverses: atom → VerseGist (via PhraseVerseGist) → VerseRef + all Phrases.
+    /// Traverses: atom → VerseGist → VerseRef + all Phrases.
     /// Works for Phrase, VerseGist, and VerseRef atoms.
     pub fn verse_context(&self, atom: NodeId) -> Option<(NodeId, Vec<NodeId>)> {
-        use crate::edge::EdgeKind;
-        use crate::node::NodeKind;
-
         let verse_gist = match self.node_kind(atom)? {
             NodeKind::VerseGist { .. } => atom,
             NodeKind::Phrase { .. } => {
-                self.find_neighbor(atom, EdgeKind::PhraseVerseGist, |k| {
-                    matches!(k, NodeKind::VerseGist { .. })
-                })?
+                self.find_neighbor(atom, |k| matches!(k, NodeKind::VerseGist { .. }))?
             }
             NodeKind::VerseRef { .. } => {
-                self.find_neighbor(atom, EdgeKind::VerseGistVerseRef, |k| {
-                    matches!(k, NodeKind::VerseGist { .. })
-                })?
+                self.find_neighbor(atom, |k| matches!(k, NodeKind::VerseGist { .. }))?
             }
             _ => return None,
         };
 
-        let reference = self.find_neighbor(verse_gist, EdgeKind::VerseGistVerseRef, |k| {
-            matches!(k, NodeKind::VerseRef { .. })
-        })?;
+        let verse_ref =
+            self.find_neighbor(verse_gist, |k| matches!(k, NodeKind::VerseRef { .. }))?;
 
         let mut phrases: Vec<(u16, NodeId)> = Vec::new();
         for &eid in self.outgoing_edges(verse_gist) {
             if let Some(edge) = self.edge(eid)
-                && edge.kind == EdgeKind::PhraseVerseGist
                 && let Some(NodeKind::Phrase { position, .. }) = self.node_kind(edge.target)
             {
                 phrases.push((*position, edge.target));
             }
         }
-        // Also check incoming (phrase→verse edges)
         for &eid in self.incoming_edges(verse_gist) {
             if let Some(edge) = self.edge(eid)
-                && edge.kind == EdgeKind::PhraseVerseGist
                 && let Some(NodeKind::Phrase { position, .. }) = self.node_kind(edge.source)
                 && !phrases.iter().any(|(_, id)| *id == edge.source)
             {
@@ -175,18 +194,12 @@ impl Graph {
         phrases.sort_by_key(|(pos, _)| *pos);
         let phrase_ids: Vec<NodeId> = phrases.into_iter().map(|(_, id)| id).collect();
 
-        Some((reference, phrase_ids))
+        Some((verse_ref, phrase_ids))
     }
 
-    fn find_neighbor(
-        &self,
-        node: NodeId,
-        edge_kind: crate::edge::EdgeKind,
-        pred: impl Fn(&NodeKind) -> bool,
-    ) -> Option<NodeId> {
+    fn find_neighbor(&self, node: NodeId, pred: impl Fn(&NodeKind) -> bool) -> Option<NodeId> {
         for &eid in self.outgoing_edges(node) {
             if let Some(edge) = self.edge(eid)
-                && edge.kind == edge_kind
                 && let Some(kind) = self.node_kind(edge.target)
                 && pred(kind)
             {
@@ -195,7 +208,6 @@ impl Graph {
         }
         for &eid in self.incoming_edges(node) {
             if let Some(edge) = self.edge(eid)
-                && edge.kind == edge_kind
                 && let Some(kind) = self.node_kind(edge.source)
                 && pred(kind)
             {
@@ -228,9 +240,9 @@ mod tests {
             position: 1,
         });
 
-        g.add_bi_edge(EdgeKind::PhraseVerseGist, p1, v);
-        g.add_bi_edge(EdgeKind::PhraseVerseGist, p2, v);
-        g.add_bi_edge(EdgeKind::PhrasePhrase, p1, p2);
+        g.add_bi_edge(p1, v);
+        g.add_bi_edge(p2, v);
+        g.add_bi_edge(p1, p2);
 
         assert_eq!(g.node_count(), 3);
         assert_eq!(g.edge_count(), 6);
@@ -248,7 +260,7 @@ mod tests {
             verse: 2,
         });
 
-        let (fwd, bwd) = g.add_bi_edge(EdgeKind::VerseGistVerseGist, a, b);
+        let (fwd, bwd) = g.add_bi_edge(a, b);
 
         let fwd_edge = g.edge(fwd).unwrap();
         assert_eq!(fwd_edge.source, a);
@@ -273,7 +285,7 @@ mod tests {
         });
         let ch = g.add_node(NodeKind::ChapterGist { chapter: 1 });
 
-        g.add_edge(EdgeKind::VerseGistChapterGist, v, ch);
+        g.add_edge(v, ch);
 
         assert_eq!(g.outgoing_edges(v).len(), 1);
         assert_eq!(g.outgoing_edges(ch).len(), 0);
@@ -293,8 +305,24 @@ mod tests {
             verse: 1,
         });
 
-        let eid = g.add_edge(EdgeKind::VerseGistVerseRef, v, r);
+        let eid = g.add_edge(v, r);
         let state = g.edge(eid).unwrap().state;
         assert_eq!(state.difficulty, 5.0);
+    }
+
+    #[test]
+    fn role_is_optional() {
+        let mut g = Graph::new();
+        let ch = g.add_node(NodeKind::ChapterGist { chapter: 1 });
+        let v = g.add_node(NodeKind::VerseGist {
+            chapter: 1,
+            verse: 1,
+        });
+
+        let plain = g.add_edge(v, ch);
+        assert!(g.edge(plain).unwrap().role.is_none());
+
+        let endpoint = g.add_edge_with_role(ch, v, EdgeRole::FirstChild, DEFAULT_EDGE_STATE);
+        assert_eq!(g.edge(endpoint).unwrap().role, Some(EdgeRole::FirstChild));
     }
 }

--- a/crates/core/src/graph.rs
+++ b/crates/core/src/graph.rs
@@ -197,6 +197,19 @@ impl Graph {
         Some((verse_ref, phrase_ids))
     }
 
+    /// Walk `verse_ref → chapter_ref → book_ref` via the structural ref-chain
+    /// edges. Returns the (chapter_ref, book_ref) pair, or None if either link
+    /// is missing (e.g. graphs built before the chapter/book layers existed).
+    /// Used by session re-drill / new-verse cards to assemble the full ref
+    /// triple at render time.
+    pub fn verse_ref_parents(&self, verse_ref: NodeId) -> Option<(NodeId, NodeId)> {
+        let chapter_ref =
+            self.find_neighbor(verse_ref, |k| matches!(k, NodeKind::ChapterRef { .. }))?;
+        let book_ref =
+            self.find_neighbor(chapter_ref, |k| matches!(k, NodeKind::BookRef { .. }))?;
+        Some((chapter_ref, book_ref))
+    }
+
     fn find_neighbor(&self, node: NodeId, pred: impl Fn(&NodeKind) -> bool) -> Option<NodeId> {
         for &eid in self.outgoing_edges(node) {
             if let Some(edge) = self.edge(eid)

--- a/crates/core/src/path.rs
+++ b/crates/core/src/path.rs
@@ -86,7 +86,6 @@ fn dfs(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::EdgeKind;
     use crate::node::NodeKind;
 
     fn make_chain_graph() -> (Graph, NodeId, NodeId, NodeId) {
@@ -104,8 +103,8 @@ mod tests {
             chapter: 1,
             verse: 3,
         });
-        g.add_edge(EdgeKind::VerseGistVerseGist, a, b);
-        g.add_edge(EdgeKind::VerseGistVerseGist, b, c);
+        g.add_edge(a, b);
+        g.add_edge(b, c);
         (g, a, b, c)
     }
 
@@ -148,7 +147,7 @@ mod tests {
             }));
         }
         for i in 0..6 {
-            g.add_edge(EdgeKind::VerseGistVerseGist, nodes[i], nodes[i + 1]);
+            g.add_edge(nodes[i], nodes[i + 1]);
         }
 
         let sources = HashSet::from([nodes[0]]);
@@ -175,9 +174,9 @@ mod tests {
             chapter: 1,
             verse: 3,
         });
-        g.add_edge(EdgeKind::VerseGistVerseGist, a, b);
-        g.add_edge(EdgeKind::VerseGistVerseGist, b, c);
-        g.add_edge(EdgeKind::VerseGistVerseGist, c, a);
+        g.add_edge(a, b);
+        g.add_edge(b, c);
+        g.add_edge(c, a);
 
         // Source = a, target = a: skip self
         let sources = HashSet::from([a]);
@@ -215,10 +214,10 @@ mod tests {
             chapter: 1,
             verse: 4,
         });
-        g.add_edge(EdgeKind::VerseGistVerseGist, a, b);
-        g.add_edge(EdgeKind::VerseGistVerseGist, a, c);
-        g.add_edge(EdgeKind::VerseGistVerseGist, b, d);
-        g.add_edge(EdgeKind::VerseGistVerseGist, c, d);
+        g.add_edge(a, b);
+        g.add_edge(a, c);
+        g.add_edge(b, d);
+        g.add_edge(c, d);
 
         let sources = HashSet::from([a]);
         let paths = enumerate_paths(&g, &sources, d, MAX_HOPS);

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -242,7 +242,7 @@ fn path_r_at(graph: &Graph, edges: &[EdgeId], fsrs: &FsrsBridge, at_secs: i64) -
 mod tests {
     use super::*;
     use crate::card::{Card, CardState};
-    use crate::edge::{EdgeKind, EdgeState};
+    use crate::edge::EdgeState;
     use crate::node::NodeKind;
     use crate::types::CardId;
 
@@ -275,10 +275,10 @@ mod tests {
             last_review_secs: 0,
         };
 
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p1, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p2, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p1, p2, state);
+        g.add_bi_edge_with_state(v, r, state);
+        g.add_bi_edge_with_state(p1, v, state);
+        g.add_bi_edge_with_state(p2, v, state);
+        g.add_bi_edge_with_state(p1, p2, state);
 
         let card = Card {
             id: CardId(0),
@@ -408,13 +408,13 @@ mod tests {
                 verse_id: 0,
                 position: i as u16,
             });
-            g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p, v, state);
+            g.add_bi_edge_with_state(p, v, state);
             if let Some(&prev) = phrases.last() {
-                g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, prev, p, state);
+                g.add_bi_edge_with_state(prev, p, state);
             }
             phrases.push(p);
         }
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
+        g.add_bi_edge_with_state(v, r, state);
 
         let full = Card {
             id: CardId(0),

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -488,7 +488,7 @@ impl NewVerseProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::{EdgeKind, EdgeState};
+    use crate::edge::EdgeState;
     use crate::node::NodeKind;
 
     const DAY: i64 = 86400;
@@ -524,12 +524,12 @@ mod tests {
             difficulty: 5.0,
             last_review_secs: 0,
         };
-        g.add_bi_edge_with_state(EdgeKind::VerseGistVerseRef, v, r, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p1, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p2, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhraseVerseGist, p3, v, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p1, p2, state);
-        g.add_bi_edge_with_state(EdgeKind::PhrasePhrase, p2, p3, state);
+        g.add_bi_edge_with_state(v, r, state);
+        g.add_bi_edge_with_state(p1, v, state);
+        g.add_bi_edge_with_state(p2, v, state);
+        g.add_bi_edge_with_state(p3, v, state);
+        g.add_bi_edge_with_state(p1, p2, state);
+        g.add_bi_edge_with_state(p2, p3, state);
 
         let full = Card {
             id: CardId(0),

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -39,22 +39,38 @@ pub enum ReDrillKind {
 pub struct ReDrill {
     pub kind: ReDrillKind,
     pub verse_ref: NodeId,
+    /// Parent refs for the verse, if the graph carries the chapter/book
+    /// layers. Populated alongside `verse_ref` so card rendering carries the
+    /// full ref triple. Both fields are `Some` together or both `None`.
+    pub chapter_ref: Option<NodeId>,
+    pub book_ref: Option<NodeId>,
     pub verse_phrases: Vec<NodeId>,
     pub origin_card: Option<CardId>,
+}
+
+fn ref_triple(book: Option<NodeId>, chapter: Option<NodeId>, verse: NodeId) -> Vec<NodeId> {
+    let mut out = Vec::with_capacity(3);
+    if let Some(b) = book {
+        out.push(b);
+    }
+    if let Some(c) = chapter {
+        out.push(c);
+    }
+    out.push(verse);
+    out
 }
 
 impl ReDrill {
     pub fn to_session_card(&self) -> SessionCard {
         match &self.kind {
             ReDrillKind::FillInBlank { target_atom } => {
-                let shown: Vec<NodeId> = std::iter::once(self.verse_ref)
-                    .chain(
-                        self.verse_phrases
-                            .iter()
-                            .copied()
-                            .filter(|p| p != target_atom),
-                    )
-                    .collect();
+                let mut shown = ref_triple(self.book_ref, self.chapter_ref, self.verse_ref);
+                shown.extend(
+                    self.verse_phrases
+                        .iter()
+                        .copied()
+                        .filter(|p| p != target_atom),
+                );
                 SessionCard {
                     shown,
                     hidden: vec![*target_atom],
@@ -63,7 +79,7 @@ impl ReDrill {
                 }
             }
             ReDrillKind::FullRecitation => SessionCard {
-                shown: vec![self.verse_ref],
+                shown: ref_triple(self.book_ref, self.chapter_ref, self.verse_ref),
                 hidden: self.verse_phrases.clone(),
                 is_reading: false,
                 source: SessionCardSource::ReDrill,
@@ -85,6 +101,8 @@ pub enum RevealStage {
 #[derive(Debug, Clone)]
 pub struct NewVerseProgress {
     pub verse_ref: NodeId,
+    pub chapter_ref: Option<NodeId>,
+    pub book_ref: Option<NodeId>,
     pub verse_phrases: Vec<NodeId>,
     pub stage: RevealStage,
 }
@@ -92,19 +110,20 @@ pub struct NewVerseProgress {
 impl NewVerseProgress {
     pub fn to_session_card(&self) -> SessionCard {
         match &self.stage {
-            RevealStage::Reading => SessionCard {
-                shown: std::iter::once(self.verse_ref)
-                    .chain(self.verse_phrases.iter().copied())
-                    .collect(),
-                hidden: vec![],
-                is_reading: true,
-                source: SessionCardSource::NewVerse,
-            },
+            RevealStage::Reading => {
+                let mut shown = ref_triple(self.book_ref, self.chapter_ref, self.verse_ref);
+                shown.extend(self.verse_phrases.iter().copied());
+                SessionCard {
+                    shown,
+                    hidden: vec![],
+                    is_reading: true,
+                    source: SessionCardSource::NewVerse,
+                }
+            }
             RevealStage::FillInBlank { index } => {
                 let target = self.verse_phrases[*index];
-                let shown: Vec<NodeId> = std::iter::once(self.verse_ref)
-                    .chain(self.verse_phrases.iter().copied().filter(|&p| p != target))
-                    .collect();
+                let mut shown = ref_triple(self.book_ref, self.chapter_ref, self.verse_ref);
+                shown.extend(self.verse_phrases.iter().copied().filter(|&p| p != target));
                 SessionCard {
                     shown,
                     hidden: vec![target],
@@ -113,7 +132,7 @@ impl NewVerseProgress {
                 }
             }
             RevealStage::FullRecitation => SessionCard {
-                shown: vec![self.verse_ref],
+                shown: ref_triple(self.book_ref, self.chapter_ref, self.verse_ref),
                 hidden: self.verse_phrases.clone(),
                 is_reading: false,
                 source: SessionCardSource::NewVerse,
@@ -225,8 +244,14 @@ impl Session {
                 }
             }
             introduced_verses.push(nv.verse_phrases.clone());
+            let (chapter_ref, book_ref) = match engine.graph.verse_ref_parents(nv.verse_ref) {
+                Some((cr, br)) => (Some(cr), Some(br)),
+                None => (None, None),
+            };
             queue.push_back(SessionEntry::NewVerse(NewVerseProgress {
                 verse_ref: nv.verse_ref,
+                chapter_ref,
+                book_ref,
                 verse_phrases: nv.verse_phrases.clone(),
                 stage: RevealStage::Reading,
             }));
@@ -375,6 +400,8 @@ impl Session {
                     let redrills = self.insert_redrills_from_context(
                         &failed,
                         progress.verse_ref,
+                        progress.chapter_ref,
+                        progress.book_ref,
                         &progress.verse_phrases,
                         None,
                     );
@@ -411,8 +438,19 @@ impl Session {
             Some(ctx) => ctx,
             None => return 0,
         };
+        let (chapter_ref, book_ref) = match engine.graph.verse_ref_parents(verse_ref) {
+            Some((cr, br)) => (Some(cr), Some(br)),
+            None => (None, None),
+        };
 
-        self.insert_redrills_from_context(&failed, verse_ref, &verse_phrases, origin_card)
+        self.insert_redrills_from_context(
+            &failed,
+            verse_ref,
+            chapter_ref,
+            book_ref,
+            &verse_phrases,
+            origin_card,
+        )
     }
 
     fn prune_no_longer_due(&mut self, engine: &ReviewEngine, now_secs: i64) {
@@ -439,10 +477,13 @@ impl Session {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn insert_redrills_from_context(
         &mut self,
         failed: &[NodeId],
         verse_ref: NodeId,
+        chapter_ref: Option<NodeId>,
+        book_ref: Option<NodeId>,
         verse_phrases: &[NodeId],
         origin_card: Option<CardId>,
     ) -> usize {
@@ -453,6 +494,8 @@ impl Session {
             vec![ReDrill {
                 kind: ReDrillKind::FullRecitation,
                 verse_ref,
+                chapter_ref,
+                book_ref,
                 verse_phrases: verse_phrases.to_vec(),
                 origin_card,
             }]
@@ -462,6 +505,8 @@ impl Session {
                 .map(|&atom| ReDrill {
                     kind: ReDrillKind::FillInBlank { target_atom: atom },
                     verse_ref,
+                    chapter_ref,
+                    book_ref,
                     verse_phrases: verse_phrases.to_vec(),
                     origin_card,
                 })
@@ -556,6 +601,8 @@ mod tests {
                 target_atom: NodeId(3),
             },
             verse_ref: NodeId(0),
+            chapter_ref: None,
+            book_ref: None,
             verse_phrases: vec![NodeId(2), NodeId(3), NodeId(4)],
             origin_card: None,
         };
@@ -568,9 +615,41 @@ mod tests {
     }
 
     #[test]
+    fn redrill_includes_ref_triple_when_parents_known() {
+        let rd = ReDrill {
+            kind: ReDrillKind::FullRecitation,
+            verse_ref: NodeId(7),
+            chapter_ref: Some(NodeId(5)),
+            book_ref: Some(NodeId(3)),
+            verse_phrases: vec![NodeId(10), NodeId(11)],
+            origin_card: None,
+        };
+        let card = rd.to_session_card();
+        // book_ref → chapter_ref → verse_ref ordering, then phrases hidden.
+        assert_eq!(card.shown, vec![NodeId(3), NodeId(5), NodeId(7)]);
+        assert_eq!(card.hidden, vec![NodeId(10), NodeId(11)]);
+    }
+
+    #[test]
+    fn new_verse_includes_ref_triple_when_parents_known() {
+        let nv = NewVerseProgress {
+            verse_ref: NodeId(7),
+            chapter_ref: Some(NodeId(5)),
+            book_ref: Some(NodeId(3)),
+            verse_phrases: vec![NodeId(10), NodeId(11)],
+            stage: RevealStage::FullRecitation,
+        };
+        let card = nv.to_session_card();
+        assert_eq!(card.shown, vec![NodeId(3), NodeId(5), NodeId(7)]);
+        assert_eq!(card.hidden, vec![NodeId(10), NodeId(11)]);
+    }
+
+    #[test]
     fn progressive_reveal_stages() {
         let mut nv = NewVerseProgress {
             verse_ref: NodeId(0),
+            chapter_ref: None,
+            book_ref: None,
             verse_phrases: vec![NodeId(1), NodeId(2)],
             stage: RevealStage::Reading,
         };

--- a/crates/wasm/test-smoke.js
+++ b/crates/wasm/test-smoke.js
@@ -5,8 +5,8 @@ import { WasmEngine } from './pkg/verse_vault_wasm.js';
 
 const edgeState = { stability: 5.0, difficulty: 5.0, last_review_secs: 0 };
 
-function makeEdge(id, kind, source, target) {
-  return { id, kind, source, target, state: edgeState };
+function makeEdge(id, source, target) {
+  return { id, source, target, state: edgeState };
 }
 
 const graph = {
@@ -24,23 +24,24 @@ const graph = {
   next_edge_id: 0,
 };
 
-function addBi(kind, a, b) {
+function addBi(a, b) {
   const fwd = graph.next_edge_id++;
   const bwd = graph.next_edge_id++;
-  graph.edges[String(fwd)] = makeEdge(fwd, kind, a, b);
-  graph.edges[String(bwd)] = makeEdge(bwd, kind, b, a);
+  graph.edges[String(fwd)] = makeEdge(fwd, a, b);
+  graph.edges[String(bwd)] = makeEdge(bwd, b, a);
   graph.outgoing[String(a)].push(fwd);
   graph.incoming[String(b)].push(fwd);
   graph.outgoing[String(b)].push(bwd);
   graph.incoming[String(a)].push(bwd);
 }
 
-addBi('VerseGistVerseRef', 1, 0);
-addBi('PhraseVerseGist', 2, 1);
-addBi('PhraseVerseGist', 3, 1);
-addBi('PhraseVerseGist', 4, 1);
-addBi('PhrasePhrase', 2, 3);
-addBi('PhrasePhrase', 3, 4);
+// Edge identity derives from endpoint node kinds; no `kind` field needed.
+addBi(1, 0); // VerseGist ↔ VerseRef
+addBi(2, 1); // Phrase ↔ VerseGist
+addBi(3, 1);
+addBi(4, 1);
+addBi(2, 3); // Phrase ↔ Phrase
+addBi(3, 4);
 
 const cards = [
   {

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -2,7 +2,6 @@
 //! Run with: cargo test -p verse-vault-wasm
 
 use verse_vault_core::card::{Card, CardState};
-use verse_vault_core::edge::EdgeKind;
 use verse_vault_core::graph::Graph;
 use verse_vault_core::node::NodeKind;
 use verse_vault_core::types::{CardId, NodeId};
@@ -18,7 +17,7 @@ fn print_graph_json_shape() {
         chapter: 3,
         verse: 16,
     });
-    g.add_bi_edge(EdgeKind::VerseGistVerseRef, v, r);
+    g.add_bi_edge(v, r);
 
     let graph_json = serde_json::to_string_pretty(&g).unwrap();
     println!("Graph JSON:\n{graph_json}");

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -21,10 +21,18 @@ of many items, the edge does not exist — the relationship is either expressed 
 lets the listing become a sequence of single retrievals (see `ChapterClubMember`), or not modeled in
 the graph at all.
 
-**Every edge is learnable.** There are no structural edges — each edge carries FSRS state. This was
-not always true: the original design had one `ChapterGistClubEntry` structural edge to support club
-listings from a chapter, but that role was replaced by proper `ChapterClubMember` atoms when the
-club hierarchy was fleshed out.
+**Every edge is learnable.** There are no structural edges — each edge carries FSRS state.
+
+**The "kind" of an edge is derived, not stored.** An `Edge` struct holds `source`, `target`,
+`state`, and an optional `role: Option<EdgeRole>` where `EdgeRole ∈ {FirstChild, LastChild}`. The
+retrieval proposition an edge represents is determined by its endpoint node kinds plus its role —
+the graph does not carry a separate per-edge type tag. This is the minimum data model: renaming a
+node kind doesn't cascade through dozens of redundant edge-kind names, and adding a new layer needs
+no enum-variant churn.
+
+`EdgeRole` exists only because parent → first-child and parent → last-child edges share the same
+`(source.kind, target.kind)` pair. Every other edge in the graph has `role: None` and gets its
+identity from endpoints alone.
 
 ## Theoretical grounding
 
@@ -75,20 +83,25 @@ prompt.
 Every containment layer (book → chapter → verse, and the parallel club-membership hierarchies) has
 the same five-edge shape:
 
-| Pattern                        | Direction | Example                                |
-| ------------------------------ | --------- | -------------------------------------- |
-| gist ↔ ref                     | bi        | `ChapterGistChapterRef`                |
-| child_gist → parent_gist       | uni       | `VerseGistChapterGist`                 |
-| parent_gist → first_child_gist | uni       | `ChapterGistFirstVerseGist`            |
-| parent_gist → last_child_gist  | uni       | `ChapterGistLastVerseGist`             |
-| parent-consecutive gist ↔ gist | bi        | `ChapterGistChapterGist` (within book) |
-| child_ref → parent_ref         | uni       | `VerseRefChapterRef`                   |
+| Pattern                        | Direction | Role marker  | Example retrieval                   |
+| ------------------------------ | --------- | ------------ | ----------------------------------- |
+| gist ↔ ref                     | bi        | —            | chapter gist ↔ chapter ref          |
+| child_gist → parent_gist       | uni       | —            | verse gist → chapter gist           |
+| parent_gist → first_child_gist | uni       | `FirstChild` | chapter gist → first verse gist     |
+| parent_gist → last_child_gist  | uni       | `LastChild`  | chapter gist → last verse gist      |
+| parent-consecutive gist ↔ gist | bi        | —            | chapter gist ↔ chapter gist in book |
+| child_ref → parent_ref         | uni       | —            | verse ref → chapter ref             |
 
 Child→parent is always a unique retrieval ("which chapter is this verse in?"). Parent→child is only
-unique via the endpoint edges ("what's the first verse of this chapter?") — there's no
-`ChapterGist → some_verse_gist` for arbitrary verses because it's non-unique.
+unique via the endpoint edges ("what's the first verse of this chapter?") — those carry the
+`FirstChild`/`LastChild` role to distinguish them from each other (they'd be indistinguishable in a
+one-child parent otherwise).
 
-## Edge inventory (43 kinds)
+## Edge taxonomy
+
+The graph supports the following retrieval propositions. These are a taxonomy, not enum variants —
+the code identifies each edge from `(source.kind, target.kind, role)`. Names in the tables below are
+convenient labels for discussion; they don't appear in `EdgeKind` (there isn't one).
 
 ### Phrase / verse layer
 
@@ -326,15 +339,8 @@ that chain is weak the anchor path is weak.
 
 ## Open questions
 
-* **Generalised edge-kind enum.** The book/chapter/verse/heading/club-member layers all follow the
-  same five-edge containment shape (gist↔ref, child→parent, parent→first/last child,
-  parent-consecutive chain, child_ref→parent_ref). A future cleanup could collapse `EdgeKind` to
-  generic variants parameterised by a layer discriminator (`ContainsStart`, `ContainsEnd`,
-  `ParentRef`, …). Kept explicit for now while the schema is still iterating.
-* **Cross-book anchor transfer.** `BookGistBookGist` exists in the schema but isn't exercised in
+* **Cross-book anchor transfer.** Book-consecutive edges exist in the schema but aren't exercised in
   card generation today. Once multi-book materials land, the anchor-transfer algorithm may want to
   use book-level chains for cross-book references.
-* **Reverse club_entry chain.** The `VerseClubMemberVerseClubMember` edge is now bi (previous + next
-  verse in tier). Earlier versions had it uni.
 * **Phrase boundaries for non-KJV.** Unresolved: do phrase atoms transfer across translations or
   chunk each translation independently?

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -105,7 +105,7 @@ convenient labels for discussion; they don't appear in `EdgeKind` (there isn't o
 
 ### Phrase / verse layer
 
-| Edge                 | Shape | Role                                   |
+| Edge                 | Shape | Meaning                                |
 | -------------------- | ----- | -------------------------------------- |
 | `PhrasePhrase`       | bi    | sequential phrase chain within a verse |
 | `PhraseVerseGist`    | bi    | hub between phrase and verse gist      |
@@ -114,7 +114,7 @@ convenient labels for discussion; they don't appear in `EdgeKind` (there isn't o
 
 ### Chapter layer
 
-| Edge                        | Shape | Role                           |
+| Edge                        | Shape | Meaning                        |
 | --------------------------- | ----- | ------------------------------ |
 | `ChapterGistChapterRef`     | bi    | chapter gist ↔ ref             |
 | `VerseGistChapterGist`      | uni   | verse knows its chapter        |
@@ -125,7 +125,7 @@ convenient labels for discussion; they don't appear in `EdgeKind` (there isn't o
 
 ### Book layer
 
-| Edge                       | Shape | Role                            |
+| Edge                       | Shape | Meaning                         |
 | -------------------------- | ----- | ------------------------------- |
 | `BookGistBookRef`          | bi    | book gist ↔ ref                 |
 | `ChapterGistBookGist`      | uni   | chapter knows its book          |
@@ -136,7 +136,7 @@ convenient labels for discussion; they don't appear in `EdgeKind` (there isn't o
 
 ### Heading layer
 
-| Edge                    | Shape | Role                                        |
+| Edge                    | Shape | Meaning                                     |
 | ----------------------- | ----- | ------------------------------------------- |
 | `VerseGistHeading`      | uni   | verse knows its section                     |
 | `HeadingHeading`        | bi    | section-to-section chain (within-book only) |
@@ -150,7 +150,7 @@ is a graph-building invariant rather than an edge.
 
 ### Club hierarchy (verse + chapter)
 
-| Edge                                    | Shape | Role                                  |
+| Edge                                    | Shape | Meaning                               |
 | --------------------------------------- | ----- | ------------------------------------- |
 | `VerseRefVerseClubMember`               | bi    | "is this verse in club N?"            |
 | `VerseClubMemberVerseClubMember`        | bi    | prev/next verse in same tier          |
@@ -170,7 +170,7 @@ is a graph-building invariant rather than an edge.
 
 Same shape as chapter-club, applied at the section level.
 
-| Edge                                    | Shape | Role                                    |
+| Edge                                    | Shape | Meaning                                 |
 | --------------------------------------- | ----- | --------------------------------------- |
 | `HeadingHeadingClubMember`              | bi    | section ↔ its club-presence atom        |
 | `HeadingClubMemberHeadingClubMember`    | bi    | prev/next section with club presence    |
@@ -189,7 +189,7 @@ and reinforce.
 
 ### FTV
 
-| Edge           | Shape | Role                   |
+| Edge           | Shape | Meaning                |
 | -------------- | ----- | ---------------------- |
 | `FtvPhrase`    | uni   | FTV cue → first phrase |
 | `FtvVerseGist` | uni   | FTV cue → verse gist   |

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -194,18 +194,31 @@ and reinforce.
 | `FtvPhrase`    | uni   | FTV cue → first phrase |
 | `FtvVerseGist` | uni   | FTV cue → verse gist   |
 
-## Card coupling
+## Card scopes + coupling
+
+Card types in `card_types.toml` declare a `scope` that decides what context bundle they iterate
+over. Three scopes exist today:
+
+* **Verse** (default): one card per `VerseAtoms`. Roles like `ref`, `phrases`, `ftv`, `heading`
+  resolve against the current verse.
+* **ChapterClub**: one card per `(book, chapter, tier)` that has at least one club member. Roles
+  available: `club_gist`, `book_ref`, `chapter_ref`, `chapter_club_verse_refs`.
+* **Heading**: one card per heading with at least one verse in range. Roles available: `heading`,
+  `heading_verse_refs`.
 
 Cards enforce these co-presence rules so grading and credit assignment have the right source atoms:
 
-* **Ref-chain coupling** (implemented): the `ref` atom role in `card_types.toml` resolves to the
-  full triple `[book_ref, chapter_ref, verse_ref]`. Every card whose definition uses `ref` — shown
-  or hidden — carries all three atoms in that slot. `VerseAtoms` (in `crates/core/src/builder.rs`)
-  collects the matching `chapter_ref` and `book_ref` per verse; `resolve_roles` expands `Ref` into
-  the triple. Card-types authors don't need to list the three atoms separately.
-* **Club-gist coupling** (design intent): whenever any `*ClubMember` atom is in `shown` or `hidden`,
-  add its `ClubGist`. Not yet implemented — club listing cards aren't emitted by the card-type
-  pipeline today, so this will land with the club-card TOML work.
+* **Ref-chain coupling** (implemented, verse scope): the `ref` atom role resolves to the full triple
+  `[book_ref, chapter_ref, verse_ref]`. Every verse-scope card whose TOML uses `ref` — shown or
+  hidden — carries all three atoms in that slot. Card-type authors don't need to list the three
+  atoms separately.
+* **Listing-role scopes** (implemented): the `chapter_club_verse_refs` and `heading_verse_refs`
+  roles expand to every `VerseRef` for verses in the card's scope. They do **not** trigger the
+  ref-chain coupling — the chapter/book context is either already present explicitly in `shown`
+  (chapter-club cards) or implicit (heading cards render the range client-side).
+* **Club-gist coupling** (design intent): whenever any `*ClubMember` atom appears in `shown` or
+  `hidden`, add its `ClubGist`. Not yet implemented — no card type currently puts a `*ClubMember`
+  atom in a slot directly.
 * Do **not** auto-add chapter/heading `*ClubMember` atoms when a verse-member appears — those are
   hub atoms, not transitively present.
 

--- a/docs/graph.md
+++ b/docs/graph.md
@@ -194,21 +194,20 @@ and reinforce.
 | `FtvPhrase`    | uni   | FTV cue → first phrase |
 | `FtvVerseGist` | uni   | FTV cue → verse gist   |
 
-## Card coupling (design intent)
+## Card coupling
 
-When card generation code lands, it should enforce these co-presence rules so grading and credit
-assignment have the right source atoms:
+Cards enforce these co-presence rules so grading and credit assignment have the right source atoms:
 
-* **Ref-chain coupling**: whenever a `VerseRef` is in `shown` or `hidden`, add its `ChapterRef`.
-  Whenever `ChapterRef` is present, add its `BookRef`. Transitively, any `VerseRef` pulls all three
-  refs together.
-* **Club-gist coupling**: whenever any `*ClubMember` atom is in `shown` or `hidden`, add its
-  `ClubGist`. Listing cards that hide verse-members are automatically sourced from the club tier.
+* **Ref-chain coupling** (implemented): the `ref` atom role in `card_types.toml` resolves to the
+  full triple `[book_ref, chapter_ref, verse_ref]`. Every card whose definition uses `ref` — shown
+  or hidden — carries all three atoms in that slot. `VerseAtoms` (in `crates/core/src/builder.rs`)
+  collects the matching `chapter_ref` and `book_ref` per verse; `resolve_roles` expands `Ref` into
+  the triple. Card-types authors don't need to list the three atoms separately.
+* **Club-gist coupling** (design intent): whenever any `*ClubMember` atom is in `shown` or `hidden`,
+  add its `ClubGist`. Not yet implemented — club listing cards aren't emitted by the card-type
+  pipeline today, so this will land with the club-card TOML work.
 * Do **not** auto-add chapter/heading `*ClubMember` atoms when a verse-member appears — those are
   hub atoms, not transitively present.
-
-These rules are not yet implemented in code; they're documented here as the design contract for the
-eventual card generator.
 
 ## Per-component grading (design intent)
 

--- a/docs/review.md
+++ b/docs/review.md
@@ -8,23 +8,41 @@ How learner reviews update the memory graph. Depends on the graph structure defi
 A card is a **mask** over the graph: `shown = {atoms}`, `hidden = {atoms}`. The learner sees the
 shown atoms and must produce the hidden ones. Cards are modes of testing, not memory units.
 
-Example cards:
+Example cards (using `{ref}` as shorthand for the `[book_ref, chapter_ref, verse_ref]` triple — see
+"Reference triple" below):
 
-| Card               | Shown                  | Hidden                         |
-| ------------------ | ---------------------- | ------------------------------ |
-| ref → verse        | {ref}                  | {p1, p2, p3, p4}               |
-| verse → ref        | {p1, p2, p3, p4}       | {ref}                          |
-| first words → rest | {p1}                   | {p2, p3, p4}                   |
-| fill-in-blank (p2) | {ref, p1, p3, p4}      | {p2}                           |
-| cross-verse        | {last phrase of prev}  | {p1, p2, p3, p4}               |
-| club listing       | {chapter_gist}         | {ref(2:1), ref(2:4), ref(2:7)} |
-| verse → heading    | {ref} or {p1, p2, ...} | {heading}                      |
-| ref → heading      | {ref}                  | {heading}                      |
-| finish this verse  | {ftv}                  | {p1, p2, p3, p4}               |
+| Card               | Shown                                | Hidden                                           |
+| ------------------ | ------------------------------------ | ------------------------------------------------ |
+| ref → verse        | {ref}                                | {p1, p2, p3, p4}                                 |
+| verse → ref        | {p1, p2, p3, p4}                     | {ref}                                            |
+| first words → rest | {p1}                                 | {p2, p3, p4}                                     |
+| fill-in-blank (p2) | {ref, p1, p3, p4}                    | {p2}                                             |
+| cross-verse        | {last phrase of prev}                | {p1, p2, p3, p4}                                 |
+| club listing       | {club_gist, book_ref, chapter_ref}   | {verse_ref(2:1), verse_ref(2:4), verse_ref(2:7)} |
+| verses → heading   | {verse_ref(10:23) … verse_ref(11:1)} | {heading}                                        |
+| verse → heading    | {ref} or {p1, p2, ...}               | {heading}                                        |
+| finish this verse  | {ftv}                                | {p1, p2, p3, p4}                                 |
 
 All possible cards for a verse are **pre-generated** and stored in the card DB with precomputed
 effective_R and due_date (see [scheduling.md](scheduling.md)). The scheduler picks from this catalog
 — it does not generate cards on the fly.
+
+### Reference triple
+
+A verse reference is three atoms: `book_ref`, `chapter_ref`, `verse_ref`. The card-types TOML role
+`ref` resolves to all three; verse-scoped cards that name `ref` in `show` or `hide` carry the full
+triple in that slot. This means the source set for credit assignment includes all three refs
+whenever a verse-style card is reviewed, and graders can produce three independent pass/fail signals
+(one per component) if the frontend chooses to split the typed answer. See
+[graph.md § Card scopes + coupling](graph.md#card-scopes--coupling).
+
+Listing-style cards (`club_chapter_listing`, `verses_to_heading`) carry the verse-ref atoms directly
+without the per-verse triple coupling — the chapter/book context is supplied either explicitly in
+`shown` (chapter-club) or implicit in the rendered verse range (heading).
+
+Session re-drills and progressive-reveal cards (constructed at runtime in
+`crates/core/src/session.rs`) populate the same triple in `shown` via `Graph::verse_ref_parents`, so
+the source set stays consistent between catalog cards and session-generated cards.
 
 ## Review interaction
 

--- a/docs/session.md
+++ b/docs/session.md
@@ -54,7 +54,7 @@ handling — the progressive reveal is just a sequence of cards in the queue.
 
 A re-drill needs to know the verse context: which reference and which phrases. The graph provides
 this via `verse_context(atom)` — traverses from the atom to its VerseGist hub, then collects the
-Reference and all Phrases (sorted by position).
+VerseRef and all Phrases (sorted by position).
 
 Fill-in-blank: `shown = {ref, all other phrases}`, `hidden = {failed phrase}` Full recitation:
 `shown = {ref}`, `hidden = {all phrases}`

--- a/docs/wasm-api.md
+++ b/docs/wasm-api.md
@@ -78,13 +78,17 @@ The `Graph` type serializes as:
 ```json
 {
   "nodes": { "<NodeId>": { "id": <NodeId>, "kind": <NodeKind> }, ... },
-  "edges": { "<EdgeId>": { "id": <EdgeId>, "kind": "<EdgeKind>", "source": <NodeId>, "target": <NodeId>, "state": {...} | null }, ... },
+  "edges": { "<EdgeId>": { "id": <EdgeId>, "source": <NodeId>, "target": <NodeId>, "state": {...}, "role": "FirstChild" | "LastChild" | null }, ... },
   "outgoing": { "<NodeId>": [<EdgeId>, ...], ... },
   "incoming": { "<NodeId>": [<EdgeId>, ...], ... },
   "next_node_id": <u32>,
   "next_edge_id": <u32>
 }
 ```
+
+Edges do not carry a `kind` tag — an edge's retrieval proposition is derived from
+`(source.kind, target.kind, role)`. `role` is omitted (or `null`) on the majority of edges; it's
+only set to `FirstChild` / `LastChild` on parent→first/last endpoint edges.
 
 Note that HashMap keys in JSON are always strings, even though the underlying NodeId/EdgeId are
 `u32` newtypes. NodeIds appearing as values (not keys) serialize as plain numbers.

--- a/packages/api/src/lib/materials.ts
+++ b/packages/api/src/lib/materials.ts
@@ -34,10 +34,10 @@ export interface MaterialGraph {
 
 interface MaterialEdge {
   id: number;
-  kind: string;
   source: number;
   target: number;
   state: { stability: number; difficulty: number; last_review_secs: number };
+  role?: 'FirstChild' | 'LastChild';
 }
 
 export interface MaterialCard {
@@ -75,23 +75,24 @@ function buildSingleVerseTemplate(): MaterialTemplate {
     next_edge_id: 0,
   };
 
-  const addBi = (kind: string, a: number, b: number) => {
+  const addBi = (a: number, b: number) => {
     const fwd = graph.next_edge_id++;
     const bwd = graph.next_edge_id++;
-    graph.edges[String(fwd)] = { id: fwd, kind, source: a, target: b, state: edgeState };
-    graph.edges[String(bwd)] = { id: bwd, kind, source: b, target: a, state: edgeState };
+    graph.edges[String(fwd)] = { id: fwd, source: a, target: b, state: edgeState };
+    graph.edges[String(bwd)] = { id: bwd, source: b, target: a, state: edgeState };
     graph.outgoing[String(a)]!.push(fwd);
     graph.incoming[String(b)]!.push(fwd);
     graph.outgoing[String(b)]!.push(bwd);
     graph.incoming[String(a)]!.push(bwd);
   };
 
-  addBi('VerseGistVerseRef', 1, 0);
-  addBi('PhraseVerseGist', 2, 1);
-  addBi('PhraseVerseGist', 3, 1);
-  addBi('PhraseVerseGist', 4, 1);
-  addBi('PhrasePhrase', 2, 3);
-  addBi('PhrasePhrase', 3, 4);
+  // Edge identity derives from endpoint node kinds — no `kind` field.
+  addBi(1, 0); // VerseGist ↔ VerseRef
+  addBi(2, 1); // Phrase ↔ VerseGist
+  addBi(3, 1);
+  addBi(4, 1);
+  addBi(2, 3); // Phrase ↔ Phrase
+  addBi(3, 4);
 
   const cards: MaterialCard[] = [{ id: 0, shown: [0], hidden: [2, 3, 4], state: 'New' }];
 


### PR DESCRIPTION
## Summary

Three connected pieces of graph data-model and card-catalog cleanup.

### 1. Drop the `EdgeKind` enum

\`EdgeKind\` had 43 variants that were mostly redundant encoding of \`(source.kind, target.kind)\` pairs already carried by typed nodes. Only the 8 parent → first/last child endpoint pairs needed disambiguation.

- \`Edge.kind: EdgeKind\` → \`Edge.role: Option<EdgeRole>\` where \`EdgeRole = { FirstChild, LastChild }\`.
- \`EdgeKind\` enum removed entirely.
- Graph API: \`add_edge(kind, src, dst)\` → \`add_edge(src, dst)\`; new \`add_edge_with_role\` for endpoint edges. Bi/with-state variants lose their kind parameter.
- New \`Graph::edge_connects(edge, src_pred, dst_pred)\` helper replaces \`edge.kind == EdgeKind::X\` checks with node-kind predicates.
- Builder, all test helpers, JSON wire fixtures (\`test-smoke.js\`, \`materials.ts\`) drop \`kind\` arguments and JSON fields.
- \`apply_reverse_reinforcement\` matches reverse edges by \`role\` instead of \`kind\`.

Net win: renaming a node kind stops cascading through ~6 edge-kind names; adding a new layer needs no new variants; wire format shrinks (~380 KB per snapshot for 1 Cor).

### 2. Align card catalog to the new graph

- \`VerseAtoms\` carries \`chapter_ref\` and \`book_ref\` alongside \`ref_node\`, populated from the existing lookup maps.
- \`AtomRole::Ref\` expands to the full triple \`[book_ref, chapter_ref, verse_ref]\`. Every existing card type using \`ref\` (full_recitation, fill_in_blank, verse_to_ref, verse_to_heading) automatically picks up the triple — no TOML change needed.
- \`heading_to_prev\` removed; \`heading_to_next\` stays.

### 3. Add card scopes for listing-style retrievals

- New \`CardScope\` enum (\`Verse\` | \`ChapterClub\` | \`Heading\`); default is \`Verse\`. Cards opt into a different iteration axis with \`scope = \"chapter_club\"\` or \`scope = \"heading\"\` in TOML.
- New atom roles: \`ClubGist\`, \`BookRef\`, \`ChapterRef\`, \`ChapterClubVerseRefs\`, \`HeadingVerseRefs\`. The first three name specific atoms without the \`ref\` triple coupling; the last two are listing roles.
- \`generate_cards\` dispatches on scope; new \`ChapterClubAtoms\` / \`HeadingAtoms\` bundles + their resolvers.
- \`build_club_hierarchy\` returns the \`ClubGist\` per tier so the caller can populate \`ChapterClubAtoms.club_gist\`.
- Two new card types in \`card_types.toml\`:
  - \`club_chapter_listing\` (scope=chapter_club): "which verses in Acts 2 are in club 150?"
  - \`verses_to_heading\` (scope=heading): "given this verse range, what's the section heading?"

### 4. Couple session-generated cards to the ref triple

- New \`Graph::verse_ref_parents(verse_ref)\` walks \`verse_ref → chapter_ref → book_ref\` via structural edges.
- \`ReDrill\` and \`NewVerseProgress\` carry optional \`chapter_ref\` and \`book_ref\` fields, populated at construction time. \`to_session_card\` prepends the triple in \`shown\`. Falls back to bare \`verse_ref\` if parents aren't reachable (graphs without the chapter/book layers).

### 5. Docs

- \`docs/graph.md\` rewritten: derivation principle for edge identity, card scopes, listing-role rules, retired the "generic edge-kind enum" open question.
- \`docs/wasm-api.md\` Edge JSON shape updated.
- \`docs/review.md\` covers the ref triple shorthand + how listing cards interact with the source set.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`cargo test --workspace\` — 76 core + 1 real-data + 4 sim + 1 wasm
- [x] \`wasm-pack build crates/wasm --target nodejs --out-dir pkg && node crates/wasm/test-smoke.js\` — passes
- [x] \`pnpm --filter @verse-vault/api test\` — 41 tests pass
- [x] \`dprint check\` — clean
- [x] \`cargo run -p verse-vault-sim --release -- data/corinthians.json 13 30\` — runs cleanly with the new listing cards (118 cards, 80.8% pass rate)

## Deferred

- Other card types we discussed (chapter endpoints, book endpoints, club navigation, FTV→ref) — straightforward additions on the new scope machinery; deferred to keep this PR focused.
- Schedule-recompute caching for sim performance — separate optimization.
- FSRS audit (review.md credit-assignment math) against the awesome-fsrs reference — separate workstream.