### PR TITLE
Content pipeline: colpkg import + apibible diff tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -58,6 +58,29 @@ imports stay cheap:
 python3 tools/extract_phrases.py data/corinthians.json data/corinthians-phrases.json
 ```
 
+### 5. Verify against canonical NKJV (optional)
+
+The Anki deck is the source of truth in this pipeline, but it can drift from the canonical NKJV text
+— typos slipping in during edits, etc. `check_against_apibible.py` fetches the chapter via api.bible
+(NKJV by default), strips the deck's `<b>`/`<i>`/`<span>` markup, and reports any verses whose
+wording diverges:
+
+```bash
+export API_BIBLE_KEY=<your api.bible key>
+python3 tools/check_against_apibible.py data/corinthians.json \
+    --book "1 Corinthians" --chapter 1
+```
+
+Subject to the
+[API.Bible Minimum Acceptable Use Agreement](https://docs.api.bible/guides/terms-of-use):
+
+* Fetched passages are cached at `data/apibible-cache.json` and re-fetched after 30 days per the
+  cache-refresh requirement.
+* Output prints the required citation line.
+* The cached content is for **runtime diagnostic use only** — not for training generative AI.
+* Starter-plan callers must include a visible citation + link to https://api.bible in any UI
+  surfacing the content.
+
 ## Legacy path: text export
 
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -4,6 +4,62 @@ Scripts for converting Bible content into verse-vault's intermediate JSON format
 
 ## Pipeline overview
 
+The fast path imports an Anki `.colpkg` backup directly and reuses already-chunked phrases from a
+sidecar cache, so the LLM step only runs for verses whose text actually changed:
+
+```
+Anki .colpkg backup
+    │
+    ▼
+import_colpkg.py + phrases cache ──→ JSON
+    │
+    ▼
+(if any verses lacked a cached split)
+prepare_batches.py / LLM agents / validate_and_merge.py
+    │
+    ▼
+extract_phrases.py ──→ updated phrases cache (commit)
+```
+
+The legacy path (text export → parse_anki.py) still works and is documented at the bottom.
+
+## Fast path: re-importing from a colpkg
+
+### 1. Drop the .colpkg in `data/`
+
+Anki desktop: `File → Export → Anki Collection Package → with scheduling/media as you like`.
+
+### 2. Run the importer with the cached phrases
+
+```bash
+python3 tools/import_colpkg.py \
+    data/collection-2026-05-08.colpkg \
+    data/corinthians.json \
+    --year 3-C \
+    --phrases data/corinthians-phrases.json
+```
+
+The script extracts the SQLite (handles zstd-compressed `collection.anki21b`), reads the `Verse` and
+`Heading` notetypes, and merges in cached splits from the phrases sidecar. Verses whose text matches
+the cache reuse the cached phrases; mismatches fall back to `[whole verse]` and are listed at exit.
+
+### 3. Re-chunk only the verses that changed
+
+If `import_colpkg.py` reported any verses needing re-chunking, run the LLM pipeline (steps in
+"Legacy path" below) on a subset, then merge. Or — if the changes look like incidental noise (typos,
+quote stripping) — fix them in Anki and re-export.
+
+### 4. Refresh the phrases cache
+
+After validate_and_merge produces a fresh `corinthians.json`, dump the cache so future `.colpkg`
+imports stay cheap:
+
+```bash
+python3 tools/extract_phrases.py data/corinthians.json data/corinthians-phrases.json
+```
+
+## Legacy path: text export
+
 ```
 Anki export (.txt)
     │
@@ -19,8 +75,6 @@ LLM agents (Claude Code subagents) ──→ chunks-N.json files
     ▼
 validate_and_merge.py ──→ final JSON (phrases = [chunked phrases])
 ```
-
-## Step-by-step
 
 ### 1. Parse the Anki export
 

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Diagnostic: diff verse text in a verse-vault JSON against the canonical
+NKJV pulled from api.bible.
+
+Useful for catching typos or accidental edits introduced when maintaining
+the source Anki deck. The API.Bible endpoint returns plain text; this
+script strips the deck text of its <b>/<i>/<span> markup before
+comparison so the diff is over actual wording, not formatting.
+
+API.Bible Minimum Acceptable Use (paraphrased):
+  - Don't modify scripture content. Cite per the citation rules.
+  - Cached content must be refreshed every 30 days.
+  - Do NOT use the content to train an AI / LLM. Runtime use,
+    diagnostics, and downstream display in the user's app are fine.
+  - Starter plan callers must include a visible citation + link to
+    https://api.bible in any UI surfacing the content.
+
+Usage:
+    export API_BIBLE_KEY=<your key>
+    python3 tools/check_against_apibible.py \\
+        data/corinthians.json \\
+        --book "1 Corinthians" --chapter 1 \\
+        [--bible de4e12af7f28f599-01]   # NKJV id; well-known
+        [--cache data/apibible-cache.json]
+
+The cache stores fetched passages keyed by (bibleId, passageId) with a
+fetched-at timestamp. Entries older than 30 days are re-fetched per the
+API terms.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# api.bible's well-known NKJV id (English, Thomas Nelson). Override via
+# --bible if needed; full list at GET /v1/bibles.
+DEFAULT_NKJV_ID = "de4e12af7f28f599-01"
+API_BASE = "https://api.scripture.api.bible/v1"
+CACHE_TTL_SECS = 30 * 24 * 60 * 60  # 30 days per the API terms
+
+# USX book codes used by api.bible's passageId.
+BOOK_CODES = {
+    "1 Corinthians": "1CO",
+    "2 Corinthians": "2CO",
+    "Genesis": "GEN", "Exodus": "EXO", "Leviticus": "LEV", "Numbers": "NUM",
+    "Deuteronomy": "DEU", "Joshua": "JOS", "Judges": "JDG", "Ruth": "RUT",
+    "1 Samuel": "1SA", "2 Samuel": "2SA", "1 Kings": "1KI", "2 Kings": "2KI",
+    "1 Chronicles": "1CH", "2 Chronicles": "2CH", "Ezra": "EZR", "Nehemiah": "NEH",
+    "Esther": "EST", "Job": "JOB", "Psalms": "PSA", "Proverbs": "PRO",
+    "Ecclesiastes": "ECC", "Song of Solomon": "SNG", "Isaiah": "ISA",
+    "Jeremiah": "JER", "Lamentations": "LAM", "Ezekiel": "EZK", "Daniel": "DAN",
+    "Hosea": "HOS", "Joel": "JOL", "Amos": "AMO", "Obadiah": "OBA", "Jonah": "JON",
+    "Micah": "MIC", "Nahum": "NAM", "Habakkuk": "HAB", "Zephaniah": "ZEP",
+    "Haggai": "HAG", "Zechariah": "ZEC", "Malachi": "MAL",
+    "Matthew": "MAT", "Mark": "MRK", "Luke": "LUK", "John": "JHN", "Acts": "ACT",
+    "Romans": "ROM", "Galatians": "GAL", "Ephesians": "EPH", "Philippians": "PHP",
+    "Colossians": "COL", "1 Thessalonians": "1TH", "2 Thessalonians": "2TH",
+    "1 Timothy": "1TI", "2 Timothy": "2TI", "Titus": "TIT", "Philemon": "PHM",
+    "Hebrews": "HEB", "James": "JAS", "1 Peter": "1PE", "2 Peter": "2PE",
+    "1 John": "1JN", "2 John": "2JN", "3 John": "3JN", "Jude": "JUD",
+    "Revelation": "REV",
+}
+
+
+def passage_id(book: str, chapter: int) -> str:
+    code = BOOK_CODES.get(book)
+    if code is None:
+        raise SystemExit(f"No USX code mapped for book: {book!r}")
+    return f"{code}.{chapter}"
+
+
+def fetch_passage(bible_id: str, pid: str, api_key: str) -> dict:
+    """GET a passage as plain text. Returns api.bible's data envelope."""
+    qs = urllib.parse.urlencode({
+        "content-type": "text",
+        "include-notes": "false",
+        "include-titles": "false",
+        "include-chapter-numbers": "false",
+        "include-verse-numbers": "true",
+        "include-verse-spans": "false",
+    })
+    url = f"{API_BASE}/bibles/{bible_id}/passages/{urllib.parse.quote(pid)}?{qs}"
+    req = urllib.request.Request(url, headers={"api-key": api_key, "accept": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")
+        raise SystemExit(f"api.bible HTTP {e.code} for {pid}: {body[:200]}")
+
+
+def load_cache(path: str | None) -> dict:
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_cache(path: str, cache: dict) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(cache, f, indent=2, ensure_ascii=False)
+
+
+def get_passage(bible_id: str, pid: str, api_key: str, cache: dict) -> str:
+    """Cache-aware passage fetch. Returns the plain-text passage."""
+    key = f"{bible_id}|{pid}"
+    entry = cache.get(key)
+    now = int(time.time())
+    if entry and now - entry.get("fetched_at", 0) < CACHE_TTL_SECS:
+        return entry["content"]
+    data = fetch_passage(bible_id, pid, api_key)
+    content = data.get("data", {}).get("content", "")
+    cache[key] = {"content": content, "fetched_at": now, "passageId": pid}
+    return content
+
+
+# api.bible returns chapter text with verse numbers inline like
+# "[1] Paul, called…  [2] To the church…". This regex pulls each (n, text).
+VERSE_PREFIX = re.compile(r"\[(\d+)\]\s*")
+
+
+def parse_verses_from_passage(passage: str) -> dict[int, str]:
+    """Map verse number → plain-text content."""
+    out: dict[int, str] = {}
+    pieces = VERSE_PREFIX.split(passage)
+    # split returns [prefix, n, text, n, text, …]
+    for i in range(1, len(pieces), 2):
+        n = int(pieces[i])
+        text = pieces[i + 1].strip()
+        # Squash runs of whitespace.
+        text = re.sub(r"\s+", " ", text).strip()
+        out[n] = text
+    return out
+
+
+# Strip the deck markup so we compare apples to apples.
+DECK_MARKUP = re.compile(r"<[^>]+>")
+
+
+def normalize_deck_text(s: str) -> str:
+    s = DECK_MARKUP.sub("", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    # api.bible's plain text uses curly quotes by default; deck text may use
+    # straight quotes. Normalise both ways.
+    s = s.replace("“", '"').replace("”", '"').replace("‘", "'").replace("’", "'")
+    return s
+
+
+def normalize_api_text(s: str) -> str:
+    s = re.sub(r"\s+", " ", s).strip()
+    s = s.replace("“", '"').replace("”", '"').replace("‘", "'").replace("’", "'")
+    return s
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", help="verse-vault chunked JSON (e.g. data/corinthians.json)")
+    ap.add_argument("--book", help="Limit to one book name (e.g. '1 Corinthians')")
+    ap.add_argument("--chapter", type=int, help="Limit to one chapter")
+    ap.add_argument("--bible", default=DEFAULT_NKJV_ID, help="api.bible bibleId (default: NKJV)")
+    ap.add_argument(
+        "--cache",
+        default="data/apibible-cache.json",
+        help="Cache file for fetched passages (refreshed every 30 days per API terms)",
+    )
+    args = ap.parse_args()
+
+    api_key = os.environ.get("API_BIBLE_KEY")
+    if not api_key:
+        sys.exit("API_BIBLE_KEY not set in environment")
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    cache = load_cache(args.cache)
+
+    # Group verses by (book, chapter) so we fetch one passage per chapter.
+    by_chapter: dict[tuple[str, int], list[dict]] = {}
+    for v in data.get("verses", []):
+        if args.book and v["book"] != args.book:
+            continue
+        if args.chapter and v["chapter"] != args.chapter:
+            continue
+        if not v.get("text"):
+            continue
+        by_chapter.setdefault((v["book"], v["chapter"]), []).append(v)
+
+    if not by_chapter:
+        print("No verses to compare (filters too strict, or input has no text).")
+        return
+
+    total = 0
+    diffs: list[dict] = []
+    for (book, chapter), verses in sorted(by_chapter.items()):
+        pid = passage_id(book, chapter)
+        passage = get_passage(args.bible, pid, api_key, cache)
+        canonical = parse_verses_from_passage(passage)
+        for v in verses:
+            total += 1
+            theirs = normalize_deck_text(v["text"])
+            ours = normalize_api_text(canonical.get(v["verse"], ""))
+            if not ours:
+                diffs.append({"ref": f"{book} {chapter}:{v['verse']}", "kind": "missing-canonical", "deck": theirs})
+                continue
+            if theirs != ours:
+                diffs.append({
+                    "ref": f"{book} {chapter}:{v['verse']}",
+                    "kind": "diff",
+                    "deck": theirs,
+                    "canonical": ours,
+                })
+
+    save_cache(args.cache, cache)
+
+    print(f"Compared {total} verses; {len(diffs)} diffs found.\n")
+    for d in diffs:
+        print(f"--- {d['ref']} ({d['kind']})")
+        print(f"  deck     : {d['deck'][:200]}")
+        if "canonical" in d:
+            print(f"  canonical: {d['canonical'][:200]}")
+        print()
+
+    print(
+        "NKJV © Thomas Nelson. Used by permission via API.Bible "
+        "(https://api.bible). Cached entries refreshed every 30 days "
+        "per the Minimum Acceptable Use Agreement."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -88,13 +88,24 @@ def fetch_passage(bible_id: str, pid: str, api_key: str) -> dict:
         "include-verse-spans": "false",
     })
     url = f"{API_BASE}/bibles/{bible_id}/passages/{urllib.parse.quote(pid)}?{qs}"
+    return _get_json(url, api_key, pid)
+
+
+def fetch_sections(bible_id: str, book_code: str, api_key: str) -> list[dict]:
+    """GET /books/{bookId}/sections. Returns the sections list directly."""
+    url = f"{API_BASE}/bibles/{bible_id}/books/{book_code}/sections"
+    data = _get_json(url, api_key, f"sections/{book_code}")
+    return data.get("data", []) or []
+
+
+def _get_json(url: str, api_key: str, label: str) -> dict:
     req = urllib.request.Request(url, headers={"api-key": api_key, "accept": "application/json"})
     try:
         with urllib.request.urlopen(req, timeout=20) as resp:
             return json.loads(resp.read().decode("utf-8"))
     except urllib.error.HTTPError as e:
         body = e.read().decode("utf-8", "replace")
-        raise SystemExit(f"api.bible HTTP {e.code} for {pid}: {body[:200]}")
+        raise SystemExit(f"api.bible HTTP {e.code} for {label}: {body[:200]}")
 
 
 def load_cache(path: str | None) -> dict:
@@ -112,7 +123,7 @@ def save_cache(path: str, cache: dict) -> None:
 
 def get_passage(bible_id: str, pid: str, api_key: str, cache: dict) -> str:
     """Cache-aware passage fetch. Returns the plain-text passage."""
-    key = f"{bible_id}|{pid}"
+    key = f"{bible_id}|passage|{pid}"
     entry = cache.get(key)
     now = int(time.time())
     if entry and now - entry.get("fetched_at", 0) < CACHE_TTL_SECS:
@@ -121,6 +132,29 @@ def get_passage(bible_id: str, pid: str, api_key: str, cache: dict) -> str:
     content = data.get("data", {}).get("content", "")
     cache[key] = {"content": content, "fetched_at": now, "passageId": pid}
     return content
+
+
+def get_sections(bible_id: str, book_code: str, api_key: str, cache: dict) -> list[dict]:
+    """Cache-aware sections fetch."""
+    key = f"{bible_id}|sections|{book_code}"
+    entry = cache.get(key)
+    now = int(time.time())
+    if entry and now - entry.get("fetched_at", 0) < CACHE_TTL_SECS:
+        return entry["sections"]
+    sections = fetch_sections(bible_id, book_code, api_key)
+    cache[key] = {"sections": sections, "fetched_at": now, "bookCode": book_code}
+    return sections
+
+
+VERSE_ID = re.compile(r"^([A-Z0-9]+)\.(\d+)\.(\d+)$")
+
+
+def parse_verse_id(vid: str) -> tuple[str, int, int]:
+    """`1CO.1.3` → (`1CO`, 1, 3). Errors out on a malformed input."""
+    m = VERSE_ID.match(vid)
+    if not m:
+        raise SystemExit(f"Cannot parse verseId: {vid!r}")
+    return m.group(1), int(m.group(2)), int(m.group(3))
 
 
 # api.bible returns chapter text with verse numbers inline like
@@ -161,16 +195,28 @@ def normalize_api_text(s: str) -> str:
     return s
 
 
+def normalize_title(s: str) -> str:
+    """Compare titles case-insensitively with curly→straight apostrophes."""
+    s = s.replace("“", '"').replace("”", '"').replace("‘", "'").replace("’", "'")
+    return s.strip().lower()
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("input", help="verse-vault chunked JSON (e.g. data/corinthians.json)")
+    ap.add_argument(
+        "--mode",
+        choices=("verses", "headings"),
+        default="verses",
+        help="What to compare: verse text (default) or section headings",
+    )
     ap.add_argument("--book", help="Limit to one book name (e.g. '1 Corinthians')")
-    ap.add_argument("--chapter", type=int, help="Limit to one chapter")
+    ap.add_argument("--chapter", type=int, help="(verses mode only) Limit to one chapter")
     ap.add_argument("--bible", default=DEFAULT_NKJV_ID, help="api.bible bibleId (default: NKJV)")
     ap.add_argument(
         "--cache",
         default="data/apibible-cache.json",
-        help="Cache file for fetched passages (refreshed every 30 days per API terms)",
+        help="Cache file (refreshed every 30 days per API terms)",
     )
     args = ap.parse_args()
 
@@ -182,8 +228,22 @@ def main():
         data = json.load(f)
 
     cache = load_cache(args.cache)
+    try:
+        if args.mode == "verses":
+            check_verses(data, args, api_key, cache)
+        else:
+            check_headings(data, args, api_key, cache)
+    finally:
+        save_cache(args.cache, cache)
 
-    # Group verses by (book, chapter) so we fetch one passage per chapter.
+    print(
+        "\nNKJV © Thomas Nelson. Used by permission via API.Bible "
+        "(https://api.bible). Cached entries refreshed every 30 days "
+        "per the Minimum Acceptable Use Agreement."
+    )
+
+
+def check_verses(data: dict, args, api_key: str, cache: dict) -> None:
     by_chapter: dict[tuple[str, int], list[dict]] = {}
     for v in data.get("verses", []):
         if args.book and v["book"] != args.book:
@@ -219,8 +279,6 @@ def main():
                     "canonical": ours,
                 })
 
-    save_cache(args.cache, cache)
-
     print(f"Compared {total} verses; {len(diffs)} diffs found.\n")
     for d in diffs:
         print(f"--- {d['ref']} ({d['kind']})")
@@ -229,11 +287,86 @@ def main():
             print(f"  canonical: {d['canonical'][:200]}")
         print()
 
-    print(
-        "NKJV © Thomas Nelson. Used by permission via API.Bible "
-        "(https://api.bible). Cached entries refreshed every 30 days "
-        "per the Minimum Acceptable Use Agreement."
-    )
+
+def check_headings(data: dict, args, api_key: str, cache: dict) -> None:
+    deck_by_book: dict[str, list[dict]] = {}
+    for h in data.get("headings", []):
+        if args.book and h["book"] != args.book:
+            continue
+        deck_by_book.setdefault(h["book"], []).append(h)
+
+    books = list(deck_by_book.keys())
+    if not args.book:
+        # Also include books that have canonical sections but no deck headings.
+        books = sorted({h["book"] for h in data.get("headings", [])} | set(deck_by_book.keys()))
+    if not books:
+        print("No headings to compare.")
+        return
+
+    diffs: list[dict] = []
+    deck_count = 0
+    canonical_count = 0
+    for book in sorted(books):
+        code = BOOK_CODES.get(book)
+        if code is None:
+            print(f"!! No USX code mapped for {book!r}; skipping")
+            continue
+        sections = get_sections(args.bible, code, api_key, cache)
+        # Map both sides keyed by start (chapter, verse).
+        canonical_by_start = {}
+        for s in sections:
+            _, ch, v = parse_verse_id(s["firstVerseId"])
+            _, ech, ev = parse_verse_id(s["lastVerseId"])
+            canonical_by_start[(ch, v)] = {
+                "title": s.get("title", ""),
+                "start": (ch, v),
+                "end": (ech, ev),
+            }
+        deck_by_start = {}
+        for h in deck_by_book.get(book, []):
+            deck_by_start[(h["start_chapter"], h["start_verse"])] = {
+                "title": h.get("text", ""),
+                "start": (h["start_chapter"], h["start_verse"]),
+                "end": (h["end_chapter"], h["end_verse"]),
+            }
+        deck_count += len(deck_by_start)
+        canonical_count += len(canonical_by_start)
+
+        for start, deck in sorted(deck_by_start.items()):
+            canon = canonical_by_start.get(start)
+            if canon is None:
+                diffs.append({"book": book, "kind": "extra-in-deck", "deck": deck})
+                continue
+            title_match = normalize_title(deck["title"]) == normalize_title(canon["title"])
+            range_match = deck["end"] == canon["end"]
+            if not title_match or not range_match:
+                diffs.append({
+                    "book": book,
+                    "kind": "title-mismatch" if not title_match else "range-mismatch",
+                    "deck": deck,
+                    "canonical": canon,
+                })
+        for start, canon in sorted(canonical_by_start.items()):
+            if start not in deck_by_start:
+                diffs.append({"book": book, "kind": "missing-in-deck", "canonical": canon})
+
+    print(f"Compared headings: {deck_count} deck vs {canonical_count} canonical; {len(diffs)} diffs.\n")
+    for d in diffs:
+        ref = format_range(d.get("deck") or d["canonical"])
+        print(f"--- {d['book']} {ref} ({d['kind']})")
+        if "deck" in d:
+            print(f"  deck     : {d['deck']['title']}  [{format_range(d['deck'])}]")
+        if "canonical" in d:
+            print(f"  canonical: {d['canonical']['title']}  [{format_range(d['canonical'])}]")
+        print()
+
+
+def format_range(h: dict) -> str:
+    sc, sv = h["start"]
+    ec, ev = h["end"]
+    if sc == ec:
+        return f"{sc}:{sv}-{ev}" if sv != ev else f"{sc}:{sv}"
+    return f"{sc}:{sv}-{ec}:{ev}"
 
 
 if __name__ == "__main__":

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -20,7 +20,7 @@ Usage:
     python3 tools/check_against_apibible.py \\
         data/corinthians.json \\
         --book "1 Corinthians" --chapter 1 \\
-        [--bible de4e12af7f28f599-01]   # NKJV id; well-known
+        [--bible 63097d2a0a2f7db3-01]   # NKJV (account-specific; see DEFAULT_NKJV_ID)
         [--cache data/apibible-cache.json]
 
 The cache stores fetched passages keyed by (bibleId, passageId) with a

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -38,6 +38,8 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+import parse_anki
+
 # api.bible's NKJV id. Override via --bible if your account exposes a
 # different one (run `curl -H "api-key: $BIBLE_API_KEY"
 # 'https://rest.api.bible/v1/bibles?language=eng&abbreviation=NKJV'`
@@ -189,12 +191,10 @@ def parse_verses_from_passage(passage: str) -> dict[int, str]:
     return out
 
 
-# Strip the deck markup so we compare apples to apples.
-DECK_MARKUP = re.compile(r"<[^>]+>")
-
-
 def normalize_deck_text(s: str) -> str:
-    s = DECK_MARKUP.sub("", s)
+    # Strip the deck markup so we compare apples to apples; reuses the same
+    # tag regex parse_anki.strip_tags applies during deck import.
+    s = parse_anki.strip_tags(s)
     s = re.sub(r"\s+", " ", s).strip()
     # api.bible's plain text uses curly quotes by default; deck text may use
     # straight quotes. Normalise both ways.
@@ -281,12 +281,13 @@ def check_verses(data: dict, args, api_key: str, cache: dict) -> None:
             total += 1
             theirs = normalize_deck_text(v["text"])
             ours = normalize_api_text(canonical.get(v["verse"], ""))
+            ref = parse_anki.format_reference(book, chapter, v["verse"])
             if not ours:
-                diffs.append({"ref": f"{book} {chapter}:{v['verse']}", "kind": "missing-canonical", "deck": theirs})
+                diffs.append({"ref": ref, "kind": "missing-canonical", "deck": theirs})
                 continue
             if theirs != ours:
                 diffs.append({
-                    "ref": f"{book} {chapter}:{v['verse']}",
+                    "ref": ref,
                     "kind": "diff",
                     "deck": theirs,
                     "canonical": ours,

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -38,10 +38,12 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
-# api.bible's well-known NKJV id (English, Thomas Nelson). Override via
-# --bible if needed; full list at GET /v1/bibles.
-DEFAULT_NKJV_ID = "de4e12af7f28f599-01"
-API_BASE = "https://api.scripture.api.bible/v1"
+# api.bible's NKJV id. Override via --bible if your account exposes a
+# different one (run `curl -H "api-key: $BIBLE_API_KEY"
+# 'https://rest.api.bible/v1/bibles?language=eng&abbreviation=NKJV'`
+# to discover yours).
+DEFAULT_NKJV_ID = "63097d2a0a2f7db3-01"
+API_BASE = "https://rest.api.bible/v1"
 CACHE_TTL_SECS = 30 * 24 * 60 * 60  # 30 days per the API terms
 
 # USX book codes used by api.bible's passageId.

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -16,7 +16,7 @@ API.Bible Minimum Acceptable Use (paraphrased):
     https://api.bible in any UI surfacing the content.
 
 Usage:
-    export API_BIBLE_KEY=<your key>
+    export BIBLE_API_KEY=<your key>     # or API_BIBLE_KEY
     python3 tools/check_against_apibible.py \\
         data/corinthians.json \\
         --book "1 Corinthians" --chapter 1 \\
@@ -172,9 +172,9 @@ def main():
     )
     args = ap.parse_args()
 
-    api_key = os.environ.get("API_BIBLE_KEY")
+    api_key = os.environ.get("BIBLE_API_KEY") or os.environ.get("API_BIBLE_KEY")
     if not api_key:
-        sys.exit("API_BIBLE_KEY not set in environment")
+        sys.exit("BIBLE_API_KEY (or API_BIBLE_KEY) not set in environment")
 
     with open(args.input, "r", encoding="utf-8") as f:
         data = json.load(f)

--- a/tools/check_against_apibible.py
+++ b/tools/check_against_apibible.py
@@ -109,10 +109,23 @@ def _get_json(url: str, api_key: str, label: str) -> dict:
 
 
 def load_cache(path: str | None) -> dict:
+    """Load the on-disk cache, dropping any entries that have expired.
+
+    The API terms require all cached api.bible content to be refreshed
+    every 30 days. Pruning on load makes that guarantee structural: the
+    file never holds entries past CACHE_TTL_SECS, so even if a passage
+    isn't read again it can't sit stale in storage.
+    """
     if not path or not os.path.exists(path):
         return {}
     with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
+        raw = json.load(f)
+    now = int(time.time())
+    pruned = {k: v for k, v in raw.items() if now - v.get("fetched_at", 0) < CACHE_TTL_SECS}
+    dropped = len(raw) - len(pruned)
+    if dropped:
+        print(f"Pruned {dropped} cache entries older than 30 days from {path}")
+    return pruned
 
 
 def save_cache(path: str, cache: dict) -> None:

--- a/tools/extract_phrases.py
+++ b/tools/extract_phrases.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Extract a phrase-cache sidecar from a chunked verse-vault JSON.
+
+The chunking pipeline (prepare_batches → LLM agents → validate_and_merge)
+is slow and costs real money to re-run. To make `import_colpkg.py` cheap
+when only an Anki backup changes, dump a flat phrase cache once and reuse
+it forever — verses whose text matches a cache entry skip re-chunking.
+
+Usage:
+    python3 tools/extract_phrases.py data/corinthians.json data/corinthians-phrases.json
+
+Output shape (keyed by 'Book Chapter:Verse'; `text` is the fingerprint):
+
+    {
+      "1 Corinthians 1:1": {
+        "text": "Paul, called to be an apostle …",
+        "phrases": ["Paul, called …", "and <b>Sosthenes</b> our brother,"]
+      },
+      …
+    }
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input", help="Chunked verse-vault JSON (e.g. data/corinthians.json)")
+    ap.add_argument("output", help="Phrase cache JSON to write")
+    args = ap.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    cache: dict[str, dict] = {}
+    skipped = 0
+    for v in data.get("verses", []):
+        ref = f"{v['book']} {v['chapter']}:{v['verse']}"
+        text = v.get("text", "")
+        phrases = v.get("phrases", [])
+        if not text or not isinstance(phrases, list) or not phrases:
+            skipped += 1
+            continue
+        # Skip entries that are still placeholder [whole verse] — caching
+        # those defeats the purpose. A single-element phrase list whose
+        # joined value equals the text isn't necessarily a placeholder
+        # (some short verses are one phrase), so leave that case alone.
+        cache[ref] = {"text": text, "phrases": phrases}
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(cache, f, indent=2, ensure_ascii=False)
+
+    print(f"Wrote {len(cache)} phrase entries to {args.output}")
+    if skipped:
+        print(f"Skipped {skipped} verses with empty text/phrases")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extract_phrases.py
+++ b/tools/extract_phrases.py
@@ -23,7 +23,8 @@ Output shape (keyed by 'Book Chapter:Verse'; `text` is the fingerprint):
 import argparse
 import json
 import os
-import sys
+
+import parse_anki
 
 
 def main():
@@ -38,16 +39,12 @@ def main():
     cache: dict[str, dict] = {}
     skipped = 0
     for v in data.get("verses", []):
-        ref = f"{v['book']} {v['chapter']}:{v['verse']}"
+        ref = parse_anki.format_reference(v["book"], v["chapter"], v["verse"])
         text = v.get("text", "")
         phrases = v.get("phrases", [])
         if not text or not isinstance(phrases, list) or not phrases:
             skipped += 1
             continue
-        # Skip entries that are still placeholder [whole verse] — caching
-        # those defeats the purpose. A single-element phrase list whose
-        # joined value equals the text isn't necessarily a placeholder
-        # (some short verses are one phrase), so leave that case alone.
         cache[ref] = {"text": text, "phrases": phrases}
 
     os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)

--- a/tools/import_colpkg.py
+++ b/tools/import_colpkg.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Import an Anki .colpkg directly into verse-vault's intermediate JSON.
+
+Replaces the older `parse_anki.py` flow that depended on a manual
+`Notes in Plain Text` export. A `.colpkg` is a zip of:
+    collection.anki21b   (Anki 23+, zstd-compressed SQLite)
+    collection.anki21    (Anki 2.1.40+, plain SQLite)
+    collection.anki2     (legacy compatibility stub — usually 1 row)
+    media + numbered media files
+
+We prefer anki21b → anki21 → anki2 in that order. zstd decompression
+shells out to `/usr/bin/zstd` to keep this dependency-free.
+
+Phrase splits aren't carried in Anki — they come from the LLM chunking
+pipeline (see tools/README.md). To avoid re-running the LLM after every
+content update, pass `--phrases path/to/phrases.json`. Each verse whose
+text matches the cached fingerprint reuses the cached phrases; mismatches
+fall back to `[whole verse]` and are listed at exit so you know what to
+re-chunk.
+
+Usage:
+    python3 tools/import_colpkg.py \\
+        data/collection-2026-05-08.colpkg \\
+        data/corinthians.json \\
+        --year 3-C \\
+        --phrases data/corinthians-phrases.json
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+import parse_anki
+
+VERSE_FIELDS = ("Sort", "Ref", "Text", "FTV", "club")
+HEADING_FIELDS = ("Sort", "Front", "Back", "Add Reverse")
+ANKI_FIELD_SEP = "\x1f"
+
+
+def extract_collection(colpkg_path: str, dest_dir: str) -> str:
+    """Extract the .colpkg, return path to the readable SQLite collection."""
+    with zipfile.ZipFile(colpkg_path) as zf:
+        zf.extractall(dest_dir)
+
+    anki21b = os.path.join(dest_dir, "collection.anki21b")
+    anki21 = os.path.join(dest_dir, "collection.anki21")
+    anki2 = os.path.join(dest_dir, "collection.anki2")
+
+    if os.path.exists(anki21b):
+        out = os.path.join(dest_dir, "collection.real.anki21")
+        zstd = shutil.which("zstd")
+        if zstd is None:
+            sys.exit("zstd binary not found on PATH (needed to decompress collection.anki21b)")
+        subprocess.run([zstd, "-d", "-q", "-f", anki21b, "-o", out], check=True)
+        return out
+    if os.path.exists(anki21):
+        return anki21
+    if os.path.exists(anki2):
+        # Legacy fallback. In modern .colpkg files anki2 is a 1-row stub —
+        # the caller should sanity-check note count after.
+        return anki2
+    sys.exit(f"No collection.anki21b/anki21/anki2 found in {colpkg_path}")
+
+
+def query_notes(db_path: str):
+    """Yield (notetype_name, deck_name, fields_tuple, tags) per note."""
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    # Anki declares a custom `unicase` collation on a few columns. SQLite
+    # refuses to open the DB until it's registered, so stand in with a
+    # case-insensitive Python comparator (we don't ORDER BY collated cols
+    # but the DDL still references unicase).
+    con.create_collation("unicase", lambda a, b: (a.casefold() > b.casefold()) - (a.casefold() < b.casefold()))
+    try:
+        cur = con.execute(
+            """
+            SELECT n.id, n.flds, n.tags, m.name AS notetype,
+                   (SELECT d.name FROM cards c
+                    JOIN decks d ON c.did = d.id
+                    WHERE c.nid = n.id LIMIT 1) AS deck
+            FROM notes n
+            JOIN notetypes m ON n.mid = m.id
+            WHERE m.name IN ('Verse', 'Heading')
+            """
+        )
+        for _id, flds, tags, notetype, deck in cur:
+            if deck is None:
+                # Note has no card → orphaned; skip
+                continue
+            yield notetype, deck, flds.split(ANKI_FIELD_SEP), tags
+    finally:
+        con.close()
+
+
+def load_phrases_cache(path: str | None) -> dict[str, dict]:
+    if path is None or not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("colpkg", help="Anki .colpkg backup file")
+    ap.add_argument("output", help="Path to output JSON file")
+    ap.add_argument("--year", required=True, help="Year prefix to match in deck names (e.g. '3-C')")
+    ap.add_argument(
+        "--phrases",
+        default=None,
+        help="Optional path to a phrases cache JSON (see tools/extract_phrases.py)",
+    )
+    args = ap.parse_args()
+
+    cache = load_phrases_cache(args.phrases)
+    if args.phrases:
+        print(f"Loaded {len(cache)} cached phrase splits from {args.phrases}")
+
+    with tempfile.TemporaryDirectory(prefix="vv-colpkg-") as tmp:
+        db = extract_collection(args.colpkg, tmp)
+        verses, headings, stats = process(db, args.year, cache)
+
+    verses.sort(key=lambda v: (v["book"], v["chapter"], v["verse"]))
+    chapters = parse_anki.build_chapters(verses)
+    books = sorted({v["book"] for v in verses})
+    year_num = int(args.year.split("-")[0]) if "-" in args.year else 0
+
+    out = {
+        "year": year_num,
+        "books": books,
+        "chapters": chapters,
+        "verses": verses,
+        "headings": headings,
+    }
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2, ensure_ascii=False)
+
+    print(f"\nWritten to {args.output}")
+    print(f"  {len(verses)} verses, {len(headings)} headings, {len(chapters)} chapters")
+    print(
+        f"  {stats['cached']} cached, "
+        f"{stats['needs_chunking']} need re-chunking, "
+        f"{stats['empty']} empty (no text)"
+    )
+    missing = stats["missing_refs"]
+    if missing:
+        print("\nVerses without a cached split (using [whole verse] placeholder):")
+        for ref in missing[:20]:
+            print(f"  {ref}")
+        if len(missing) > 20:
+            print(f"  …and {len(missing) - 20} more")
+
+
+def process(db_path: str, year_prefix: str, cache: dict[str, dict]):
+    verses: list[dict] = []
+    headings: list[dict] = []
+    stats = {"cached": 0, "needs_chunking": 0, "empty": 0, "missing_refs": []}
+
+    for notetype, deck, fields, _tags in query_notes(db_path):
+        if year_prefix not in deck:
+            continue
+
+        if notetype == "Verse":
+            if len(fields) < 5:
+                continue
+            _sort, ref_str, text_html, ftv_html, club = fields[:5]
+            try:
+                book, chapter, verse = parse_anki.parse_reference(ref_str)
+            except ValueError:
+                continue
+            text = parse_anki.clean_text(text_html)
+            ftv = parse_anki.clean_text(ftv_html) if ftv_html else ""
+            clubs = []
+            if "150" in club:
+                clubs.append(150)
+            if "300" in club:
+                clubs.append(300)
+
+            ref_key = f"{book} {chapter}:{verse}"
+            if not text:
+                phrases = []
+                stats["empty"] += 1
+            else:
+                cached = cache.get(ref_key)
+                if cached and cached.get("text") == text and isinstance(cached.get("phrases"), list):
+                    phrases = cached["phrases"]
+                    stats["cached"] += 1
+                else:
+                    phrases = [text]
+                    stats["needs_chunking"] += 1
+                    stats["missing_refs"].append(ref_key)
+
+            verses.append({
+                "book": book,
+                "chapter": chapter,
+                "verse": verse,
+                "text": text,
+                "ftv": ftv,
+                "clubs": clubs,
+                "phrases": phrases,
+            })
+
+        elif notetype == "Heading":
+            if len(fields) < 3:
+                continue
+            sort_field, front, back, *_ = (*fields, "")
+            heading_text = back.strip()
+            try:
+                start_ch, start_v, end_ch, end_v = parse_anki.parse_heading_id(sort_field)
+            except ValueError:
+                continue
+            headings.append({
+                "text": heading_text,
+                "book": front.strip(),
+                "start_chapter": start_ch,
+                "start_verse": start_v,
+                "end_chapter": end_ch,
+                "end_verse": end_v,
+            })
+
+    return verses, headings, stats
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/import_colpkg.py
+++ b/tools/import_colpkg.py
@@ -44,29 +44,35 @@ HEADING_FIELDS = ("Sort", "Front", "Back", "Add Reverse")
 ANKI_FIELD_SEP = "\x1f"
 
 
+COLLECTION_CANDIDATES = ("collection.anki21b", "collection.anki21", "collection.anki2")
+
+
 def extract_collection(colpkg_path: str, dest_dir: str) -> str:
-    """Extract the .colpkg, return path to the readable SQLite collection."""
+    """Extract the .colpkg's collection file, return path to readable SQLite.
+
+    A .colpkg also contains media files (potentially MB of images) — extract
+    just the collection candidates we care about.
+    """
     with zipfile.ZipFile(colpkg_path) as zf:
-        zf.extractall(dest_dir)
+        names = set(zf.namelist())
+        present = [c for c in COLLECTION_CANDIDATES if c in names]
+        for name in present:
+            zf.extract(name, dest_dir)
+    if not present:
+        sys.exit(f"No {'/'.join(COLLECTION_CANDIDATES)} found in {colpkg_path}")
 
-    anki21b = os.path.join(dest_dir, "collection.anki21b")
-    anki21 = os.path.join(dest_dir, "collection.anki21")
-    anki2 = os.path.join(dest_dir, "collection.anki2")
-
-    if os.path.exists(anki21b):
+    if "collection.anki21b" in present:
+        src = os.path.join(dest_dir, "collection.anki21b")
         out = os.path.join(dest_dir, "collection.real.anki21")
         zstd = shutil.which("zstd")
         if zstd is None:
             sys.exit("zstd binary not found on PATH (needed to decompress collection.anki21b)")
-        subprocess.run([zstd, "-d", "-q", "-f", anki21b, "-o", out], check=True)
+        subprocess.run([zstd, "-d", "-q", "-f", src, "-o", out], check=True)
         return out
-    if os.path.exists(anki21):
-        return anki21
-    if os.path.exists(anki2):
-        # Legacy fallback. In modern .colpkg files anki2 is a 1-row stub —
-        # the caller should sanity-check note count after.
-        return anki2
-    sys.exit(f"No collection.anki21b/anki21/anki2 found in {colpkg_path}")
+    # Legacy fallback for anki2: in modern backups it's a 1-row stub — the
+    # caller should sanity-check note count after.
+    chosen = "collection.anki21" if "collection.anki21" in present else "collection.anki2"
+    return os.path.join(dest_dir, chosen)
 
 
 def query_notes(db_path: str):
@@ -176,13 +182,9 @@ def process(db_path: str, year_prefix: str, cache: dict[str, dict]):
                 continue
             text = parse_anki.clean_text(text_html)
             ftv = parse_anki.clean_text(ftv_html) if ftv_html else ""
-            clubs = []
-            if "150" in club:
-                clubs.append(150)
-            if "300" in club:
-                clubs.append(300)
+            clubs = parse_anki.parse_clubs(club)
 
-            ref_key = f"{book} {chapter}:{verse}"
+            ref_key = parse_anki.format_reference(book, chapter, verse)
             if not text:
                 phrases = []
                 stats["empty"] += 1
@@ -209,7 +211,7 @@ def process(db_path: str, year_prefix: str, cache: dict[str, dict]):
         elif notetype == "Heading":
             if len(fields) < 3:
                 continue
-            sort_field, front, back, *_ = (*fields, "")
+            sort_field, front, back, *_ = fields
             heading_text = back.strip()
             try:
                 start_ch, start_v, end_ch, end_v = parse_anki.parse_heading_id(sort_field)

--- a/tools/parse_anki.py
+++ b/tools/parse_anki.py
@@ -102,6 +102,20 @@ def parse_reference(ref_str: str) -> tuple[str, int, int]:
     return match.group(1), int(match.group(2)), int(match.group(3))
 
 
+def format_reference(book: str, chapter: int, verse: int) -> str:
+    return f"{book} {chapter}:{verse}"
+
+
+def parse_clubs(club_str: str) -> list[int]:
+    """Parse the Anki `club` field into the canonical 150/300 tier list."""
+    clubs: list[int] = []
+    if "150" in club_str:
+        clubs.append(150)
+    if "300" in club_str:
+        clubs.append(300)
+    return clubs
+
+
 def parse_heading_id(id_str: str) -> tuple[int, int, int, int]:
     parts = id_str.strip().rstrip(",").split(",")
     if len(parts) != 2:
@@ -146,11 +160,7 @@ def parse_anki_export(filepath: str, year_prefix: str):
                 cleaned = clean_text(text_html)
                 ftv_clean = clean_text(ftv) if ftv else ""
 
-                clubs = []
-                if "150" in club:
-                    clubs.append(150)
-                if "300" in club:
-                    clubs.append(300)
+                clubs = parse_clubs(club)
 
                 verses.append({
                     "book": book,

--- a/typos.toml
+++ b/typos.toml
@@ -8,3 +8,4 @@ extend-exclude = [
 
 [default.extend-words]
 OT = "OT" # old testament
+NAM = "NAM" # USX book code for Nahum


### PR DESCRIPTION
## Summary

Tools-only PR — no runtime changes. Adds a faster content pipeline and an api.bible-driven verifier.

- **\`tools/import_colpkg.py\`** — replaces the manual \"Notes in Plain Text\" Anki export step. Unzips a \`.colpkg\` directly, decompresses the zstd-compressed \`collection.anki21b\` via \`/usr/bin/zstd\`, queries the SQLite for Verse + Heading notes, and produces the same intermediate JSON \`parse_anki.py\` emits. Reuses cached phrase splits for verses whose text matches a fingerprint, listing mismatches so the LLM chunking pipeline only re-runs where it has to.
- **\`tools/extract_phrases.py\`** — dumps the chunked-phrase output to a sidecar cache keyed by \`Book Chapter:Verse\` with the verse text as fingerprint. Run once from your existing \`corinthians.json\`; future colpkg imports stay free.
- **\`tools/check_against_apibible.py\`** — diff mode against the canonical NKJV from api.bible. Two sub-modes:
  - \`--mode verses\` (default) — fetches a chapter, parses verse numbers from the inline \`[N]\` markers, strips deck markup, prints any verses where wording diverges. Catches typos accidentally introduced when editing the Anki deck.
  - \`--mode headings\` — fetches \`/v1/bibles/{id}/books/{bookCode}/sections\`, matches sections to the deck's headings array by start (chapter, verse), reports four diff kinds (title-mismatch, range-mismatch, extra-in-deck, missing-in-deck).
- **TOS compliance**: caches passages and sections at \`data/apibible-cache.json\`, refreshed every 30 days per api.bible's Minimum Acceptable Use Agreement. Stale entries are pruned on load so the on-disk file never holds expired content. Every run prints the required NKJV citation.

## Test plan

- [x] \`python3 tools/extract_phrases.py data/corinthians.json data/corinthians-phrases.json\` — wrote 553 phrase entries
- [x] \`python3 tools/import_colpkg.py …\` — round-tripped a real colpkg: 694 verses, 85 headings, 29 chapters; 550 cached, 101 needed re-chunking, 43 empty
- [x] \`tools/check_against_apibible.py … --mode verses 1 Cor 1\` — caught real deck typos (Stephanas/Staphanas, wisdom-of-the-wife/wise, etc.)
- [x] \`tools/check_against_apibible.py … --mode headings\` — caught the \"Final Exortations\" → \"Exhortations\" typo and three missing-in-deck headings
- [x] \`cargo test --workspace --quiet\` — clean (no Rust impact)
- [x] Adds \`NAM\` (USX code for Nahum) to typos allowlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)