### PR TITLE
feat: phase 4a thin client

### DIFF
--- a/apps/web/env.d.ts
+++ b/apps/web/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+  readonly VITE_MATERIAL_ID?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>verse-vault</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "type-check": "vue-tsc --build"
   },
   "dependencies": {
+    "better-auth": "^1.6.5",
     "vue": "^3.5.28",
     "vue-router": "^4.5.1"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@verse-vault/web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "run-p type-check \"build-only {@}\" --",
+    "preview": "vite preview",
+    "build-only": "vite build",
+    "type-check": "vue-tsc --build"
+  },
+  "dependencies": {
+    "vue": "^3.5.28",
+    "vue-router": "^4.5.1"
+  },
+  "devDependencies": {
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^24.10.13",
+    "@vitejs/plugin-vue": "^6.0.4",
+    "@vue/tsconfig": "^0.8.1",
+    "npm-run-all2": "^8.0.4",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.1",
+    "vue-tsc": "^3.2.4"
+  }
+}

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,14 +1,29 @@
 <script setup lang="ts">
-import { RouterLink, RouterView } from 'vue-router'
+import { computed } from 'vue'
+import { RouterLink, RouterView, useRouter } from 'vue-router'
+
+import { useAuth } from '@/composables/useAuth'
+
+const { session, signOut } = useAuth()
+const router = useRouter()
+
+const user = computed(() => session.value?.data?.user ?? null)
+
+async function onSignOut() {
+  signOut()
+  await router.push('/signin')
+}
 </script>
 
 <template>
   <div class="site">
     <header class="site-header">
       <RouterLink to="/" class="brand">verse-vault</RouterLink>
-      <nav class="nav">
+      <nav v-if="user" class="nav">
         <RouterLink to="/session">Session</RouterLink>
         <RouterLink to="/stats">Stats</RouterLink>
+        <span class="who">{{ user.email }}</span>
+        <button type="button" class="sign-out" @click="onSignOut">Sign out</button>
       </nav>
     </header>
     <main class="site-main">
@@ -42,6 +57,7 @@ import { RouterLink, RouterView } from 'vue-router'
 
 .nav {
   display: flex;
+  align-items: center;
   gap: 1rem;
 }
 
@@ -55,6 +71,24 @@ import { RouterLink, RouterView } from 'vue-router'
 .nav :deep(a.router-link-active) {
   color: var(--color-accent);
   background: var(--color-accent-soft);
+}
+
+.who {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.sign-out {
+  background: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-muted);
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.sign-out:hover {
+  color: var(--color-text);
 }
 
 .site-main {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { RouterLink, RouterView } from 'vue-router'
+</script>
+
+<template>
+  <div class="site">
+    <header class="site-header">
+      <RouterLink to="/" class="brand">verse-vault</RouterLink>
+      <nav class="nav">
+        <RouterLink to="/session">Session</RouterLink>
+        <RouterLink to="/stats">Stats</RouterLink>
+      </nav>
+    </header>
+    <main class="site-main">
+      <RouterView />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.site {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1.5rem;
+  background: var(--color-bg-card);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.brand {
+  font-weight: 600;
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 1.1rem;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav :deep(a) {
+  color: var(--color-muted);
+  text-decoration: none;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+}
+
+.nav :deep(a.router-link-active) {
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.site-main {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+</style>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,9 +1,8 @@
 /**
  * Typed fetch wrapper for the verse-vault Hono API. Mirrors the
  * `createApiClient` factory pattern from `~/Code/qzr-sheet`. All endpoints
- * here require an authenticated user; in dev we attach the
- * `x-vv-dev-user: 1` header so the API's env-gated bypass triggers (real
- * Better Auth integration is out of scope for v1).
+ * require an authenticated user; the Better Auth session cookie flows
+ * through `credentials: 'include'`.
  */
 
 export type Grade = 1 | 2 | 3 | 4
@@ -79,14 +78,9 @@ export interface ApiClient {
   getStats(materialId: string): Promise<StatsResponse>
 }
 
-/**
- * Build an API client targeting `apiUrl`. Always sends `credentials:
- * 'include'` so future Better Auth cookies flow through. In dev,
- * additionally attaches the dev bypass header.
- */
-export function createApiClient(apiUrl: string, opts?: { devBypass?: boolean }): ApiClient {
-  const devBypass = opts?.devBypass ?? import.meta.env.DEV
-
+/** Build an API client targeting `apiUrl`. Sends `credentials: 'include'`
+ *  so the Better Auth session cookie flows through on every call. */
+export function createApiClient(apiUrl: string): ApiClient {
   async function request<T>(
     method: 'GET' | 'POST',
     path: string,
@@ -94,7 +88,6 @@ export function createApiClient(apiUrl: string, opts?: { devBypass?: boolean }):
   ): Promise<T> {
     const headers: Record<string, string> = {}
     if (body !== undefined) headers['Content-Type'] = 'application/json'
-    if (devBypass) headers['x-vv-dev-user'] = '1'
     const res = await fetch(`${apiUrl}${path}`, {
       method,
       headers,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,0 +1,140 @@
+/**
+ * Typed fetch wrapper for the verse-vault Hono API. Mirrors the
+ * `createApiClient` factory pattern from `~/Code/qzr-sheet`. All endpoints
+ * here require an authenticated user; in dev we attach the
+ * `x-vv-dev-user: 1` header so the API's env-gated bypass triggers (real
+ * Better Auth integration is out of scope for v1).
+ */
+
+export type Grade = 1 | 2 | 3 | 4
+
+export interface CardRender {
+  cardId: number
+  verseId: number
+  kind: CardKind
+  position?: number
+  headingIdx?: number
+  tier?: 'Club150' | 'Club300'
+  withCitation?: boolean
+  verse: VerseRender
+}
+
+export type CardKind =
+  | 'PhraseFill'
+  | 'PhraseChain'
+  | 'VerseAtVerseRef'
+  | 'VerseInChapter'
+  | 'VerseInBook'
+  | 'VerseInHeading'
+  | 'VerseInClub'
+  | 'Recitation'
+  | 'Citation'
+  | 'Ftv'
+  | 'Reading'
+
+export interface VerseRender {
+  book: string
+  chapter: number
+  verse: number
+  text: string
+  phrases: string[]
+  ftv: string | null
+  headings: { headingIdx: number; text: string }[]
+  clubs: ('Club150' | 'Club300')[]
+}
+
+export interface TestUpdate {
+  key: { kind: string; element: unknown }
+  kind: 'Root' | 'Sub'
+  before: TestState
+  after: TestState
+}
+
+export interface TestState {
+  stability: number
+  difficulty: number
+  last_seen_secs: number
+  last_base_secs: number
+  last_root_secs: number
+}
+
+export interface ReviewResponse {
+  updates: TestUpdate[]
+  nextCardId: number | null
+}
+
+export interface StatsResponse {
+  materialId: string
+  versesLearned: number
+  retentionRate: number | null
+  totalGrades: number
+  testDistribution: Record<'weak' | 'learning' | 'familiar' | 'strong' | 'mastered', number>
+}
+
+export interface ApiClient {
+  enroll(materialId: string): Promise<{ snapshotId: string; version: number }>
+  getNextCard(materialId: string): Promise<{ cardId: number | null }>
+  getCardRender(materialId: string, cardId: number): Promise<CardRender>
+  submitReview(materialId: string, cardId: number, grade: Grade): Promise<ReviewResponse>
+  getStats(materialId: string): Promise<StatsResponse>
+}
+
+/**
+ * Build an API client targeting `apiUrl`. Always sends `credentials:
+ * 'include'` so future Better Auth cookies flow through. In dev,
+ * additionally attaches the dev bypass header.
+ */
+export function createApiClient(apiUrl: string, opts?: { devBypass?: boolean }): ApiClient {
+  const devBypass = opts?.devBypass ?? import.meta.env.DEV
+
+  async function request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: unknown,
+  ): Promise<T> {
+    const headers: Record<string, string> = {}
+    if (body !== undefined) headers['Content-Type'] = 'application/json'
+    if (devBypass) headers['x-vv-dev-user'] = '1'
+    const res = await fetch(`${apiUrl}${path}`, {
+      method,
+      headers,
+      credentials: 'include',
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+    if (!res.ok) {
+      const text = await res.text().catch(() => '')
+      throw new ApiError(res.status, text || res.statusText)
+    }
+    return res.json() as Promise<T>
+  }
+
+  return {
+    enroll: (materialId) =>
+      request('POST', '/api/materials/enroll', { materialId }),
+    getNextCard: (materialId) =>
+      request('GET', `/api/cards/next?materialId=${encodeURIComponent(materialId)}`),
+    getCardRender: (materialId, cardId) =>
+      request('GET', `/api/cards/${cardId}?materialId=${encodeURIComponent(materialId)}`),
+    submitReview: (materialId, cardId, grade) =>
+      request('POST', '/api/cards/review', { materialId, cardId, grade }),
+    getStats: (materialId) =>
+      request('GET', `/api/stats/${encodeURIComponent(materialId)}`),
+  }
+}
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(`API error ${status}: ${message}`)
+    this.name = 'ApiError'
+  }
+}
+
+/** Singleton instance configured against the Vite-injected API URL.
+ *  Falls back to the local dev server when no override is provided. */
+export const api = createApiClient(import.meta.env.VITE_API_URL ?? 'http://localhost:3000')
+
+/** Material id rendered in the thin client. Override with VITE_MATERIAL_ID. */
+export const MATERIAL_ID = import.meta.env.VITE_MATERIAL_ID ?? 'nkjv-1cor'

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -30,7 +30,6 @@ export interface ComposedRender {
 
 export type CardKind =
   | 'PhraseFill'
-  | 'PhraseChain'
   | 'VerseAtVerseRef'
   | 'VerseInChapter'
   | 'VerseInBook'

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -16,6 +16,16 @@ export interface CardRender {
   tier?: 'Club150' | 'Club300'
   withCitation?: boolean
   verse: VerseRender
+  /** Server-composed HTML from the api.bible cache layered with user
+   *  annotations. `null` when the cache is unavailable (e.g. BIBLE_API_KEY
+   *  unset on the server). */
+  composed: ComposedRender | null
+}
+
+export interface ComposedRender {
+  phraseHtml: string[]
+  ftvHtml: string | null
+  headings: { headingIdx: number; title: string | null }[]
 }
 
 export type CardKind =
@@ -35,10 +45,16 @@ export interface VerseRender {
   book: string
   chapter: number
   verse: number
-  text: string
-  phrases: string[]
-  ftv: string | null
-  headings: { headingIdx: number; text: string }[]
+  phraseWordCounts: number[]
+  annotations: { wordIndex: number; kind: 'bold' | 'italic' | 'boldItalic' }[]
+  ftvWordCount: number | null
+  headings: {
+    headingIdx: number
+    startChapter: number
+    startVerse: number
+    endChapter: number
+    endVerse: number
+  }[]
   clubs: ('Club150' | 'Club300')[]
 }
 

--- a/apps/web/src/assets/colors.css
+++ b/apps/web/src/assets/colors.css
@@ -1,0 +1,52 @@
+:root {
+  --color-bg: #f5f2ec;
+  --color-bg-card: #ffffff;
+  --color-text: #2a2724;
+  --color-muted: #78716c;
+  --color-border: #e0ddd4;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-accent-soft: #dbeafe;
+  --color-grade-again: #b91c1c;
+  --color-grade-again-bg: #fee2e2;
+  --color-grade-hard: #c2410c;
+  --color-grade-hard-bg: #ffedd5;
+  --color-grade-good: #15803d;
+  --color-grade-good-bg: #dcfce7;
+  --color-grade-easy: #1e40af;
+  --color-grade-easy-bg: #dbeafe;
+  --color-success: #15803d;
+  --color-success-bg: #dcfce7;
+  --color-error: #b91c1c;
+  --color-error-bg: #fee2e2;
+}
+
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}

--- a/apps/web/src/assets/colors.css
+++ b/apps/web/src/assets/colors.css
@@ -19,6 +19,20 @@
   --color-success-bg: #dcfce7;
   --color-error: #b91c1c;
   --color-error-bg: #fee2e2;
+
+  /* Verse colours — ported from the Anki deck's _colours.js. Indexed by
+     (verseNumber - 1) % 10 to give every verse-within-a-chapter its own
+     hue, so "verse 5" looks the same regardless of book/chapter. */
+  --verse-c1: oklch(56% 0.21 24.87); /* red */
+  --verse-c2: oklch(75% 0.15 358.59); /* pink */
+  --verse-c3: oklch(68% 0.17 24.68); /* salmon */
+  --verse-c4: oklch(73% 0.17 55.11); /* orange */
+  --verse-c5: oklch(88% 0.18 107.15); /* yellow */
+  --verse-c6: oklch(68% 0.16 142.16); /* green */
+  --verse-c7: oklch(72% 0.12 235.93); /* light blue */
+  --verse-c8: oklch(50% 0.18 263.47); /* dark blue */
+  --verse-c9: oklch(58% 0.18 293.9); /* blue violet */
+  --verse-c10: oklch(50% 0.19 333.28); /* dark magenta */
 }
 
 *,

--- a/apps/web/src/assets/colors.css
+++ b/apps/web/src/assets/colors.css
@@ -7,6 +7,7 @@
   --color-accent: #2563eb;
   --color-accent-hover: #1d4ed8;
   --color-accent-soft: #dbeafe;
+  --color-on-accent: #ffffff;
   --color-grade-again: #b91c1c;
   --color-grade-again-bg: #fee2e2;
   --color-grade-hard: #c2410c;
@@ -22,7 +23,9 @@
 
   /* Verse colours — ported from the Anki deck's _colours.js. Indexed by
      (verseNumber - 1) % 10 to give every verse-within-a-chapter its own
-     hue, so "verse 5" looks the same regardless of book/chapter. */
+     hue, so "verse 5" looks the same regardless of book/chapter. Same
+     values in light and dark since oklch keeps perceived lightness
+     consistent across surfaces. */
   --verse-c1: oklch(56% 0.21 24.87); /* red */
   --verse-c2: oklch(75% 0.15 358.59); /* pink */
   --verse-c3: oklch(68% 0.17 24.68); /* salmon */
@@ -33,6 +36,37 @@
   --verse-c8: oklch(50% 0.18 263.47); /* dark blue */
   --verse-c9: oklch(58% 0.18 293.9); /* blue violet */
   --verse-c10: oklch(50% 0.19 333.28); /* dark magenta */
+}
+
+/* Dark theme picks up automatically on OS preference. Background is a
+   warm charcoal rather than pitch black so the cream-paper card sits
+   against something that still feels lit (Anki's night mode does the
+   same). Grade tint backgrounds stay deeply desaturated; their text
+   stays bright. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #14110f;
+    --color-bg-card: #1f1c19;
+    --color-text: #f1ede5;
+    --color-muted: #9a938a;
+    --color-border: #332e2a;
+    --color-accent: #93c5fd;
+    --color-accent-hover: #bfdbfe;
+    --color-accent-soft: #1e293b;
+    --color-on-accent: #0a1322;
+    --color-grade-again: #fca5a5;
+    --color-grade-again-bg: #3f1d1d;
+    --color-grade-hard: #fdba74;
+    --color-grade-hard-bg: #3d2516;
+    --color-grade-good: #86efac;
+    --color-grade-good-bg: #14361f;
+    --color-grade-easy: #93c5fd;
+    --color-grade-easy-bg: #172244;
+    --color-success: #86efac;
+    --color-success-bg: #14361f;
+    --color-error: #fca5a5;
+    --color-error-bg: #3f1d1d;
+  }
 }
 
 *,

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { CardRender } from '@/api'
+
+const props = defineProps<{
+  card: CardRender
+  revealed: boolean
+}>()
+
+const ref = computed(() => `${props.card.verse.book} ${props.card.verse.chapter}:${props.card.verse.verse}`)
+
+const promptLabel = computed(() => {
+  switch (props.card.kind) {
+    case 'PhraseFill':
+      return `Fill in phrase ${props.card.position! + 1}`
+    case 'PhraseChain':
+      return `What comes after phrase ${props.card.position}?`
+    case 'VerseAtVerseRef':
+      return 'Recite this verse'
+    case 'VerseInChapter':
+      return 'What chapter?'
+    case 'VerseInBook':
+      return 'What book?'
+    case 'VerseInHeading':
+      return 'What heading?'
+    case 'VerseInClub':
+      return 'What club?'
+    case 'Recitation':
+      return 'Recite the whole verse + reference'
+    case 'Citation':
+      return 'What is the reference?'
+    case 'Ftv':
+      return 'Continue from these first words'
+    case 'Reading':
+      return 'Reading'
+    default:
+      return 'Card'
+  }
+})
+
+const headingText = computed(() => props.card.verse.headings[0]?.text ?? '')
+const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
+</script>
+
+<template>
+  <div class="prompt">
+    <div class="meta">{{ promptLabel }}</div>
+
+    <!-- Phrase-position cards: show all phrases except the target. -->
+    <div v-if="card.kind === 'PhraseFill'" class="phrases">
+      <div
+        v-for="(phrase, i) in card.verse.phrases"
+        :key="i"
+        :class="['phrase', { 'phrase-hidden': i === card.position && !revealed }]"
+      >
+        {{ i === card.position && !revealed ? '___' : phrase }}
+      </div>
+      <div class="ref small">{{ ref }}</div>
+    </div>
+
+    <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
+      <div class="phrase">{{ card.verse.phrases[card.position! - 1] }}</div>
+      <div class="phrase phrase-hidden">
+        {{ revealed ? card.verse.phrases[card.position!] : '___' }}
+      </div>
+      <div class="ref small">{{ ref }}</div>
+    </div>
+
+    <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
+      <div class="ref">{{ ref }}</div>
+      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div v-else class="placeholder">…recite the verse…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
+      <div class="verse-text">{{ card.verse.text }}</div>
+      <div v-if="revealed" class="ref">{{ ref }}</div>
+      <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
+      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="ref small">{{ ref }}</div>
+      <div v-if="revealed" class="answer">Heading: {{ headingText }}</div>
+      <div v-else class="placeholder">…what heading?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'VerseInClub'" class="centered">
+      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="ref small">{{ ref }}</div>
+      <div v-if="revealed" class="answer">Club: {{ clubLabel }}</div>
+      <div v-else class="placeholder">…which club?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Recitation'" class="centered">
+      <div class="ref">{{ ref }}</div>
+      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div v-else class="placeholder">…recite the whole verse…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Citation'" class="centered">
+      <div class="verse-text">{{ card.verse.text }}</div>
+      <div v-if="revealed" class="ref">{{ ref }}</div>
+      <div v-else class="placeholder">…what is the reference?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Ftv'" class="centered">
+      <div class="verse-text ftv">{{ card.verse.ftv }}…</div>
+      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div v-else class="placeholder">…continue the verse…</div>
+      <div v-if="revealed && card.withCitation" class="ref">{{ ref }}</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Reading'" class="centered">
+      <div class="ref">{{ ref }}</div>
+      <div class="verse-text">{{ card.verse.text }}</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 12rem;
+}
+
+.meta {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.phrases {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.phrase {
+  font-size: 1.15rem;
+  line-height: 1.5;
+}
+
+.phrase-hidden {
+  background: var(--color-accent-soft);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  display: inline-block;
+  width: fit-content;
+}
+
+.centered {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.ref {
+  font-weight: 500;
+  color: var(--color-accent);
+}
+
+.ref.small {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  font-weight: 400;
+}
+
+.verse-text {
+  font-size: 1.15rem;
+  line-height: 1.6;
+}
+
+.verse-text.ftv {
+  font-style: italic;
+}
+
+.placeholder {
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.answer {
+  background: var(--color-success-bg);
+  color: var(--color-success);
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+</style>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -227,9 +227,8 @@ const composedMissing = computed(() => props.card.composed === null)
 }
 
 /* Verse-coloured flashcard box — the only bordered surface on the
-   page. Min-height reserves enough room that the box doesn't pop
-   bigger when reveal adds the answer text — content sits at the top
-   of a fixed-height frame, with empty space below before reveal. */
+   page. Hugs its content; empty space below before reveal lives
+   outside this box, on the page. */
 .card-box {
   border-width: 5px;
   border-style: solid;
@@ -238,7 +237,6 @@ const composedMissing = computed(() => props.card.composed === null)
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 18rem;
   background: var(--color-bg-card);
 }
 
@@ -247,7 +245,6 @@ const composedMissing = computed(() => props.card.composed === null)
     border-width: 4px;
     padding: 1.25rem 1rem;
     border-radius: 8px;
-    min-height: 14rem;
   }
 }
 

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -223,7 +223,7 @@ const composedMissing = computed(() => props.card.composed === null)
   color: var(--color-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  text-align: center;
+  text-align: left;
 }
 
 /* Verse-coloured flashcard box — the only bordered surface on the

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -400,9 +400,16 @@ const composedMissing = computed(() => props.card.composed === null)
   font-weight: 700;
 }
 
-.verse-text :deep(i),
-.verse-text :deep(.it) {
+/* Deck keyword annotations rendered as <i> stay italic. api.bible's
+   .it class (translator-supplied words like "corner stone", "It is as",
+   "Him") is left in default upright — the editorial italics distract
+   from the memorisation task. */
+.verse-text :deep(i) {
   font-style: italic;
+}
+
+.verse-text :deep(.it) {
+  font-style: normal;
 }
 
 .verse-text :deep(.sc) {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -19,8 +19,44 @@ const verseColour = computed(() => {
   return `var(${VERSE_COLOUR_VARS[idx]})`
 })
 
-const refPrefix = computed(() => `${props.card.verse.book} ${props.card.verse.chapter}:`)
-const refVerseNum = computed(() => props.card.verse.verse)
+/** Per-card visibility of each ref component. For "what chapter?" /
+ *  "what book?" / "what verse?" / Citation, the asked-about parts stay
+ *  blanked until reveal so the prompt doesn't leak the answer. Other
+ *  kinds show the full ref. */
+const refParts = computed(() => {
+  const reveal = props.revealed
+  switch (props.card.kind) {
+    case 'VerseInBook':
+      return { showBook: reveal, showChapter: true, showVerse: true }
+    case 'VerseInChapter':
+      return { showBook: true, showChapter: reveal, showVerse: true }
+    case 'Citation':
+      return { showBook: reveal, showChapter: reveal, showVerse: reveal }
+    default:
+      return { showBook: true, showChapter: true, showVerse: true }
+  }
+})
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
+/** Renders the reference with each part either revealed or shown as a
+ *  `?` placeholder. The verse number carries the verse-colour inline so
+ *  it picks up the same hue as the verse text. */
+const refHtml = computed(() => {
+  const { showBook, showChapter, showVerse } = refParts.value
+  const hidden = '<span class="ref-hidden">?</span>'
+  const book = showBook ? escapeHtml(props.card.verse.book) : hidden
+  const chap = showChapter ? String(props.card.verse.chapter) : hidden
+  const verse = showVerse
+    ? `<span style="color: ${verseColour.value}">${props.card.verse.verse}</span>`
+    : hidden
+  return `${book} ${chap}:${verse}`
+})
 
 const promptLabel = computed(() => {
   switch (props.card.kind) {
@@ -73,7 +109,7 @@ const composedMissing = computed(() => props.card.composed === null)
          output, never user input. -->
     <template v-else>
       <div v-if="card.kind === 'PhraseFill'" class="centered">
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref small" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }">
           <template v-for="(phrase, i) in phraseHtml" :key="i">
             <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
@@ -82,14 +118,14 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'PhraseChain'" class="centered">
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref small" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }">
           <span v-html="phraseHtml[card.position! - 1]" />{{ ' ' }}<span v-if="revealed" class="phrase-hidden" v-html="phraseHtml[card.position!]" /><span v-else class="phrase-hidden">___</span>
         </div>
       </div>
 
       <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
-        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref" v-html="refHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
@@ -97,20 +133,18 @@ const composedMissing = computed(() => props.card.composed === null)
         <div v-else class="placeholder">…recite the verse…</div>
       </div>
 
-      <!-- Ref-as-answer cards: ref slot is empty before reveal so we don't
-           give the answer away; on reveal it appears above the verse, with
-           hr.type marking the now-above answer vs the prompt below. -->
+      <!-- Ref-as-answer cards: ref is always present, but the asked-about
+           part(s) render as `?` until reveal. The `?` placeholder is the
+           prompt itself — no separate "what chapter?" hint needed. hr
+           appears on reveal as the prompt/answer divider. -->
       <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-        <template v-if="revealed">
-          <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
-          <hr class="type" />
-        </template>
+        <div class="ref" v-html="refHtml" />
+        <hr v-if="revealed" class="type" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        <div v-if="!revealed" class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref small" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
@@ -120,7 +154,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref small" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
@@ -130,7 +164,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Recitation'" class="centered">
-        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref" v-html="refHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
@@ -139,16 +173,13 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Citation'" class="centered">
-        <template v-if="revealed">
-          <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
-          <hr class="type" />
-        </template>
+        <div class="ref" v-html="refHtml" />
+        <hr v-if="revealed" class="type" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        <div v-if="!revealed" class="placeholder">…what is the reference?…</div>
       </div>
 
       <div v-else-if="card.kind === 'Ftv'" class="centered">
-        <div v-if="revealed && card.withCitation" class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
         <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
         <template v-if="revealed">
           <hr class="type" />
@@ -158,7 +189,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Reading'" class="centered">
-        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="ref" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
       </div>
     </template>
@@ -207,6 +238,17 @@ const composedMissing = computed(() => props.card.composed === null)
   font-size: 0.9rem;
   color: var(--color-muted);
   font-weight: 400;
+}
+
+/* `?` placeholder for ref parts that are the answer being tested. Slightly
+   muted vs the surrounding revealed text so the question is visually clear
+   without being a giant chip like phrase-hidden. */
+.ref :deep(.ref-hidden) {
+  background: var(--color-accent-soft);
+  border-radius: 3px;
+  padding: 0 0.25rem;
+  color: var(--color-muted);
+  font-weight: 600;
 }
 
 .verse-text {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -145,7 +145,7 @@ const composedMissing = computed(() => props.card.composed === null)
          output, never user input. -->
     <template v-else>
     <div v-if="card.kind === 'PhraseFill'" class="centered">
-      <div class="ref small" v-html="refHtml" />
+      <div class="ref" v-html="refHtml" />
       <hr />
       <div class="verse-text" :style="{ color: verseTextColour }">
         <template v-for="(phrase, i) in phraseHtml" :key="i">
@@ -177,7 +177,7 @@ const composedMissing = computed(() => props.card.composed === null)
     </div>
 
     <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-      <div class="ref small" v-html="refHtml" />
+      <div class="ref" v-html="refHtml" />
       <hr />
       <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       <template v-if="revealed">
@@ -188,7 +188,7 @@ const composedMissing = computed(() => props.card.composed === null)
     </div>
 
     <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-      <div class="ref small" v-html="refHtml" />
+      <div class="ref" v-html="refHtml" />
       <hr />
       <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       <template v-if="revealed">
@@ -332,29 +332,20 @@ const composedMissing = computed(() => props.card.composed === null)
   align-items: center;
 }
 
-/* Headline-style ref for cards where the reference is the focus
-   (VerseAtVerseRef / Recitation prompts, Citation / VerseInChapter /
-   VerseInBook answers). Book + chapter render in the neutral text
-   colour so the only accent in the line is the verse-number digit
-   (which picks up the verse colour via its own inline rule). */
+/* Single ref style across all card kinds. A moderate headline — bigger
+   than body so it reads as the title of the card, smaller than a
+   dominant header so it doesn't overpower the verse text on cards
+   where the verse is the real focus (PhraseFill / VerseInHeading).
+   Book + chapter render in the neutral text colour so the only accent
+   in the line is the verse-number digit (which picks up the verse
+   colour via its own inline rule). */
 .ref {
   font-weight: 600;
   color: var(--color-text);
-  font-size: 1.75rem;
+  font-size: 1.4rem;
   text-align: center;
   align-self: stretch;
   letter-spacing: 0.01em;
-}
-
-/* Context-style ref for cards where the reference is just a label
-   alongside the verse text (PhraseFill, VerseInHeading, VerseInClub).
-   Kept compact and muted so it doesn't compete with the main prompt. */
-.ref.small {
-  font-size: 0.95rem;
-  color: var(--color-muted);
-  font-weight: 400;
-  text-align: center;
-  align-self: stretch;
 }
 
 /* `?` placeholder for ref parts that are the answer being tested, and

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -62,8 +62,6 @@ const promptLabel = computed(() => {
   switch (props.card.kind) {
     case 'PhraseFill':
       return `Fill in phrase ${props.card.position! + 1}`
-    case 'PhraseChain':
-      return `What comes after phrase ${props.card.position}?`
     case 'VerseAtVerseRef':
       return 'Recite this verse'
     case 'VerseInChapter':
@@ -114,13 +112,6 @@ const composedMissing = computed(() => props.card.composed === null)
           <template v-for="(phrase, i) in phraseHtml" :key="i">
             <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
           </template>
-        </div>
-      </div>
-
-      <div v-else-if="card.kind === 'PhraseChain'" class="centered">
-        <div class="ref small" v-html="refHtml" />
-        <div class="verse-text" :style="{ color: verseColour }">
-          <span v-html="phraseHtml[card.position! - 1]" />{{ ' ' }}<span v-if="revealed" class="phrase-hidden" v-html="phraseHtml[card.position!]" /><span v-else class="phrase-hidden">___</span>
         </div>
       </div>
 
@@ -211,8 +202,8 @@ const composedMissing = computed(() => props.card.composed === null)
   letter-spacing: 0.05em;
 }
 
-/* PhraseFill/PhraseChain blanks render inline within the verse-text run
-   so the surrounding phrases keep flowing naturally. */
+/* PhraseFill blanks render inline within the verse-text run so the
+   surrounding phrases keep flowing naturally. */
 .phrase-hidden {
   background: var(--color-accent-soft);
   border-radius: 4px;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -39,83 +39,92 @@ const promptLabel = computed(() => {
   }
 })
 
-const headingText = computed(() => props.card.verse.headings[0]?.text ?? '')
+const phraseHtml = computed(() => props.card.composed?.phraseHtml ?? [])
+const verseHtml = computed(() => phraseHtml.value.join(' '))
+const ftvHtml = computed(() => props.card.composed?.ftvHtml ?? null)
+const headingTitle = computed(() => props.card.composed?.headings[0]?.title ?? null)
 const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
+const composedMissing = computed(() => props.card.composed === null)
 </script>
 
 <template>
   <div class="prompt">
     <div class="meta">{{ promptLabel }}</div>
 
-    <!-- Phrase-position cards: show all phrases except the target.
-         v-html renders <b>/<i>/<span> markup from the curated source data
-         (NKJV typography: bold / bold-italic keywords + small-caps LORD).
-         Safe: content originates from the server-side material catalog, not
-         user input. -->
-    <div v-if="card.kind === 'PhraseFill'" class="phrases">
-      <template v-for="(phrase, i) in card.verse.phrases" :key="i">
-        <div v-if="i === card.position && !revealed" class="phrase phrase-hidden">___</div>
-        <div v-else class="phrase" v-html="phrase" />
-      </template>
-      <div class="ref small">{{ ref }}</div>
+    <div v-if="composedMissing" class="placeholder">
+      Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
     </div>
 
-    <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
-      <div class="phrase" v-html="card.verse.phrases[card.position! - 1]" />
-      <div v-if="revealed" class="phrase phrase-hidden" v-html="card.verse.phrases[card.position!]" />
-      <div v-else class="phrase phrase-hidden">___</div>
-      <div class="ref small">{{ ref }}</div>
-    </div>
+    <!-- v-html renders api.bible's NKJV typography (small caps for LORD,
+         translator italics, divine-name bold) layered with the user's
+         keyword <b>/<i> annotations. Source is the server-composed
+         output, never user input. -->
+    <template v-else>
+      <div v-if="card.kind === 'PhraseFill'" class="phrases">
+        <template v-for="(phrase, i) in phraseHtml" :key="i">
+          <div v-if="i === card.position && !revealed" class="phrase phrase-hidden">___</div>
+          <div v-else class="phrase" v-html="phrase" />
+        </template>
+        <div class="ref small">{{ ref }}</div>
+      </div>
 
-    <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
-      <div class="ref">{{ ref }}</div>
-      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
-      <div v-else class="placeholder">…recite the verse…</div>
-    </div>
+      <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
+        <div class="phrase" v-html="phraseHtml[card.position! - 1]" />
+        <div v-if="revealed" class="phrase phrase-hidden" v-html="phraseHtml[card.position!]" />
+        <div v-else class="phrase phrase-hidden">___</div>
+        <div class="ref small">{{ ref }}</div>
+      </div>
 
-    <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-      <div class="verse-text" v-html="card.verse.text" />
-      <div v-if="revealed" class="ref">{{ ref }}</div>
-      <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
+        <div class="ref">{{ ref }}</div>
+        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <div v-else class="placeholder">…recite the verse…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-      <div class="verse-text" v-html="card.verse.text" />
-      <div class="ref small">{{ ref }}</div>
-      <div v-if="revealed" class="answer">Heading: {{ headingText }}</div>
-      <div v-else class="placeholder">…what heading?…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
+        <div class="verse-text" v-html="verseHtml" />
+        <div v-if="revealed" class="ref">{{ ref }}</div>
+        <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-      <div class="verse-text" v-html="card.verse.text" />
-      <div class="ref small">{{ ref }}</div>
-      <div v-if="revealed" class="answer">Club: {{ clubLabel }}</div>
-      <div v-else class="placeholder">…which club?…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
+        <div class="verse-text" v-html="verseHtml" />
+        <div class="ref small">{{ ref }}</div>
+        <div v-if="revealed" class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+        <div v-else class="placeholder">…what heading?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Recitation'" class="centered">
-      <div class="ref">{{ ref }}</div>
-      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
-      <div v-else class="placeholder">…recite the whole verse…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseInClub'" class="centered">
+        <div class="verse-text" v-html="verseHtml" />
+        <div class="ref small">{{ ref }}</div>
+        <div v-if="revealed" class="answer">Club: {{ clubLabel }}</div>
+        <div v-else class="placeholder">…which club?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Citation'" class="centered">
-      <div class="verse-text" v-html="card.verse.text" />
-      <div v-if="revealed" class="ref">{{ ref }}</div>
-      <div v-else class="placeholder">…what is the reference?…</div>
-    </div>
+      <div v-else-if="card.kind === 'Recitation'" class="centered">
+        <div class="ref">{{ ref }}</div>
+        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <div v-else class="placeholder">…recite the whole verse…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Ftv'" class="centered">
-      <div class="verse-text ftv" v-html="`${card.verse.ftv ?? ''}…`" />
-      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
-      <div v-else class="placeholder">…continue the verse…</div>
-      <div v-if="revealed && card.withCitation" class="ref">{{ ref }}</div>
-    </div>
+      <div v-else-if="card.kind === 'Citation'" class="centered">
+        <div class="verse-text" v-html="verseHtml" />
+        <div v-if="revealed" class="ref">{{ ref }}</div>
+        <div v-else class="placeholder">…what is the reference?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Reading'" class="centered">
-      <div class="ref">{{ ref }}</div>
-      <div class="verse-text" v-html="card.verse.text" />
-    </div>
+      <div v-else-if="card.kind === 'Ftv'" class="centered">
+        <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
+        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <div v-else class="placeholder">…continue the verse…</div>
+        <div v-if="revealed && card.withCitation" class="ref">{{ ref }}</div>
+      </div>
+
+      <div v-else-if="card.kind === 'Reading'" class="centered">
+        <div class="ref">{{ ref }}</div>
+        <div class="verse-text" v-html="verseHtml" />
+      </div>
+    </template>
   </div>
 </template>
 
@@ -180,21 +189,27 @@ const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
   font-style: italic;
 }
 
-/* NKJV markup, rendered via v-html in verse-text and phrase blocks.
-   :deep() reaches inside since Vue's scoped CSS doesn't tag dynamically
+/* Typography rendered via v-html — both api.bible's editorial classes
+   (.sc small caps for LORD, .bd divine-name bold, .it translator
+   italics) and the deck's user-annotation tags (<b>/<i>). :deep()
+   reaches inside since Vue's scoped CSS doesn't tag dynamically
    inserted nodes. */
 .verse-text :deep(b),
-.phrase :deep(b) {
+.phrase :deep(b),
+.verse-text :deep(.bd),
+.phrase :deep(.bd) {
   font-weight: 600;
 }
 
 .verse-text :deep(i),
-.phrase :deep(i) {
+.phrase :deep(i),
+.verse-text :deep(.it),
+.phrase :deep(.it) {
   font-style: italic;
 }
 
-.verse-text :deep(span[style*='small-caps']),
-.phrase :deep(span[style*='small-caps']) {
+.verse-text :deep(.sc),
+.phrase :deep(.sc) {
   font-variant: small-caps;
 }
 
@@ -209,5 +224,12 @@ const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
   padding: 0.5rem 0.75rem;
   border-radius: 4px;
   font-weight: 500;
+}
+
+code {
+  background: var(--color-accent-soft);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-family: monospace;
 }
 </style>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -216,8 +216,6 @@ const composedMissing = computed(() => props.card.composed === null)
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  flex: 1;
-  min-height: 0;
 }
 
 .meta {
@@ -235,9 +233,8 @@ const composedMissing = computed(() => props.card.composed === null)
    (a thin line at the deck's OKLCH lightness looks noticeably darker
    than anti-aliased text on either light or dark backgrounds).
 
-   Fills the available height inside .prompt so the inner frame
-   tracks the outer card. Content is centred vertically so short
-   verses don't pin themselves to the top. */
+   Hugs its content; the verse, ref, and any reveal sit at the top
+   of the frame rather than spreading to fill the outer card. */
 .card-box {
   border-width: 5px;
   border-style: solid;
@@ -245,10 +242,7 @@ const composedMissing = computed(() => props.card.composed === null)
   padding: 2rem 1.75rem;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   gap: 1rem;
-  flex: 1;
-  min-height: 0;
 }
 
 @media (max-width: 600px) {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -220,15 +220,28 @@ const composedMissing = computed(() => props.card.composed === null)
   align-items: flex-start;
 }
 
+/* Headline-style ref for cards where the reference is the focus
+   (VerseAtVerseRef / Recitation prompts, Citation / VerseInChapter /
+   VerseInBook answers). Centered and large like the Anki deck's
+   centered 20px body — scaled up here to suit the bigger card area. */
 .ref {
-  font-weight: 500;
+  font-weight: 600;
   color: var(--color-accent);
+  font-size: 1.75rem;
+  text-align: center;
+  align-self: stretch;
+  letter-spacing: 0.01em;
 }
 
+/* Context-style ref for cards where the reference is just a label
+   alongside the verse text (PhraseFill, VerseInHeading, VerseInClub).
+   Kept compact and muted so it doesn't compete with the main prompt. */
 .ref.small {
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--color-muted);
   font-weight: 400;
+  text-align: center;
+  align-self: stretch;
 }
 
 /* `?` placeholder for ref parts that are the answer being tested. Slightly
@@ -236,8 +249,8 @@ const composedMissing = computed(() => props.card.composed === null)
    without being a giant chip like phrase-hidden. */
 .ref :deep(.ref-hidden) {
   background: var(--color-accent-soft);
-  border-radius: 3px;
-  padding: 0 0.25rem;
+  border-radius: 4px;
+  padding: 0 0.4rem;
   color: var(--color-muted);
   font-weight: 600;
 }

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -450,9 +450,11 @@ code {
 
 /* Dotted hr.type — the prompt/answer divider, ported from the Anki
    deck's `hr.type`. Appears on reveal to mark "below this line is
-   the answer / the typed-in check / the supporting context". Picks up
-   the verse hue so it ties to the rest of the reveal-state chrome. */
+   the answer / the typed-in check / the supporting context". Stays
+   on the neutral border tone so it reads as a UI divider rather than
+   carrying verse-colour weight (some hues — verse 1's red, verse 5's
+   yellow — would otherwise read as alarm/warning, not "answer"). */
 .card-box :deep(hr.type) {
-  border-top: 1px dotted color-mix(in oklch, var(--active-verse-colour) 50%, var(--color-border));
+  border-top: 1px dotted var(--color-border);
 }
 </style>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -217,7 +217,7 @@ const composedMissing = computed(() => props.card.composed === null)
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  align-items: flex-start;
+  align-items: center;
 }
 
 /* Headline-style ref for cards where the reference is the focus
@@ -258,6 +258,8 @@ const composedMissing = computed(() => props.card.composed === null)
 .verse-text {
   font-size: 1.15rem;
   line-height: 1.6;
+  text-align: center;
+  align-self: stretch;
 }
 
 .verse-text.ftv {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -19,14 +19,6 @@ const verseColour = computed(() => {
   return `var(${VERSE_COLOUR_VARS[idx]})`
 })
 
-/** Verse text colour. Suppressed (falls back to neutral text) on cards
- *  whose answer is the verse number itself — VerseAtVerseRef and
- *  Citation pre-reveal — so the verse-colour palette doesn't leak which
- *  verse this is. Same gate used by the top-stripe accent. */
-const verseTextColour = computed(() =>
-  refParts.value.showVerse ? verseColour.value : undefined,
-)
-
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
  *  blanked until reveal so the prompt doesn't leak the answer. Other
@@ -144,91 +136,91 @@ const composedMissing = computed(() => props.card.composed === null)
          keyword <b>/<i> annotations. Source is the server-composed
          output, never user input. -->
     <template v-else>
-    <div v-if="card.kind === 'PhraseFill'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr />
-      <div class="verse-text" :style="{ color: verseTextColour }">
-        <template v-for="(phrase, i) in phraseHtml" :key="i">
-          <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else-if="i === card.position" class="phrase-revealed" v-html="phrase" /><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
-        </template>
+      <div v-if="card.kind === 'PhraseFill'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr />
+        <div class="verse-text">
+          <template v-for="(phrase, i) in phraseHtml" :key="i">
+            <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else-if="i === card.position" class="phrase-revealed" v-html="phrase" /><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
+          </template>
+        </div>
       </div>
-    </div>
 
-    <!-- VerseAtVerseRef is the atomic "what verse?" card — verse text
-         is the prompt, verse number is the answer. Same layout
-         pattern as VerseInChapter / VerseInBook / Citation. -->
-    <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr v-if="revealed" class="type" />
-      <hr v-else />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-    </div>
+      <!-- VerseAtVerseRef is the atomic "what verse?" card — verse text
+           is the prompt, verse number is the answer. Same layout
+           pattern as VerseInChapter / VerseInBook / Citation. -->
+      <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr v-if="revealed" class="type" />
+        <hr v-else />
+        <div class="verse-text" v-html="verseHtml" />
+      </div>
 
-    <!-- Ref-as-answer cards: ref is always present, but the asked-about
-         part(s) render as `?` until reveal. The `?` placeholder is the
-         prompt itself — no separate "what chapter?" hint needed. The
-         dotted hr appears on reveal as the prompt/answer divider; a
-         solid hr stands in pre-reveal to anchor ref above text. -->
-    <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr v-if="revealed" class="type" />
-      <hr v-else />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-    </div>
+      <!-- Ref-as-answer cards: ref is always present, but the asked-about
+           part(s) render as `?` until reveal. The `?` placeholder is the
+           prompt itself — no separate "what chapter?" hint needed. The
+           dotted hr appears on reveal as the prompt/answer divider; a
+           solid hr stands in pre-reveal to anchor ref above text. -->
+      <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr v-if="revealed" class="type" />
+        <hr v-else />
+        <div class="verse-text" v-html="verseHtml" />
+      </div>
 
-    <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-      <template v-if="revealed">
-        <hr class="type" />
-        <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
-      </template>
-      <div v-else class="placeholder">…what heading?…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr />
+        <div class="verse-text" v-html="verseHtml" />
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+        </template>
+        <div v-else class="placeholder">…what heading?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-      <template v-if="revealed">
-        <hr class="type" />
-        <div class="answer">Club: {{ clubLabel }}</div>
-      </template>
-      <div v-else class="placeholder">…which club?…</div>
-    </div>
+      <div v-else-if="card.kind === 'VerseInClub'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr />
+        <div class="verse-text" v-html="verseHtml" />
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="answer">Club: {{ clubLabel }}</div>
+        </template>
+        <div v-else class="placeholder">…which club?…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Recitation'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <template v-if="revealed">
-        <hr class="type" />
-        <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-      </template>
-      <div v-else class="placeholder">…recite the whole verse…</div>
-    </div>
+      <div v-else-if="card.kind === 'Recitation'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="verse-text" v-html="verseHtml" />
+        </template>
+        <div v-else class="placeholder">…recite the whole verse…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Citation'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr v-if="revealed" class="type" />
-      <hr v-else />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-    </div>
+      <div v-else-if="card.kind === 'Citation'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr v-if="revealed" class="type" />
+        <hr v-else />
+        <div class="verse-text" v-html="verseHtml" />
+      </div>
 
-    <div v-else-if="card.kind === 'Ftv'" class="centered">
-      <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
-      <div class="verse-text ftv" :style="{ color: verseTextColour }" v-html="`${ftvHtml ?? ''}…`" />
-      <template v-if="revealed">
-        <hr class="type" />
-        <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-      </template>
-      <div v-else class="placeholder">…continue the verse…</div>
-    </div>
+      <div v-else-if="card.kind === 'Ftv'" class="centered">
+        <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
+        <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="verse-text" v-html="verseHtml" />
+        </template>
+        <div v-else class="placeholder">…continue the verse…</div>
+      </div>
 
-    <div v-else-if="card.kind === 'Reading'" class="centered">
-      <div class="ref" v-html="refHtml" />
-      <hr />
-      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
-    </div>
+      <div v-else-if="card.kind === 'Reading'" class="centered">
+        <div class="ref" v-html="refHtml" />
+        <hr />
+        <div class="verse-text" v-html="verseHtml" />
+      </div>
     </template>
   </div>
 </template>
@@ -241,6 +233,12 @@ const composedMissing = computed(() => props.card.composed === null)
    hr.type) layered onto our themed colour tokens so it adapts to
    light/dark via the same vars. */
 .card-box {
+  /* Verse text inherits `--active-verse-colour`; `no-verse-accent` flips
+     it back to neutral pre-reveal on the cards whose answer is the
+     verse number (VerseAtVerseRef, Citation). Child elements with their
+     own `color` (the ref, the .deck label, .answer, etc.) override. */
+  --chip-bg: color-mix(in oklch, var(--color-text) 16%, transparent);
+
   position: relative;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
@@ -253,6 +251,10 @@ const composedMissing = computed(() => props.card.composed === null)
   font-size: 1.25rem;
   line-height: 1.6;
   text-align: center;
+  color: var(--active-verse-colour);
+}
+
+.card-box.no-verse-accent {
   color: var(--color-text);
 }
 
@@ -312,7 +314,7 @@ const composedMissing = computed(() => props.card.composed === null)
    made the chip nearly invisible). */
 .phrase-hidden,
 .phrase-revealed {
-  background: color-mix(in oklch, var(--color-text) 16%, transparent);
+  background: var(--chip-bg);
   border-radius: 0.25em;
   padding: 0.1em 0.3em;
   -webkit-box-decoration-break: clone;
@@ -355,7 +357,7 @@ const composedMissing = computed(() => props.card.composed === null)
    phrase chip so all four chip variants read identically. */
 .ref :deep(.ref-hidden),
 .ref :deep(.ref-revealed) {
-  background: color-mix(in oklch, var(--color-text) 16%, transparent);
+  background: var(--chip-bg);
   border-radius: 0.25em;
   padding: 0.1em 0.3em;
   -webkit-box-decoration-break: clone;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -384,35 +384,16 @@ const composedMissing = computed(() => props.card.composed === null)
   font-style: italic;
 }
 
-/* Typography rendered via v-html — both api.bible's editorial classes
-   (.sc small caps for LORD, .bd divine-name bold, .it translator
-   italics) and the deck's user-annotation tags (<b>/<i>). :deep()
-   reaches inside since Vue's scoped CSS doesn't tag dynamically
-   inserted nodes.
-
-   Deck keyword annotations: `<b>` renders bold-900 + underlined per
-   the Anki convention. api.bible's `.bd` (divine-name bold) is forced
-   back to normal weight so it doesn't compete with the user's keyword
-   bold for visual weight. */
+/* Typography rendered via v-html. :deep() reaches inside since Vue's
+   scoped CSS doesn't tag dynamically inserted nodes. The deck's
+   keyword annotations (`<b>` bold-900 + underlined, `<i>` italic via
+   the UA default) are the only emphasis carried through; api.bible's
+   `.bd` (divine-name bold) and `.it` (translator italics) inherit
+   normal styling from the parent and read as plain text. `.sc` keeps
+   small caps as canonical NKJV typography for LORD. */
 .verse-text :deep(b) {
   font-weight: 900;
   text-decoration: underline;
-}
-
-.verse-text :deep(.bd) {
-  font-weight: normal;
-}
-
-/* Deck keyword annotations rendered as <i> stay italic. api.bible's
-   .it class (translator-supplied words like "corner stone", "It is as",
-   "Him") is left in default upright — the editorial italics distract
-   from the memorisation task. */
-.verse-text :deep(i) {
-  font-style: italic;
-}
-
-.verse-text :deep(.it) {
-  font-style: normal;
 }
 
 .verse-text :deep(.sc) {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -108,7 +108,7 @@ const phraseHtml = computed(() => props.card.composed?.phraseHtml ?? [])
 const verseHtml = computed(() => phraseHtml.value.join(' '))
 const ftvHtml = computed(() => props.card.composed?.ftvHtml ?? null)
 const headingTitle = computed(() => props.card.composed?.headings[0]?.title ?? null)
-const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
+const clubLabel = computed(() => props.card.tier ?? props.card.verse.clubs[0] ?? '')
 const composedMissing = computed(() => props.card.composed === null)
 </script>
 

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -53,15 +53,16 @@ function escapeHtml(s: string): string {
 }
 
 /** Renders the reference with each part either revealed or shown as a
- *  `?` placeholder. The verse number carries the verse-colour inline so
- *  it picks up the same hue as the verse text. */
+ *  `?` placeholder. The verse number references the same `--active-
+ *  verse-colour` custom property as the card-box border, so the two
+ *  are guaranteed to render with the identical CSS value. */
 const refHtml = computed(() => {
   const { showBook, showChapter, showVerse } = refParts.value
   const hidden = '<span class="ref-hidden">?</span>'
   const book = showBook ? escapeHtml(props.card.verse.book) : hidden
   const chap = showChapter ? String(props.card.verse.chapter) : hidden
   const verse = showVerse
-    ? `<span style="color: ${verseColour.value}">${props.card.verse.verse}</span>`
+    ? `<span class="verse-number">${props.card.verse.verse}</span>`
     : hidden
   return `${book} ${chap}:${verse}`
 })
@@ -108,8 +109,10 @@ const composedMissing = computed(() => props.card.composed === null)
     <!-- The bordered content box wears the verse-number colour on its
          edge so each verse has a consistent visual identity. When the
          verse number is hidden (Citation pre-reveal) the border falls
-         back to neutral so it doesn't leak the answer. -->
-    <div class="card-box" :style="{ borderColor: borderColour }">
+         back to neutral so it doesn't leak the answer. Both the border
+         and the verse-number span resolve `--active-verse-colour` from
+         this scope, guaranteeing they render the same hue. -->
+    <div class="card-box" :style="{ '--active-verse-colour': verseColour, borderColor: borderColour }">
       <div v-if="composedMissing" class="placeholder">
         Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
       </div>
@@ -280,6 +283,12 @@ const composedMissing = computed(() => props.card.composed === null)
   padding: 0 0.4rem;
   color: var(--color-muted);
   font-weight: 600;
+}
+
+/* Verse-number digit inside the ref. Pulls from the same custom
+   property as the card-box border so the two always match. */
+.ref :deep(.verse-number) {
+  color: var(--active-verse-colour);
 }
 
 .verse-text {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -19,6 +19,14 @@ const verseColour = computed(() => {
   return `var(${VERSE_COLOUR_VARS[idx]})`
 })
 
+/** Verse text colour. Suppressed (falls back to neutral text) on cards
+ *  whose answer is the verse number itself — VerseAtVerseRef and
+ *  Citation pre-reveal — so the verse-colour palette doesn't leak which
+ *  verse this is. Same gate used by the top-stripe accent. */
+const verseTextColour = computed(() =>
+  refParts.value.showVerse ? verseColour.value : undefined,
+)
+
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
  *  blanked until reveal so the prompt doesn't leak the answer. Other
@@ -139,7 +147,7 @@ const composedMissing = computed(() => props.card.composed === null)
     <div v-if="card.kind === 'PhraseFill'" class="centered">
       <div class="ref small" v-html="refHtml" />
       <hr />
-      <div class="verse-text" :style="{ color: verseColour }">
+      <div class="verse-text" :style="{ color: verseTextColour }">
         <template v-for="(phrase, i) in phraseHtml" :key="i">
           <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else-if="i === card.position" class="phrase-revealed" v-html="phrase" /><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
         </template>
@@ -153,7 +161,7 @@ const composedMissing = computed(() => props.card.composed === null)
       <div class="ref" v-html="refHtml" />
       <hr v-if="revealed" class="type" />
       <hr v-else />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
     </div>
 
     <!-- Ref-as-answer cards: ref is always present, but the asked-about
@@ -165,13 +173,13 @@ const composedMissing = computed(() => props.card.composed === null)
       <div class="ref" v-html="refHtml" />
       <hr v-if="revealed" class="type" />
       <hr v-else />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
     </div>
 
     <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
       <div class="ref small" v-html="refHtml" />
       <hr />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       <template v-if="revealed">
         <hr class="type" />
         <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
@@ -182,7 +190,7 @@ const composedMissing = computed(() => props.card.composed === null)
     <div v-else-if="card.kind === 'VerseInClub'" class="centered">
       <div class="ref small" v-html="refHtml" />
       <hr />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       <template v-if="revealed">
         <hr class="type" />
         <div class="answer">Club: {{ clubLabel }}</div>
@@ -194,7 +202,7 @@ const composedMissing = computed(() => props.card.composed === null)
       <div class="ref" v-html="refHtml" />
       <template v-if="revealed">
         <hr class="type" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       </template>
       <div v-else class="placeholder">…recite the whole verse…</div>
     </div>
@@ -203,15 +211,15 @@ const composedMissing = computed(() => props.card.composed === null)
       <div class="ref" v-html="refHtml" />
       <hr v-if="revealed" class="type" />
       <hr v-else />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
     </div>
 
     <div v-else-if="card.kind === 'Ftv'" class="centered">
       <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
-      <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
+      <div class="verse-text ftv" :style="{ color: verseTextColour }" v-html="`${ftvHtml ?? ''}…`" />
       <template v-if="revealed">
         <hr class="type" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
       </template>
       <div v-else class="placeholder">…continue the verse…</div>
     </div>
@@ -219,7 +227,7 @@ const composedMissing = computed(() => props.card.composed === null)
     <div v-else-if="card.kind === 'Reading'" class="centered">
       <div class="ref" v-html="refHtml" />
       <hr />
-      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <div class="verse-text" :style="{ color: verseTextColour }" v-html="verseHtml" />
     </div>
     </template>
   </div>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -8,7 +8,19 @@ const props = defineProps<{
   revealed: boolean
 }>()
 
-const ref = computed(() => `${props.card.verse.book} ${props.card.verse.chapter}:${props.card.verse.verse}`)
+/** Verse-colour palette ported from the deck's _colours.js. The CSS vars
+ *  themselves live in assets/colors.css; we pick by (verse - 1) % 10. */
+const VERSE_COLOUR_VARS = [
+  '--verse-c1', '--verse-c2', '--verse-c3', '--verse-c4', '--verse-c5',
+  '--verse-c6', '--verse-c7', '--verse-c8', '--verse-c9', '--verse-c10',
+]
+const verseColour = computed(() => {
+  const idx = (props.card.verse.verse - 1) % VERSE_COLOUR_VARS.length
+  return `var(${VERSE_COLOUR_VARS[idx]})`
+})
+
+const refPrefix = computed(() => `${props.card.verse.book} ${props.card.verse.chapter}:`)
+const refVerseNum = computed(() => props.card.verse.verse)
 
 const promptLabel = computed(() => {
   switch (props.card.kind) {
@@ -65,63 +77,84 @@ const composedMissing = computed(() => props.card.composed === null)
           <div v-if="i === card.position && !revealed" class="phrase phrase-hidden">___</div>
           <div v-else class="phrase" v-html="phrase" />
         </template>
-        <div class="ref small">{{ ref }}</div>
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
       <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
         <div class="phrase" v-html="phraseHtml[card.position! - 1]" />
         <div v-if="revealed" class="phrase phrase-hidden" v-html="phraseHtml[card.position!]" />
         <div v-else class="phrase phrase-hidden">___</div>
-        <div class="ref small">{{ ref }}</div>
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
       <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
-        <div class="ref">{{ ref }}</div>
-        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="verse-text" v-html="verseHtml" />
+        </template>
         <div v-else class="placeholder">…recite the verse…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
         <div class="verse-text" v-html="verseHtml" />
-        <div v-if="revealed" class="ref">{{ ref }}</div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        </template>
         <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
         <div class="verse-text" v-html="verseHtml" />
-        <div class="ref small">{{ ref }}</div>
-        <div v-if="revealed" class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+        </template>
         <div v-else class="placeholder">…what heading?…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInClub'" class="centered">
         <div class="verse-text" v-html="verseHtml" />
-        <div class="ref small">{{ ref }}</div>
-        <div v-if="revealed" class="answer">Club: {{ clubLabel }}</div>
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="answer">Club: {{ clubLabel }}</div>
+        </template>
         <div v-else class="placeholder">…which club?…</div>
       </div>
 
       <div v-else-if="card.kind === 'Recitation'" class="centered">
-        <div class="ref">{{ ref }}</div>
-        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="verse-text" v-html="verseHtml" />
+        </template>
         <div v-else class="placeholder">…recite the whole verse…</div>
       </div>
 
       <div v-else-if="card.kind === 'Citation'" class="centered">
         <div class="verse-text" v-html="verseHtml" />
-        <div v-if="revealed" class="ref">{{ ref }}</div>
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        </template>
         <div v-else class="placeholder">…what is the reference?…</div>
       </div>
 
       <div v-else-if="card.kind === 'Ftv'" class="centered">
         <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
-        <div v-if="revealed" class="verse-text" v-html="verseHtml" />
+        <template v-if="revealed">
+          <hr class="type" />
+          <div class="verse-text" v-html="verseHtml" />
+          <div v-if="card.withCitation" class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        </template>
         <div v-else class="placeholder">…continue the verse…</div>
-        <div v-if="revealed && card.withCitation" class="ref">{{ ref }}</div>
       </div>
 
       <div v-else-if="card.kind === 'Reading'" class="centered">
-        <div class="ref">{{ ref }}</div>
+        <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <div class="verse-text" v-html="verseHtml" />
       </div>
     </template>
@@ -194,11 +227,17 @@ const composedMissing = computed(() => props.card.composed === null)
    italics) and the deck's user-annotation tags (<b>/<i>). :deep()
    reaches inside since Vue's scoped CSS doesn't tag dynamically
    inserted nodes. */
+/* User keyword annotations: deck convention is bold-900 + underlined.
+   api.bible's divine-name `.bd` stays bold-only (no underline). */
 .verse-text :deep(b),
-.phrase :deep(b),
+.phrase :deep(b) {
+  font-weight: 900;
+  text-decoration: underline;
+}
+
 .verse-text :deep(.bd),
 .phrase :deep(.bd) {
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .verse-text :deep(i),
@@ -231,5 +270,15 @@ code {
   padding: 0.1rem 0.3rem;
   border-radius: 3px;
   font-family: monospace;
+}
+
+/* Prompt-vs-answer divider, ported from the Anki deck's `hr.type` —
+   dotted to distinguish from any future solid-rule usage. Matches the
+   typography hint on the Anki cards. */
+hr.type {
+  width: 100%;
+  border: none;
+  border-top: 1px dotted var(--color-border);
+  margin: 0.25rem 0;
 }
 </style>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -73,19 +73,19 @@ const composedMissing = computed(() => props.card.composed === null)
          output, never user input. -->
     <template v-else>
       <div v-if="card.kind === 'PhraseFill'" class="centered">
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <div class="verse-text" :style="{ color: verseColour }">
           <template v-for="(phrase, i) in phraseHtml" :key="i">
             <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
           </template>
         </div>
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
       <div v-else-if="card.kind === 'PhraseChain'" class="centered">
+        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <div class="verse-text" :style="{ color: verseColour }">
           <span v-html="phraseHtml[card.position! - 1]" />{{ ' ' }}<span v-if="revealed" class="phrase-hidden" v-html="phraseHtml[card.position!]" /><span v-else class="phrase-hidden">___</span>
         </div>
-        <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
       <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
@@ -97,18 +97,21 @@ const composedMissing = computed(() => props.card.composed === null)
         <div v-else class="placeholder">…recite the verse…</div>
       </div>
 
+      <!-- Ref-as-answer cards: ref slot is empty before reveal so we don't
+           give the answer away; on reveal it appears above the verse, with
+           hr.type marking the now-above answer vs the prompt below. -->
       <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
-          <hr class="type" />
           <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+          <hr class="type" />
         </template>
-        <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+        <div v-if="!revealed" class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
@@ -117,8 +120,8 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="answer">Club: {{ clubLabel }}</div>
@@ -136,20 +139,20 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Citation'" class="centered">
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
-          <hr class="type" />
           <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
+          <hr class="type" />
         </template>
-        <div v-else class="placeholder">…what is the reference?…</div>
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+        <div v-if="!revealed" class="placeholder">…what is the reference?…</div>
       </div>
 
       <div v-else-if="card.kind === 'Ftv'" class="centered">
+        <div v-if="revealed && card.withCitation" class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-          <div v-if="card.withCitation" class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         </template>
         <div v-else class="placeholder">…continue the verse…</div>
       </div>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -47,47 +47,47 @@ const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
   <div class="prompt">
     <div class="meta">{{ promptLabel }}</div>
 
-    <!-- Phrase-position cards: show all phrases except the target. -->
+    <!-- Phrase-position cards: show all phrases except the target.
+         v-html renders <b>/<i>/<span> markup from the curated source data
+         (NKJV typography: bold / bold-italic keywords + small-caps LORD).
+         Safe: content originates from the server-side material catalog, not
+         user input. -->
     <div v-if="card.kind === 'PhraseFill'" class="phrases">
-      <div
-        v-for="(phrase, i) in card.verse.phrases"
-        :key="i"
-        :class="['phrase', { 'phrase-hidden': i === card.position && !revealed }]"
-      >
-        {{ i === card.position && !revealed ? '___' : phrase }}
-      </div>
+      <template v-for="(phrase, i) in card.verse.phrases" :key="i">
+        <div v-if="i === card.position && !revealed" class="phrase phrase-hidden">___</div>
+        <div v-else class="phrase" v-html="phrase" />
+      </template>
       <div class="ref small">{{ ref }}</div>
     </div>
 
     <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
-      <div class="phrase">{{ card.verse.phrases[card.position! - 1] }}</div>
-      <div class="phrase phrase-hidden">
-        {{ revealed ? card.verse.phrases[card.position!] : '___' }}
-      </div>
+      <div class="phrase" v-html="card.verse.phrases[card.position! - 1]" />
+      <div v-if="revealed" class="phrase phrase-hidden" v-html="card.verse.phrases[card.position!]" />
+      <div v-else class="phrase phrase-hidden">___</div>
       <div class="ref small">{{ ref }}</div>
     </div>
 
     <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
       <div class="ref">{{ ref }}</div>
-      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
       <div v-else class="placeholder">…recite the verse…</div>
     </div>
 
     <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text" v-html="card.verse.text" />
       <div v-if="revealed" class="ref">{{ ref }}</div>
       <div v-else class="placeholder">…what {{ card.kind === 'VerseInBook' ? 'book' : 'chapter' }}?…</div>
     </div>
 
     <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text" v-html="card.verse.text" />
       <div class="ref small">{{ ref }}</div>
       <div v-if="revealed" class="answer">Heading: {{ headingText }}</div>
       <div v-else class="placeholder">…what heading?…</div>
     </div>
 
     <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text" v-html="card.verse.text" />
       <div class="ref small">{{ ref }}</div>
       <div v-if="revealed" class="answer">Club: {{ clubLabel }}</div>
       <div v-else class="placeholder">…which club?…</div>
@@ -95,26 +95,26 @@ const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
 
     <div v-else-if="card.kind === 'Recitation'" class="centered">
       <div class="ref">{{ ref }}</div>
-      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
       <div v-else class="placeholder">…recite the whole verse…</div>
     </div>
 
     <div v-else-if="card.kind === 'Citation'" class="centered">
-      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text" v-html="card.verse.text" />
       <div v-if="revealed" class="ref">{{ ref }}</div>
       <div v-else class="placeholder">…what is the reference?…</div>
     </div>
 
     <div v-else-if="card.kind === 'Ftv'" class="centered">
-      <div class="verse-text ftv">{{ card.verse.ftv }}…</div>
-      <div v-if="revealed" class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text ftv" v-html="`${card.verse.ftv ?? ''}…`" />
+      <div v-if="revealed" class="verse-text" v-html="card.verse.text" />
       <div v-else class="placeholder">…continue the verse…</div>
       <div v-if="revealed && card.withCitation" class="ref">{{ ref }}</div>
     </div>
 
     <div v-else-if="card.kind === 'Reading'" class="centered">
       <div class="ref">{{ ref }}</div>
-      <div class="verse-text">{{ card.verse.text }}</div>
+      <div class="verse-text" v-html="card.verse.text" />
     </div>
   </div>
 </template>
@@ -178,6 +178,24 @@ const clubLabel = computed(() => props.card.verse.clubs[0] ?? '')
 
 .verse-text.ftv {
   font-style: italic;
+}
+
+/* NKJV markup, rendered via v-html in verse-text and phrase blocks.
+   :deep() reaches inside since Vue's scoped CSS doesn't tag dynamically
+   inserted nodes. */
+.verse-text :deep(b),
+.phrase :deep(b) {
+  font-weight: 600;
+}
+
+.verse-text :deep(i),
+.phrase :deep(i) {
+  font-style: italic;
+}
+
+.verse-text :deep(span[style*='small-caps']),
+.phrase :deep(span[style*='small-caps']) {
+  font-variant: small-caps;
 }
 
 .placeholder {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -216,7 +216,8 @@ const composedMissing = computed(() => props.card.composed === null)
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 12rem;
+  flex: 1;
+  min-height: 0;
 }
 
 .meta {
@@ -232,7 +233,11 @@ const composedMissing = computed(() => props.card.composed === null)
    and only the border tints. Width and weight are tuned so the line
    reads with the same perceived saturation as the verse-number digit
    (a thin line at the deck's OKLCH lightness looks noticeably darker
-   than anti-aliased text on either light or dark backgrounds). */
+   than anti-aliased text on either light or dark backgrounds).
+
+   Fills the available height inside .prompt so the inner frame
+   tracks the outer card. Content is centred vertically so short
+   verses don't pin themselves to the top. */
 .card-box {
   border-width: 5px;
   border-style: solid;
@@ -240,7 +245,10 @@ const composedMissing = computed(() => props.card.composed === null)
   padding: 2rem 1.75rem;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   gap: 1rem;
+  flex: 1;
+  min-height: 0;
 }
 
 @media (max-width: 600px) {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -45,6 +45,8 @@ const refParts = computed(() => {
       return { showBook: reveal, showChapter: true, showVerse: true }
     case 'VerseInChapter':
       return { showBook: true, showChapter: reveal, showVerse: true }
+    case 'VerseAtVerseRef':
+      return { showBook: true, showChapter: true, showVerse: reveal }
     case 'Citation':
       return { showBook: reveal, showChapter: reveal, showVerse: reveal }
     default:
@@ -79,7 +81,7 @@ const promptLabel = computed(() => {
     case 'PhraseFill':
       return `Fill in phrase ${props.card.position! + 1}`
     case 'VerseAtVerseRef':
-      return 'Recite this verse'
+      return 'What verse?'
     case 'VerseInChapter':
       return 'What chapter?'
     case 'VerseInBook':
@@ -138,13 +140,13 @@ const composedMissing = computed(() => props.card.composed === null)
         </div>
       </div>
 
+      <!-- VerseAtVerseRef is the atomic "what verse?" card — verse text
+           is the prompt, verse number is the answer. Same layout
+           pattern as VerseInChapter / VerseInBook / Citation. -->
       <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
         <div class="ref" v-html="refHtml" />
-        <template v-if="revealed">
-          <hr class="type" />
-          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        </template>
-        <div v-else class="placeholder">…recite the verse…</div>
+        <hr v-if="revealed" class="type" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
       </div>
 
       <!-- Ref-as-answer cards: ref is always present, but the asked-about

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -317,10 +317,15 @@ const composedMissing = computed(() => props.card.composed === null)
    soft radius, and `box-decoration-break: clone` so a multi-line
    revealed phrase gets a fully-rounded chip on every line. The 0.1em
    vertical padding stays inside `.verse-text`'s 1.6 line-height so
-   it doesn't push lines apart. */
+   it doesn't push lines apart.
+
+   Chip background derives from `--color-text` rather than a fixed
+   accent token so its contrast stays the same in light and dark mode
+   (the accent-soft palette flips to near-bg-card values in dark, which
+   made the chip nearly invisible). */
 .phrase-hidden,
 .phrase-revealed {
-  background: var(--color-accent-soft);
+  background: color-mix(in oklch, var(--color-text) 16%, transparent);
   border-radius: 0.25em;
   padding: 0.1em 0.3em;
   -webkit-box-decoration-break: clone;
@@ -368,10 +373,11 @@ const composedMissing = computed(() => props.card.composed === null)
 /* `?` placeholder for ref parts that are the answer being tested, and
    its reveal-side counterpart on the same ref. Em-scaled padding keeps
    the chip proportional whether the ref is the big headline (1.75rem)
-   or the small label (0.95rem). */
+   or the small label (0.95rem). Same foreground-mix background as the
+   phrase chip so all four chip variants read identically. */
 .ref :deep(.ref-hidden),
 .ref :deep(.ref-revealed) {
-  background: var(--color-accent-soft);
+  background: color-mix(in oklch, var(--color-text) 16%, transparent);
   border-radius: 0.25em;
   padding: 0.1em 0.3em;
   -webkit-box-decoration-break: clone;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -226,15 +226,10 @@ const composedMissing = computed(() => props.card.composed === null)
   text-align: center;
 }
 
-/* Verse-coloured inner box — the flashcard frame. Sits inside the
-   outer SessionView card surface, so it shares that white background
-   and only the border tints. Width and weight are tuned so the line
-   reads with the same perceived saturation as the verse-number digit
-   (a thin line at the deck's OKLCH lightness looks noticeably darker
-   than anti-aliased text on either light or dark backgrounds).
-
-   Hugs its content; the verse, ref, and any reveal sit at the top
-   of the frame rather than spreading to fill the outer card. */
+/* Verse-coloured flashcard box — the only bordered surface on the
+   page. Min-height reserves enough room that the box doesn't pop
+   bigger when reveal adds the answer text — content sits at the top
+   of a fixed-height frame, with empty space below before reveal. */
 .card-box {
   border-width: 5px;
   border-style: solid;
@@ -243,6 +238,8 @@ const composedMissing = computed(() => props.card.composed === null)
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  min-height: 18rem;
+  background: var(--color-bg-card);
 }
 
 @media (max-width: 600px) {
@@ -250,6 +247,7 @@ const composedMissing = computed(() => props.card.composed === null)
     border-width: 4px;
     padding: 1.25rem 1rem;
     border-radius: 8px;
+    min-height: 14rem;
   }
 }
 

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -231,16 +231,24 @@ const composedMissing = computed(() => props.card.composed === null)
    outer SessionView card surface, so it shares that white background
    and only the border tints. Width and weight are tuned so the line
    reads with the same perceived saturation as the verse-number digit
-   (a 2px line at the deck's OKLCH lightness looks noticeably darker
+   (a thin line at the deck's OKLCH lightness looks noticeably darker
    than anti-aliased text on either light or dark backgrounds). */
 .card-box {
-  border-width: 3px;
+  border-width: 5px;
   border-style: solid;
-  border-radius: 8px;
-  padding: 1.5rem 1.25rem;
+  border-radius: 10px;
+  padding: 2rem 1.75rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .card-box {
+    border-width: 4px;
+    padding: 1.25rem 1rem;
+    border-radius: 8px;
+  }
 }
 
 /* PhraseFill blanks render inline within the verse-text run so the

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -268,11 +268,12 @@ const composedMissing = computed(() => props.card.composed === null)
 
 /* Headline-style ref for cards where the reference is the focus
    (VerseAtVerseRef / Recitation prompts, Citation / VerseInChapter /
-   VerseInBook answers). Centered and large like the Anki deck's
-   centered 20px body — scaled up here to suit the bigger card area. */
+   VerseInBook answers). Book + chapter render in the neutral text
+   colour so the only accent in the line is the verse-number digit
+   (which picks up the verse colour via its own inline rule). */
 .ref {
   font-weight: 600;
-  color: var(--color-accent);
+  color: var(--color-text);
   font-size: 1.75rem;
   text-align: center;
   align-self: stretch;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -209,13 +209,13 @@ const composedMissing = computed(() => props.card.composed === null)
   text-align: center;
 }
 
-/* The bordered surface wrapping ref + verse content. Border colour is
-   bound inline to the verse-colour so it picks up the per-verse hue. */
+/* Verse-coloured inner box — the flashcard frame. Sits inside the
+   outer SessionView card surface, so it shares that white background
+   and only the border tints. */
 .card-box {
   border: 2px solid currentColor;
-  border-radius: 10px;
-  padding: 1.75rem 1.5rem;
-  background: var(--color-bg-card);
+  border-radius: 8px;
+  padding: 1.5rem 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -19,6 +19,14 @@ const verseColour = computed(() => {
   return `var(${VERSE_COLOUR_VARS[idx]})`
 })
 
+/** Border colour for the flashcard box. Tracks the verse-number colour
+ *  whenever the verse number is visible (which is always except on a
+ *  Citation card before reveal); otherwise falls back to the neutral
+ *  border tone so the hue doesn't leak the answer. */
+const borderColour = computed(() =>
+  refParts.value.showVerse ? verseColour.value : 'var(--color-border)',
+)
+
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
  *  blanked until reveal so the prompt doesn't leak the answer. Other
@@ -97,11 +105,11 @@ const composedMissing = computed(() => props.card.composed === null)
   <div class="prompt">
     <div class="meta">{{ promptLabel }}</div>
 
-    <!-- The bordered content box wears the verse colour on its edge so
-         each verse has a consistent visual identity. The meta label
-         (above) and the grade buttons (rendered by the parent view)
-         stay outside this border. -->
-    <div class="card-box" :style="{ borderColor: verseColour }">
+    <!-- The bordered content box wears the verse-number colour on its
+         edge so each verse has a consistent visual identity. When the
+         verse number is hidden (Citation pre-reveal) the border falls
+         back to neutral so it doesn't leak the answer. -->
+    <div class="card-box" :style="{ borderColor: borderColour }">
       <div v-if="composedMissing" class="placeholder">
         Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
       </div>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -388,16 +388,19 @@ const composedMissing = computed(() => props.card.composed === null)
    (.sc small caps for LORD, .bd divine-name bold, .it translator
    italics) and the deck's user-annotation tags (<b>/<i>). :deep()
    reaches inside since Vue's scoped CSS doesn't tag dynamically
-   inserted nodes. */
-/* User keyword annotations: deck convention is bold-900 + underlined.
-   api.bible's divine-name `.bd` stays bold-only (no underline). */
+   inserted nodes.
+
+   Deck keyword annotations: `<b>` renders bold-900 + underlined per
+   the Anki convention. api.bible's `.bd` (divine-name bold) is forced
+   back to normal weight so it doesn't compete with the user's keyword
+   bold for visual weight. */
 .verse-text :deep(b) {
   font-weight: 900;
   text-decoration: underline;
 }
 
 .verse-text :deep(.bd) {
-  font-weight: 700;
+  font-weight: normal;
 }
 
 /* Deck keyword annotations rendered as <i> stay italic. api.bible's

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -97,15 +97,20 @@ const composedMissing = computed(() => props.card.composed === null)
   <div class="prompt">
     <div class="meta">{{ promptLabel }}</div>
 
-    <div v-if="composedMissing" class="placeholder">
-      Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
-    </div>
+    <!-- The bordered content box wears the verse colour on its edge so
+         each verse has a consistent visual identity. The meta label
+         (above) and the grade buttons (rendered by the parent view)
+         stay outside this border. -->
+    <div class="card-box" :style="{ borderColor: verseColour }">
+      <div v-if="composedMissing" class="placeholder">
+        Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
+      </div>
 
-    <!-- v-html renders api.bible's NKJV typography (small caps for LORD,
-         translator italics, divine-name bold) layered with the user's
-         keyword <b>/<i> annotations. Source is the server-composed
-         output, never user input. -->
-    <template v-else>
+      <!-- v-html renders api.bible's NKJV typography (small caps for LORD,
+           translator italics, divine-name bold) layered with the user's
+           keyword <b>/<i> annotations. Source is the server-composed
+           output, never user input. -->
+      <template v-else>
       <div v-if="card.kind === 'PhraseFill'" class="centered">
         <div class="ref small" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }">
@@ -183,7 +188,8 @@ const composedMissing = computed(() => props.card.composed === null)
         <div class="ref" v-html="refHtml" />
         <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
       </div>
-    </template>
+      </template>
+    </div>
   </div>
 </template>
 
@@ -200,6 +206,19 @@ const composedMissing = computed(() => props.card.composed === null)
   color: var(--color-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  text-align: center;
+}
+
+/* The bordered surface wrapping ref + verse content. Border colour is
+   bound inline to the verse-colour so it picks up the per-verse hue. */
+.card-box {
+  border: 2px solid currentColor;
+  border-radius: 10px;
+  padding: 1.75rem 1.5rem;
+  background: var(--color-bg-card);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 /* PhraseFill blanks render inline within the verse-text run so the

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -130,7 +130,7 @@ const composedMissing = computed(() => props.card.composed === null)
        `--active-verse-colour` from this scope, so they always agree. -->
   <div
     class="card-box"
-    :class="{ 'no-verse-accent': !refParts.showVerse, revealed }"
+    :class="{ 'no-verse-accent': !refParts.showVerse }"
     :style="{ '--active-verse-colour': verseColour }"
   >
     <div class="deck">{{ promptLabel }}</div>
@@ -254,22 +254,14 @@ const composedMissing = computed(() => props.card.composed === null)
   line-height: 1.6;
   text-align: center;
   color: var(--color-text);
-  transition: background-color 0.18s ease, border-color 0.18s ease;
-}
-
-/* Reveal state: the card surface picks up a soft verse-coloured wash
-   and the border deepens toward the verse hue, so the Q→A transition
-   is obvious at a glance. Pre-reveal stays on the plain card surface
-   so it reads as "still thinking". */
-.card-box.revealed {
-  background: color-mix(in oklch, var(--active-verse-colour) 8%, var(--color-bg-card));
-  border-color: color-mix(in oklch, var(--active-verse-colour) 40%, var(--color-border));
 }
 
 /* Verse-coloured top stripe — sits inside the rounded corners via the
    same radius on its own top edge. Hidden on cards where revealing the
-   verse colour would leak the answer (Citation pre-reveal, etc.).
-   Thickens slightly on reveal alongside the surface wash. */
+   verse colour would leak the answer (Citation pre-reveal, etc.). The
+   card surface itself stays the same front/back so the reveal doesn't
+   flicker; the answer state shows through the chips and the dotted
+   `hr.type` divider tinting picked up below. */
 .card-box::before {
   content: '';
   position: absolute;
@@ -277,11 +269,6 @@ const composedMissing = computed(() => props.card.composed === null)
   height: 3px;
   background: var(--active-verse-colour);
   border-radius: 6px 6px 0 0;
-  transition: height 0.18s ease;
-}
-
-.card-box.revealed::before {
-  height: 5px;
 }
 
 .card-box.no-verse-accent::before {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -130,7 +130,7 @@ const composedMissing = computed(() => props.card.composed === null)
        `--active-verse-colour` from this scope, so they always agree. -->
   <div
     class="card-box"
-    :class="{ 'no-verse-accent': !refParts.showVerse }"
+    :class="{ 'no-verse-accent': !refParts.showVerse, revealed }"
     :style="{ '--active-verse-colour': verseColour }"
   >
     <div class="deck">{{ promptLabel }}</div>
@@ -254,11 +254,22 @@ const composedMissing = computed(() => props.card.composed === null)
   line-height: 1.6;
   text-align: center;
   color: var(--color-text);
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+
+/* Reveal state: the card surface picks up a soft verse-coloured wash
+   and the border deepens toward the verse hue, so the Q→A transition
+   is obvious at a glance. Pre-reveal stays on the plain card surface
+   so it reads as "still thinking". */
+.card-box.revealed {
+  background: color-mix(in oklch, var(--active-verse-colour) 8%, var(--color-bg-card));
+  border-color: color-mix(in oklch, var(--active-verse-colour) 40%, var(--color-border));
 }
 
 /* Verse-coloured top stripe — sits inside the rounded corners via the
    same radius on its own top edge. Hidden on cards where revealing the
-   verse colour would leak the answer (Citation pre-reveal, etc.). */
+   verse colour would leak the answer (Citation pre-reveal, etc.).
+   Thickens slightly on reveal alongside the surface wash. */
 .card-box::before {
   content: '';
   position: absolute;
@@ -266,6 +277,11 @@ const composedMissing = computed(() => props.card.composed === null)
   height: 3px;
   background: var(--active-verse-colour);
   border-radius: 6px 6px 0 0;
+  transition: height 0.18s ease;
+}
+
+.card-box.revealed::before {
+  height: 5px;
 }
 
 .card-box.no-verse-accent::before {
@@ -441,8 +457,9 @@ code {
 
 /* Dotted hr.type — the prompt/answer divider, ported from the Anki
    deck's `hr.type`. Appears on reveal to mark "below this line is
-   the answer / the typed-in check / the supporting context". */
+   the answer / the typed-in check / the supporting context". Picks up
+   the verse hue so it ties to the rest of the reveal-state chrome. */
 .card-box :deep(hr.type) {
-  border-top: 1px dotted var(--color-border);
+  border-top: 1px dotted color-mix(in oklch, var(--active-verse-colour) 50%, var(--color-border));
 }
 </style>

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -72,18 +72,19 @@ const composedMissing = computed(() => props.card.composed === null)
          keyword <b>/<i> annotations. Source is the server-composed
          output, never user input. -->
     <template v-else>
-      <div v-if="card.kind === 'PhraseFill'" class="phrases">
-        <template v-for="(phrase, i) in phraseHtml" :key="i">
-          <div v-if="i === card.position && !revealed" class="phrase phrase-hidden">___</div>
-          <div v-else class="phrase" v-html="phrase" />
-        </template>
+      <div v-if="card.kind === 'PhraseFill'" class="centered">
+        <div class="verse-text" :style="{ color: verseColour }">
+          <template v-for="(phrase, i) in phraseHtml" :key="i">
+            <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
+          </template>
+        </div>
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
-      <div v-else-if="card.kind === 'PhraseChain'" class="phrases">
-        <div class="phrase" v-html="phraseHtml[card.position! - 1]" />
-        <div v-if="revealed" class="phrase phrase-hidden" v-html="phraseHtml[card.position!]" />
-        <div v-else class="phrase phrase-hidden">___</div>
+      <div v-else-if="card.kind === 'PhraseChain'" class="centered">
+        <div class="verse-text" :style="{ color: verseColour }">
+          <span v-html="phraseHtml[card.position! - 1]" />{{ ' ' }}<span v-if="revealed" class="phrase-hidden" v-html="phraseHtml[card.position!]" /><span v-else class="phrase-hidden">___</span>
+        </div>
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
       </div>
 
@@ -91,13 +92,13 @@ const composedMissing = computed(() => props.card.composed === null)
         <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <template v-if="revealed">
           <hr class="type" />
-          <div class="verse-text" v-html="verseHtml" />
+          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         </template>
         <div v-else class="placeholder">…recite the verse…</div>
       </div>
 
       <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-        <div class="verse-text" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
@@ -106,7 +107,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-        <div class="verse-text" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <template v-if="revealed">
           <hr class="type" />
@@ -116,7 +117,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-        <div class="verse-text" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <div class="ref small">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <template v-if="revealed">
           <hr class="type" />
@@ -129,13 +130,13 @@ const composedMissing = computed(() => props.card.composed === null)
         <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         <template v-if="revealed">
           <hr class="type" />
-          <div class="verse-text" v-html="verseHtml" />
+          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         </template>
         <div v-else class="placeholder">…recite the whole verse…</div>
       </div>
 
       <div v-else-if="card.kind === 'Citation'" class="centered">
-        <div class="verse-text" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
         <template v-if="revealed">
           <hr class="type" />
           <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
@@ -144,10 +145,10 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Ftv'" class="centered">
-        <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
+        <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
         <template v-if="revealed">
           <hr class="type" />
-          <div class="verse-text" v-html="verseHtml" />
+          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
           <div v-if="card.withCitation" class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
         </template>
         <div v-else class="placeholder">…continue the verse…</div>
@@ -155,7 +156,7 @@ const composedMissing = computed(() => props.card.composed === null)
 
       <div v-else-if="card.kind === 'Reading'" class="centered">
         <div class="ref">{{ refPrefix }}<span :style="{ color: verseColour }">{{ refVerseNum }}</span></div>
-        <div class="verse-text" v-html="verseHtml" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
       </div>
     </template>
   </div>
@@ -176,23 +177,15 @@ const composedMissing = computed(() => props.card.composed === null)
   letter-spacing: 0.05em;
 }
 
-.phrases {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.phrase {
-  font-size: 1.15rem;
-  line-height: 1.5;
-}
-
+/* PhraseFill/PhraseChain blanks render inline within the verse-text run
+   so the surrounding phrases keep flowing naturally. */
 .phrase-hidden {
   background: var(--color-accent-soft);
   border-radius: 4px;
-  padding: 0.25rem 0.5rem;
-  display: inline-block;
-  width: fit-content;
+  padding: 0 0.4rem;
+  /* Cancel the verse colour cascade on the placeholder text only — the
+     chrome stays visible regardless of the verse hue. */
+  color: var(--color-text);
 }
 
 .centered {
@@ -229,26 +222,21 @@ const composedMissing = computed(() => props.card.composed === null)
    inserted nodes. */
 /* User keyword annotations: deck convention is bold-900 + underlined.
    api.bible's divine-name `.bd` stays bold-only (no underline). */
-.verse-text :deep(b),
-.phrase :deep(b) {
+.verse-text :deep(b) {
   font-weight: 900;
   text-decoration: underline;
 }
 
-.verse-text :deep(.bd),
-.phrase :deep(.bd) {
+.verse-text :deep(.bd) {
   font-weight: 700;
 }
 
 .verse-text :deep(i),
-.phrase :deep(i),
-.verse-text :deep(.it),
-.phrase :deep(.it) {
+.verse-text :deep(.it) {
   font-style: italic;
 }
 
-.verse-text :deep(.sc),
-.phrase :deep(.sc) {
+.verse-text :deep(.sc) {
   font-variant: small-caps;
 }
 

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -22,9 +22,16 @@ const verseColour = computed(() => {
 /** Border colour for the flashcard box. Tracks the verse-number colour
  *  whenever the verse number is visible (which is always except on a
  *  Citation card before reveal); otherwise falls back to the neutral
- *  border tone so the hue doesn't leak the answer. */
+ *  border tone so the hue doesn't leak the answer.
+ *
+ *  We lighten the verse hue by ~18% white via color-mix so the thin
+ *  border reads at the same perceived brightness as the anti-aliased
+ *  verse-number text. Without the lift the border looks noticeably
+ *  darker on dark backgrounds even though the CSS colour matches. */
 const borderColour = computed(() =>
-  refParts.value.showVerse ? verseColour.value : 'var(--color-border)',
+  refParts.value.showVerse
+    ? `color-mix(in oklch, ${verseColour.value} 82%, white)`
+    : 'var(--color-border)',
 )
 
 /** Per-card visibility of each ref component. For "what chapter?" /
@@ -222,9 +229,13 @@ const composedMissing = computed(() => props.card.composed === null)
 
 /* Verse-coloured inner box — the flashcard frame. Sits inside the
    outer SessionView card surface, so it shares that white background
-   and only the border tints. */
+   and only the border tints. Width and weight are tuned so the line
+   reads with the same perceived saturation as the verse-number digit
+   (a 2px line at the deck's OKLCH lightness looks noticeably darker
+   than anti-aliased text on either light or dark backgrounds). */
 .card-box {
-  border: 2px solid currentColor;
+  border-width: 3px;
+  border-style: solid;
   border-radius: 8px;
   padding: 1.5rem 1.25rem;
   display: flex;

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -19,21 +19,6 @@ const verseColour = computed(() => {
   return `var(${VERSE_COLOUR_VARS[idx]})`
 })
 
-/** Border colour for the flashcard box. Tracks the verse-number colour
- *  whenever the verse number is visible (which is always except on a
- *  Citation card before reveal); otherwise falls back to the neutral
- *  border tone so the hue doesn't leak the answer.
- *
- *  We lighten the verse hue by ~18% white via color-mix so the thin
- *  border reads at the same perceived brightness as the anti-aliased
- *  verse-number text. Without the lift the border looks noticeably
- *  darker on dark backgrounds even though the CSS colour matches. */
-const borderColour = computed(() =>
-  refParts.value.showVerse
-    ? `color-mix(in oklch, ${verseColour.value} 82%, white)`
-    : 'var(--color-border)',
-)
-
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
  *  blanked until reveal so the prompt doesn't leak the answer. Other
@@ -64,15 +49,31 @@ function escapeHtml(s: string): string {
 /** Renders the reference with each part either revealed or shown as a
  *  `?` placeholder. The verse number references the same `--active-
  *  verse-colour` custom property as the card-box border, so the two
- *  are guaranteed to render with the identical CSS value. */
+ *  are guaranteed to render with the identical CSS value.
+ *
+ *  When a ref part is the asked-about answer (was a `?` on the prompt
+ *  side), the revealed value is wrapped in `.ref-revealed` so it carries
+ *  the same soft-accent chip the `?` placeholder did — the eye lands on
+ *  the part that just filled in. */
 const refHtml = computed(() => {
   const { showBook, showChapter, showVerse } = refParts.value
+  const kind = props.card.kind
   const hidden = '<span class="ref-hidden">?</span>'
-  const book = showBook ? escapeHtml(props.card.verse.book) : hidden
-  const chap = showChapter ? String(props.card.verse.chapter) : hidden
-  const verse = showVerse
-    ? `<span class="verse-number">${props.card.verse.verse}</span>`
-    : hidden
+  const wrap = (inner: string) => `<span class="ref-revealed">${inner}</span>`
+  const isAnswer = (part: 'book' | 'chap' | 'verse') => {
+    if (!props.revealed) return false
+    if (kind === 'Citation') return true
+    if (kind === 'VerseInBook') return part === 'book'
+    if (kind === 'VerseInChapter') return part === 'chap'
+    if (kind === 'VerseAtVerseRef') return part === 'verse'
+    return false
+  }
+  const bookText = escapeHtml(props.card.verse.book)
+  const chapText = String(props.card.verse.chapter)
+  const verseText = `<span class="verse-number">${props.card.verse.verse}</span>`
+  const book = !showBook ? hidden : (isAnswer('book') ? wrap(bookText) : bookText)
+  const chap = !showChapter ? hidden : (isAnswer('chap') ? wrap(chapText) : chapText)
+  const verse = !showVerse ? hidden : (isAnswer('verse') ? wrap(verseText) : verseText)
   return `${book} ${chap}:${verse}`
 })
 
@@ -112,150 +113,197 @@ const composedMissing = computed(() => props.card.composed === null)
 </script>
 
 <template>
-  <div class="prompt">
-    <div class="meta">{{ promptLabel }}</div>
+  <!-- The bordered content box carries a thin verse-coloured top stripe
+       so each verse has a consistent visual identity, sitting on a
+       plain card surface — same shape Anki's Verse note type renders
+       with (centred Arial, .deck label top-right, solid <hr> between
+       ref and text, dotted <hr class="type"> as the prompt/answer
+       divider). The verse-number span and the top stripe both pull
+       `--active-verse-colour` from this scope, so they always agree. -->
+  <div
+    class="card-box"
+    :class="{ 'no-verse-accent': !refParts.showVerse }"
+    :style="{ '--active-verse-colour': verseColour }"
+  >
+    <div class="deck">{{ promptLabel }}</div>
 
-    <!-- The bordered content box wears the verse-number colour on its
-         edge so each verse has a consistent visual identity. When the
-         verse number is hidden (Citation pre-reveal) the border falls
-         back to neutral so it doesn't leak the answer. Both the border
-         and the verse-number span resolve `--active-verse-colour` from
-         this scope, guaranteeing they render the same hue. -->
-    <div class="card-box" :style="{ '--active-verse-colour': verseColour, borderColor: borderColour }">
-      <div v-if="composedMissing" class="placeholder">
-        Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
-      </div>
-
-      <!-- v-html renders api.bible's NKJV typography (small caps for LORD,
-           translator italics, divine-name bold) layered with the user's
-           keyword <b>/<i> annotations. Source is the server-composed
-           output, never user input. -->
-      <template v-else>
-      <div v-if="card.kind === 'PhraseFill'" class="centered">
-        <div class="ref small" v-html="refHtml" />
-        <div class="verse-text" :style="{ color: verseColour }">
-          <template v-for="(phrase, i) in phraseHtml" :key="i">
-            <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
-          </template>
-        </div>
-      </div>
-
-      <!-- VerseAtVerseRef is the atomic "what verse?" card — verse text
-           is the prompt, verse number is the answer. Same layout
-           pattern as VerseInChapter / VerseInBook / Citation. -->
-      <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
-        <div class="ref" v-html="refHtml" />
-        <hr v-if="revealed" class="type" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-      </div>
-
-      <!-- Ref-as-answer cards: ref is always present, but the asked-about
-           part(s) render as `?` until reveal. The `?` placeholder is the
-           prompt itself — no separate "what chapter?" hint needed. hr
-           appears on reveal as the prompt/answer divider. -->
-      <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
-        <div class="ref" v-html="refHtml" />
-        <hr v-if="revealed" class="type" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-      </div>
-
-      <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
-        <div class="ref small" v-html="refHtml" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        <template v-if="revealed">
-          <hr class="type" />
-          <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
-        </template>
-        <div v-else class="placeholder">…what heading?…</div>
-      </div>
-
-      <div v-else-if="card.kind === 'VerseInClub'" class="centered">
-        <div class="ref small" v-html="refHtml" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        <template v-if="revealed">
-          <hr class="type" />
-          <div class="answer">Club: {{ clubLabel }}</div>
-        </template>
-        <div v-else class="placeholder">…which club?…</div>
-      </div>
-
-      <div v-else-if="card.kind === 'Recitation'" class="centered">
-        <div class="ref" v-html="refHtml" />
-        <template v-if="revealed">
-          <hr class="type" />
-          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        </template>
-        <div v-else class="placeholder">…recite the whole verse…</div>
-      </div>
-
-      <div v-else-if="card.kind === 'Citation'" class="centered">
-        <div class="ref" v-html="refHtml" />
-        <hr v-if="revealed" class="type" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-      </div>
-
-      <div v-else-if="card.kind === 'Ftv'" class="centered">
-        <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
-        <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
-        <template v-if="revealed">
-          <hr class="type" />
-          <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-        </template>
-        <div v-else class="placeholder">…continue the verse…</div>
-      </div>
-
-      <div v-else-if="card.kind === 'Reading'" class="centered">
-        <div class="ref" v-html="refHtml" />
-        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
-      </div>
-      </template>
+    <div v-if="composedMissing" class="placeholder">
+      Canonical text unavailable. Set <code>BIBLE_API_KEY</code> on the server to render NKJV verses.
     </div>
+
+    <!-- v-html renders api.bible's NKJV typography (small caps for LORD,
+         translator italics, divine-name bold) layered with the user's
+         keyword <b>/<i> annotations. Source is the server-composed
+         output, never user input. -->
+    <template v-else>
+    <div v-if="card.kind === 'PhraseFill'" class="centered">
+      <div class="ref small" v-html="refHtml" />
+      <hr />
+      <div class="verse-text" :style="{ color: verseColour }">
+        <template v-for="(phrase, i) in phraseHtml" :key="i">
+          <span v-if="i === card.position && !revealed" class="phrase-hidden">___</span><span v-else-if="i === card.position" class="phrase-revealed" v-html="phrase" /><span v-else v-html="phrase" /><template v-if="i &lt; phraseHtml.length - 1">{{ ' ' }}</template>
+        </template>
+      </div>
+    </div>
+
+    <!-- VerseAtVerseRef is the atomic "what verse?" card — verse text
+         is the prompt, verse number is the answer. Same layout
+         pattern as VerseInChapter / VerseInBook / Citation. -->
+    <div v-else-if="card.kind === 'VerseAtVerseRef'" class="centered">
+      <div class="ref" v-html="refHtml" />
+      <hr v-if="revealed" class="type" />
+      <hr v-else />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+    </div>
+
+    <!-- Ref-as-answer cards: ref is always present, but the asked-about
+         part(s) render as `?` until reveal. The `?` placeholder is the
+         prompt itself — no separate "what chapter?" hint needed. The
+         dotted hr appears on reveal as the prompt/answer divider; a
+         solid hr stands in pre-reveal to anchor ref above text. -->
+    <div v-else-if="card.kind === 'VerseInChapter' || card.kind === 'VerseInBook'" class="centered">
+      <div class="ref" v-html="refHtml" />
+      <hr v-if="revealed" class="type" />
+      <hr v-else />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+    </div>
+
+    <div v-else-if="card.kind === 'VerseInHeading'" class="centered">
+      <div class="ref small" v-html="refHtml" />
+      <hr />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <template v-if="revealed">
+        <hr class="type" />
+        <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+      </template>
+      <div v-else class="placeholder">…what heading?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'VerseInClub'" class="centered">
+      <div class="ref small" v-html="refHtml" />
+      <hr />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      <template v-if="revealed">
+        <hr class="type" />
+        <div class="answer">Club: {{ clubLabel }}</div>
+      </template>
+      <div v-else class="placeholder">…which club?…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Recitation'" class="centered">
+      <div class="ref" v-html="refHtml" />
+      <template v-if="revealed">
+        <hr class="type" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      </template>
+      <div v-else class="placeholder">…recite the whole verse…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Citation'" class="centered">
+      <div class="ref" v-html="refHtml" />
+      <hr v-if="revealed" class="type" />
+      <hr v-else />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+    </div>
+
+    <div v-else-if="card.kind === 'Ftv'" class="centered">
+      <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
+      <div class="verse-text ftv" :style="{ color: verseColour }" v-html="`${ftvHtml ?? ''}…`" />
+      <template v-if="revealed">
+        <hr class="type" />
+        <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+      </template>
+      <div v-else class="placeholder">…continue the verse…</div>
+    </div>
+
+    <div v-else-if="card.kind === 'Reading'" class="centered">
+      <div class="ref" v-html="refHtml" />
+      <hr />
+      <div class="verse-text" :style="{ color: verseColour }" v-html="verseHtml" />
+    </div>
+    </template>
   </div>
 </template>
 
 <style scoped>
-.prompt {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.meta {
-  font-size: 0.85rem;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  text-align: left;
-}
-
-/* Verse-coloured flashcard box — the only bordered surface on the
-   page. Hugs its content; empty space below before reveal lives
-   outside this box, on the page. */
+/* Anki-faithful card surface: Arial body, plain bg-card surface, a
+   single 1px neutral border, a thin verse-coloured stripe along the
+   top edge for identity, and centred content. Mirrors the Verse note
+   type's baseline CSS (Arial 20px, black-on-white, centred, dotted
+   hr.type) layered onto our themed colour tokens so it adapts to
+   light/dark via the same vars. */
 .card-box {
-  border-width: 5px;
-  border-style: solid;
-  border-radius: 10px;
-  padding: 2rem 1.75rem;
+  position: relative;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 2.5rem 2rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  background: var(--color-bg-card);
+  font-family: Arial, Helvetica, system-ui, sans-serif;
+  font-size: 1.25rem;
+  line-height: 1.6;
+  text-align: center;
+  color: var(--color-text);
+}
+
+/* Verse-coloured top stripe — sits inside the rounded corners via the
+   same radius on its own top edge. Hidden on cards where revealing the
+   verse colour would leak the answer (Citation pre-reveal, etc.). */
+.card-box::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 3px;
+  background: var(--active-verse-colour);
+  border-radius: 6px 6px 0 0;
+}
+
+.card-box.no-verse-accent::before {
+  display: none;
 }
 
 @media (max-width: 600px) {
   .card-box {
-    border-width: 4px;
-    padding: 1.25rem 1rem;
-    border-radius: 8px;
+    padding: 2rem 1.25rem 1.5rem;
+    font-size: 1.1rem;
   }
 }
 
-/* PhraseFill blanks render inline within the verse-text run so the
-   surrounding phrases keep flowing naturally. */
-.phrase-hidden {
+/* Anki's `.deck { float: right; font-size: 10px; }`, restated with
+   absolute positioning so it sits in the top-right corner of the card
+   surface without disrupting the centred content flow. Uppercased +
+   tracked so it reads as a label, not a sentence. */
+.deck {
+  position: absolute;
+  top: 0.65rem;
+  right: 0.85rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-family: Arial, Helvetica, system-ui, sans-serif;
+}
+
+/* PhraseFill blanks (and their reveal-side counterpart) render inline
+   within the verse-text run so the surrounding phrases keep flowing
+   naturally. The chip reads as a marker highlight rather than a UI
+   tag: em-scaled padding so it tracks the surrounding text size, a
+   soft radius, and `box-decoration-break: clone` so a multi-line
+   revealed phrase gets a fully-rounded chip on every line. The 0.1em
+   vertical padding stays inside `.verse-text`'s 1.6 line-height so
+   it doesn't push lines apart. */
+.phrase-hidden,
+.phrase-revealed {
   background: var(--color-accent-soft);
-  border-radius: 4px;
-  padding: 0 0.4rem;
+  border-radius: 0.25em;
+  padding: 0.1em 0.3em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.phrase-hidden {
   /* Cancel the verse colour cascade on the placeholder text only — the
      chrome stays visible regardless of the verse hue. */
   color: var(--color-text);
@@ -293,13 +341,20 @@ const composedMissing = computed(() => props.card.composed === null)
   align-self: stretch;
 }
 
-/* `?` placeholder for ref parts that are the answer being tested. Slightly
-   muted vs the surrounding revealed text so the question is visually clear
-   without being a giant chip like phrase-hidden. */
-.ref :deep(.ref-hidden) {
+/* `?` placeholder for ref parts that are the answer being tested, and
+   its reveal-side counterpart on the same ref. Em-scaled padding keeps
+   the chip proportional whether the ref is the big headline (1.75rem)
+   or the small label (0.95rem). */
+.ref :deep(.ref-hidden),
+.ref :deep(.ref-revealed) {
   background: var(--color-accent-soft);
-  border-radius: 4px;
-  padding: 0 0.4rem;
+  border-radius: 0.25em;
+  padding: 0.1em 0.3em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+.ref :deep(.ref-hidden) {
   color: var(--color-muted);
   font-weight: 600;
 }
@@ -366,13 +421,20 @@ code {
   font-family: monospace;
 }
 
-/* Prompt-vs-answer divider, ported from the Anki deck's `hr.type` —
-   dotted to distinguish from any future solid-rule usage. Matches the
-   typography hint on the Anki cards. */
-hr.type {
+/* Solid hr — within-card section divider (ref above, verse text below).
+   Anki templates use a bare `<hr>` for this; we keep the same
+   semantics so the layout reads identically to a printed Anki card. */
+.card-box :deep(hr) {
   width: 100%;
   border: none;
-  border-top: 1px dotted var(--color-border);
+  border-top: 1px solid var(--color-border);
   margin: 0.25rem 0;
+}
+
+/* Dotted hr.type — the prompt/answer divider, ported from the Anki
+   deck's `hr.type`. Appears on reveal to mark "below this line is
+   the answer / the typed-in check / the supporting context". */
+.card-box :deep(hr.type) {
+  border-top: 1px dotted var(--color-border);
 }
 </style>

--- a/apps/web/src/components/SignInForm.vue
+++ b/apps/web/src/components/SignInForm.vue
@@ -215,7 +215,7 @@ form {
   background: var(--color-accent);
   border: none;
   border-radius: 6px;
-  color: #fff;
+  color: var(--color-on-accent);
   font-size: 0.9rem;
   font-family: inherit;
   cursor: pointer;

--- a/apps/web/src/components/SignInForm.vue
+++ b/apps/web/src/components/SignInForm.vue
@@ -1,0 +1,232 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+import type { SocialProvider } from '@/lib/authClient'
+
+type SignInResult = { error?: { message?: string | null } | null } | undefined
+
+const props = defineProps<{
+  signInSocial: (provider: SocialProvider) => void
+  signInEmail: (email: string, password: string) => Promise<SignInResult>
+  signUpEmail: (email: string, password: string) => Promise<SignInResult>
+}>()
+
+const emit = defineEmits<{ (e: 'success'): void }>()
+
+const mode = ref<'pick' | 'signin' | 'signup'>('pick')
+const email = ref('')
+const password = ref('')
+const error = ref('')
+const pending = ref(false)
+
+async function submitEmail() {
+  error.value = ''
+  pending.value = true
+  const fn = mode.value === 'signup' ? props.signUpEmail : props.signInEmail
+  const result = await fn(email.value, password.value)
+  pending.value = false
+  if (result?.error) {
+    error.value = result.error.message ?? 'Something went wrong'
+  } else {
+    emit('success')
+  }
+}
+</script>
+
+<template>
+  <div class="auth-card">
+    <template v-if="mode === 'pick'">
+      <button class="provider-btn" @click="signInSocial('google')">
+        <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            fill="#4285F4"
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+          />
+          <path
+            fill="#34A853"
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          />
+          <path
+            fill="#FBBC05"
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+          />
+          <path
+            fill="#EA4335"
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          />
+        </svg>
+        Continue with Google
+      </button>
+      <div class="divider"><span>or</span></div>
+      <button class="email-toggle" @click="mode = 'signin'">Sign in with email</button>
+      <button class="email-toggle" @click="mode = 'signup'">Create account</button>
+    </template>
+
+    <template v-else>
+      <button class="back-btn" @click="mode = 'pick'">← Back</button>
+      <p class="form-title">{{ mode === 'signup' ? 'Create account' : 'Sign in' }}</p>
+      <form @submit.prevent="submitEmail">
+        <input
+          v-model="email"
+          type="email"
+          placeholder="Email"
+          autocomplete="email"
+          required
+          class="field"
+        />
+        <input
+          v-model="password"
+          type="password"
+          placeholder="Password"
+          autocomplete="current-password"
+          required
+          class="field"
+        />
+        <p v-if="error" class="error-msg">{{ error }}</p>
+        <button type="submit" class="submit-btn" :disabled="pending">
+          {{ pending ? 'Please wait…' : mode === 'signup' ? 'Create account' : 'Sign in' }}
+        </button>
+      </form>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.auth-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 22rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.provider-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.provider-btn:hover {
+  background: var(--color-bg);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+.email-toggle {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.email-toggle:hover {
+  color: var(--color-text);
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-muted);
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  align-self: flex-start;
+}
+
+.back-btn:hover {
+  color: var(--color-text);
+}
+
+.form-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+.field:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.error-msg {
+  font-size: 0.8rem;
+  color: var(--color-error);
+  margin: 0;
+}
+
+.submit-btn {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  background: var(--color-accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.submit-btn:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.submit-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+</style>

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,0 +1,5 @@
+import { createAppAuthClient } from '@/lib/authClient'
+
+const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
+
+export const { authClient, useAuth } = createAppAuthClient(apiUrl)

--- a/apps/web/src/lib/authClient.ts
+++ b/apps/web/src/lib/authClient.ts
@@ -1,0 +1,41 @@
+import { createAuthClient } from 'better-auth/vue'
+
+/** Mirrors qzr-sheet's `createAppAuthClient` factory: a `createAuthClient`
+ *  bound to a base URL plus a `useAuth` composable that exposes the
+ *  reactive session and the action verbs the UI needs. Skipping GitHub
+ *  for now — Google + email/password only. */
+
+export type SocialProvider = 'google'
+
+export function createAppAuthClient(baseURL: string) {
+  const authClient = createAuthClient({ baseURL })
+
+  function useAuth() {
+    const session = authClient.useSession()
+
+    function signInSocial(provider: SocialProvider) {
+      authClient.signIn.social({ provider, callbackURL: window.location.href })
+    }
+
+    async function signInEmail(email: string, password: string) {
+      return authClient.signIn.email({ email, password, callbackURL: window.location.href })
+    }
+
+    async function signUpEmail(email: string, password: string) {
+      return authClient.signUp.email({
+        email,
+        password,
+        name: email,
+        callbackURL: window.location.href,
+      })
+    }
+
+    function signOut() {
+      authClient.signOut()
+    }
+
+    return { session, signInSocial, signInEmail, signUpEmail, signOut }
+  }
+
+  return { authClient, useAuth }
+}

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,0 +1,7 @@
+import { createApp } from 'vue'
+
+import './assets/colors.css'
+import App from './App.vue'
+import router from './router'
+
+createApp(App).use(router).mount('#app')

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,9 +1,17 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
+import { useAuth } from '@/composables/useAuth'
+
 const router = createRouter({
   history: createWebHistory(),
   routes: [
     { path: '/', redirect: '/session' },
+    {
+      path: '/signin',
+      name: 'signin',
+      component: () => import('@/views/SignInView.vue'),
+      meta: { public: true },
+    },
     {
       path: '/session',
       name: 'session',
@@ -15,6 +23,14 @@ const router = createRouter({
       component: () => import('@/views/StatsView.vue'),
     },
   ],
+})
+
+router.beforeEach((to) => {
+  if (to.meta.public) return true
+  const { session } = useAuth()
+  // session.value.data is the live Better Auth session; null when signed out.
+  if (session.value?.data?.user) return true
+  return { name: 'signin', query: to.fullPath !== '/' ? { redirect: to.fullPath } : {} }
 })
 
 export default router

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { useAuth } from '@/composables/useAuth'
+import { authClient, useAuth } from '@/composables/useAuth'
 
 const router = createRouter({
   history: createWebHistory(),
@@ -25,11 +25,28 @@ const router = createRouter({
   ],
 })
 
-router.beforeEach((to) => {
-  if (to.meta.public) return true
+// Better Auth's `useSession()` issues an async fetch; on the very first
+// navigation (e.g. after a hard refresh) the reactive session is still
+// `{ data: null, isPending: true }`, so a guard that reads `data.user`
+// synchronously would bounce a signed-in user to /signin. Cache the
+// initial `getSession()` promise and await it once before the guard
+// makes a decision — subsequent navigations resolve instantly off the
+// already-populated reactive session.
+let initialSession: Promise<unknown> | null = null
+
+router.beforeEach(async (to) => {
+  initialSession ??= authClient.getSession()
+  await initialSession
   const { session } = useAuth()
-  // session.value.data is the live Better Auth session; null when signed out.
-  if (session.value?.data?.user) return true
+  const signedIn = !!session.value?.data?.user
+  if (to.meta.public) {
+    if (signedIn && to.name === 'signin') {
+      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/session'
+      return redirect
+    }
+    return true
+  }
+  if (signedIn) return true
   return { name: 'signin', query: to.fullPath !== '/' ? { redirect: to.fullPath } : {} }
 })
 

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -28,15 +28,16 @@ const router = createRouter({
 // Better Auth's `useSession()` issues an async fetch; on the very first
 // navigation (e.g. after a hard refresh) the reactive session is still
 // `{ data: null, isPending: true }`, so a guard that reads `data.user`
-// synchronously would bounce a signed-in user to /signin. Cache the
-// initial `getSession()` promise and await it once before the guard
-// makes a decision — subsequent navigations resolve instantly off the
-// already-populated reactive session.
-let initialSession: Promise<unknown> | null = null
+// synchronously would bounce a signed-in user to /signin. Resolve the
+// initial `getSession()` once and gate on the flag — subsequent
+// navigations skip the microtask hop entirely.
+let initialSessionResolved = false
 
 router.beforeEach(async (to) => {
-  initialSession ??= authClient.getSession()
-  await initialSession
+  if (!initialSessionResolved) {
+    await authClient.getSession()
+    initialSessionResolved = true
+  }
   const { session } = useAuth()
   const signedIn = !!session.value?.data?.user
   if (to.meta.public) {

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,0 +1,20 @@
+import { createRouter, createWebHistory } from 'vue-router'
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: '/', redirect: '/session' },
+    {
+      path: '/session',
+      name: 'session',
+      component: () => import('@/views/SessionView.vue'),
+    },
+    {
+      path: '/stats',
+      name: 'stats',
+      component: () => import('@/views/StatsView.vue'),
+    },
+  ],
+})
+
+export default router

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -173,10 +173,8 @@ onMounted(async () => {
 
 /* Outer card surface: white-on-page with a neutral border, holding
    the meta label, the verse-coloured flashcard box (rendered by
-   CardPrompt), and the grade buttons. Stretches to fill the
-   available vertical space inside .session so the card occupies the
-   whole reading area regardless of how much content the flashcard
-   itself holds. */
+   CardPrompt), and the grade buttons. Sizes to its content so the
+   card stays compact regardless of how tall the viewport is. */
 .card {
   background: var(--color-bg-card);
   border: 1.5px solid var(--color-text);
@@ -186,7 +184,6 @@ onMounted(async () => {
   flex-direction: column;
   gap: 1.75rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-  flex: 1;
 }
 
 /* Narrow viewports: tighten padding so the card doesn't crowd the

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -171,19 +171,24 @@ onMounted(async () => {
   font-weight: 500;
 }
 
-/* Layout wrapper only — no surface or border. Meta label, the inner
-   verse-coloured flashcard box (rendered by CardPrompt), and the
-   grade buttons sit directly on the page background as siblings. */
+/* Layout wrapper only — no surface or border. Stretches to fill the
+   session column so the grade buttons can pin themselves to the
+   bottom while the meta label + flashcard box sit at the top. */
 .card {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  flex: 1;
 }
 
+/* Push the grade buttons (and the Reveal button before they appear)
+   to the bottom of the .card column. Empty space goes between the
+   flashcard box and the buttons. */
 .actions {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin-top: auto;
 }
 
 .reveal {

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -171,14 +171,19 @@ onMounted(async () => {
   font-weight: 500;
 }
 
+/* Card container: a clearly-bordered box echoing the Anki card surface
+   (white-on-page, dotted/solid hr divider inside, centered body). The
+   border is deliberately stronger than the surrounding chrome so the
+   reading area reads as a distinct surface. */
 .card {
   background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  padding: 2rem;
+  border: 1.5px solid var(--color-text);
+  border-radius: 10px;
+  padding: 2.5rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .actions {

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -171,19 +171,13 @@ onMounted(async () => {
   font-weight: 500;
 }
 
-/* Card container: a clearly-bordered box echoing the Anki card surface
-   (white-on-page, dotted/solid hr divider inside, centered body). The
-   border is deliberately stronger than the surrounding chrome so the
-   reading area reads as a distinct surface. */
+/* Layout-only container — the bordered surface lives inside CardPrompt
+   so the box can pick up the per-verse colour on its edge. Buttons and
+   meta label sit outside that inner box but inside this column. */
 .card {
-  background: var(--color-bg-card);
-  border: 1.5px solid var(--color-text);
-  border-radius: 10px;
-  padding: 2.5rem 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .actions {

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -129,7 +129,7 @@ onMounted(async () => {
 <style scoped>
 .session {
   width: 100%;
-  max-width: 640px;
+  max-width: 880px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
@@ -177,12 +177,22 @@ onMounted(async () => {
 .card {
   background: var(--color-bg-card);
   border: 1.5px solid var(--color-text);
-  border-radius: 10px;
-  padding: 2rem;
+  border-radius: 12px;
+  padding: 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.75rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+/* Narrow viewports: tighten padding so the card doesn't crowd the
+   screen edges on phones. Below ~600px the outer container would
+   otherwise consume most of the screen with padding alone. */
+@media (max-width: 600px) {
+  .card {
+    padding: 1.25rem;
+    border-radius: 8px;
+  }
 }
 
 .actions {

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -194,7 +194,7 @@ onMounted(async () => {
 .reveal {
   padding: 0.75rem 1.5rem;
   background: var(--color-accent);
-  color: white;
+  color: var(--color-on-accent);
   border: none;
   border-radius: 6px;
   font-weight: 500;

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -173,7 +173,10 @@ onMounted(async () => {
 
 /* Outer card surface: white-on-page with a neutral border, holding
    the meta label, the verse-coloured flashcard box (rendered by
-   CardPrompt), and the grade buttons. */
+   CardPrompt), and the grade buttons. Stretches to fill the
+   available vertical space inside .session so the card occupies the
+   whole reading area regardless of how much content the flashcard
+   itself holds. */
 .card {
   background: var(--color-bg-card);
   border: 1.5px solid var(--color-text);
@@ -183,6 +186,7 @@ onMounted(async () => {
   flex-direction: column;
   gap: 1.75rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  flex: 1;
 }
 
 /* Narrow viewports: tighten padding so the card doesn't crowd the

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -171,29 +171,13 @@ onMounted(async () => {
   font-weight: 500;
 }
 
-/* Outer card surface: white-on-page with a neutral border, holding
-   the meta label, the verse-coloured flashcard box (rendered by
-   CardPrompt), and the grade buttons. Sizes to its content so the
-   card stays compact regardless of how tall the viewport is. */
+/* Layout wrapper only — no surface or border. Meta label, the inner
+   verse-coloured flashcard box (rendered by CardPrompt), and the
+   grade buttons sit directly on the page background as siblings. */
 .card {
-  background: var(--color-bg-card);
-  border: 1.5px solid var(--color-text);
-  border-radius: 12px;
-  padding: 2.5rem;
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-}
-
-/* Narrow viewports: tighten padding so the card doesn't crowd the
-   screen edges on phones. Below ~600px the outer container would
-   otherwise consume most of the screen with padding alone. */
-@media (max-width: 600px) {
-  .card {
-    padding: 1.25rem;
-    border-radius: 8px;
-  }
+  gap: 1.5rem;
 }
 
 .actions {

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -129,7 +129,7 @@ onMounted(async () => {
 <style scoped>
 .session {
   width: 100%;
-  max-width: 880px;
+  max-width: 720px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -1,0 +1,241 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+import {
+  ApiError,
+  type CardRender,
+  type Grade,
+  MATERIAL_ID,
+  api,
+} from '@/api'
+import CardPrompt from '@/components/CardPrompt.vue'
+
+const card = ref<CardRender | null>(null)
+const revealed = ref(false)
+const done = ref(false)
+const error = ref<string | null>(null)
+const loading = ref(false)
+const submitting = ref(false)
+
+async function loadNext() {
+  loading.value = true
+  error.value = null
+  try {
+    const { cardId } = await api.getNextCard(MATERIAL_ID)
+    if (cardId === null) {
+      card.value = null
+      done.value = true
+    } else {
+      card.value = await api.getCardRender(MATERIAL_ID, cardId)
+      revealed.value = false
+      done.value = false
+    }
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit(grade: Grade) {
+  if (!card.value || submitting.value) return
+  submitting.value = true
+  error.value = null
+  try {
+    const res = await api.submitReview(MATERIAL_ID, card.value.cardId, grade)
+    if (res.nextCardId === null) {
+      card.value = null
+      done.value = true
+    } else {
+      card.value = await api.getCardRender(MATERIAL_ID, res.nextCardId)
+      revealed.value = false
+    }
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function ensureEnrolled() {
+  try {
+    await api.enroll(MATERIAL_ID)
+  } catch (err) {
+    // 409 = already enrolled, expected on subsequent loads.
+    if (err instanceof ApiError && err.status === 409) return
+    throw err
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+onMounted(async () => {
+  try {
+    await ensureEnrolled()
+    await loadNext()
+  } catch (err) {
+    error.value = formatError(err)
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="session">
+    <div v-if="error" class="banner banner-error">{{ error }}</div>
+
+    <div v-if="loading && !card" class="status">Loading…</div>
+
+    <div v-else-if="done" class="done">
+      <h2>Session complete</h2>
+      <p>Nothing else is due right now.</p>
+      <RouterLink to="/stats" class="link-button">View stats →</RouterLink>
+    </div>
+
+    <div v-else-if="card" class="card">
+      <CardPrompt :card="card" :revealed="revealed" />
+
+      <div class="actions">
+        <button
+          v-if="!revealed"
+          class="reveal"
+          :disabled="submitting"
+          @click="revealed = true"
+        >
+          Reveal answer
+        </button>
+        <div v-else class="grades">
+          <button class="grade grade-again" :disabled="submitting" @click="submit(1)">
+            Again
+          </button>
+          <button class="grade grade-hard" :disabled="submitting" @click="submit(2)">
+            Hard
+          </button>
+          <button class="grade grade-good" :disabled="submitting" @click="submit(3)">
+            Good
+          </button>
+          <button class="grade grade-easy" :disabled="submitting" @click="submit(4)">
+            Easy
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.session {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.banner {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.status {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.done {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.done h2 {
+  margin-bottom: 0.5rem;
+}
+
+.link-button {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+.card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.reveal {
+  padding: 0.75rem 1.5rem;
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.reveal:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.grades {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.grade {
+  padding: 0.75rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.grade-again {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+
+.grade-hard {
+  background: var(--color-grade-hard-bg);
+  color: var(--color-grade-hard);
+}
+
+.grade-good {
+  background: var(--color-grade-good-bg);
+  color: var(--color-grade-good);
+}
+
+.grade-easy {
+  background: var(--color-grade-easy-bg);
+  color: var(--color-grade-easy);
+}
+
+.grade:hover:not(:disabled) {
+  border-color: currentColor;
+}
+</style>

--- a/apps/web/src/views/SessionView.vue
+++ b/apps/web/src/views/SessionView.vue
@@ -171,13 +171,18 @@ onMounted(async () => {
   font-weight: 500;
 }
 
-/* Layout-only container — the bordered surface lives inside CardPrompt
-   so the box can pick up the per-verse colour on its edge. Buttons and
-   meta label sit outside that inner box but inside this column. */
+/* Outer card surface: white-on-page with a neutral border, holding
+   the meta label, the verse-coloured flashcard box (rendered by
+   CardPrompt), and the grade buttons. */
 .card {
+  background: var(--color-bg-card);
+  border: 1.5px solid var(--color-text);
+  border-radius: 10px;
+  padding: 2rem;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 }
 
 .actions {

--- a/apps/web/src/views/SignInView.vue
+++ b/apps/web/src/views/SignInView.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router'
+
+import SignInForm from '@/components/SignInForm.vue'
+import { useAuth } from '@/composables/useAuth'
+
+const { signInSocial, signInEmail, signUpEmail } = useAuth()
+const router = useRouter()
+const route = useRoute()
+
+function onSuccess() {
+  const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/session'
+  router.replace(redirect)
+}
+</script>
+
+<template>
+  <div class="signin">
+    <h2>Sign in</h2>
+    <SignInForm
+      :sign-in-social="signInSocial"
+      :sign-in-email="signInEmail"
+      :sign-up-email="signUpEmail"
+      @success="onSuccess"
+    />
+  </div>
+</template>
+
+<style scoped>
+.signin {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  width: 100%;
+  max-width: 22rem;
+}
+
+h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+</style>

--- a/apps/web/src/views/StatsView.vue
+++ b/apps/web/src/views/StatsView.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+import { MATERIAL_ID, type StatsResponse, api } from '@/api'
+
+const stats = ref<StatsResponse | null>(null)
+const error = ref<string | null>(null)
+const loading = ref(true)
+
+const buckets = computed(() => {
+  if (!stats.value) return []
+  const dist = stats.value.testDistribution
+  const total = Object.values(dist).reduce((a, b) => a + b, 0)
+  if (total === 0) return []
+  const labels: Array<keyof typeof dist> = ['weak', 'learning', 'familiar', 'strong', 'mastered']
+  return labels.map((label) => ({
+    label,
+    count: dist[label],
+    percent: (dist[label] / total) * 100,
+  }))
+})
+
+const retentionPct = computed(() =>
+  stats.value && stats.value.retentionRate !== null
+    ? `${(stats.value.retentionRate * 100).toFixed(0)}%`
+    : '—',
+)
+
+onMounted(async () => {
+  try {
+    stats.value = await api.getStats(MATERIAL_ID)
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="stats">
+    <div v-if="error" class="banner banner-error">{{ error }}</div>
+    <div v-else-if="loading" class="status">Loading…</div>
+    <div v-else-if="stats" class="content">
+      <h2>Stats</h2>
+
+      <div class="grid">
+        <div class="metric">
+          <div class="metric-label">Verses learned</div>
+          <div class="metric-value">{{ stats.versesLearned }}</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Retention</div>
+          <div class="metric-value">{{ retentionPct }}</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Total reviews</div>
+          <div class="metric-value">{{ stats.totalGrades }}</div>
+        </div>
+      </div>
+
+      <div class="histogram">
+        <div class="histogram-title">Test stability</div>
+        <div v-for="b in buckets" :key="b.label" class="bar-row">
+          <div class="bar-label">{{ b.label }}</div>
+          <div class="bar-track">
+            <div :class="['bar', `bar-${b.label}`]" :style="{ width: `${b.percent}%` }" />
+          </div>
+          <div class="bar-count">{{ b.count }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stats {
+  width: 100%;
+  max-width: 640px;
+}
+
+.status {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.banner {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+h2 {
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.metric {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 1rem;
+}
+
+.metric-label {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.metric-value {
+  font-size: 1.75rem;
+  font-weight: 500;
+  margin-top: 0.25rem;
+}
+
+.histogram {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.histogram-title {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.5rem;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 6rem 1fr 3rem;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.bar-label {
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  text-transform: capitalize;
+}
+
+.bar-track {
+  height: 0.75rem;
+  background: var(--color-bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.2s;
+}
+
+.bar-weak { background: var(--color-grade-again); }
+.bar-learning { background: var(--color-grade-hard); }
+.bar-familiar { background: var(--color-grade-good); }
+.bar-strong { background: var(--color-accent); }
+.bar-mastered { background: var(--color-grade-easy); }
+
+.bar-count {
+  text-align: right;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.app.json" }
+  ]
+}

--- a/apps/web/tsconfig.node.json
+++ b/apps/web/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["vite.config.*"],
+  "compilerOptions": {
+    "noEmit": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  }
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from 'node:url'
+
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [vue()],
+  server: { port: 5180, strictPort: true },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+})

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -33,24 +33,22 @@ pub struct BuildResult {
     pub verse_render_data: HashMap<u32, VerseRender>,
 }
 
-/// Tier-subset rule: in the Anki export a verse tagged "150" is implicitly a
-/// member of both club 150 and club 300. Expand a raw tier list (as written
-/// in `VerseData.clubs`) to the full set of tiers.
-fn expand_tiers(raw: &[u16]) -> Vec<ClubTier> {
+/// Parse a raw tier list (as written in `VerseData.clubs`) into the
+/// concrete `ClubTier` carried by VerseInClub / VerseClubBinding. The
+/// quizzer's tier-subset rule (a Club-150 verse is implicitly also in
+/// Club 300) is *not* expanded here: each verse is associated with one
+/// most-specific tier, since the broader membership is trivially known
+/// and the user shouldn't be asked the same "what club?" twice per verse.
+fn parse_tiers(raw: &[u16]) -> Vec<ClubTier> {
     let mut tiers: Vec<ClubTier> = Vec::new();
-    let mut push = |t: ClubTier| {
+    for &n in raw {
+        let t = match n {
+            150 => ClubTier::Club150,
+            300 => ClubTier::Club300,
+            _ => continue,
+        };
         if !tiers.contains(&t) {
             tiers.push(t);
-        }
-    };
-    for &n in raw {
-        match n {
-            150 => {
-                push(ClubTier::Club150);
-                push(ClubTier::Club300);
-            }
-            300 => push(ClubTier::Club300),
-            _ => {}
         }
     }
     tiers
@@ -116,7 +114,7 @@ pub fn build(data: &MaterialData, now_secs: i64) -> BuildResult {
             .copied();
         let headings: Vec<u16> = heading_idx.into_iter().collect();
 
-        let clubs = expand_tiers(&verse.clubs);
+        let clubs = parse_tiers(&verse.clubs);
 
         verse_index.add_verse(
             verse_id,
@@ -378,13 +376,21 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c.kind, CardKind::VerseInClub { .. }))
         );
-        // Tier-subset rule expands [150] to both Club150 and Club300.
-        let club_cards = r
+        // One VerseInClub card per verse, carrying the most-specific tier.
+        // The Club-150-implies-Club-300 subset rule is intentionally not
+        // expanded — the broader membership is trivially known.
+        let club_cards: Vec<&Card> = r
             .cards
             .iter()
             .filter(|c| matches!(c.kind, CardKind::VerseInClub { .. }))
-            .count();
-        assert_eq!(club_cards, 2);
+            .collect();
+        assert_eq!(club_cards.len(), 1);
+        assert!(matches!(
+            club_cards[0].kind,
+            CardKind::VerseInClub {
+                tier: ClubTier::Club150
+            }
+        ));
     }
 
     #[test]

--- a/crates/core/src/element.rs
+++ b/crates/core/src/element.rs
@@ -2,8 +2,9 @@ use serde::{Deserialize, Serialize};
 
 /// Bible-quizzer club tier: verses are grouped into clubs by total
 /// memorisation count (the 150-verse club, the 300-verse club, etc.).
-/// A verse tagged at one tier is implicitly in higher tiers too — see
-/// the tier-subset rule in `builder::expand_tiers`.
+/// A verse tagged at one tier is implicitly in every higher tier too,
+/// but the `VerseInClub` card / `VerseClubBinding` test stores only the
+/// *most specific* tier — the broader memberships are trivially derived.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum ClubTier {
     Club150,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev:api": "pnpm --filter @verse-vault/api dev",
+    "dev:web": "pnpm --filter @verse-vault/web dev",
+    "dev:all": "pnpm --parallel --filter @verse-vault/api --filter @verse-vault/web dev",
     "type-check": "pnpm --filter '*' type-check",
     "test": "pnpm --filter '*' test",
     "lint": "eslint",

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -1,15 +1,27 @@
-# Required
+# Copy to .env (gitignored) and fill in real values for local dev. The api
+# package's `dev` script loads .env via Node's --env-file-if-exists; an
+# optional .env.local is loaded second and wins on overlap.
+
+# Where the API speaks. Better Auth's OAuth redirect URIs derive from this
+# (e.g. /api/auth/callback/google) — Google Cloud Console must list the
+# matching dev URL as an authorised redirect URI for the OAuth client whose
+# credentials you put below.
+API_BASE_URL=http://localhost:3000
+
+# Where the Vue thin client lives. Used for CORS + as the post-sign-in
+# redirect target. Vite picks 5180 by default in this repo.
+WEB_BASE_URL=http://localhost:5180
+
+# HMAC signing key for Better Auth sessions. Must be at least 32 chars.
+# Reusable across personal-dev apps; rotate per app in production.
 BETTER_AUTH_SECRET=change-me-to-a-32-char-or-longer-random-string
 
-# Optional (defaults shown)
-PORT=3000
-API_BASE_URL=http://localhost:3000
-WEB_BASE_URL=http://localhost:5173
-# DATABASE_PATH=./data/verse-vault.db
-
-# Required only if Google sign-in is enabled
-# GOOGLE_CLIENT_ID=
-# GOOGLE_CLIENT_SECRET=
+# Optional Google OAuth credentials. Leave blank to disable Google sign-in
+# (email/password still works). Authorised redirect URI for the matching
+# Google Cloud OAuth client must include
+# ${API_BASE_URL}/api/auth/callback/google.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
 
 # api.bible — needed for canonical NKJV text rendering. When unset the
 # cards endpoint returns structural metadata only (composed: null) and
@@ -23,3 +35,7 @@ WEB_BASE_URL=http://localhost:5173
 # leaves the api.bible text untouched. Will move to a per-user setting
 # in a later change.
 # RENDER_DIALECT=canadian
+
+# SQLite database path. Defaults to ./data/verse-vault.db when unset.
+# DATABASE_PATH=./data/verse-vault.db
+# PORT=3000

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
+    "dev": "tsx watch --env-file-if-exists=.env --env-file-if-exists=.env.local src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -43,7 +43,21 @@ export function createApp(deps: AppDeps) {
   app.use(
     '*',
     cors({
-      origin: [deps.authEnv.webOrigin],
+      // In dev (VV_DEV_USER_ID set), accept any localhost origin so the
+      // Vue thin client running on whatever port Vite picked can talk to
+      // the API without a coordinated WEB_BASE_URL env. In prod, only the
+      // configured webOrigin is allowed.
+      origin: (origin) => {
+        if (origin === deps.authEnv.webOrigin) return origin;
+        if (
+          process.env.VV_DEV_USER_ID &&
+          origin &&
+          /^http:\/\/(localhost|127\.0\.0\.1):\d+$/.test(origin)
+        ) {
+          return origin;
+        }
+        return null;
+      },
       credentials: true,
     }),
   );

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -40,17 +40,18 @@ export function createApp(deps: AppDeps) {
   const app = new Hono<{ Variables: SessionVariables }>();
 
   app.use('*', logger());
+  const isProd = process.env.NODE_ENV === 'production';
   app.use(
     '*',
     cors({
-      // In dev (VV_DEV_USER_ID set), accept any localhost origin so the
-      // Vue thin client running on whatever port Vite picked can talk to
-      // the API without a coordinated WEB_BASE_URL env. In prod, only the
+      // Outside production, accept any http://localhost:PORT origin so the
+      // thin client running on whatever port Vite picked can talk to the
+      // API without a coordinated WEB_BASE_URL. In production only the
       // configured webOrigin is allowed.
       origin: (origin) => {
         if (origin === deps.authEnv.webOrigin) return origin;
         if (
-          process.env.VV_DEV_USER_ID &&
+          !isProd &&
           origin &&
           /^http:\/\/(localhost|127\.0\.0\.1):\d+$/.test(origin)
         ) {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -12,11 +12,19 @@ export interface AuthEnv {
 }
 
 export function createAuth(db: DB, env: AuthEnv) {
+  const isProd = process.env.NODE_ENV === 'production';
+  // In dev, trust any localhost port the thin client might land on (Vite
+  // falls back through 5180/5181/… when ports collide). Production sticks
+  // to the single configured origin.
+  const trustedOrigins = isProd
+    ? [env.webOrigin]
+    : [env.webOrigin, 'http://localhost:5173', 'http://localhost:5180'];
+
   return betterAuth({
     baseURL: env.baseUrl,
     secret: env.secret,
     database: drizzleAdapter(db, { provider: 'sqlite', schema }),
-    trustedOrigins: [env.webOrigin],
+    trustedOrigins,
     emailAndPassword: { enabled: true },
     socialProviders: env.googleOAuth ? { google: env.googleOAuth } : {},
     account: {

--- a/packages/api/src/middleware/session.ts
+++ b/packages/api/src/middleware/session.ts
@@ -14,17 +14,6 @@ export interface SessionVariables {
 
 export function sessionMiddleware(auth: Auth): MiddlewareHandler<{ Variables: SessionVariables }> {
   return async (c, next) => {
-    // Dev-mode bypass: when VV_DEV_USER_ID is set and the client opts in via
-    // header, skip Better Auth and use the configured dev user. Lets the
-    // Vue thin client run without wiring up OAuth in development. Two
-    // safeguards make this safe: env var must be set (production won't),
-    // and the client has to explicitly send the header.
-    const devUserId = process.env.VV_DEV_USER_ID;
-    if (devUserId && c.req.header('x-vv-dev-user') === '1') {
-      c.set('user', { id: devUserId, email: 'dev@local', name: 'dev' });
-      await next();
-      return;
-    }
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     if (session?.user) {
       c.set('user', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,43 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  apps/web:
+    dependencies:
+      better-auth:
+        specifier: ^1.6.5
+        version: 1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(vitest@2.1.9(@types/node@24.12.3))(vue@3.5.34(typescript@5.9.3))
+      vue:
+        specifier: ^3.5.28
+        version: 3.5.34(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.5.1
+        version: 4.6.4(vue@3.5.34(typescript@5.9.3))
+    devDependencies:
+      '@tsconfig/node24':
+        specifier: ^24.0.4
+        version: 24.0.4
+      '@types/node':
+        specifier: ^24.10.13
+        version: 24.12.3
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.4
+        version: 6.0.6(vite@7.3.3(@types/node@24.12.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@5.9.3))
+      '@vue/tsconfig':
+        specifier: ^0.8.1
+        version: 0.8.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
+      npm-run-all2:
+        specifier: ^8.0.4
+        version: 8.0.4
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.3(@types/node@24.12.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue-tsc:
+        specifier: ^3.2.4
+        version: 3.2.8(typescript@5.9.3)
+
   crates/wasm/pkg: {}
 
   packages/api:
@@ -39,7 +76,7 @@ importers:
         version: 1.19.14(hono@4.12.14)
       better-auth:
         specifier: ^1.2.0
-        version: 1.6.5(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17))
+        version: 1.6.5(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17))(vue@3.5.34(typescript@5.9.3))
       better-sqlite3:
         specifier: ^11.0.0
         version: 11.10.0
@@ -84,8 +121,21 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@better-auth/core@1.6.5':
@@ -897,6 +947,9 @@ packages:
     resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
     engines: {node: '>=14'}
 
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
@@ -1025,6 +1078,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tsconfig/node24@24.0.4':
+    resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
+
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -1037,8 +1093,18 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/node@24.12.3':
+    resolution: {integrity: sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@vitejs/plugin-vue@6.0.6':
+    resolution: {integrity: sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -1069,12 +1135,70 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vue/compiler-core@3.5.34':
+    resolution: {integrity: sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==}
+
+  '@vue/compiler-dom@3.5.34':
+    resolution: {integrity: sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==}
+
+  '@vue/compiler-sfc@3.5.34':
+    resolution: {integrity: sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==}
+
+  '@vue/compiler-ssr@3.5.34':
+    resolution: {integrity: sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
+
+  '@vue/language-core@3.2.8':
+    resolution: {integrity: sha512-9OiSPQFiAAWNVnXb0d2dcTmcKnFQamhuNES6ayyISrb/mwPWVgoGdAqSfCWqKhQpa3D5gDTcYD+w7ObiheZ81g==}
+
+  '@vue/reactivity@3.5.34':
+    resolution: {integrity: sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==}
+
+  '@vue/runtime-core@3.5.34':
+    resolution: {integrity: sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==}
+
+  '@vue/runtime-dom@3.5.34':
+    resolution: {integrity: sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==}
+
+  '@vue/server-renderer@3.5.34':
+    resolution: {integrity: sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==}
+    peerDependencies:
+      vue: 3.5.34
+
+  '@vue/shared@3.5.34':
+    resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
+
+  '@vue/tsconfig@0.8.1':
+    resolution: {integrity: sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==}
+    peerDependencies:
+      typescript: 5.x
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vue:
+        optional: true
+
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  alien-signals@3.1.2:
+    resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -1294,6 +1418,9 @@ packages:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -1456,6 +1583,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -1494,6 +1625,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1517,6 +1651,15 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -1631,6 +1774,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1647,6 +1794,10 @@ packages:
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -1716,6 +1867,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -1748,6 +1903,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1766,6 +1924,15 @@ packages:
 
   node-html-parser@7.1.0:
     resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
+
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-run-all2@8.0.4:
+    resolution: {integrity: sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==}
+    engines: {node: ^20.5.0 || >=22.0.0, npm: '>= 10'}
+    hasBin: true
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -1801,6 +1968,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@5.0.0:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1827,6 +1997,10 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -1834,6 +2008,10 @@ packages:
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -1853,6 +2031,10 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  read-package-json-fast@4.0.0:
+    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
 
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -1910,6 +2092,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2012,6 +2198,10 @@ packages:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2043,6 +2233,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -2093,6 +2286,46 @@ packages:
       terser:
         optional: true
 
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2118,9 +2351,36 @@ packages:
       jsdom:
         optional: true
 
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue-tsc@3.2.8:
+    resolution: {integrity: sha512-27vTLJ6Q2370obOd0PFYoYoKnmXJ521uUIedrs3Zhhhg/8YG10VOCMmwt+JQslatpAMTDbnWiitLnoD5VlIvog==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+
+  vue@3.5.34:
+    resolution: {integrity: sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
   why-is-node-running@2.3.0:
@@ -2171,7 +2431,18 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)':
     dependencies:
@@ -2681,6 +2952,8 @@ snapshots:
 
   '@opentelemetry/semantic-conventions@1.40.0': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -2758,6 +3031,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tsconfig/node24@24.0.4': {}
+
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
@@ -2772,9 +3047,19 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.12.3':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@vitejs/plugin-vue@6.0.6(vite@7.3.3(@types/node@24.12.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 7.3.3(@types/node@24.12.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vue: 3.5.34(typescript@5.9.3)
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -2790,6 +3075,15 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@24.12.3))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@24.12.3)
+    optional: true
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -2816,6 +3110,89 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vue/compiler-core@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/shared': 3.5.34
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.34':
+    dependencies:
+      '@vue/compiler-core': 3.5.34
+      '@vue/shared': 3.5.34
+
+  '@vue/compiler-sfc@3.5.34':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.34
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.14
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.34':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
+
+  '@vue/devtools-api@6.6.4': {}
+
+  '@vue/language-core@3.2.8':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@vue/compiler-dom': 3.5.34
+      '@vue/shared': 3.5.34
+      alien-signals: 3.1.2
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+      picomatch: 4.0.4
+
+  '@vue/reactivity@3.5.34':
+    dependencies:
+      '@vue/shared': 3.5.34
+
+  '@vue/runtime-core@3.5.34':
+    dependencies:
+      '@vue/reactivity': 3.5.34
+      '@vue/shared': 3.5.34
+
+  '@vue/runtime-dom@3.5.34':
+    dependencies:
+      '@vue/reactivity': 3.5.34
+      '@vue/runtime-core': 3.5.34
+      '@vue/shared': 3.5.34
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.34(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.34
+      '@vue/shared': 3.5.34
+      vue: 3.5.34(typescript@5.9.3)
+
+  '@vue/shared@3.5.34': {}
+
+  '@vue/tsconfig@0.8.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))':
+    optionalDependencies:
+      typescript: 5.9.3
+      vue: 3.5.34(typescript@5.9.3)
+
   JSONStream@1.3.5:
     dependencies:
       jsonparse: 1.3.1
@@ -2827,6 +3204,8 @@ snapshots:
       fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  alien-signals@3.1.2: {}
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -2850,7 +3229,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.6.5(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17)):
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
       '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
@@ -2874,6 +3253,34 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16)
       vitest: 2.1.9(@types/node@22.19.17)
+      vue: 3.5.34(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-auth@1.6.5(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(vitest@2.1.9(@types/node@24.12.3))(vue@3.5.34(typescript@5.9.3)):
+    dependencies:
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
+      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.5(zod@4.3.6)
+      defu: 6.1.7
+      jose: 6.2.2
+      kysely: 0.28.16
+      nanostores: 1.3.0
+      zod: 4.3.6
+    optionalDependencies:
+      drizzle-kit: 0.31.10
+      vitest: 2.1.9(@types/node@24.12.3)
+      vue: 3.5.34(typescript@5.9.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -3010,6 +3417,8 @@ snapshots:
 
   css-what@6.2.2: {}
 
+  csstype@3.2.3: {}
+
   dargs@8.1.0: {}
 
   debug@4.4.3:
@@ -3085,6 +3494,8 @@ snapshots:
       once: 1.4.0
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -3207,6 +3618,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -3232,6 +3645,10 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-uri-to-path@1.0.0: {}
 
@@ -3315,6 +3732,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@3.1.5: {}
+
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
@@ -3326,6 +3745,8 @@ snapshots:
       argparse: 2.0.1
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-parse-even-better-errors@4.0.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -3397,6 +3818,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  memorystream@0.3.1: {}
+
   meow@12.1.1: {}
 
   merge-stream@2.0.0: {}
@@ -3418,6 +3841,8 @@ snapshots:
 
   ms@2.1.3: {}
 
+  muggle-string@0.4.1: {}
+
   nanoid@3.3.11: {}
 
   nanostores@1.3.0: {}
@@ -3432,6 +3857,19 @@ snapshots:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0
+
+  npm-normalize-package-bin@4.0.0: {}
+
+  npm-run-all2@8.0.4:
+    dependencies:
+      ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.4
+      pidtree: 0.6.0
+      read-package-json-fast: 4.0.0
+      shell-quote: 1.8.3
+      which: 5.0.0
 
   npm-run-path@5.3.0:
     dependencies:
@@ -3472,6 +3910,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  path-browserify@1.0.1: {}
+
   path-exists@5.0.0: {}
 
   path-key@3.1.1: {}
@@ -3486,9 +3926,17 @@ snapshots:
 
   picomatch@2.3.2: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
 
   postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -3522,6 +3970,11 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  read-package-json-fast@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      npm-normalize-package-bin: 4.0.0
 
   readable-stream@3.6.2:
     dependencies:
@@ -3590,6 +4043,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
 
@@ -3685,6 +4140,11 @@ snapshots:
 
   tinyexec@1.1.1: {}
 
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
@@ -3709,6 +4169,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.16.0: {}
 
   undici-types@7.19.2: {}
 
@@ -3736,6 +4198,25 @@ snapshots:
       - supports-color
       - terser
 
+  vite-node@2.1.9(@types/node@24.12.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@24.12.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    optional: true
+
   vite@5.4.21(@types/node@22.19.17):
     dependencies:
       esbuild: 0.21.5
@@ -3744,6 +4225,31 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+
+  vite@5.4.21(@types/node@24.12.3):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 24.12.3
+      fsevents: 2.3.3
+    optional: true
+
+  vite@7.3.3(@types/node@24.12.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rollup: 4.60.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.3
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      yaml: 2.8.3
 
   vitest@2.1.9(@types/node@22.19.17):
     dependencies:
@@ -3780,9 +4286,72 @@ snapshots:
       - supports-color
       - terser
 
+  vitest@2.1.9(@types/node@24.12.3):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.3))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@24.12.3)
+      vite-node: 2.1.9(@types/node@24.12.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.3
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    optional: true
+
+  vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.34(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.34(typescript@5.9.3)
+
+  vue-tsc@3.2.8(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 2.4.28
+      '@vue/language-core': 3.2.8
+      typescript: 5.9.3
+
+  vue@3.5.34(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      '@vue/compiler-sfc': 3.5.34
+      '@vue/runtime-dom': 3.5.34
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@5.9.3))
+      '@vue/shared': 3.5.34
+    optionalDependencies:
+      typescript: 5.9.3
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.5
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Vue 3 thin client (`apps/web/`) wired to the Hono API: Better Auth sign-in, session view, stats view.
- Server-side composer: `cards.ts` reads the apibible cache + structural deck and returns per-verse `phraseHtml` so the client just paints it.
- Card surface follows Anki Verse note-type conventions (Arial body, deck label top-right, solid `<hr>` between ref and text, dotted `<hr class="type">` reveal divider, verse-coloured top stripe). System-pref dark mode via `prefers-color-scheme`.
- Core fix: VerseInClub now emits **one** card per verse carrying its most-specific tier — Club-150 verses no longer surface two identical "what club?" cards.
- Router guard awaits the initial Better Auth session once, so hard-refresh no longer bounces signed-in users to /signin.

## Test plan
- [ ] `cargo test` (60 core + 11 builder + 2 sim + 9 wasm = green locally)
- [ ] `pnpm -C packages/api test` (75 vitest cases pass locally)
- [ ] `pnpm -C apps/web type-check` and `pnpm -C apps/web build` (clean locally)
- [ ] Hard-refresh on `/session` while signed-in → stays on session (no /signin bounce)
- [ ] Light vs dark mode visual sweep across PhraseFill / VerseAtVerseRef / Citation / Recitation / Ftv / VerseInHeading / VerseInClub
- [ ] Club-150 verse session → only one VerseInClub card per verse

🤖 Generated with [Claude Code](https://claude.com/claude-code)