### PR TITLE
feat(phrase-splitter): commit the skill + split years 3 and 4

### DIFF
--- a/.claude/skills/phrase-splitter/SKILL.md
+++ b/.claude/skills/phrase-splitter/SKILL.md
@@ -108,16 +108,20 @@ Claude Code.
 
 When running this skill inside Claude Code, dispatch parallel `Agent` calls to judge instead of (or
 in addition to) `--llm-judge`. Use `superpowers:dispatching-parallel-agents` to manage the fan-out.
-Each subagent gets:
 
-* The contents of `references/quality-criteria.md`
-* The body of `JUDGE_PROMPT` from `tools/phrase_splitter/prompts.py`
-* A batch of verses (ref + canonical text + current phrase slices)
+Each subagent's prompt should point at
+[`references/judge-agent-instructions.md`](references/judge-agent-instructions.md), which is the
+canonical entry-point doc for judging subagents. The instructions tell the subagent to read
+`quality-criteria.md`, lay out the workflow, and specify the output shape. The dispatch prompt just
+needs to:
 
-…and returns a JSON array of `{"ref": …, "verdict": "ok" | "needs_resplit", "reasons": [...]}`.
-Batch ~10–20 verses per agent. Merge the verdicts with the deterministic flags to build the resplit
-worklist. This path is preferred when the skill is being driven interactively, because it keeps the
-judging in the same evaluation loop as everything else.
+1. Point at the instructions doc.
+2. Give the batch file path (JSON array of `{ref, text, phrases}`).
+3. Give the output file path.
+
+Build batches of ~15–20 verses each. Merge the verdicts with the deterministic flags to build the
+resplit worklist. This path is preferred when the skill is being driven interactively, because it
+keeps the judging in the same evaluation loop as everything else.
 
 ### 3. Re-split
 
@@ -136,8 +140,12 @@ land in one place). Refresh the criteria from `references/quality-criteria.md` b
 verse where the judgement call isn't obvious.
 
 For a small worklist (≤ 10 verses), the main agent answers each prompt directly. For a large
-worklist, dispatch parallel subagents (one verse per agent, or small batches) using
-`superpowers:dispatching-parallel-agents`.
+worklist, dispatch parallel subagents (small batches per agent, typically 12–15 verses) using
+`superpowers:dispatching-parallel-agents`. The subagent's prompt should point at
+[`references/splitter-agent-instructions.md`](references/splitter-agent-instructions.md), the
+canonical entry-point doc — and give it the batch file path + output file path. The instructions
+handle the rest (read criteria, follow the embedded `SPLIT_PROMPT` in each batch entry, verify
+rejoin, write proposals).
 
 Each LLM reply is a single JSON array of phrase strings. Collect proposals into a JSON file shaped
 as:

--- a/.claude/skills/phrase-splitter/SKILL.md
+++ b/.claude/skills/phrase-splitter/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: phrase-splitter
+description: >-
+  Use whenever the verse-vault project's phrase splitting comes up — auditing
+  existing splits in the structural deck, regenerating bad ones, splitting a
+  new verse from scratch, or anything touching `data/corinthians.json`'s
+  `phraseWordCounts` field. Trigger phrases include "evaluate phrase splits",
+  "re-split this verse", "bad phrase chunking", "the splits are awkward",
+  "split this verse for memorisation", "the splitter prompt", or any mention of
+  `corinthians.json`, `evaluate_phrases.py`, or `split_phrases.py`. Drive a tight
+  loop: deterministic audit → LLM resplit on flagged verses → write-back to the
+  structural file.
+version: 0.2.0
+---
+
+# Phrase Splitter
+
+The verse-vault deck stores memorisation phrases as **word counts**, not strings:
+`data/corinthians.json`'s per-verse `phraseWordCounts: [n1, n2, …]` slices the canonical NKJV
+(fetched from api.bible) into phrases. Splits should chunk each verse into 3–12 word phrases that
+fall on natural reciting pauses (clause starts, parallel items, connectives that introduce new
+thoughts). This skill is the loop for keeping that structural data high-quality.
+
+## When to invoke
+
+* The user asks to evaluate or audit phrase splits.
+* The user names a specific bad verse split (e.g. "the 'But one' fragment in 12:11 is wrong").
+* The user wants splits regenerated, either for specific refs or for whatever the evaluator flags.
+* A new verse has no real split (single-phrase placeholder) and the user wants it chunked.
+* The user mentions the splitter prompt or the splitter pipeline.
+
+## Architecture
+
+The splitter operates on two stores:
+
+* **`data/corinthians.json`** — the committed structural deck file. Per-verse `phraseWordCounts` is
+  the durable record of where phrase boundaries fall. Other relevant fields the audit reads:
+  `annotations` (keyword markup), `ftvWordCount`, `headings`, `clubs`.
+* **api.bible cache** — `packages/api/data/verse-vault.db`, table `apibible_passages`. Holds
+  canonical NKJV HTML; tools fetch on demand and write back. Honour the 30-day TTL per API.Bible
+  MAUA.
+
+Verse text and word boundaries come from api.bible, **never the deck**. `phraseWordCounts` indexes
+the api.bible token stream — same convention as `packages/api/src/lib/render.ts` at runtime.
+
+## Workflow
+
+### 1. Audit (`tools/evaluate_phrases.py`)
+
+```bash
+python3 tools/evaluate_phrases.py --top 20
+python3 tools/evaluate_phrases.py --refs "1 Cor 12:11"
+python3 tools/evaluate_phrases.py --out /tmp/report.json
+```
+
+Deterministic checks:
+
+* `phraseWordCounts` sum matches api.bible's token count (catches drift)
+* Each phrase word count in `[3, 12]`; edge phrases may be shorter
+* Single-phrase verse with > 10 words → missing split
+* `ftvWordCount` in range
+
+Pass `--llm-judge` to add a Claude Haiku quality pass for verses that clear the deterministic checks
+but might still feel awkward (needs `anthropic` + `ANTHROPIC_API_KEY`).
+
+### 2. Re-split
+
+```bash
+# Print prompts for the worst N entries in a report
+python3 tools/split_phrases.py print-prompt --from-report /tmp/report.json \
+    --top 10 --json > /tmp/prompts.json
+
+# Or target specific refs
+python3 tools/split_phrases.py print-prompt --refs "1 Cor 12:11"
+```
+
+The prompt lives in `tools/phrase_splitter/prompts.py` (shared with this skill so iterations land in
+one place). Refresh the criteria from `references/quality-criteria.md` before splitting any verse
+where the judgement call isn't obvious.
+
+The LLM in the loop (you, the model running this skill) answers each prompt with a single JSON array
+of phrase strings. Collect proposals into a JSON file shaped as:
+
+```json
+[
+  {
+    "ref": "1 Corinthians 12:11",
+    "phrases": [
+      "But one and the same Spirit works all these things,",
+      "distributing to each one individually as He wills."
+    ]
+  }
+]
+```
+
+Apply with deterministic validation (word counts sum to canonical token count; each phrase ≤ 12
+words):
+
+```bash
+python3 tools/split_phrases.py apply --input /tmp/proposed.json --dry-run
+python3 tools/split_phrases.py apply --input /tmp/proposed.json
+```
+
+`apply` rewrites only `phraseWordCounts` for the targeted verses. `annotations.wordIndex` and
+`ftvWordCount` are positions in the canonical token stream and don't shift, so they're preserved
+untouched.
+
+### 3. Verify
+
+```bash
+python3 tools/evaluate_phrases.py --refs "1 Cor 12:11"
+```
+
+The deck is committed; once `corinthians.json` is happy, the change ships through git like any other
+code edit. No regeneration step is needed — `corinthians.json` IS the file.
+
+## Single-verse path (no audit needed)
+
+When the user pastes a verse and asks for a split without referencing a specific ref or the deck,
+the workflow shortens to: read `references/quality-criteria.md`, generate the split applying those
+rules, return a JSON array. Still mentally check the rejoin (joined phrases match the input) before
+answering.
+
+## Reference files
+
+* `references/quality-criteria.md` — what makes a split good or bad, with worked examples. Read
+  before splitting any verse you're not sure about.
+* `references/prompt-design.md` — current state of the prompt and notes on prior iterations. Read
+  before editing `tools/phrase_splitter/prompts.py`.
+
+## Sibling audit tools
+
+The same `corinthians.json` + api.bible cache pair powers two adjacent auditors — useful to combine
+with the splitter on a quality pass:
+
+* `tools/find_ftvs.py` — shortest unique opening prefix per verse; audits the deck's `ftvWordCount`.
+* `tools/find_keywords.py` — audits `annotations` (`bold` keywords, 1 verse occurrence; `boldItalic`
+  context-keys, within ±5 verses) against canonical word occurrences.
+* `tools/audit_colpkg.py` — read-only diff of an Anki `.colpkg` against `corinthians.json` and
+  api.bible, flagging text typos / FTV / keyword markup / clubs drift between the Anki source and
+  the structural file.
+
+## Notes
+
+* The CLIs live in `/home/amberson/Code/verse-vault/tools/`. Run them from the repo root.
+* The user prefers atomic commits — one logical change per commit (see `CLAUDE.md`). When this skill
+  writes splits, commit the `corinthians.json` change separately from any prompt-design or
+  tool-script changes.

--- a/.claude/skills/phrase-splitter/SKILL.md
+++ b/.claude/skills/phrase-splitter/SKILL.md
@@ -2,38 +2,56 @@
 name: phrase-splitter
 description: >-
   Use whenever the verse-vault project's phrase splitting comes up — auditing
-  existing splits in the structural deck, regenerating bad ones, splitting a
-  new verse from scratch, or anything touching `data/corinthians.json`'s
+  existing splits in any year deck (`data/<N>-<book>.json`), regenerating bad
+  splits, splitting a new verse from scratch, or anything touching a deck's
   `phraseWordCounts` field. Trigger phrases include "evaluate phrase splits",
   "re-split this verse", "bad phrase chunking", "the splits are awkward",
-  "split this verse for memorisation", "the splitter prompt", or any mention of
-  `corinthians.json`, `evaluate_phrases.py`, or `split_phrases.py`. Drive a tight
-  loop: deterministic audit → LLM resplit on flagged verses → write-back to the
-  structural file.
-version: 0.2.0
+  "split this verse for memorisation", "the splitter prompt", or any mention
+  of `evaluate_phrases.py`, `split_phrases.py`, or a year-deck file like
+  `3-corinthians.json` / `4-john.json`. Drive a tight loop: deterministic
+  audit → LLM judge → LLM resplit on flagged verses → write-back to the
+  structural file. The judge and resplit steps run either via the
+  `--llm-judge` flag (programmatic Haiku) or by dispatching parallel Claude
+  Code subagents in-session.
+version: 0.3.0
 ---
 
 # Phrase Splitter
 
-The verse-vault deck stores memorisation phrases as **word counts**, not strings:
-`data/corinthians.json`'s per-verse `phraseWordCounts: [n1, n2, …]` slices the canonical NKJV
-(fetched from api.bible) into phrases. Splits should chunk each verse into 3–12 word phrases that
-fall on natural reciting pauses (clause starts, parallel items, connectives that introduce new
-thoughts). This skill is the loop for keeping that structural data high-quality.
+The verse-vault deck stores memorisation phrases as **word counts**, not strings: each year deck
+(`data/<N>-<book>.json` — e.g. `data/3-corinthians.json`, `data/4-john.json`) has a per-verse
+`phraseWordCounts: [n1, n2, …]` that slices the canonical NKJV (fetched from api.bible) into
+phrases. Splits should chunk each verse into 3–12 word phrases that fall on natural reciting pauses
+(clause starts, parallel items, connectives that introduce new thoughts). This skill is the loop for
+keeping that structural data high-quality.
 
 ## When to invoke
 
 * The user asks to evaluate or audit phrase splits.
-* The user names a specific bad verse split (e.g. "the 'But one' fragment in 12:11 is wrong").
+* The user names a specific bad verse split (e.g. "the 'But one' fragment in 1 Cor 12:11 is wrong").
 * The user wants splits regenerated, either for specific refs or for whatever the evaluator flags.
 * A new verse has no real split (single-phrase placeholder) and the user wants it chunked.
 * The user mentions the splitter prompt or the splitter pipeline.
+
+## Deck files
+
+One JSON per year. The tooling defaults to year 3 but every CLI accepts a deck path argument:
+
+| Year | File                      | Books                 |
+| ---- | ------------------------- | --------------------- |
+| 3    | `data/3-corinthians.json` | 1–2 Corinthians       |
+| 4    | `data/4-john.json`        | John                  |
+| 5    | `data/5-hp.json`          | (Hebrews-Philippians) |
+| 6    | `data/6-ot-survey.json`   | OT Survey             |
+| 7    | `data/7-rj.json`          | Romans–Jude           |
+
+(Years 1–2 use different deck shapes and are not phrase-split here.)
 
 ## Architecture
 
 The splitter operates on two stores:
 
-* **`data/corinthians.json`** — the committed structural deck file. Per-verse `phraseWordCounts` is
+* **`data/<N>-<book>.json`** — the committed structural deck file. Per-verse `phraseWordCounts` is
   the durable record of where phrase boundaries fall. Other relevant fields the audit reads:
   `annotations` (keyword markup), `ftvWordCount`, `headings`, `clubs`.
 * **api.bible cache** — `packages/api/data/verse-vault.db`, table `apibible_passages`. Holds
@@ -47,10 +65,20 @@ the api.bible token stream — same convention as `packages/api/src/lib/render.t
 
 ### 1. Audit (`tools/evaluate_phrases.py`)
 
+Pass the target deck explicitly (year 3 is the implicit default):
+
 ```bash
+# Year 3 — uses the default
 python3 tools/evaluate_phrases.py --top 20
-python3 tools/evaluate_phrases.py --refs "1 Cor 12:11"
-python3 tools/evaluate_phrases.py --out /tmp/report.json
+
+# Year 4
+python3 tools/evaluate_phrases.py data/4-john.json --top 20
+
+# Specific refs
+python3 tools/evaluate_phrases.py data/4-john.json --refs "John 1:1, John 1:14"
+
+# Write a JSON report for later filtering
+python3 tools/evaluate_phrases.py data/4-john.json --out /tmp/john-report.json
 ```
 
 Deterministic checks:
@@ -60,26 +88,59 @@ Deterministic checks:
 * Single-phrase verse with > 10 words → missing split
 * `ftvWordCount` in range
 
-Pass `--llm-judge` to add a Claude Haiku quality pass for verses that clear the deterministic checks
-but might still feel awkward (needs `anthropic` + `ANTHROPIC_API_KEY`).
+### 2. LLM-judge (catches awkward-but-valid splits)
 
-### 2. Re-split
+The deterministic pass misses splits that obey the bounds but still read badly (stranded fragments,
+lumped parallels, lopsided distribution). Two ways to run the judge — both use `JUDGE_PROMPT` in
+`tools/phrase_splitter/prompts.py`:
+
+**a. `--llm-judge` (programmatic, Anthropic SDK)**
 
 ```bash
-# Print prompts for the worst N entries in a report
-python3 tools/split_phrases.py print-prompt --from-report /tmp/report.json \
-    --top 10 --json > /tmp/prompts.json
-
-# Or target specific refs
-python3 tools/split_phrases.py print-prompt --refs "1 Cor 12:11"
+python3 tools/evaluate_phrases.py data/4-john.json --llm-judge --out /tmp/john-report.json
 ```
 
-The prompt lives in `tools/phrase_splitter/prompts.py` (shared with this skill so iterations land in
-one place). Refresh the criteria from `references/quality-criteria.md` before splitting any verse
-where the judgement call isn't obvious.
+Needs `pip install anthropic` and `ANTHROPIC_API_KEY`. Runs the judge prompt over each verse that
+cleared deterministic checks; merges verdicts into the report. Fast for one-shot CLI use outside
+Claude Code.
 
-The LLM in the loop (you, the model running this skill) answers each prompt with a single JSON array
-of phrase strings. Collect proposals into a JSON file shaped as:
+**b. Subagent fan-out (in-session, parallel)**
+
+When running this skill inside Claude Code, dispatch parallel `Agent` calls to judge instead of (or
+in addition to) `--llm-judge`. Use `superpowers:dispatching-parallel-agents` to manage the fan-out.
+Each subagent gets:
+
+* The contents of `references/quality-criteria.md`
+* The body of `JUDGE_PROMPT` from `tools/phrase_splitter/prompts.py`
+* A batch of verses (ref + canonical text + current phrase slices)
+
+…and returns a JSON array of `{"ref": …, "verdict": "ok" | "needs_resplit", "reasons": [...]}`.
+Batch ~10–20 verses per agent. Merge the verdicts with the deterministic flags to build the resplit
+worklist. This path is preferred when the skill is being driven interactively, because it keeps the
+judging in the same evaluation loop as everything else.
+
+### 3. Re-split
+
+```bash
+# From an evaluator report
+python3 tools/split_phrases.py --deck data/4-john.json print-prompt \
+    --from-report /tmp/john-report.json --top 10 --json > /tmp/prompts.json
+
+# Or target specific refs
+python3 tools/split_phrases.py --deck data/4-john.json print-prompt \
+    --refs "John 1:14, John 3:16"
+```
+
+`SPLIT_PROMPT` lives in `tools/phrase_splitter/prompts.py` (shared with this skill so iterations
+land in one place). Refresh the criteria from `references/quality-criteria.md` before splitting any
+verse where the judgement call isn't obvious.
+
+For a small worklist (≤ 10 verses), the main agent answers each prompt directly. For a large
+worklist, dispatch parallel subagents (one verse per agent, or small batches) using
+`superpowers:dispatching-parallel-agents`.
+
+Each LLM reply is a single JSON array of phrase strings. Collect proposals into a JSON file shaped
+as:
 
 ```json
 [
@@ -97,22 +158,24 @@ Apply with deterministic validation (word counts sum to canonical token count; e
 words):
 
 ```bash
-python3 tools/split_phrases.py apply --input /tmp/proposed.json --dry-run
-python3 tools/split_phrases.py apply --input /tmp/proposed.json
+python3 tools/split_phrases.py --deck data/4-john.json apply \
+    --input /tmp/proposed.json --dry-run
+python3 tools/split_phrases.py --deck data/4-john.json apply \
+    --input /tmp/proposed.json
 ```
 
 `apply` rewrites only `phraseWordCounts` for the targeted verses. `annotations.wordIndex` and
 `ftvWordCount` are positions in the canonical token stream and don't shift, so they're preserved
 untouched.
 
-### 3. Verify
+### 4. Verify
 
 ```bash
-python3 tools/evaluate_phrases.py --refs "1 Cor 12:11"
+python3 tools/evaluate_phrases.py data/4-john.json --refs "John 1:14"
 ```
 
-The deck is committed; once `corinthians.json` is happy, the change ships through git like any other
-code edit. No regeneration step is needed — `corinthians.json` IS the file.
+The deck is committed; once the year deck is happy, the change ships through git like any other code
+edit. No regeneration step is needed — the year deck IS the file.
 
 ## Single-verse path (no audit needed)
 
@@ -124,25 +187,27 @@ answering.
 ## Reference files
 
 * `references/quality-criteria.md` — what makes a split good or bad, with worked examples. Read
-  before splitting any verse you're not sure about.
+  before splitting any verse you're not sure about, and pass to subagents that are judging or
+  splitting.
 * `references/prompt-design.md` — current state of the prompt and notes on prior iterations. Read
   before editing `tools/phrase_splitter/prompts.py`.
 
 ## Sibling audit tools
 
-The same `corinthians.json` + api.bible cache pair powers two adjacent auditors — useful to combine
-with the splitter on a quality pass:
+The same year-deck + api.bible cache pair powers two adjacent auditors — useful to combine with the
+splitter on a quality pass:
 
-* `tools/find_ftvs.py` — shortest unique opening prefix per verse; audits the deck's `ftvWordCount`.
-* `tools/find_keywords.py` — audits `annotations` (`bold` keywords, 1 verse occurrence; `boldItalic`
-  context-keys, within ±5 verses) against canonical word occurrences.
-* `tools/audit_colpkg.py` — read-only diff of an Anki `.colpkg` against `corinthians.json` and
-  api.bible, flagging text typos / FTV / keyword markup / clubs drift between the Anki source and
-  the structural file.
+* `tools/find_ftvs.py --deck data/4-john.json` — shortest unique opening prefix per verse; audits
+  the deck's `ftvWordCount`.
+* `tools/find_keywords.py --deck data/4-john.json` — audits `annotations` (`bold` keywords, 1 verse
+  occurrence; `boldItalic` context-keys, within ±5 verses) against canonical word occurrences.
+* `tools/audit_colpkg.py --deck data/4-john.json` — read-only diff of an Anki `.colpkg` against the
+  year deck and api.bible, flagging text typos / FTV / keyword markup / clubs drift between the Anki
+  source and the structural file.
 
 ## Notes
 
 * The CLIs live in `/home/amberson/Code/verse-vault/tools/`. Run them from the repo root.
 * The user prefers atomic commits — one logical change per commit (see `CLAUDE.md`). When this skill
-  writes splits, commit the `corinthians.json` change separately from any prompt-design or
-  tool-script changes.
+  writes splits, commit the year-deck change separately from any prompt-design or tool-script
+  changes. When auditing multiple years in one session, one commit per year deck is the norm.

--- a/.claude/skills/phrase-splitter/evals/evals.json
+++ b/.claude/skills/phrase-splitter/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "phrase-splitter",
+  "evals": [
+    {
+      "id": 1,
+      "name": "evaluate-cache",
+      "prompt": "Audit data/corinthians-phrases.json with the phrase-splitter tools and show me the 10 worst splits. For each, name the verse and explain what's wrong in a sentence.",
+      "expected_output": "A ranked list of ~10 verses including 1 Corinthians 12:11 (stranded 'But one' fragment), 1 Corinthians 1:26 (14-word first phrase), and 1 Corinthians 11:14 (~15-word first phrase). Each entry has a severity and a human-readable reason. The skill ran tools/evaluate_phrases.py rather than eyeballing the cache.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "resplit-known-bad",
+      "prompt": "The split for 1 Corinthians 12:11 in data/corinthians-phrases.json starts with 'But one' as its own phrase, which reads as a stranded fragment. Re-split that verse and write the fix back to the cache.",
+      "expected_output": "A re-split where no phrase is shorter than 3 words mid-verse, all phrases rejoin to the original text (including <b>distributing</b> markup), and split_phrases.py apply succeeds (not just print-prompt). The cache file is updated. Ideally: ['But one and the same Spirit works all these things,', '<b>distributing</b> to each one individually as He wills.'].",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "split-from-scratch",
+      "prompt": "Split this verse into memorisation phrases (3-12 words each, breaks on natural pauses): 'For God so loved the world that He gave His only begotten Son, that whoever believes in Him should not perish but have everlasting life.'",
+      "expected_output": "A JSON array of phrases where joining with spaces equals the input verbatim, every phrase has 3-12 words, breaks fall at clause boundaries (likely after 'world,' 'Son,' and around 'should not perish but have everlasting life.'). The skill consulted quality-criteria before answering — no need to invoke CLI tools for this single-verse case.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/phrase-splitter/references/judge-agent-instructions.md
+++ b/.claude/skills/phrase-splitter/references/judge-agent-instructions.md
@@ -24,17 +24,9 @@ Be **conservative** — only flag `needs_resplit` when there's a clear quality i
 Borderline cases default to `ok`. Memorisation aids carry stylistic variation; you're flagging real
 awkwardness, not personal preference.
 
-Common real issues:
-
-* **Awkward breakpoints** — a tight idiom or prepositional phrase severed.
-* **Missed parallel structure** — parallel items lumped instead of becoming siblings.
-* **Lopsided distribution** — one phrase carrying most of the verse while others are stubs.
-* **Verb separated from its content clause** — `that`/`how`/`whether` after `know`, `say`,
-  `believe`, etc. severed from the verb. `"Do you not know"` / `"that we shall judge angels?"` is
-  the canonical bad break — the rhetorical question is one unit.
-* **Mid-question breaks** — a rhetorical question stem split from its content; split _after_ the
-  question mark.
-* **Anything jarring when reciting the verse aloud.**
+The full set of soft rules (parallel structure, content clauses, lop-side, rhetorical question
+integrity, etc.) lives in [`quality-criteria.md`](./quality-criteria.md) — read it before judging.
+Anything jarring when reciting aloud is a candidate.
 
 ## Workflow
 

--- a/.claude/skills/phrase-splitter/references/judge-agent-instructions.md
+++ b/.claude/skills/phrase-splitter/references/judge-agent-instructions.md
@@ -1,0 +1,64 @@
+# Judge Subagent Instructions
+
+You are auditing existing memorisation phrase splits for quality. This file is the entry point when
+a subagent is dispatched for the LLM-judge step of the phrase-splitter workflow.
+
+## Inputs you will be given
+
+* A **batch file path** — JSON array of `{ref, text, phrases}` entries. The split has already passed
+  deterministic checks (rejoin invariant, no word-count blocker); your job is to catch lingering
+  quality issues that need a human eye.
+* An **output file path** — write your `{ref, verdict, reasons}` verdicts here.
+
+## Required reading (do this once at start)
+
+* [`quality-criteria.md`](./quality-criteria.md) — the full quality rubric (guiding principle, hard
+  rules, soft rules, edge cases, worked examples).
+
+The active `JUDGE_PROMPT` lives in `tools/phrase_splitter/prompts.py`. Its rules are summarised
+below — if you want the canonical wording, read that file.
+
+## What to flag
+
+Be **conservative** — only flag `needs_resplit` when there's a clear quality issue per the criteria.
+Borderline cases default to `ok`. Memorisation aids carry stylistic variation; you're flagging real
+awkwardness, not personal preference.
+
+Common real issues:
+
+* **Awkward breakpoints** — a tight idiom or prepositional phrase severed.
+* **Missed parallel structure** — parallel items lumped instead of becoming siblings.
+* **Lopsided distribution** — one phrase carrying most of the verse while others are stubs.
+* **Verb separated from its content clause** — `that`/`how`/`whether` after `know`, `say`,
+  `believe`, etc. severed from the verb. `"Do you not know"` / `"that we shall judge angels?"` is
+  the canonical bad break — the rhetorical question is one unit.
+* **Mid-question breaks** — a rhetorical question stem split from its content; split _after_ the
+  question mark.
+* **Anything jarring when reciting the verse aloud.**
+
+## Workflow
+
+1. Read the **batch file** at the path given.
+2. For each entry, evaluate the split per the criteria. Decide `"ok"` or `"needs_resplit"`.
+3. Collect verdicts as a JSON array. Every input ref must appear in the output.
+4. Write the array to the **output path**.
+5. Reply with one short summary line (e.g. `Batch 04: 18 judged, 1 needs_resplit`).
+
+## Output shape
+
+```json
+[
+  {"ref": "1 Corinthians 1:3", "verdict": "ok", "reasons": []},
+  {
+    "ref": "1 Corinthians 6:3",
+    "verdict": "needs_resplit",
+    "reasons": ["stranded 'How much more,' fragment between two longer phrases"]
+  }
+]
+```
+
+`reasons` may be empty when verdict is `ok`. When `needs_resplit`, include one sentence per issue.
+
+## Scope
+
+Read-only on the codebase and the deck. Write only the output JSON. Do not modify any splits.

--- a/.claude/skills/phrase-splitter/references/prompt-design.md
+++ b/.claude/skills/phrase-splitter/references/prompt-design.md
@@ -1,0 +1,70 @@
+# Prompt design notes
+
+The active split prompt lives in `/home/amberson/Code/verse-vault/tools/phrase_splitter/prompts.py`
+as `SPLIT_PROMPT` (the main work) and `JUDGE_PROMPT` (the optional LLM auditor). Keep iterating in
+that file so the skill and the CLI stay in sync. This document captures _why_ the prompt is shaped
+the way it is, so future edits move it forward rather than recreating past mistakes.
+
+## Core moves in the current draft
+
+1. **Goal-first framing.** Open with "you're splitting a verse for memorisation; chunks should feel
+   like natural pauses." This sets the judgement frame before any rule list. Goal framing
+   outperforms rule enumeration for fluent text tasks.
+2. **Soft rules with cues, not absolutes.** The prompt lists clause/ parallel/connector cues but
+   reminds the model that connectors only count when they start a new thought, not when they're
+   glued to a list. This avoids the previous "break before every `and`" failure mode.
+3. **Negative examples integrated.** `"But one"` is called out by name as a stranded-fragment
+   failure. This anchors the model on the biggest practical class of errors.
+4. **HTML preservation as a contract.** Tagged spans are treated as indivisible units; the prompt
+   frames the rejoin invariant explicitly.
+5. **Few-shot examples cover the main shapes.**
+   * The intro-connector case (1 Cor 1:1) — break after the head clause.
+   * The whole-verse case (1 Cor 4:20) — short enough to stay one phrase.
+   * The parallel-structure case (1 Cor 1:26) — siblings, not lumps.
+   * The "stranded fragment fixed" case (1 Cor 12:11) — the corrected form, so the model has a
+     positive target.
+   * The clause-with-relative-pronoun case (1 Cor 5:5) — internal break on `that` to keep each half
+     under the soft ceiling.
+6. **JSON-only reply on one line.** Reduces post-processing failure; the apply step parses the
+   response directly.
+
+## What's not in the current prompt (deliberately)
+
+* **No hard "max 8 words per phrase".** That was the old rule and it forced mechanical breaks on
+  short verses. The soft 3–12 ceiling lets the model honour idioms.
+* **No batch mode.** Per-verse calls give the model full attention. The previous batch-of-50
+  approach was the main source of mangled outputs (lost punctuation, dropped tags).
+* **No instruction to "fix typos".** The previous prompt accidentally invited corrections, which
+  broke the rejoin invariant. Now the preservation contract is explicit.
+
+## Known weak spots to watch for in iteration
+
+* **Single-word opener policy.** The current examples include splits with `"Therefore,"` joined to
+  the next clause (combining intro + rest into one phrase). The deck cache often has them as
+  separate phrases (`"Therefore," / "my beloved," / ...`) which can read as bad fragments. The
+  prompt currently leans toward merging; the evaluator treats both as acceptable. If users push
+  back, tighten the prompt by adding a "prefer to merge short intro fragments" rule with an example.
+* **Long lists.** Verses with extended enumerations (1 Cor 13:4-7 love list) need each item as a
+  phrase. The parallel-structure example covers a 3-element case; if the model lumps longer lists,
+  add a 5+ element example.
+* **Quoted speech.** Verses containing `"He said: \"..."` round-trip fine through JSON escaping but
+  the prompt doesn't explicitly say "preserve quotation marks". So far no failures observed; add an
+  example if a future iteration introduces them.
+
+## How to iterate
+
+1. Run the evaluator → pick 5–10 verses where the prompt produces an awkward split.
+2. Edit `tools/phrase_splitter/prompts.py`. Prefer adding/swapping a few-shot example over adding a
+   new rule.
+3. Re-run those verses through the prompt (manually, or via the skill-creator eval loop in
+   `phrase-splitter-workspace/`).
+4. If the regression catches the targeted failure without breaking verses that were passing, commit
+   the prompt change with a message describing the failure class. Otherwise back it out.
+
+## Prior iterations (running log)
+
+* **v0** (this draft) — first cohesive prompt with 5 examples, goal-first framing, and the rejoin
+  invariant as a contract. Replaces the legacy bullet-list rules from the old `prepare_batches.py`
+  prompt. Known wins: gets 1 Cor 12:11, 1 Cor 1:26, 1 Cor 11:14 right when called per-verse. Known
+  unknowns: behaviour on long lists, on quoted speech, on multi-clause verses with three or more
+  natural breaks.

--- a/.claude/skills/phrase-splitter/references/quality-criteria.md
+++ b/.claude/skills/phrase-splitter/references/quality-criteria.md
@@ -3,6 +3,13 @@
 A phrase is a unit a reciter holds in working memory while saying the verse from memory. The split
 should feel like natural pauses — where a careful reader would breathe.
 
+## Guiding principle
+
+**Keep splits small, but completeness of thought matters more than size.** Every phrase should be a
+self-contained unit of meaning. A 9-word phrase that finishes a thought is better than 4 + 5 that
+severs it. When in doubt between a shorter awkward split and a longer natural one, choose the
+natural one. All the rules below are in service of this principle, not above it.
+
 ## Hard rules (deterministic checks enforce these)
 
 * **Rejoin invariant.** `" ".join(phrases) == text` — exact match including HTML tags, punctuation,
@@ -27,6 +34,16 @@ should feel like natural pauses — where a careful reader would breathe.
   * after a comma, semicolon, or colon
   * before a connector that starts a new thought: `and`, `but`, `for`, `that`, `who`, `which`, `or`
     — only when it really begins a new clause, not when it just glues list items
+* **Never split a verb from its content clause.** `that` (and `what`, `how`, `whether`, `if`) after
+  a verb of perception or speech — `know`, `see`, `tell`, `say`, `believe`, `think`, `hear`,
+  `understand`, `remember`, `perceive` — is introducing the _object_ of the verb, not a new clause
+  for recitation. `"Do you not know"` / `"that we shall judge angels?"` is a bad break; the
+  rhetorical question is one unit. Same for `"I declare to you"` /
+  `"that flesh and blood cannot inherit..."`. The auditor flags this pattern automatically
+  (`verb-clause-split`).
+* **Keep rhetorical questions whole.** A question stem (`"Do you not know that..."`,
+  `"Are you not aware that..."`) belongs with its content. Split _after_ the question mark, not
+  inside it.
 * **Don't lop-side.** A verse split into one 15-word phrase and one 3-word phrase is worse than two
   9-word phrases. Aim for relatively even chunks while still respecting clause boundaries.
 * **Single-phrase verses.** Anything over ~10 words should split somewhere. Anything under ~8 can

--- a/.claude/skills/phrase-splitter/references/quality-criteria.md
+++ b/.claude/skills/phrase-splitter/references/quality-criteria.md
@@ -7,9 +7,12 @@ should feel like natural pauses — where a careful reader would breathe.
 
 * **Rejoin invariant.** `" ".join(phrases) == text` — exact match including HTML tags, punctuation,
   and quotation marks. If a split doesn't round-trip, it's wrong.
-* **Phrase length 1–12 words.** 12 words is the soft ceiling — past that the phrase is too long to
-  chunk. The validator allows 1+ to admit short trailing closures like `"and Him crucified."`, but
-  the **target** is 3–10.
+* **Phrase length: target 3–10 words.** 12 is the soft warning ceiling that the auditor surfaces for
+  review. There is no validator cap: a phrase can exceed 12 when a clause is genuinely continuous
+  and has no natural internal breakpoint (e.g.
+  `"that his spirit may be saved in the day of the Lord Jesus."`). The lower bound allows 1+ to
+  admit short trailing closures like `"and Him crucified."`. Prefer naturalness over hitting the
+  target.
 * **HTML tag balance.** Every `<b>`, `<i>`, `<span ...>` open must close inside the same phrase.
   Never split inside a tag.
 

--- a/.claude/skills/phrase-splitter/references/quality-criteria.md
+++ b/.claude/skills/phrase-splitter/references/quality-criteria.md
@@ -1,0 +1,98 @@
+# Phrase-split quality criteria
+
+A phrase is a unit a reciter holds in working memory while saying the verse from memory. The split
+should feel like natural pauses — where a careful reader would breathe.
+
+## Hard rules (deterministic checks enforce these)
+
+* **Rejoin invariant.** `" ".join(phrases) == text` — exact match including HTML tags, punctuation,
+  and quotation marks. If a split doesn't round-trip, it's wrong.
+* **Phrase length 1–12 words.** 12 words is the soft ceiling — past that the phrase is too long to
+  chunk. The validator allows 1+ to admit short trailing closures like `"and Him crucified."`, but
+  the **target** is 3–10.
+* **HTML tag balance.** Every `<b>`, `<i>`, `<span ...>` open must close inside the same phrase.
+  Never split inside a tag.
+
+## Soft rules (where most quality problems hide)
+
+* **No stranded short fragments mid-verse.** `"But one"` followed by the rest of the verse is the
+  classic bad break. If a 1–2 word phrase sits between two longer ones, it almost always belongs
+  glued to the next.
+* **Honour parallel structure.** `"not many wise / not many mighty / not many noble"` should be
+  three sibling phrases, not lumped into one or arbitrarily merged.
+* **Break at clause boundaries.** Strong cues:
+  * after a comma, semicolon, or colon
+  * before a connector that starts a new thought: `and`, `but`, `for`, `that`, `who`, `which`, `or`
+    — only when it really begins a new clause, not when it just glues list items
+* **Don't lop-side.** A verse split into one 15-word phrase and one 3-word phrase is worse than two
+  9-word phrases. Aim for relatively even chunks while still respecting clause boundaries.
+* **Single-phrase verses.** Anything over ~10 words should split somewhere. Anything under ~8 can
+  stay whole.
+
+## Edge cases that are usually fine
+
+* A single-word opener like `"Moreover,"` or `"Therefore,"` at position 0. Stylistic, often
+  deliberate in memorisation aids. Flagged `medium` by the evaluator, not `high`.
+* A short final phrase like `"are called."` or `"and Him crucified."` that carries closing
+  punctuation. Same treatment — `medium`, not blocking.
+* A pair of short intro phrases like `"Therefore," / "my beloved,"`. Often the natural break is to
+  merge them into one `"Therefore, my beloved,"` phrase, but both forms are defensible — the
+  evaluator will surface this as `high` (middle 2-word phrase) for human review.
+
+## Worked examples
+
+### Long clause that needs a break
+
+Bad:
+
+```
+["For you see your calling, brethren, that not many wise according to the flesh,",
+ "not many mighty, not many <b>noble</b>,",
+ "are called."]
+```
+
+Phrase 1 is 14 words. Split it on the comma after `brethren,`:
+
+```
+["For you see your calling, brethren,",
+ "that not many wise according to the flesh,",
+ "not many mighty, not many <b>noble</b>,",
+ "are called."]
+```
+
+### Stranded fragment
+
+Bad (1 Cor 12:11):
+
+```
+["But one",
+ "and the same Spirit works all these things,",
+ "<b>distributing</b> to each one individually as He wills."]
+```
+
+`"But one"` belongs glued to the same-Spirit clause; the natural break is after the comma:
+
+```
+["But one and the same Spirit works all these things,",
+ "<b>distributing</b> to each one individually as He wills."]
+```
+
+### Parallel structure
+
+Verse:
+
+```
+For you see your calling, brethren, that not many wise according to the flesh, not many mighty, not many <b>noble</b>, are called.
+```
+
+Good split: each parallel `"not many …"` item gets its own phrase rather than being lumped together.
+
+### Whole-verse short verse
+
+`"For the kingdom of God is not in word but in power."` — 10 words and one self-contained idea. One
+phrase is correct; forcing a break would weaken the unit.
+
+### HTML markup
+
+`"<b><i>asking</i></b>"` is one word, one indivisible unit. A split that strips or rewrites the
+markup fails the rejoin invariant and the HTML- balance check. Always preserve markup byte-for-byte.

--- a/.claude/skills/phrase-splitter/references/splitter-agent-instructions.md
+++ b/.claude/skills/phrase-splitter/references/splitter-agent-instructions.md
@@ -47,16 +47,16 @@ need to read `prompts.py` separately. If anything in the embedded prompt conflic
 
 Every input ref must appear in the output. No commentary in the file — just the JSON array.
 
-## Common pitfalls
+## Subagent-specific pitfalls
 
-* **Don't paraphrase.** Use the exact tokens from the embedded prompt (canonical api.bible NKJV).
-* **Don't drop punctuation or smart quotes.** Curly `“ ” ‘ ’` and straight quotes are distinct
-  bytes; copy them verbatim.
-* **Don't split inside HTML tags.** `<b>asking</b>` is one indivisible unit.
-* **Don't sever a verb from its content clause.** `"Do you not know"` /
-  `"that we shall judge angels?"` is a _bad_ break — keep the rhetorical question whole.
-* **Don't worry about a hard word-count cap.** Target 3–10 per phrase but the validator has no upper
-  cap; a 14- or 18-word continuous clause is fine when there's no natural internal break.
+The splitting rules live in the embedded `SPLIT_PROMPT` and
+[`quality-criteria.md`](./quality-criteria.md). The points below are the operational gotchas that
+trip up a subagent reading a JSON batch:
+
+* **Don't paraphrase.** Use the exact tokens from the embedded prompt — they are canonical api.bible
+  NKJV.
+* **Smart quotes are distinct bytes.** Curly `“ ” ‘ ’` and straight quotes don't compare equal; copy
+  them verbatim or the rejoin invariant fails.
 
 ## Scope
 

--- a/.claude/skills/phrase-splitter/references/splitter-agent-instructions.md
+++ b/.claude/skills/phrase-splitter/references/splitter-agent-instructions.md
@@ -1,0 +1,64 @@
+# Splitter Subagent Instructions
+
+You are generating memorisation phrase splits for Bible verses. This file is the entry point when a
+subagent is dispatched for the re-split step of the phrase-splitter workflow.
+
+## Inputs you will be given
+
+* A **batch file path** — JSON array of `{ref, prompt}` entries. Each `prompt` already contains the
+  full `SPLIT_PROMPT` (from `tools/phrase_splitter/prompts.py`) with the verse text inlined.
+* An **output file path** — write your `{ref, phrases}` results here.
+
+## Required reading (do this once at start)
+
+* [`quality-criteria.md`](./quality-criteria.md) — what makes a split good or bad, with worked
+  examples and the guiding principle (completeness of thought > size).
+
+The embedded `prompt` field in each batch entry contains the active `SPLIT_PROMPT`, so you don't
+need to read `prompts.py` separately. If anything in the embedded prompt conflicts with
+`quality-criteria.md`, the prompt wins (it's the version actually shipped to production).
+
+## Workflow
+
+1. Read the **batch file** at the path given.
+2. For each entry, follow the embedded `prompt` to produce a JSON array of phrase strings.
+3. Before adding to the output, **mentally verify the rejoin**: `" ".join(phrases)` must exactly
+   equal the verse text from the prompt (single spaces, all punctuation, smart quotes, HTML tags
+   preserved byte-for-byte). If it doesn't match, fix the split.
+4. Collect results as a JSON array of `{ref, phrases}` objects.
+5. Write the array to the **output path**.
+6. Reply with one short summary line (e.g.
+   `Batch 07: 15 verses, longest 18w (rhetorical question)`).
+
+## Output shape
+
+```json
+[
+  {
+    "ref": "John 1:1",
+    "phrases": [
+      "In the beginning was the Word,",
+      "and the Word was with God,",
+      "and the Word was God."
+    ]
+  }
+]
+```
+
+Every input ref must appear in the output. No commentary in the file — just the JSON array.
+
+## Common pitfalls
+
+* **Don't paraphrase.** Use the exact tokens from the embedded prompt (canonical api.bible NKJV).
+* **Don't drop punctuation or smart quotes.** Curly `“ ” ‘ ’` and straight quotes are distinct
+  bytes; copy them verbatim.
+* **Don't split inside HTML tags.** `<b>asking</b>` is one indivisible unit.
+* **Don't sever a verb from its content clause.** `"Do you not know"` /
+  `"that we shall judge angels?"` is a _bad_ break — keep the rhetorical question whole.
+* **Don't worry about a hard word-count cap.** Target 3–10 per phrase but the validator has no upper
+  cap; a 14- or 18-word continuous clause is fine when there's no natural internal break.
+
+## Scope
+
+Read-only on the codebase. Write only the output JSON. Do not modify the deck, the skill, or any
+other file.

--- a/.gitignore
+++ b/.gitignore
@@ -132,7 +132,8 @@ __pycache__/
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-/.claude/
+/.claude/*
+!/.claude/skills/
 /target
 
 # Python bytecode caches (tools/)

--- a/data/3-corinthians.json
+++ b/data/3-corinthians.json
@@ -445,8 +445,7 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        4,
-        8
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2317,8 +2316,7 @@
       "chapter": 6,
       "verse": 3,
       "phraseWordCounts": [
-        4,
-        5,
+        9,
         9
       ],
       "annotations": [
@@ -2589,8 +2587,7 @@
       "chapter": 6,
       "verse": 15,
       "phraseWordCounts": [
-        4,
-        7,
+        11,
         8,
         7,
         2
@@ -2609,8 +2606,7 @@
       "chapter": 6,
       "verse": 16,
       "phraseWordCounts": [
-        5,
-        13,
+        18,
         5,
         4
       ],
@@ -2660,8 +2656,7 @@
       "chapter": 6,
       "verse": 19,
       "phraseWordCounts": [
-        5,
-        10,
+        15,
         4,
         5,
         6
@@ -5219,8 +5214,7 @@
       "chapter": 11,
       "verse": 3,
       "phraseWordCounts": [
-        6,
-        8,
+        14,
         6,
         7
       ],
@@ -7749,10 +7743,8 @@
       "chapter": 15,
       "verse": 12,
       "phraseWordCounts": [
-        5,
-        8,
-        6,
-        8
+        13,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -13799,8 +13791,7 @@
       "chapter": 11,
       "verse": 21,
       "phraseWordCounts": [
-        5,
-        7,
+        12,
         6,
         3,
         4
@@ -14779,8 +14770,7 @@
       "chapter": 13,
       "verse": 6,
       "phraseWordCounts": [
-        7,
-        5
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,

--- a/data/3-corinthians.json
+++ b/data/3-corinthians.json
@@ -186,7 +186,8 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        14,
+        9,
+        5,
         4
       ],
       "annotations": [
@@ -206,8 +207,10 @@
       "verse": 2,
       "phraseWordCounts": [
         9,
-        12,
-        15,
+        8,
+        4,
+        6,
+        9,
         4
       ],
       "annotations": [
@@ -252,8 +255,8 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        11,
-        3
+        8,
+        6
       ],
       "annotations": [
         {
@@ -287,7 +290,9 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        18
+        8,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -304,7 +309,8 @@
       "verse": 8,
       "phraseWordCounts": [
         8,
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -326,7 +332,9 @@
       "chapter": 1,
       "verse": 9,
       "phraseWordCounts": [
-        18
+        3,
+        11,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -337,11 +345,12 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        14,
+        6,
+        8,
         7,
         8,
-        11,
-        5
+        7,
+        9
       ],
       "annotations": [
         {
@@ -382,7 +391,10 @@
       "verse": 12,
       "phraseWordCounts": [
         9,
-        19
+        4,
+        5,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -411,8 +423,9 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        11,
-        2
+        3,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -432,7 +445,8 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -484,9 +498,10 @@
       "chapter": 1,
       "verse": 18,
       "phraseWordCounts": [
-        10,
-        3,
-        13
+        8,
+        5,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -551,7 +566,8 @@
       "chapter": 1,
       "verse": 21,
       "phraseWordCounts": [
-        15,
+        7,
+        8,
         10,
         5
       ],
@@ -588,7 +604,8 @@
       "chapter": 1,
       "verse": 23,
       "phraseWordCounts": [
-        11,
+        5,
+        6,
         5
       ],
       "annotations": [],
@@ -602,7 +619,9 @@
       "chapter": 1,
       "verse": 24,
       "phraseWordCounts": [
-        16,
+        6,
+        4,
+        5,
         5
       ],
       "annotations": [],
@@ -633,8 +652,10 @@
       "chapter": 1,
       "verse": 26,
       "phraseWordCounts": [
-        14,
         6,
+        8,
+        3,
+        3,
         2
       ],
       "annotations": [
@@ -651,9 +672,10 @@
       "chapter": 1,
       "verse": 27,
       "phraseWordCounts": [
-        16,
-        16,
-        3
+        10,
+        6,
+        10,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -701,9 +723,8 @@
       "verse": 30,
       "phraseWordCounts": [
         8,
-        8,
-        4,
-        3
+        7,
+        6
       ],
       "annotations": [
         {
@@ -735,8 +756,9 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        15,
-        10
+        8,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -776,9 +798,9 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        14,
         6,
-        3
+        8,
+        9
       ],
       "annotations": [
         {
@@ -800,7 +822,7 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        10,
+        11,
         6
       ],
       "annotations": [],
@@ -834,7 +856,8 @@
       "verse": 7,
       "phraseWordCounts": [
         10,
-        11
+        6,
+        6
       ],
       "annotations": [
         {
@@ -853,7 +876,8 @@
       "verse": 8,
       "phraseWordCounts": [
         9,
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -871,8 +895,9 @@
       "phraseWordCounts": [
         5,
         7,
-        16,
-        3
+        8,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -909,9 +934,10 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        15,
-        4,
-        14
+        9,
+        10,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -924,9 +950,11 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        10,
+        4,
+        6,
         7,
-        15
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -964,9 +992,11 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        14,
+        7,
+        7,
         6,
-        10
+        5,
+        5
       ],
       "annotations": [
         {
@@ -1470,7 +1500,7 @@
       "phraseWordCounts": [
         6,
         7,
-        8,
+        7,
         3
       ],
       "annotations": [],
@@ -1601,10 +1631,13 @@
       "chapter": 4,
       "verse": 6,
       "phraseWordCounts": [
-        12,
+        4,
+        8,
         3,
-        13,
-        15
+        6,
+        7,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -1645,7 +1678,7 @@
       "phraseWordCounts": [
         4,
         4,
-        8,
+        7,
         8,
         7
       ],
@@ -1719,8 +1752,10 @@
       "chapter": 4,
       "verse": 11,
       "phraseWordCounts": [
-        9,
-        7,
+        4,
+        5,
+        5,
+        2,
         2
       ],
       "annotations": [
@@ -1884,7 +1919,8 @@
       "phraseWordCounts": [
         7,
         4,
-        13,
+        4,
+        9,
         3
       ],
       "annotations": [
@@ -1933,7 +1969,7 @@
       "verse": 1,
       "phraseWordCounts": [
         11,
-        13,
+        12,
         7
       ],
       "annotations": [
@@ -1960,7 +1996,8 @@
       "phraseWordCounts": [
         5,
         5,
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -1976,8 +2013,10 @@
       "chapter": 5,
       "verse": 3,
       "phraseWordCounts": [
-        11,
-        15
+        3,
+        8,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2121,7 +2160,8 @@
       "chapter": 5,
       "verse": 9,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -2143,10 +2183,9 @@
       "chapter": 5,
       "verse": 10,
       "phraseWordCounts": [
-        14,
-        4,
-        2,
-        2,
+        6,
+        8,
+        8,
         11
       ],
       "annotations": [
@@ -2169,13 +2208,12 @@
       "chapter": 5,
       "verse": 11,
       "phraseWordCounts": [
-        16,
-        4,
-        2,
-        3,
-        3,
-        3,
-        12
+        7,
+        9,
+        6,
+        6,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -2213,7 +2251,8 @@
       "chapter": 5,
       "verse": 12,
       "phraseWordCounts": [
-        13,
+        8,
+        5,
         8
       ],
       "annotations": [
@@ -2278,9 +2317,9 @@
       "chapter": 6,
       "verse": 3,
       "phraseWordCounts": [
-        9,
-        3,
-        6
+        4,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -2296,8 +2335,10 @@
       "chapter": 6,
       "verse": 4,
       "phraseWordCounts": [
-        11,
-        13
+        5,
+        6,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -2352,8 +2393,8 @@
       "chapter": 6,
       "verse": 7,
       "phraseWordCounts": [
-        2,
-        16,
+        10,
+        8,
         7,
         9
       ],
@@ -2377,9 +2418,7 @@
       "chapter": 6,
       "verse": 8,
       "phraseWordCounts": [
-        1,
-        4,
-        2,
+        7,
         8
       ],
       "annotations": [
@@ -2398,7 +2437,8 @@
       "chapter": 6,
       "verse": 9,
       "phraseWordCounts": [
-        14,
+        7,
+        7,
         4,
         2,
         2,
@@ -2538,7 +2578,7 @@
       "verse": 14,
       "phraseWordCounts": [
         7,
-        8
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2549,7 +2589,8 @@
       "chapter": 6,
       "verse": 15,
       "phraseWordCounts": [
-        11,
+        4,
+        7,
         8,
         7,
         2
@@ -2568,7 +2609,8 @@
       "chapter": 6,
       "verse": 16,
       "phraseWordCounts": [
-        18,
+        5,
+        13,
         5,
         4
       ],
@@ -2586,7 +2628,8 @@
       "chapter": 6,
       "verse": 17,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2617,7 +2660,9 @@
       "chapter": 6,
       "verse": 19,
       "phraseWordCounts": [
-        19,
+        5,
+        10,
+        4,
         5,
         6
       ],
@@ -2660,8 +2705,7 @@
       "chapter": 7,
       "verse": 2,
       "phraseWordCounts": [
-        1,
-        4,
+        5,
         7,
         8
       ],
@@ -2709,10 +2753,12 @@
       "chapter": 7,
       "verse": 5,
       "phraseWordCounts": [
-        11,
+        5,
+        6,
+        9,
+        4,
         7,
-        2,
-        17
+        6
       ],
       "annotations": [
         {
@@ -2773,9 +2819,9 @@
       "chapter": 7,
       "verse": 8,
       "phraseWordCounts": [
-        6,
-        4,
-        12
+        10,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -2822,8 +2868,7 @@
       "verse": 10,
       "phraseWordCounts": [
         6,
-        3,
-        3,
+        6,
         9
       ],
       "annotations": [
@@ -2859,9 +2904,7 @@
       "chapter": 7,
       "verse": 12,
       "phraseWordCounts": [
-        5,
-        3,
-        1,
+        9,
         10,
         8,
         5
@@ -2927,8 +2970,7 @@
       "phraseWordCounts": [
         5,
         3,
-        2,
-        10,
+        12,
         7
       ],
       "annotations": [
@@ -2953,11 +2995,10 @@
       "chapter": 7,
       "verse": 16,
       "phraseWordCounts": [
-        5,
-        2,
+        7,
         6,
-        5,
-        8
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3050,7 +3091,8 @@
       "chapter": 7,
       "verse": 20,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3080,8 +3122,10 @@
       "chapter": 7,
       "verse": 22,
       "phraseWordCounts": [
-        15,
-        10
+        11,
+        4,
+        7,
+        3
       ],
       "annotations": [
         {
@@ -3121,8 +3165,8 @@
       "chapter": 7,
       "verse": 24,
       "phraseWordCounts": [
-        1,
-        14
+        7,
+        8
       ],
       "annotations": [
         {
@@ -3142,7 +3186,8 @@
       "phraseWordCounts": [
         3,
         7,
-        15
+        6,
+        9
       ],
       "annotations": [
         {
@@ -3162,7 +3207,9 @@
       "chapter": 7,
       "verse": 26,
       "phraseWordCounts": [
-        25
+        7,
+        5,
+        12
       ],
       "annotations": [
         {
@@ -3228,7 +3275,8 @@
       "phraseWordCounts": [
         5,
         4,
-        17
+        10,
+        7
       ],
       "annotations": [
         {
@@ -3297,7 +3345,6 @@
       "phraseWordCounts": [
         8,
         11,
-        1,
         6
       ],
       "annotations": [
@@ -3315,7 +3362,6 @@
       "verse": 33,
       "phraseWordCounts": [
         12,
-        1,
         6
       ],
       "annotations": [
@@ -3336,7 +3382,6 @@
         10,
         11,
         12,
-        1,
         6
       ],
       "annotations": [
@@ -3424,7 +3469,8 @@
         8,
         3,
         7,
-        13,
+        7,
+        6,
         2
       ],
       "annotations": [],
@@ -3459,7 +3505,9 @@
       "phraseWordCounts": [
         12,
         5,
-        15
+        7,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -3479,7 +3527,6 @@
       "phraseWordCounts": [
         10,
         4,
-        1,
         10
       ],
       "annotations": [
@@ -3561,7 +3608,8 @@
       "verse": 5,
       "phraseWordCounts": [
         7,
-        15
+        6,
+        8
       ],
       "annotations": [
         {
@@ -3591,8 +3639,7 @@
       "chapter": 8,
       "verse": 6,
       "phraseWordCounts": [
-        7,
-        2,
+        9,
         5,
         4,
         5,
@@ -3610,14 +3657,10 @@
       "chapter": 8,
       "verse": 7,
       "phraseWordCounts": [
-        1,
+        8,
         7,
-        2,
-        5,
         11,
-        3,
-        2,
-        2
+        7
       ],
       "annotations": [
         {
@@ -3650,7 +3693,8 @@
       "chapter": 8,
       "verse": 9,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [
         {
@@ -3668,8 +3712,10 @@
       "chapter": 8,
       "verse": 10,
       "phraseWordCounts": [
-        13,
-        18
+        8,
+        5,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -3726,8 +3772,7 @@
       "chapter": 8,
       "verse": 13,
       "phraseWordCounts": [
-        1,
-        6,
+        7,
         6,
         6
       ],
@@ -3832,7 +3877,8 @@
       "chapter": 9,
       "verse": 6,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -3850,7 +3896,8 @@
       "phraseWordCounts": [
         9,
         11,
-        15
+        5,
+        10
       ],
       "annotations": [
         {
@@ -3933,9 +3980,8 @@
       "verse": 10,
       "phraseWordCounts": [
         9,
-        3,
-        2,
-        11,
+        8,
+        8,
         12
       ],
       "annotations": [
@@ -4008,8 +4054,10 @@
       "chapter": 9,
       "verse": 13,
       "phraseWordCounts": [
-        18,
-        14
+        11,
+        7,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -4025,7 +4073,9 @@
       "chapter": 9,
       "verse": 14,
       "phraseWordCounts": [
-        17
+        6,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4039,8 +4089,10 @@
       "verse": 15,
       "phraseWordCounts": [
         8,
-        14,
-        17
+        6,
+        8,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -4063,8 +4115,7 @@
         6,
         6,
         6,
-        1,
-        10
+        11
       ],
       "annotations": [
         {
@@ -4152,7 +4203,7 @@
       "chapter": 9,
       "verse": 20,
       "phraseWordCounts": [
-        8,
+        9,
         5,
         7,
         4,
@@ -4182,8 +4233,9 @@
       "chapter": 9,
       "verse": 21,
       "phraseWordCounts": [
+        9,
         6,
-        14,
+        5,
         9
       ],
       "annotations": [
@@ -4244,8 +4296,8 @@
       "chapter": 9,
       "verse": 24,
       "phraseWordCounts": [
-        13,
-        5,
+        11,
+        7,
         10
       ],
       "annotations": [
@@ -4370,8 +4422,7 @@
       "verse": 27,
       "phraseWordCounts": [
         10,
-        1,
-        6,
+        7,
         5
       ],
       "annotations": [
@@ -4394,9 +4445,8 @@
       "chapter": 10,
       "verse": 1,
       "phraseWordCounts": [
-        1,
-        1,
-        16,
+        10,
+        8,
         5
       ],
       "annotations": [
@@ -4502,7 +4552,8 @@
       "verse": 6,
       "phraseWordCounts": [
         6,
-        15
+        11,
+        4
       ],
       "annotations": [
         {
@@ -4605,8 +4656,7 @@
       "chapter": 10,
       "verse": 10,
       "phraseWordCounts": [
-        2,
-        6,
+        8,
         6
       ],
       "annotations": [
@@ -4681,9 +4731,11 @@
       "chapter": 10,
       "verse": 13,
       "phraseWordCounts": [
-        12,
+        5,
+        7,
         4,
-        13,
+        8,
+        5,
         11,
         8
       ],
@@ -4727,9 +4779,7 @@
       "chapter": 10,
       "verse": 14,
       "phraseWordCounts": [
-        1,
-        2,
-        3
+        6
       ],
       "annotations": [
         {
@@ -4782,9 +4832,7 @@
       "chapter": 10,
       "verse": 17,
       "phraseWordCounts": [
-        2,
-        2,
-        6,
+        10,
         8
       ],
       "annotations": [],
@@ -4826,9 +4874,8 @@
       "chapter": 10,
       "verse": 20,
       "phraseWordCounts": [
-        1,
-        11,
-        4,
+        8,
+        8,
         11
       ],
       "annotations": [
@@ -5036,7 +5083,8 @@
       "phraseWordCounts": [
         6,
         5,
-        13,
+        4,
+        9,
         4,
         6,
         4
@@ -5059,10 +5107,8 @@
       "chapter": 10,
       "verse": 29,
       "phraseWordCounts": [
-        1,
-        2,
         3,
-        5,
+        8,
         10
       ],
       "annotations": [],
@@ -5075,7 +5121,8 @@
       "verse": 30,
       "phraseWordCounts": [
         6,
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5086,8 +5133,7 @@
       "chapter": 10,
       "verse": 31,
       "phraseWordCounts": [
-        1,
-        5,
+        6,
         4,
         7
       ],
@@ -5103,7 +5149,9 @@
       "verse": 32,
       "phraseWordCounts": [
         3,
-        14
+        4,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5135,8 +5183,7 @@
       "chapter": 11,
       "verse": 1,
       "phraseWordCounts": [
-        2,
-        6
+        8
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5149,10 +5196,10 @@
       "chapter": 11,
       "verse": 2,
       "phraseWordCounts": [
-        4,
-        1,
+        5,
         7,
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -5172,7 +5219,8 @@
       "chapter": 11,
       "verse": 3,
       "phraseWordCounts": [
-        14,
+        6,
+        8,
         6,
         7
       ],
@@ -5215,8 +5263,10 @@
       "chapter": 11,
       "verse": 5,
       "phraseWordCounts": [
-        14,
-        13
+        11,
+        3,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -5240,7 +5290,8 @@
       "phraseWordCounts": [
         7,
         5,
-        13,
+        8,
+        5,
         4
       ],
       "annotations": [
@@ -5341,8 +5392,7 @@
       "chapter": 11,
       "verse": 11,
       "phraseWordCounts": [
-        1,
-        6,
+        7,
         5,
         3
       ],
@@ -5378,7 +5428,8 @@
       "verse": 13,
       "phraseWordCounts": [
         3,
-        14
+        10,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5389,7 +5440,8 @@
       "chapter": 11,
       "verse": 14,
       "phraseWordCounts": [
-        14,
+        7,
+        7,
         6
       ],
       "annotations": [
@@ -5553,8 +5605,7 @@
       "chapter": 11,
       "verse": 22,
       "phraseWordCounts": [
-        1,
-        10,
+        11,
         8,
         6,
         6,
@@ -5575,8 +5626,10 @@
       "chapter": 11,
       "verse": 23,
       "phraseWordCounts": [
+        6,
+        7,
         13,
-        15
+        2
       ],
       "annotations": [
         {
@@ -5598,12 +5651,8 @@
       "chapter": 11,
       "verse": 24,
       "phraseWordCounts": [
-        6,
-        3,
-        2,
-        1,
-        1,
-        9,
+        11,
+        11,
         6
       ],
       "annotations": [
@@ -5631,10 +5680,8 @@
       "verse": 25,
       "phraseWordCounts": [
         11,
-        1,
-        9,
-        2,
-        6,
+        10,
+        8,
         4
       ],
       "annotations": [
@@ -5682,8 +5729,8 @@
       "verse": 27,
       "phraseWordCounts": [
         5,
-        17,
-        5
+        11,
+        11
       ],
       "annotations": [
         {
@@ -5728,9 +5775,8 @@
       "chapter": 11,
       "verse": 29,
       "phraseWordCounts": [
-        4,
-        7,
-        5,
+        10,
+        6,
         5
       ],
       "annotations": [
@@ -5761,8 +5807,7 @@
       "chapter": 11,
       "verse": 30,
       "phraseWordCounts": [
-        6,
-        4,
+        10,
         3
       ],
       "annotations": [
@@ -5806,8 +5851,7 @@
       "chapter": 11,
       "verse": 33,
       "phraseWordCounts": [
-        1,
-        2,
+        3,
         6,
         4
       ],
@@ -5839,8 +5883,7 @@
       "chapter": 12,
       "verse": 1,
       "phraseWordCounts": [
-        4,
-        1,
+        5,
         8
       ],
       "annotations": [],
@@ -5874,8 +5917,11 @@
       "chapter": 12,
       "verse": 3,
       "phraseWordCounts": [
-        18,
-        14
+        6,
+        9,
+        3,
+        9,
+        5
       ],
       "annotations": [
         {
@@ -5954,7 +6000,8 @@
       "chapter": 12,
       "verse": 7,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6006,8 +6053,7 @@
       "chapter": 12,
       "verse": 11,
       "phraseWordCounts": [
-        2,
-        8,
+        10,
         8
       ],
       "annotations": [
@@ -6026,11 +6072,9 @@
       "chapter": 12,
       "verse": 12,
       "phraseWordCounts": [
-        6,
-        4,
+        10,
         8,
-        2,
-        3,
+        5,
         4
       ],
       "annotations": [],
@@ -6044,10 +6088,10 @@
       "chapter": 12,
       "verse": 13,
       "phraseWordCounts": [
-        14,
-        2,
-        2,
-        13
+        11,
+        4,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6060,8 +6104,7 @@
       "chapter": 12,
       "verse": 14,
       "phraseWordCounts": [
-        9,
-        2
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6187,9 +6230,8 @@
       "chapter": 12,
       "verse": 22,
       "phraseWordCounts": [
-        1,
-        2,
-        12
+        8,
+        7
       ],
       "annotations": [
         {
@@ -6205,7 +6247,8 @@
       "chapter": 12,
       "verse": 23,
       "phraseWordCounts": [
-        13,
+        6,
+        7,
         6,
         7
       ],
@@ -6318,13 +6361,9 @@
       "verse": 28,
       "phraseWordCounts": [
         8,
-        2,
-        2,
-        2,
+        6,
         3,
-        4,
-        1,
-        1,
+        6,
         3
       ],
       "annotations": [
@@ -6409,7 +6448,8 @@
       "verse": 1,
       "phraseWordCounts": [
         11,
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -6513,7 +6553,8 @@
       "verse": 5,
       "phraseWordCounts": [
         4,
-        8,
+        5,
+        3,
         3
       ],
       "annotations": [
@@ -6736,7 +6777,8 @@
       "verse": 1,
       "phraseWordCounts": [
         2,
-        10
+        4,
+        6
       ],
       "annotations": [
         {
@@ -6754,7 +6796,8 @@
       "chapter": 14,
       "verse": 2,
       "phraseWordCounts": [
-        15,
+        7,
+        8,
         5,
         7
       ],
@@ -6799,7 +6842,10 @@
       "phraseWordCounts": [
         7,
         6,
-        22
+        6,
+        6,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -6820,7 +6866,9 @@
       "verse": 6,
       "phraseWordCounts": [
         11,
-        20
+        10,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6833,8 +6881,10 @@
       "chapter": 14,
       "verse": 7,
       "phraseWordCounts": [
+        4,
+        4,
+        5,
         8,
-        13,
         10
       ],
       "annotations": [
@@ -6892,7 +6942,8 @@
       "chapter": 14,
       "verse": 9,
       "phraseWordCounts": [
-        13,
+        3,
+        10,
         8,
         8
       ],
@@ -6910,7 +6961,8 @@
       "chapter": 14,
       "verse": 10,
       "phraseWordCounts": [
-        13,
+        5,
+        8,
         7
       ],
       "annotations": [
@@ -6964,7 +7016,8 @@
       "verse": 12,
       "phraseWordCounts": [
         10,
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -6986,7 +7039,8 @@
       "chapter": 14,
       "verse": 13,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -7043,7 +7097,9 @@
       "verse": 16,
       "phraseWordCounts": [
         7,
-        25
+        10,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -7087,7 +7143,9 @@
       "chapter": 14,
       "verse": 19,
       "phraseWordCounts": [
-        26
+        13,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7114,8 +7172,10 @@
       "verse": 21,
       "phraseWordCounts": [
         6,
-        14,
-        13
+        8,
+        6,
+        10,
+        3
       ],
       "annotations": [
         {
@@ -7131,8 +7191,10 @@
       "chapter": 14,
       "verse": 22,
       "phraseWordCounts": [
-        14,
-        11
+        6,
+        8,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7247,7 +7309,7 @@
       "verse": 28,
       "phraseWordCounts": [
         6,
-        7,
+        6,
         9
       ],
       "annotations": [
@@ -7373,7 +7435,7 @@
       "verse": 35,
       "phraseWordCounts": [
         7,
-        7,
+        8,
         10
       ],
       "annotations": [
@@ -7420,7 +7482,8 @@
       "verse": 37,
       "phraseWordCounts": [
         10,
-        17
+        11,
+        6
       ],
       "annotations": [
         {
@@ -7448,9 +7511,7 @@
       "chapter": 14,
       "verse": 39,
       "phraseWordCounts": [
-        1,
-        1,
-        4,
+        6,
         8
       ],
       "annotations": [
@@ -7467,8 +7528,7 @@
       "chapter": 14,
       "verse": 40,
       "phraseWordCounts": [
-        6,
-        3
+        9
       ],
       "annotations": [
         {
@@ -7484,11 +7544,9 @@
       "chapter": 15,
       "verse": 1,
       "phraseWordCounts": [
-        1,
-        1,
+        2,
         11,
-        4,
-        5
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7500,7 +7558,7 @@
       "verse": 2,
       "phraseWordCounts": [
         6,
-        12,
+        11,
         5
       ],
       "annotations": [
@@ -7517,8 +7575,10 @@
       "chapter": 15,
       "verse": 3,
       "phraseWordCounts": [
-        13,
-        10
+        8,
+        5,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -7659,8 +7719,7 @@
         11,
         9,
         8,
-        3,
-        9
+        12
       ],
       "annotations": [
         {
@@ -7678,10 +7737,8 @@
       "chapter": 15,
       "verse": 11,
       "phraseWordCounts": [
-        1,
-        6,
-        3,
-        4
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7692,8 +7749,10 @@
       "chapter": 15,
       "verse": 12,
       "phraseWordCounts": [
-        13,
-        14
+        5,
+        8,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7742,10 +7801,10 @@
       "chapter": 15,
       "verse": 15,
       "phraseWordCounts": [
-        1,
-        8,
-        11,
-        7,
+        9,
+        6,
+        5,
+        6,
         8
       ],
       "annotations": [
@@ -7789,7 +7848,8 @@
       "chapter": 15,
       "verse": 18,
       "phraseWordCounts": [
-        11
+        9,
+        2
       ],
       "annotations": [
         {
@@ -7878,8 +7938,7 @@
         4,
         9,
         8,
-        3,
-        2
+        5
       ],
       "annotations": [
         {
@@ -7899,7 +7958,8 @@
       "chapter": 15,
       "verse": 25,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -7933,7 +7993,8 @@
       "phraseWordCounts": [
         9,
         10,
-        13
+        11,
+        2
       ],
       "annotations": [
         {
@@ -7954,7 +8015,8 @@
       "verse": 28,
       "phraseWordCounts": [
         9,
-        16,
+        8,
+        8,
         7
       ],
       "annotations": [],
@@ -7968,8 +8030,8 @@
       "chapter": 15,
       "verse": 29,
       "phraseWordCounts": [
-        1,
-        10,
+        5,
+        6,
         8,
         8
       ],
@@ -7998,8 +8060,8 @@
       "chapter": 15,
       "verse": 31,
       "phraseWordCounts": [
-        2,
-        13,
+        7,
+        8,
         3
       ],
       "annotations": [
@@ -8016,13 +8078,11 @@
       "chapter": 15,
       "verse": 32,
       "phraseWordCounts": [
-        1,
-        5,
+        6,
         7,
         6,
         6,
-        3,
-        2,
+        5,
         4
       ],
       "annotations": [
@@ -8108,7 +8168,8 @@
       "verse": 36,
       "phraseWordCounts": [
         2,
-        10
+        7,
+        3
       ],
       "annotations": [
         {
@@ -8126,8 +8187,7 @@
       "phraseWordCounts": [
         4,
         9,
-        4,
-        6
+        9
       ],
       "annotations": [
         {
@@ -8196,8 +8256,7 @@
       "chapter": 15,
       "verse": 40,
       "phraseWordCounts": [
-        5,
-        3,
+        8,
         8,
         8
       ],
@@ -8361,8 +8420,10 @@
       "chapter": 15,
       "verse": 48,
       "phraseWordCounts": [
-        15,
-        13
+        6,
+        9,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -8434,7 +8495,7 @@
       "phraseWordCounts": [
         6,
         5,
-        7
+        6
       ],
       "annotations": [
         {
@@ -8456,7 +8517,8 @@
       "chapter": 15,
       "verse": 52,
       "phraseWordCounts": [
-        13,
+        9,
+        4,
         5,
         7,
         5
@@ -8581,7 +8643,9 @@
       "chapter": 15,
       "verse": 57,
       "phraseWordCounts": [
-        15
+        5,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -8599,7 +8663,9 @@
       "chapter": 15,
       "verse": 58,
       "phraseWordCounts": [
-        15,
+        4,
+        3,
+        8,
         11
       ],
       "annotations": [
@@ -8646,7 +8712,8 @@
       "chapter": 16,
       "verse": 2,
       "phraseWordCounts": [
-        15,
+        7,
+        8,
         6,
         8
       ],
@@ -8682,7 +8749,9 @@
       "chapter": 16,
       "verse": 3,
       "phraseWordCounts": [
-        19
+        4,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -8706,7 +8775,8 @@
       "chapter": 16,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -8819,7 +8889,8 @@
       "chapter": 16,
       "verse": 10,
       "phraseWordCounts": [
-        13,
+        4,
+        9,
         8,
         4
       ],
@@ -8851,7 +8922,8 @@
       "chapter": 16,
       "verse": 12,
       "phraseWordCounts": [
-        16,
+        5,
+        11,
         10,
         10
       ],
@@ -8882,8 +8954,7 @@
       "verse": 13,
       "phraseWordCounts": [
         6,
-        2,
-        2
+        4
       ],
       "annotations": [
         {
@@ -8918,9 +8989,10 @@
       "chapter": 16,
       "verse": 15,
       "phraseWordCounts": [
-        11,
+        4,
+        6,
         7,
-        13
+        12
       ],
       "annotations": [
         {
@@ -8957,8 +9029,8 @@
       "chapter": 16,
       "verse": 17,
       "phraseWordCounts": [
-        9,
-        2,
+        8,
+        3,
         9
       ],
       "annotations": [
@@ -9033,7 +9105,7 @@
       "chapter": 16,
       "verse": 21,
       "phraseWordCounts": [
-        8
+        7
       ],
       "annotations": [
         {
@@ -9053,7 +9125,8 @@
       "chapter": 16,
       "verse": 22,
       "phraseWordCounts": [
-        13,
+        9,
+        4,
         3
       ],
       "annotations": [],
@@ -9080,8 +9153,7 @@
       "chapter": 16,
       "verse": 24,
       "phraseWordCounts": [
-        9,
-        1
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9106,7 +9178,9 @@
       "chapter": 1,
       "verse": 2,
       "phraseWordCounts": [
-        14
+        5,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": null,
@@ -9138,7 +9212,8 @@
       "verse": 4,
       "phraseWordCounts": [
         7,
-        13,
+        8,
+        5,
         11
       ],
       "annotations": [],
@@ -9283,7 +9358,8 @@
       "verse": 11,
       "phraseWordCounts": [
         8,
-        19
+        11,
+        8
       ],
       "annotations": [
         {
@@ -9309,9 +9385,11 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        22,
-        4,
-        6,
+        5,
+        5,
+        7,
+        5,
+        10,
         5
       ],
       "annotations": [
@@ -9334,8 +9412,10 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        16,
-        10
+        10,
+        6,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -9366,7 +9446,7 @@
       "verse": 15,
       "phraseWordCounts": [
         11,
-        8
+        7
       ],
       "annotations": [
         {
@@ -9404,12 +9484,12 @@
       "chapter": 1,
       "verse": 17,
       "phraseWordCounts": [
-        1,
-        5,
+        6,
         5,
         5,
         7,
-        11
+        8,
+        3
       ],
       "annotations": [
         {
@@ -9450,8 +9530,8 @@
       "verse": 19,
       "phraseWordCounts": [
         7,
-        8,
-        6,
+        7,
+        5,
         5,
         5
       ],
@@ -9527,8 +9607,7 @@
       "chapter": 1,
       "verse": 23,
       "phraseWordCounts": [
-        4,
-        5,
+        9,
         10
       ],
       "annotations": [
@@ -9576,10 +9655,8 @@
       "verse": 2,
       "phraseWordCounts": [
         6,
-        4,
-        4,
-        3,
-        6
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9591,8 +9668,7 @@
       "verse": 3,
       "phraseWordCounts": [
         8,
-        1,
-        3,
+        4,
         6,
         7,
         5,
@@ -9607,8 +9683,8 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        13,
-        3,
+        9,
+        7,
         6,
         7,
         7
@@ -9639,7 +9715,7 @@
       "phraseWordCounts": [
         6,
         5,
-        8,
+        7,
         5
       ],
       "annotations": [
@@ -9672,7 +9748,8 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -9692,8 +9769,7 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        2,
-        3,
+        5,
         8,
         12
       ],
@@ -9745,9 +9821,11 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        8,
+        5,
+        3,
         7,
-        13
+        8,
+        5
       ],
       "annotations": [
         {
@@ -9784,8 +9862,8 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        1,
-        9,
+        6,
+        4,
         10
       ],
       "annotations": [
@@ -9862,10 +9940,8 @@
       "verse": 15,
       "phraseWordCounts": [
         9,
-        2,
-        4,
-        3,
-        3
+        6,
+        6
       ],
       "annotations": [
         {
@@ -10065,7 +10141,8 @@
         6,
         5,
         2,
-        15,
+        10,
+        5,
         7,
         5
       ],
@@ -10176,9 +10253,8 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        1,
-        5,
-        7
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -10189,9 +10265,10 @@
       "chapter": 3,
       "verse": 13,
       "phraseWordCounts": [
-        2,
+        9,
+        6,
         7,
-        18
+        5
       ],
       "annotations": [
         {
@@ -10212,7 +10289,8 @@
       "verse": 14,
       "phraseWordCounts": [
         5,
-        16,
+        9,
+        7,
         8
       ],
       "annotations": [
@@ -10338,8 +10416,7 @@
       "chapter": 4,
       "verse": 1,
       "phraseWordCounts": [
-        1,
-        5,
+        6,
         5,
         5
       ],
@@ -10357,7 +10434,9 @@
         9,
         4,
         7,
-        17
+        6,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -10511,9 +10590,8 @@
       "chapter": 4,
       "verse": 8,
       "phraseWordCounts": [
-        6,
-        6,
-        4
+        9,
+        7
       ],
       "annotations": [
         {
@@ -10542,7 +10620,7 @@
       "verse": 9,
       "phraseWordCounts": [
         4,
-        6
+        5
       ],
       "annotations": [
         {
@@ -10708,8 +10786,7 @@
       "chapter": 4,
       "verse": 18,
       "phraseWordCounts": [
-        8,
-        3,
+        11,
         8,
         8,
         9
@@ -10734,8 +10811,8 @@
       "chapter": 5,
       "verse": 1,
       "phraseWordCounts": [
-        8,
-        10,
+        12,
+        6,
         6,
         4
       ],
@@ -10804,10 +10881,10 @@
       "chapter": 5,
       "verse": 4,
       "phraseWordCounts": [
-        8,
-        9,
-        5,
-        6
+        10,
+        7,
+        3,
+        8
       ],
       "annotations": [
         {
@@ -11176,7 +11253,8 @@
       "chapter": 5,
       "verse": 21,
       "phraseWordCounts": [
-        13,
+        8,
+        5,
         10
       ],
       "annotations": [],
@@ -11585,7 +11663,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        7,
+        5,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -11613,7 +11696,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        5,
+        5,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -11627,7 +11715,11 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        11,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -11641,7 +11733,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        7,
+        5,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 17,
@@ -11659,7 +11756,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5,
+        7,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 15,
@@ -11681,7 +11783,10 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 5,
@@ -11695,7 +11800,13 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        12,
+        8,
+        6,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 27,
@@ -11709,7 +11820,13 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        5,
+        5,
+        10,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -11739,7 +11856,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        7,
+        9,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -11763,7 +11885,11 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        4,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 3,
@@ -11791,7 +11917,16 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        7,
+        6,
+        6,
+        5,
+        4,
+        6,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -11823,7 +11958,14 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        10,
+        5,
+        9,
+        6,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 1,
@@ -11841,7 +11983,11 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        10,
+        9
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -11850,7 +11996,12 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        4,
+        10,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -11864,7 +12015,11 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        8,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 9,
@@ -11878,7 +12033,9 @@
       "book": "2 Corinthians",
       "chapter": 7,
       "verse": 16,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -11887,7 +12044,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        2,
+        9,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 11,
@@ -11903,7 +12064,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        9,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -11927,7 +12092,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        5,
+        5,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -11947,7 +12117,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        6,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -11965,7 +12139,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        8,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -11979,7 +12157,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        5,
+        11
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -11993,7 +12175,13 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        6,
+        3,
+        6,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -12004,7 +12192,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        9,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -12018,7 +12210,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        5,
+        7,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -12029,7 +12226,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        13,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 5,
@@ -12053,7 +12254,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        9,
+        12
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -12077,7 +12282,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        8,
+        9
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -12086,7 +12295,10 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 9,
@@ -12100,7 +12312,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        11,
+        8,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 3,
@@ -12118,7 +12335,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        8,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 6,
       "clubs": []
@@ -12127,7 +12348,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 16,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        8,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 7,
       "clubs": []
@@ -12136,7 +12361,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 17,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        4,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -12154,7 +12383,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 18,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        6,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 14,
@@ -12168,7 +12401,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 19,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        15,
+        12,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 13,
@@ -12186,7 +12424,10 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 20,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -12212,7 +12453,11 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 21,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        8,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -12226,7 +12471,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 22,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        9,
+        5,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 13,
@@ -12244,7 +12494,13 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 23,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        9,
+        7,
+        6,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -12274,7 +12530,12 @@
       "book": "2 Corinthians",
       "chapter": 8,
       "verse": 24,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        4,
+        5,
+        7
+      ],
       "annotations": [],
       "ftvWordCount": 2,
       "clubs": [
@@ -12285,7 +12546,10 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 9,
@@ -12299,7 +12563,12 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        9,
+        7,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12321,7 +12590,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        12,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -12330,7 +12603,12 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        4,
+        5,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 3,
@@ -12352,7 +12630,14 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        11,
+        6,
+        5,
+        10,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12394,7 +12679,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        8,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12430,7 +12719,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        5,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -12458,7 +12751,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        9,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -12469,7 +12766,12 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        4,
+        6,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12489,7 +12791,12 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        4,
+        8,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12517,7 +12824,10 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -12533,7 +12843,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        8,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -12561,7 +12875,12 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        9,
+        5,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 15,
@@ -12585,7 +12904,11 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        4,
+        9
+      ],
       "annotations": [],
       "ftvWordCount": 2,
       "clubs": [
@@ -12596,7 +12919,9 @@
       "book": "2 Corinthians",
       "chapter": 9,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12612,7 +12937,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        7,
+        7,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -12632,7 +12962,13 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        10,
+        12,
+        4,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -12656,7 +12992,10 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        8
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -12667,7 +13006,10 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -12695,7 +13037,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        8,
+        5,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -12727,7 +13074,10 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12749,7 +13099,14 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        6,
+        4,
+        7,
+        6,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -12758,7 +13115,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        7,
+        5,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12772,7 +13134,9 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12786,7 +13150,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        4,
+        6,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -12812,7 +13181,13 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        8,
+        4,
+        7,
+        4
+      ],
       "annotations": [],
       "ftvWordCount": 2,
       "clubs": []
@@ -12821,7 +13196,13 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        8,
+        6,
+        5,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12843,7 +13224,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        7,
+        4,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -12869,7 +13255,12 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        9,
+        8,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12887,7 +13278,13 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        6,
+        3,
+        6,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -12917,7 +13314,10 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 16,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 16,
@@ -12935,7 +13335,9 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 17,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10
+      ],
       "annotations": [],
       "ftvWordCount": 4,
       "clubs": [
@@ -12946,7 +13348,10 @@
       "book": "2 Corinthians",
       "chapter": 10,
       "verse": 18,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -12966,7 +13371,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -12984,7 +13392,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        8,
+        11
+      ],
       "annotations": [
         {
           "wordIndex": 3,
@@ -13008,7 +13420,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        8,
+        6,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -13028,7 +13445,14 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        5,
+        7,
+        5,
+        9,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 5,
@@ -13044,7 +13468,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -13053,7 +13480,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        6,
+        8,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -13073,7 +13505,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5,
+        9,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 5,
@@ -13089,7 +13526,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 1,
@@ -13109,7 +13549,13 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        10,
+        11,
+        11,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 20,
@@ -13129,7 +13575,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        8,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 11,
@@ -13143,7 +13593,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        2
+      ],
       "annotations": [],
       "ftvWordCount": 1,
       "clubs": []
@@ -13152,7 +13605,13 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        7,
+        6,
+        7,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -13178,7 +13637,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 5,
@@ -13198,7 +13660,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -13222,7 +13687,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        10,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 10,
@@ -13238,7 +13707,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 16,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        7,
+        9,
+        7
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -13247,7 +13721,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 17,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        7,
+        5,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 14,
@@ -13261,7 +13740,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 18,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -13275,7 +13757,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 19,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 6,
       "clubs": []
@@ -13284,7 +13769,14 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 20,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        6,
+        4,
+        5,
+        4,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -13306,7 +13798,13 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 21,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        7,
+        6,
+        3,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 20,
@@ -13320,7 +13818,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 22,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        6,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -13342,7 +13844,14 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 23,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        8,
+        4,
+        4,
+        4,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 16,
@@ -13368,7 +13877,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 24,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -13386,7 +13898,12 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 25,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        4,
+        5,
+        11
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -13408,7 +13925,17 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 26,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        4,
+        4,
+        6,
+        5,
+        5,
+        5,
+        5,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 1,
@@ -13462,7 +13989,13 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 27,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        3,
+        4,
+        3,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 1,
@@ -13488,7 +14021,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 28,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        5,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 11,
@@ -13502,7 +14039,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 29,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        5,
+        7
+      ],
       "annotations": [],
       "ftvWordCount": 2,
       "clubs": []
@@ -13511,7 +14052,10 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 30,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        4,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 11,
@@ -13529,7 +14073,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 31,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        4,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 18,
@@ -13543,7 +14091,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 32,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        10,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 1,
@@ -13585,7 +14137,11 @@
       "book": "2 Corinthians",
       "chapter": 11,
       "verse": 33,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        6,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -13611,7 +14167,10 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -13629,7 +14188,12 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        8,
+        10,
+        12
+      ],
       "annotations": [
         {
           "wordIndex": 7,
@@ -13647,7 +14211,10 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        15
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -13656,7 +14223,11 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        4,
+        10
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -13674,7 +14245,11 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        7,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 17,
@@ -13688,7 +14263,12 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        13,
+        6,
+        9,
+        11
+      ],
       "annotations": [
         {
           "wordIndex": 36,
@@ -13702,7 +14282,13 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        6,
+        9,
+        7,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 15,
@@ -13726,7 +14312,10 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 4,
@@ -13742,7 +14331,13 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        6,
+        8,
+        10,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 28,
@@ -13758,7 +14353,14 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        4,
+        4,
+        3,
+        5,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 3,
@@ -13786,7 +14388,13 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        4,
+        9,
+        10,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 9,
@@ -13808,7 +14416,11 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        7,
+        7
+      ],
       "annotations": [
         {
           "wordIndex": 2,
@@ -13842,7 +14454,11 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        12,
+        9,
+        4
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -13851,7 +14467,13 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        12,
+        8,
+        8,
+        11,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 38,
@@ -13869,7 +14491,11 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 15,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        12,
+        7,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -13891,7 +14517,12 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 16,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        5,
+        3,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 13,
@@ -13909,7 +14540,10 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 17,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        6,
+        9
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -13918,7 +14552,12 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 18,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        9,
+        6,
+        8,
+        8
+      ],
       "annotations": [
         {
           "wordIndex": 30,
@@ -13932,7 +14571,12 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 19,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        6,
+        6,
+        3
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -13948,7 +14592,14 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 20,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        9,
+        14,
+        5,
+        5,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 34,
@@ -13992,7 +14643,13 @@
       "book": "2 Corinthians",
       "chapter": 12,
       "verse": 21,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        7,
+        10,
+        10,
+        4
+      ],
       "annotations": [
         {
           "wordIndex": 8,
@@ -14032,7 +14689,11 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 1,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        11,
+        8,
+        5
+      ],
       "annotations": [
         {
           "wordIndex": 13,
@@ -14050,7 +14711,13 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 2,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        10,
+        12,
+        5,
+        9
+      ],
       "annotations": [
         {
           "wordIndex": 6,
@@ -14064,7 +14731,11 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 3,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        6,
+        4
+      ],
       "annotations": [],
       "ftvWordCount": 1,
       "clubs": []
@@ -14073,7 +14744,13 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 4,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        8,
+        7,
+        6,
+        7
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -14084,7 +14761,13 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 5,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        10,
+        2,
+        5,
+        6,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 1,
       "clubs": [
@@ -14095,7 +14778,10 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 6,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -14104,7 +14790,13 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 7,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5,
+        5,
+        6,
+        8,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -14115,7 +14807,10 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 8,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        4
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": [
@@ -14126,7 +14821,12 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 9,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        8,
+        4,
+        5,
+        6
+      ],
       "annotations": [],
       "ftvWordCount": 4,
       "clubs": [
@@ -14137,7 +14837,12 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 10,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        7,
+        10,
+        6
+      ],
       "annotations": [
         {
           "wordIndex": 13,
@@ -14153,7 +14858,13 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 11,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        3,
+        2,
+        8,
+        3,
+        11
+      ],
       "annotations": [
         {
           "wordIndex": 0,
@@ -14173,7 +14884,9 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 12,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7
+      ],
       "annotations": [],
       "ftvWordCount": 1,
       "clubs": []
@@ -14182,7 +14895,9 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 13,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 3,
       "clubs": []
@@ -14191,7 +14906,12 @@
       "book": "2 Corinthians",
       "chapter": 13,
       "verse": 14,
-      "phraseWordCounts": [],
+      "phraseWordCounts": [
+        7,
+        5,
+        7,
+        5
+      ],
       "annotations": [],
       "ftvWordCount": 4,
       "clubs": [

--- a/data/4-john.json
+++ b/data/4-john.json
@@ -137,7 +137,9 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        17
+        6,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -161,7 +163,9 @@
       "chapter": 1,
       "verse": 3,
       "phraseWordCounts": [
-        15
+        6,
+        6,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -174,7 +178,8 @@
       "chapter": 1,
       "verse": 4,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -187,7 +192,8 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -207,7 +213,8 @@
       "chapter": 1,
       "verse": 6,
       "phraseWordCounts": [
-        11
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -220,7 +227,9 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        18
+        6,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -233,7 +242,8 @@
       "chapter": 1,
       "verse": 8,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -244,7 +254,8 @@
       "chapter": 1,
       "verse": 9,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -255,7 +266,9 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        19
+        5,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -268,7 +281,8 @@
       "chapter": 1,
       "verse": 11,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -281,7 +295,10 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        24
+        6,
+        6,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -294,7 +311,11 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        22
+        3,
+        3,
+        7,
+        6,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -305,7 +326,11 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        29
+        5,
+        4,
+        5,
+        10,
+        5
       ],
       "annotations": [
         {
@@ -335,7 +360,10 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        31
+        9,
+        7,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -346,7 +374,8 @@
       "chapter": 1,
       "verse": 16,
       "phraseWordCounts": [
-        12
+        8,
+        4
       ],
       "annotations": [
         {
@@ -370,7 +399,8 @@
       "chapter": 1,
       "verse": 17,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -388,7 +418,10 @@
       "chapter": 1,
       "verse": 18,
       "phraseWordCounts": [
-        24
+        8,
+        4,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -401,7 +434,10 @@
       "chapter": 1,
       "verse": 19,
       "phraseWordCounts": [
-        22
+        7,
+        7,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -417,7 +453,8 @@
       "chapter": 1,
       "verse": 20,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -433,7 +470,11 @@
       "chapter": 1,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        4,
+        5,
+        5,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -449,7 +490,11 @@
       "chapter": 1,
       "verse": 22,
       "phraseWordCounts": [
-        25
+        5,
+        3,
+        6,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 9,
@@ -462,7 +507,10 @@
       "chapter": 1,
       "verse": 23,
       "phraseWordCounts": [
-        25
+        2,
+        10,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -495,7 +543,10 @@
       "chapter": 1,
       "verse": 25,
       "phraseWordCounts": [
-        21
+        5,
+        5,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -511,7 +562,10 @@
       "chapter": 1,
       "verse": 26,
       "phraseWordCounts": [
-        19
+        4,
+        4,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -524,7 +578,10 @@
       "chapter": 1,
       "verse": 27,
       "phraseWordCounts": [
-        20
+        7,
+        4,
+        3,
+        6
       ],
       "annotations": [
         {
@@ -550,7 +607,8 @@
       "chapter": 1,
       "verse": 28,
       "phraseWordCounts": [
-        13
+        9,
+        4
       ],
       "annotations": [
         {
@@ -566,7 +624,10 @@
       "chapter": 1,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        9,
+        3,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -579,7 +640,10 @@
       "chapter": 1,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -592,7 +656,9 @@
       "chapter": 1,
       "verse": 31,
       "phraseWordCounts": [
-        19
+        5,
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -603,7 +669,10 @@
       "chapter": 1,
       "verse": 32,
       "phraseWordCounts": [
-        20
+        5,
+        7,
+        3,
+        5
       ],
       "annotations": [
         {
@@ -621,7 +690,13 @@
       "chapter": 1,
       "verse": 33,
       "phraseWordCounts": [
-        37
+        5,
+        9,
+        3,
+        7,
+        4,
+        3,
+        6
       ],
       "annotations": [
         {
@@ -652,7 +727,8 @@
       "chapter": 1,
       "verse": 35,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -665,7 +741,8 @@
       "chapter": 1,
       "verse": 36,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -691,7 +768,12 @@
       "chapter": 1,
       "verse": 38,
       "phraseWordCounts": [
-        30
+        3,
+        4,
+        7,
+        5,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -707,7 +789,11 @@
       "chapter": 1,
       "verse": 39,
       "phraseWordCounts": [
-        28
+        4,
+        3,
+        8,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -727,7 +813,9 @@
       "chapter": 1,
       "verse": 40,
       "phraseWordCounts": [
-        16
+        8,
+        3,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -740,7 +828,10 @@
       "chapter": 1,
       "verse": 41,
       "phraseWordCounts": [
-        21
+        7,
+        4,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -753,7 +844,11 @@
       "chapter": 1,
       "verse": 42,
       "phraseWordCounts": [
-        31
+        6,
+        8,
+        7,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -771,7 +866,9 @@
       "chapter": 1,
       "verse": 43,
       "phraseWordCounts": [
-        19
+        9,
+        8,
+        2
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -782,7 +879,8 @@
       "chapter": 1,
       "verse": 44,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -793,7 +891,10 @@
       "chapter": 1,
       "verse": 45,
       "phraseWordCounts": [
-        29
+        7,
+        10,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -804,7 +905,10 @@
       "chapter": 1,
       "verse": 46,
       "phraseWordCounts": [
-        19
+        5,
+        7,
+        4,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -815,7 +919,10 @@
       "chapter": 1,
       "verse": 47,
       "phraseWordCounts": [
-        19
+        6,
+        4,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -835,7 +942,12 @@
       "chapter": 1,
       "verse": 48,
       "phraseWordCounts": [
-        29
+        4,
+        5,
+        6,
+        4,
+        7,
+        3
       ],
       "annotations": [
         {
@@ -859,7 +971,9 @@
       "chapter": 1,
       "verse": 49,
       "phraseWordCounts": [
-        19
+        6,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -870,7 +984,11 @@
       "chapter": 1,
       "verse": 50,
       "phraseWordCounts": [
-        28
+        6,
+        5,
+        7,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -894,7 +1012,11 @@
       "chapter": 1,
       "verse": 51,
       "phraseWordCounts": [
-        30
+        5,
+        6,
+        6,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -912,7 +1034,9 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        19
+        8,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -948,7 +1072,9 @@
       "chapter": 2,
       "verse": 3,
       "phraseWordCounts": [
-        18
+        7,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -959,7 +1085,9 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        20
+        4,
+        10,
+        6
       ],
       "annotations": [
         {
@@ -975,7 +1103,8 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -986,7 +1115,9 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        24
+        9,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -1022,7 +1153,9 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        17
+        4,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -1046,7 +1179,10 @@
       "chapter": 2,
       "verse": 8,
       "phraseWordCounts": [
-        22
+        5,
+        4,
+        9,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -1057,7 +1193,10 @@
       "chapter": 2,
       "verse": 9,
       "phraseWordCounts": [
-        39
+        14,
+        8,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -1077,7 +1216,11 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        33
+        5,
+        10,
+        7,
+        3,
+        8
       ],
       "annotations": [
         {
@@ -1105,7 +1248,10 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        20
+        6,
+        4,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1118,7 +1264,10 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        23
+        7,
+        5,
+        3,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1129,7 +1278,8 @@
       "chapter": 2,
       "verse": 13,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1142,7 +1292,9 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        20
+        6,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -1172,7 +1324,11 @@
       "chapter": 2,
       "verse": 15,
       "phraseWordCounts": [
-        32
+        8,
+        8,
+        6,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -1214,7 +1370,9 @@
       "chapter": 2,
       "verse": 16,
       "phraseWordCounts": [
-        22
+        8,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -1236,7 +1394,8 @@
       "chapter": 2,
       "verse": 17,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [
         {
@@ -1252,7 +1411,9 @@
       "chapter": 2,
       "verse": 18,
       "phraseWordCounts": [
-        20
+        8,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1263,7 +1424,9 @@
       "chapter": 2,
       "verse": 19,
       "phraseWordCounts": [
-        18
+        6,
+        3,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -1276,7 +1439,9 @@
       "chapter": 2,
       "verse": 20,
       "phraseWordCounts": [
-        22
+        4,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -1309,7 +1474,10 @@
       "chapter": 2,
       "verse": 22,
       "phraseWordCounts": [
-        30
+        8,
+        10,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -1327,7 +1495,10 @@
       "chapter": 2,
       "verse": 23,
       "phraseWordCounts": [
-        25
+        9,
+        3,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -1345,7 +1516,8 @@
       "chapter": 2,
       "verse": 24,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [
         {
@@ -1363,7 +1535,8 @@
       "chapter": 2,
       "verse": 25,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1376,7 +1549,8 @@
       "chapter": 3,
       "verse": 1,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -1394,7 +1568,11 @@
       "chapter": 3,
       "verse": 2,
       "phraseWordCounts": [
-        37
+        7,
+        5,
+        10,
+        10,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1407,7 +1585,10 @@
       "chapter": 3,
       "verse": 3,
       "phraseWordCounts": [
-        24
+        6,
+        6,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -1420,7 +1601,10 @@
       "chapter": 3,
       "verse": 4,
       "phraseWordCounts": [
-        27
+        4,
+        10,
+        10,
+        3
       ],
       "annotations": [
         {
@@ -1436,7 +1620,9 @@
       "chapter": 3,
       "verse": 5,
       "phraseWordCounts": [
-        24
+        8,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1447,7 +1633,8 @@
       "chapter": 3,
       "verse": 6,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1458,7 +1645,8 @@
       "chapter": 3,
       "verse": 7,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1469,7 +1657,10 @@
       "chapter": 3,
       "verse": 8,
       "phraseWordCounts": [
-        33
+        6,
+        7,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -1493,7 +1684,8 @@
       "chapter": 3,
       "verse": 9,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1504,7 +1696,9 @@
       "chapter": 3,
       "verse": 10,
       "phraseWordCounts": [
-        18
+        6,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -1515,7 +1709,10 @@
       "chapter": 3,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        6,
+        5,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -1526,7 +1723,10 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -1542,7 +1742,9 @@
       "chapter": 3,
       "verse": 13,
       "phraseWordCounts": [
-        23
+        6,
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1553,7 +1755,8 @@
       "chapter": 3,
       "verse": 14,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [
         {
@@ -1571,7 +1774,8 @@
       "chapter": 3,
       "verse": 15,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1582,7 +1786,10 @@
       "chapter": 3,
       "verse": 16,
       "phraseWordCounts": [
-        25
+        6,
+        7,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1595,7 +1802,9 @@
       "chapter": 3,
       "verse": 17,
       "phraseWordCounts": [
-        23
+        10,
+        4,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1608,7 +1817,10 @@
       "chapter": 3,
       "verse": 18,
       "phraseWordCounts": [
-        32
+        8,
+        9,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -1621,7 +1833,10 @@
       "chapter": 3,
       "verse": 19,
       "phraseWordCounts": [
-        25
+        5,
+        8,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -1639,7 +1854,9 @@
       "chapter": 3,
       "verse": 20,
       "phraseWordCounts": [
-        20
+        7,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -1661,7 +1878,9 @@
       "chapter": 3,
       "verse": 21,
       "phraseWordCounts": [
-        24
+        10,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -1679,7 +1898,9 @@
       "chapter": 3,
       "verse": 22,
       "phraseWordCounts": [
-        21
+        7,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -1690,7 +1911,9 @@
       "chapter": 3,
       "verse": 23,
       "phraseWordCounts": [
-        21
+        9,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -1730,7 +1953,9 @@
       "chapter": 3,
       "verse": 25,
       "phraseWordCounts": [
-        15
+        5,
+        8,
+        2
       ],
       "annotations": [
         {
@@ -1750,7 +1975,11 @@
       "chapter": 3,
       "verse": 26,
       "phraseWordCounts": [
-        33
+        9,
+        9,
+        6,
+        3,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1761,7 +1990,9 @@
       "chapter": 3,
       "verse": 27,
       "phraseWordCounts": [
-        18
+        4,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1772,7 +2003,9 @@
       "chapter": 3,
       "verse": 28,
       "phraseWordCounts": [
-        20
+        5,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1783,7 +2016,11 @@
       "chapter": 3,
       "verse": 29,
       "phraseWordCounts": [
-        33
+        8,
+        6,
+        5,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -1833,7 +2070,10 @@
       "chapter": 3,
       "verse": 31,
       "phraseWordCounts": [
-        29
+        8,
+        8,
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1844,7 +2084,8 @@
       "chapter": 3,
       "verse": 32,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1855,7 +2096,8 @@
       "chapter": 3,
       "verse": 33,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [
         {
@@ -1871,7 +2113,8 @@
       "chapter": 3,
       "verse": 34,
       "phraseWordCounts": [
-        20
+        11,
+        9
       ],
       "annotations": [
         {
@@ -1887,7 +2130,8 @@
       "chapter": 3,
       "verse": 35,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1898,7 +2142,10 @@
       "chapter": 3,
       "verse": 36,
       "phraseWordCounts": [
-        29
+        9,
+        8,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -1916,7 +2163,8 @@
       "chapter": 4,
       "verse": 1,
       "phraseWordCounts": [
-        19
+        1,
+        18
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1969,7 +2217,10 @@
       "chapter": 4,
       "verse": 5,
       "phraseWordCounts": [
-        24
+        8,
+        4,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -1993,7 +2244,10 @@
       "chapter": 4,
       "verse": 6,
       "phraseWordCounts": [
-        23
+        5,
+        7,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -2021,7 +2275,9 @@
       "chapter": 4,
       "verse": 7,
       "phraseWordCounts": [
-        16
+        8,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -2048,7 +2304,11 @@
       "chapter": 4,
       "verse": 9,
       "phraseWordCounts": [
-        31
+        8,
+        8,
+        5,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -2070,7 +2330,11 @@
       "chapter": 4,
       "verse": 10,
       "phraseWordCounts": [
-        38
+        6,
+        7,
+        12,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -2088,7 +2352,10 @@
       "chapter": 4,
       "verse": 11,
       "phraseWordCounts": [
-        25
+        5,
+        7,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -2104,7 +2371,10 @@
       "chapter": 4,
       "verse": 12,
       "phraseWordCounts": [
-        25
+        7,
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -2124,7 +2394,8 @@
       "chapter": 4,
       "verse": 13,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -2137,7 +2408,11 @@
       "chapter": 4,
       "verse": 14,
       "phraseWordCounts": [
-        35
+        11,
+        3,
+        8,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -2159,7 +2434,10 @@
       "chapter": 4,
       "verse": 15,
       "phraseWordCounts": [
-        20
+        5,
+        5,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -2170,7 +2448,8 @@
       "chapter": 4,
       "verse": 16,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -2186,7 +2465,11 @@
       "chapter": 4,
       "verse": 17,
       "phraseWordCounts": [
-        21
+        5,
+        4,
+        4,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -2206,7 +2489,9 @@
       "chapter": 4,
       "verse": 18,
       "phraseWordCounts": [
-        22
+        6,
+        11,
+        5
       ],
       "annotations": [
         {
@@ -2226,7 +2511,8 @@
       "chapter": 4,
       "verse": 19,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -2242,7 +2528,9 @@
       "chapter": 4,
       "verse": 20,
       "phraseWordCounts": [
-        21
+        6,
+        10,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2253,7 +2541,12 @@
       "chapter": 4,
       "verse": 21,
       "phraseWordCounts": [
-        24
+        4,
+        3,
+        4,
+        7,
+        3,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2264,7 +2557,9 @@
       "chapter": 4,
       "verse": 22,
       "phraseWordCounts": [
-        18
+        7,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -2280,7 +2575,10 @@
       "chapter": 4,
       "verse": 23,
       "phraseWordCounts": [
-        29
+        8,
+        8,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -2296,7 +2594,9 @@
       "chapter": 4,
       "verse": 24,
       "phraseWordCounts": [
-        14
+        3,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -2309,7 +2609,11 @@
       "chapter": 4,
       "verse": 25,
       "phraseWordCounts": [
-        24
+        5,
+        6,
+        4,
+        3,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2320,7 +2624,8 @@
       "chapter": 4,
       "verse": 26,
       "phraseWordCounts": [
-        12
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2331,7 +2636,11 @@
       "chapter": 4,
       "verse": 27,
       "phraseWordCounts": [
-        31
+        7,
+        9,
+        4,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -2347,7 +2656,9 @@
       "chapter": 4,
       "verse": 28,
       "phraseWordCounts": [
-        17
+        6,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -2363,7 +2674,9 @@
       "chapter": 4,
       "verse": 29,
       "phraseWordCounts": [
-        18
+        4,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -2374,7 +2687,8 @@
       "chapter": 4,
       "verse": 30,
       "phraseWordCounts": [
-        11
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2403,7 +2717,9 @@
       "chapter": 4,
       "verse": 32,
       "phraseWordCounts": [
-        16
+        5,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2414,7 +2730,8 @@
       "chapter": 4,
       "verse": 33,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2425,7 +2742,9 @@
       "chapter": 4,
       "verse": 34,
       "phraseWordCounts": [
-        21
+        4,
+        12,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2438,7 +2757,11 @@
       "chapter": 4,
       "verse": 35,
       "phraseWordCounts": [
-        35
+        4,
+        10,
+        5,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -2468,7 +2791,10 @@
       "chapter": 4,
       "verse": 36,
       "phraseWordCounts": [
-        24
+        6,
+        6,
+        9,
+        3
       ],
       "annotations": [
         {
@@ -2502,7 +2828,8 @@
       "chapter": 4,
       "verse": 37,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -2524,7 +2851,9 @@
       "chapter": 4,
       "verse": 38,
       "phraseWordCounts": [
-        22
+        12,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -2554,7 +2883,9 @@
       "chapter": 4,
       "verse": 39,
       "phraseWordCounts": [
-        28
+        8,
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2567,7 +2898,9 @@
       "chapter": 4,
       "verse": 40,
       "phraseWordCounts": [
-        21
+        8,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2589,7 +2922,11 @@
       "chapter": 4,
       "verse": 42,
       "phraseWordCounts": [
-        35
+        6,
+        9,
+        6,
+        9,
+        5
       ],
       "annotations": [
         {
@@ -2611,7 +2948,8 @@
       "chapter": 4,
       "verse": 43,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -2633,7 +2971,10 @@
       "chapter": 4,
       "verse": 45,
       "phraseWordCounts": [
-        30
+        6,
+        4,
+        12,
+        8
       ],
       "annotations": [
         {
@@ -2649,7 +2990,10 @@
       "chapter": 4,
       "verse": 46,
       "phraseWordCounts": [
-        27
+        8,
+        7,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -2667,7 +3011,10 @@
       "chapter": 4,
       "verse": 47,
       "phraseWordCounts": [
-        34
+        12,
+        7,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -2685,7 +3032,9 @@
       "chapter": 4,
       "verse": 48,
       "phraseWordCounts": [
-        18
+        5,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -2701,7 +3050,8 @@
       "chapter": 4,
       "verse": 49,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [
         {
@@ -2717,7 +3067,12 @@
       "chapter": 4,
       "verse": 50,
       "phraseWordCounts": [
-        26
+        4,
+        3,
+        3,
+        6,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2730,7 +3085,9 @@
       "chapter": 4,
       "verse": 51,
       "phraseWordCounts": [
-        18
+        7,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2743,7 +3100,11 @@
       "chapter": 4,
       "verse": 52,
       "phraseWordCounts": [
-        25
+        7,
+        4,
+        5,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -2777,7 +3138,11 @@
       "chapter": 4,
       "verse": 53,
       "phraseWordCounts": [
-        28
+        11,
+        6,
+        3,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -2795,7 +3160,8 @@
       "chapter": 4,
       "verse": 54,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2806,7 +3172,8 @@
       "chapter": 5,
       "verse": 1,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2817,7 +3184,9 @@
       "chapter": 5,
       "verse": 2,
       "phraseWordCounts": [
-        20
+        11,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -2841,7 +3210,9 @@
       "chapter": 5,
       "verse": 3,
       "phraseWordCounts": [
-        19
+        9,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -2869,7 +3240,11 @@
       "chapter": 5,
       "verse": 4,
       "phraseWordCounts": [
-        36
+        12,
+        5,
+        5,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -2917,7 +3292,10 @@
       "chapter": 5,
       "verse": 6,
       "phraseWordCounts": [
-        30
+        6,
+        13,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -2935,7 +3313,11 @@
       "chapter": 5,
       "verse": 7,
       "phraseWordCounts": [
-        32
+        5,
+        11,
+        6,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -2957,7 +3339,8 @@
       "chapter": 5,
       "verse": 8,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -2975,7 +3358,9 @@
       "chapter": 5,
       "verse": 9,
       "phraseWordCounts": [
-        19
+        7,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -2993,7 +3378,9 @@
       "chapter": 5,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        9,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -3013,7 +3400,9 @@
       "chapter": 5,
       "verse": 11,
       "phraseWordCounts": [
-        18
+        3,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -3029,7 +3418,9 @@
       "chapter": 5,
       "verse": 12,
       "phraseWordCounts": [
-        18
+        4,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -3049,7 +3440,10 @@
       "chapter": 5,
       "verse": 13,
       "phraseWordCounts": [
-        22
+        6,
+        6,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -3069,7 +3463,11 @@
       "chapter": 5,
       "verse": 14,
       "phraseWordCounts": [
-        27
+        7,
+        4,
+        6,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -3085,7 +3483,8 @@
       "chapter": 5,
       "verse": 15,
       "phraseWordCounts": [
-        16
+        3,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3096,7 +3495,9 @@
       "chapter": 5,
       "verse": 16,
       "phraseWordCounts": [
-        21
+        7,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -3107,7 +3508,9 @@
       "chapter": 5,
       "verse": 17,
       "phraseWordCounts": [
-        16
+        4,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -3127,7 +3530,10 @@
       "chapter": 5,
       "verse": 18,
       "phraseWordCounts": [
-        30
+        10,
+        7,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -3149,7 +3555,12 @@
       "chapter": 5,
       "verse": 19,
       "phraseWordCounts": [
-        38
+        7,
+        6,
+        7,
+        7,
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3162,7 +3573,10 @@
       "chapter": 5,
       "verse": 20,
       "phraseWordCounts": [
-        28
+        6,
+        9,
+        9,
+        4
       ],
       "annotations": [
         {
@@ -3180,7 +3594,8 @@
       "chapter": 5,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        12,
+        10
       ],
       "annotations": [
         {
@@ -3196,7 +3611,8 @@
       "chapter": 5,
       "verse": 22,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [
         {
@@ -3212,7 +3628,10 @@
       "chapter": 5,
       "verse": 23,
       "phraseWordCounts": [
-        27
+        6,
+        6,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3223,7 +3642,11 @@
       "chapter": 5,
       "verse": 24,
       "phraseWordCounts": [
-        34
+        6,
+        12,
+        3,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 9,
@@ -3236,7 +3659,10 @@
       "chapter": 5,
       "verse": 25,
       "phraseWordCounts": [
-        31
+        6,
+        7,
+        12,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -3247,7 +3673,9 @@
       "chapter": 5,
       "verse": 26,
       "phraseWordCounts": [
-        19
+        8,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -3258,7 +3686,8 @@
       "chapter": 5,
       "verse": 27,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [
         {
@@ -3274,7 +3703,9 @@
       "chapter": 5,
       "verse": 28,
       "phraseWordCounts": [
-        22
+        5,
+        5,
+        12
       ],
       "annotations": [
         {
@@ -3290,7 +3721,10 @@
       "chapter": 5,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        8,
+        5,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3301,7 +3735,11 @@
       "chapter": 5,
       "verse": 30,
       "phraseWordCounts": [
-        33
+        6,
+        5,
+        5,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3312,7 +3750,8 @@
       "chapter": 5,
       "verse": 31,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3323,7 +3762,8 @@
       "chapter": 5,
       "verse": 32,
       "phraseWordCounts": [
-        21
+        8,
+        13
       ],
       "annotations": [
         {
@@ -3339,7 +3779,8 @@
       "chapter": 5,
       "verse": 33,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -3355,7 +3796,8 @@
       "chapter": 5,
       "verse": 34,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3366,7 +3808,9 @@
       "chapter": 5,
       "verse": 35,
       "phraseWordCounts": [
-        19
+        7,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -3394,7 +3838,10 @@
       "chapter": 5,
       "verse": 36,
       "phraseWordCounts": [
-        35
+        8,
+        11,
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3407,7 +3854,10 @@
       "chapter": 5,
       "verse": 37,
       "phraseWordCounts": [
-        24
+        7,
+        4,
+        9,
+        4
       ],
       "annotations": [
         {
@@ -3423,7 +3873,9 @@
       "chapter": 5,
       "verse": 38,
       "phraseWordCounts": [
-        19
+        10,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -3439,7 +3891,9 @@
       "chapter": 5,
       "verse": 39,
       "phraseWordCounts": [
-        21
+        4,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -3457,7 +3911,8 @@
       "chapter": 5,
       "verse": 40,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -3486,7 +3941,8 @@
       "chapter": 5,
       "verse": 42,
       "phraseWordCounts": [
-        15
+        4,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -3497,7 +3953,10 @@
       "chapter": 5,
       "verse": 43,
       "phraseWordCounts": [
-        24
+        7,
+        6,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -3508,7 +3967,10 @@
       "chapter": 5,
       "verse": 44,
       "phraseWordCounts": [
-        22
+        4,
+        6,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -3519,7 +3981,9 @@
       "chapter": 5,
       "verse": 45,
       "phraseWordCounts": [
-        22
+        11,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -3539,7 +4003,9 @@
       "chapter": 5,
       "verse": 46,
       "phraseWordCounts": [
-        14
+        5,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3552,7 +4018,8 @@
       "chapter": 5,
       "verse": 47,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -3570,7 +4037,8 @@
       "chapter": 6,
       "verse": 1,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -3581,7 +4049,9 @@
       "chapter": 6,
       "verse": 2,
       "phraseWordCounts": [
-        19
+        6,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -3597,7 +4067,8 @@
       "chapter": 6,
       "verse": 3,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3619,7 +4090,11 @@
       "chapter": 6,
       "verse": 5,
       "phraseWordCounts": [
-        27
+        6,
+        8,
+        4,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3632,7 +4107,8 @@
       "chapter": 6,
       "verse": 6,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -3650,7 +4126,10 @@
       "chapter": 6,
       "verse": 7,
       "phraseWordCounts": [
-        23
+        3,
+        6,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -3668,7 +4147,8 @@
       "chapter": 6,
       "verse": 8,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3681,7 +4161,9 @@
       "chapter": 6,
       "verse": 9,
       "phraseWordCounts": [
-        21
+        5,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -3707,7 +4189,11 @@
       "chapter": 6,
       "verse": 10,
       "phraseWordCounts": [
-        26
+        3,
+        5,
+        8,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -3737,7 +4223,12 @@
       "chapter": 6,
       "verse": 11,
       "phraseWordCounts": [
-        34
+        5,
+        6,
+        6,
+        7,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -3755,7 +4246,10 @@
       "chapter": 6,
       "verse": 12,
       "phraseWordCounts": [
-        21
+        5,
+        5,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -3771,7 +4265,10 @@
       "chapter": 6,
       "verse": 13,
       "phraseWordCounts": [
-        26
+        5,
+        7,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -3795,7 +4292,9 @@
       "chapter": 6,
       "verse": 14,
       "phraseWordCounts": [
-        25
+        13,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3808,7 +4307,9 @@
       "chapter": 6,
       "verse": 15,
       "phraseWordCounts": [
-        28
+        15,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -3828,7 +4329,8 @@
       "chapter": 6,
       "verse": 16,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3839,7 +4341,10 @@
       "chapter": 6,
       "verse": 17,
       "phraseWordCounts": [
-        23
+        4,
+        7,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -3866,7 +4371,10 @@
       "chapter": 6,
       "verse": 19,
       "phraseWordCounts": [
-        26
+        10,
+        7,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -3890,7 +4398,9 @@
       "chapter": 6,
       "verse": 20,
       "phraseWordCounts": [
-        12
+        5,
+        3,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -3901,7 +4411,9 @@
       "chapter": 6,
       "verse": 21,
       "phraseWordCounts": [
-        20
+        8,
+        8,
+        4
       ],
       "annotations": [
         {
@@ -3917,7 +4429,12 @@
       "chapter": 6,
       "verse": 22,
       "phraseWordCounts": [
-        51
+        4,
+        13,
+        8,
+        8,
+        11,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3928,7 +4445,9 @@
       "chapter": 6,
       "verse": 23,
       "phraseWordCounts": [
-        19
+        6,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -3944,7 +4463,10 @@
       "chapter": 6,
       "verse": 24,
       "phraseWordCounts": [
-        24
+        10,
+        3,
+        9,
+        2
       ],
       "annotations": [
         {
@@ -3960,7 +4482,9 @@
       "chapter": 6,
       "verse": 25,
       "phraseWordCounts": [
-        22
+        12,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -3971,7 +4495,12 @@
       "chapter": 6,
       "verse": 26,
       "phraseWordCounts": [
-        30
+        5,
+        6,
+        3,
+        6,
+        7,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -3982,7 +4511,10 @@
       "chapter": 6,
       "verse": 27,
       "phraseWordCounts": [
-        35
+        8,
+        9,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -4006,7 +4538,9 @@
       "chapter": 6,
       "verse": 28,
       "phraseWordCounts": [
-        17
+        5,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4017,7 +4551,9 @@
       "chapter": 6,
       "verse": 29,
       "phraseWordCounts": [
-        20
+        6,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -4028,7 +4564,10 @@
       "chapter": 6,
       "verse": 30,
       "phraseWordCounts": [
-        24
+        5,
+        6,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -4044,7 +4583,9 @@
       "chapter": 6,
       "verse": 31,
       "phraseWordCounts": [
-        21
+        8,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -4060,7 +4601,10 @@
       "chapter": 6,
       "verse": 32,
       "phraseWordCounts": [
-        30
+        5,
+        6,
+        9,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 12,
@@ -4071,7 +4615,9 @@
       "chapter": 6,
       "verse": 33,
       "phraseWordCounts": [
-        18
+        7,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4082,7 +4628,8 @@
       "chapter": 6,
       "verse": 34,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4093,7 +4640,10 @@
       "chapter": 6,
       "verse": 35,
       "phraseWordCounts": [
-        28
+        5,
+        6,
+        8,
+        9
       ],
       "annotations": [
         {
@@ -4111,7 +4661,8 @@
       "chapter": 6,
       "verse": 36,
       "phraseWordCounts": [
-        15
+        10,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4122,7 +4673,9 @@
       "chapter": 6,
       "verse": 37,
       "phraseWordCounts": [
-        24
+        10,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4135,7 +4688,9 @@
       "chapter": 6,
       "verse": 38,
       "phraseWordCounts": [
-        21
+        7,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4146,7 +4701,9 @@
       "chapter": 6,
       "verse": 39,
       "phraseWordCounts": [
-        30
+        10,
+        11,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4157,7 +4714,10 @@
       "chapter": 6,
       "verse": 40,
       "phraseWordCounts": [
-        34
+        10,
+        10,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4170,7 +4730,10 @@
       "chapter": 6,
       "verse": 41,
       "phraseWordCounts": [
-        18
+        6,
+        3,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4183,7 +4746,11 @@
       "chapter": 6,
       "verse": 42,
       "phraseWordCounts": [
-        30
+        3,
+        8,
+        6,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -4199,7 +4766,8 @@
       "chapter": 6,
       "verse": 43,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -4217,7 +4785,9 @@
       "chapter": 6,
       "verse": 44,
       "phraseWordCounts": [
-        24
+        6,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -4235,7 +4805,10 @@
       "chapter": 6,
       "verse": 45,
       "phraseWordCounts": [
-        27
+        6,
+        8,
+        10,
+        3
       ],
       "annotations": [
         {
@@ -4251,7 +4824,9 @@
       "chapter": 6,
       "verse": 46,
       "phraseWordCounts": [
-        18
+        7,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4262,7 +4837,8 @@
       "chapter": 6,
       "verse": 47,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 12,
@@ -4284,7 +4860,8 @@
       "chapter": 6,
       "verse": 49,
       "phraseWordCounts": [
-        11
+        8,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4297,7 +4874,8 @@
       "chapter": 6,
       "verse": 50,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4310,7 +4888,11 @@
       "chapter": 6,
       "verse": 51,
       "phraseWordCounts": [
-        40
+        10,
+        6,
+        4,
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4323,7 +4905,8 @@
       "chapter": 6,
       "verse": 52,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [
         {
@@ -4339,7 +4922,11 @@
       "chapter": 6,
       "verse": 53,
       "phraseWordCounts": [
-        31
+        5,
+        6,
+        10,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 12,
@@ -4350,7 +4937,8 @@
       "chapter": 6,
       "verse": 54,
       "phraseWordCounts": [
-        21
+        11,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4361,7 +4949,8 @@
       "chapter": 6,
       "verse": 55,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4372,7 +4961,8 @@
       "chapter": 6,
       "verse": 56,
       "phraseWordCounts": [
-        16
+        12,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4383,7 +4973,9 @@
       "chapter": 6,
       "verse": 57,
       "phraseWordCounts": [
-        24
+        6,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -4399,7 +4991,10 @@
       "chapter": 6,
       "verse": 58,
       "phraseWordCounts": [
-        27
+        9,
+        7,
+        3,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4410,7 +5005,8 @@
       "chapter": 6,
       "verse": 59,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4421,7 +5017,10 @@
       "chapter": 6,
       "verse": 60,
       "phraseWordCounts": [
-        19
+        5,
+        5,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -4437,7 +5036,9 @@
       "chapter": 6,
       "verse": 61,
       "phraseWordCounts": [
-        19
+        11,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -4453,7 +5054,8 @@
       "chapter": 6,
       "verse": 62,
       "phraseWordCounts": [
-        15
+        11,
+        4
       ],
       "annotations": [
         {
@@ -4469,7 +5071,10 @@
       "chapter": 6,
       "verse": 63,
       "phraseWordCounts": [
-        24
+        7,
+        4,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -4487,7 +5092,10 @@
       "chapter": 6,
       "verse": 64,
       "phraseWordCounts": [
-        28
+        10,
+        6,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4498,7 +5106,9 @@
       "chapter": 6,
       "verse": 65,
       "phraseWordCounts": [
-        26
+        3,
+        13,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4509,7 +5119,8 @@
       "chapter": 6,
       "verse": 66,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4520,7 +5131,8 @@
       "chapter": 6,
       "verse": 67,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4531,7 +5143,9 @@
       "chapter": 6,
       "verse": 68,
       "phraseWordCounts": [
-        18
+        5,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4544,7 +5158,8 @@
       "chapter": 6,
       "verse": 69,
       "phraseWordCounts": [
-        19
+        13,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4557,7 +5172,9 @@
       "chapter": 6,
       "verse": 70,
       "phraseWordCounts": [
-        17
+        3,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4568,7 +5185,9 @@
       "chapter": 6,
       "verse": 71,
       "phraseWordCounts": [
-        22
+        9,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4579,7 +5198,9 @@
       "chapter": 7,
       "verse": 1,
       "phraseWordCounts": [
-        23
+        7,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4606,7 +5227,10 @@
       "chapter": 7,
       "verse": 3,
       "phraseWordCounts": [
-        25
+        6,
+        7,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4617,7 +5241,10 @@
       "chapter": 7,
       "verse": 4,
       "phraseWordCounts": [
-        25
+        7,
+        8,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4639,7 +5266,9 @@
       "chapter": 7,
       "verse": 6,
       "phraseWordCounts": [
-        17
+        5,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -4655,7 +5284,9 @@
       "chapter": 7,
       "verse": 7,
       "phraseWordCounts": [
-        19
+        5,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -4673,7 +5304,9 @@
       "chapter": 7,
       "verse": 8,
       "phraseWordCounts": [
-        23
+        6,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -4689,7 +5322,8 @@
       "chapter": 7,
       "verse": 9,
       "phraseWordCounts": [
-        12
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -4700,7 +5334,10 @@
       "chapter": 7,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        7,
+        8,
+        2,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4711,7 +5348,8 @@
       "chapter": 7,
       "verse": 11,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4722,7 +5360,10 @@
       "chapter": 7,
       "verse": 12,
       "phraseWordCounts": [
-        25
+        10,
+        5,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -4748,7 +5389,8 @@
       "chapter": 7,
       "verse": 13,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4759,7 +5401,8 @@
       "chapter": 7,
       "verse": 14,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -4775,7 +5418,9 @@
       "chapter": 7,
       "verse": 15,
       "phraseWordCounts": [
-        14
+        5,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -4795,7 +5440,9 @@
       "chapter": 7,
       "verse": 16,
       "phraseWordCounts": [
-        15
+        5,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4806,7 +5453,10 @@
       "chapter": 7,
       "verse": 17,
       "phraseWordCounts": [
-        26
+        7,
+        6,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -4824,7 +5474,9 @@
       "chapter": 7,
       "verse": 18,
       "phraseWordCounts": [
-        29
+        9,
+        14,
+        6
       ],
       "annotations": [
         {
@@ -4840,7 +5492,9 @@
       "chapter": 7,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        7,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4851,7 +5505,9 @@
       "chapter": 7,
       "verse": 20,
       "phraseWordCounts": [
-        15
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4862,7 +5518,9 @@
       "chapter": 7,
       "verse": 21,
       "phraseWordCounts": [
-        14
+        6,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -4875,7 +5533,9 @@
       "chapter": 7,
       "verse": 22,
       "phraseWordCounts": [
-        23
+        5,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -4897,7 +5557,10 @@
       "chapter": 7,
       "verse": 23,
       "phraseWordCounts": [
-        33
+        8,
+        10,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -4919,7 +5582,8 @@
       "chapter": 7,
       "verse": 24,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [
         {
@@ -4937,7 +5601,8 @@
       "chapter": 7,
       "verse": 25,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4948,7 +5613,9 @@
       "chapter": 7,
       "verse": 26,
       "phraseWordCounts": [
-        22
+        5,
+        6,
+        11
       ],
       "annotations": [
         {
@@ -4964,7 +5631,9 @@
       "chapter": 7,
       "verse": 27,
       "phraseWordCounts": [
-        20
+        8,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4975,7 +5644,13 @@
       "chapter": 7,
       "verse": 28,
       "phraseWordCounts": [
-        41
+        4,
+        7,
+        4,
+        7,
+        7,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4986,7 +5661,9 @@
       "chapter": 7,
       "verse": 29,
       "phraseWordCounts": [
-        13
+        4,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4997,7 +5674,9 @@
       "chapter": 7,
       "verse": 30,
       "phraseWordCounts": [
-        21
+        6,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5010,7 +5689,10 @@
       "chapter": 7,
       "verse": 31,
       "phraseWordCounts": [
-        26
+        8,
+        6,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5023,7 +5705,8 @@
       "chapter": 7,
       "verse": 32,
       "phraseWordCounts": [
-        22
+        10,
+        12
       ],
       "annotations": [
         {
@@ -5039,7 +5722,9 @@
       "chapter": 7,
       "verse": 33,
       "phraseWordCounts": [
-        23
+        5,
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -5050,7 +5735,8 @@
       "chapter": 7,
       "verse": 34,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5061,7 +5747,10 @@
       "chapter": 7,
       "verse": 35,
       "phraseWordCounts": [
-        33
+        6,
+        12,
+        11,
+        4
       ],
       "annotations": [
         {
@@ -5085,7 +5774,9 @@
       "chapter": 7,
       "verse": 36,
       "phraseWordCounts": [
-        22
+        7,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5096,7 +5787,11 @@
       "chapter": 7,
       "verse": 37,
       "phraseWordCounts": [
-        26
+        4,
+        6,
+        6,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -5114,7 +5809,9 @@
       "chapter": 7,
       "verse": 38,
       "phraseWordCounts": [
-        20
+        5,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -5136,7 +5833,10 @@
       "chapter": 7,
       "verse": 39,
       "phraseWordCounts": [
-        28
+        7,
+        7,
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5149,7 +5849,9 @@
       "chapter": 7,
       "verse": 40,
       "phraseWordCounts": [
-        16
+        5,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5160,7 +5862,8 @@
       "chapter": 7,
       "verse": 41,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5171,7 +5874,9 @@
       "chapter": 7,
       "verse": 42,
       "phraseWordCounts": [
-        23
+        14,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -5210,7 +5915,8 @@
       "chapter": 7,
       "verse": 44,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5221,7 +5927,8 @@
       "chapter": 7,
       "verse": 45,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5286,7 +5993,8 @@
       "chapter": 7,
       "verse": 50,
       "phraseWordCounts": [
-        15
+        12,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5297,7 +6005,8 @@
       "chapter": 7,
       "verse": 51,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5308,7 +6017,10 @@
       "chapter": 7,
       "verse": 52,
       "phraseWordCounts": [
-        22
+        6,
+        5,
+        3,
+        8
       ],
       "annotations": [
         {
@@ -5355,7 +6067,9 @@
       "chapter": 8,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        11,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5368,7 +6082,9 @@
       "chapter": 8,
       "verse": 3,
       "phraseWordCounts": [
-        22
+        8,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -5390,7 +6106,9 @@
       "chapter": 8,
       "verse": 4,
       "phraseWordCounts": [
-        15
+        4,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -5412,7 +6130,9 @@
       "chapter": 8,
       "verse": 5,
       "phraseWordCounts": [
-        17
+        5,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -5434,7 +6154,11 @@
       "chapter": 8,
       "verse": 6,
       "phraseWordCounts": [
-        33
+        5,
+        10,
+        4,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -5452,7 +6176,10 @@
       "chapter": 8,
       "verse": 7,
       "phraseWordCounts": [
-        29
+        6,
+        8,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -5485,7 +6212,12 @@
       "chapter": 8,
       "verse": 9,
       "phraseWordCounts": [
-        35
+        5,
+        5,
+        5,
+        8,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -5511,7 +6243,10 @@
       "chapter": 8,
       "verse": 10,
       "phraseWordCounts": [
-        29
+        13,
+        4,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -5529,7 +6264,10 @@
       "chapter": 8,
       "verse": 11,
       "phraseWordCounts": [
-        20
+        5,
+        5,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5542,7 +6280,10 @@
       "chapter": 8,
       "verse": 12,
       "phraseWordCounts": [
-        29
+        7,
+        7,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -5560,7 +6301,9 @@
       "chapter": 8,
       "verse": 13,
       "phraseWordCounts": [
-        16
+        6,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5571,7 +6314,11 @@
       "chapter": 8,
       "verse": 14,
       "phraseWordCounts": [
-        43
+        6,
+        7,
+        4,
+        12,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -5593,7 +6340,10 @@
       "chapter": 8,
       "verse": 16,
       "phraseWordCounts": [
-        24
+        6,
+        4,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5604,7 +6354,8 @@
       "chapter": 8,
       "verse": 17,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5615,7 +6366,9 @@
       "chapter": 8,
       "verse": 18,
       "phraseWordCounts": [
-        18
+        8,
+        6,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5626,7 +6379,11 @@
       "chapter": 8,
       "verse": 19,
       "phraseWordCounts": [
-        30
+        5,
+        4,
+        9,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 8,
@@ -5639,7 +6396,10 @@
       "chapter": 8,
       "verse": 20,
       "phraseWordCounts": [
-        27
+        7,
+        6,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -5655,7 +6415,11 @@
       "chapter": 8,
       "verse": 21,
       "phraseWordCounts": [
-        27
+        6,
+        4,
+        5,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -5666,7 +6430,10 @@
       "chapter": 8,
       "verse": 22,
       "phraseWordCounts": [
-        17
+        4,
+        4,
+        3,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5677,7 +6444,11 @@
       "chapter": 8,
       "verse": 23,
       "phraseWordCounts": [
-        24
+        5,
+        4,
+        4,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -5695,7 +6466,9 @@
       "chapter": 8,
       "verse": 24,
       "phraseWordCounts": [
-        28
+        12,
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5708,7 +6481,11 @@
       "chapter": 8,
       "verse": 25,
       "phraseWordCounts": [
-        24
+        5,
+        3,
+        5,
+        8,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 9,
@@ -5719,7 +6496,10 @@
       "chapter": 8,
       "verse": 26,
       "phraseWordCounts": [
-        31
+        11,
+        7,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5741,7 +6521,12 @@
       "chapter": 8,
       "verse": 28,
       "phraseWordCounts": [
-        38
+        5,
+        8,
+        8,
+        7,
+        6,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -5754,7 +6539,9 @@
       "chapter": 8,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        8,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -5781,7 +6568,9 @@
       "chapter": 8,
       "verse": 31,
       "phraseWordCounts": [
-        20
+        9,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5794,7 +6583,8 @@
       "chapter": 8,
       "verse": 32,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -5812,7 +6602,11 @@
       "chapter": 8,
       "verse": 33,
       "phraseWordCounts": [
-        24
+        3,
+        4,
+        8,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -5838,7 +6632,9 @@
       "chapter": 8,
       "verse": 34,
       "phraseWordCounts": [
-        17
+        3,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -5860,7 +6656,8 @@
       "chapter": 8,
       "verse": 35,
       "phraseWordCounts": [
-        15
+        10,
+        5
       ],
       "annotations": [
         {
@@ -5876,7 +6673,8 @@
       "chapter": 8,
       "verse": 36,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -5898,7 +6696,9 @@
       "chapter": 8,
       "verse": 37,
       "phraseWordCounts": [
-        21
+        7,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -5914,7 +6714,8 @@
       "chapter": 8,
       "verse": 38,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5925,7 +6726,11 @@
       "chapter": 8,
       "verse": 39,
       "phraseWordCounts": [
-        26
+        6,
+        4,
+        4,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -5938,7 +6743,10 @@
       "chapter": 8,
       "verse": 40,
       "phraseWordCounts": [
-        25
+        7,
+        8,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5951,7 +6759,10 @@
       "chapter": 8,
       "verse": 41,
       "phraseWordCounts": [
-        23
+        7,
+        5,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -5967,7 +6778,11 @@
       "chapter": 8,
       "verse": 42,
       "phraseWordCounts": [
-        31
+        4,
+        9,
+        8,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -5983,7 +6798,8 @@
       "chapter": 8,
       "verse": 43,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5994,7 +6810,14 @@
       "chapter": 8,
       "verse": 44,
       "phraseWordCounts": [
-        59
+        7,
+        10,
+        7,
+        7,
+        7,
+        5,
+        6,
+        10
       ],
       "annotations": [
         {
@@ -6028,7 +6851,8 @@
       "chapter": 8,
       "verse": 45,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6039,7 +6863,9 @@
       "chapter": 8,
       "verse": 46,
       "phraseWordCounts": [
-        19
+        7,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -6055,7 +6881,9 @@
       "chapter": 8,
       "verse": 47,
       "phraseWordCounts": [
-        19
+        8,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -6071,7 +6899,8 @@
       "chapter": 8,
       "verse": 48,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6082,7 +6911,9 @@
       "chapter": 8,
       "verse": 49,
       "phraseWordCounts": [
-        17
+        8,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -6098,7 +6929,8 @@
       "chapter": 8,
       "verse": 50,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6109,7 +6941,9 @@
       "chapter": 8,
       "verse": 51,
       "phraseWordCounts": [
-        16
+        6,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -6120,7 +6954,11 @@
       "chapter": 8,
       "verse": 52,
       "phraseWordCounts": [
-        33
+        6,
+        8,
+        6,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -6136,7 +6974,9 @@
       "chapter": 8,
       "verse": 53,
       "phraseWordCounts": [
-        23
+        10,
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -6147,7 +6987,11 @@
       "chapter": 8,
       "verse": 54,
       "phraseWordCounts": [
-        26
+        2,
+        4,
+        4,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -6163,7 +7007,12 @@
       "chapter": 8,
       "verse": 55,
       "phraseWordCounts": [
-        35
+        6,
+        4,
+        4,
+        5,
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6174,7 +7023,8 @@
       "chapter": 8,
       "verse": 56,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [
         {
@@ -6190,7 +7040,9 @@
       "chapter": 8,
       "verse": 57,
       "phraseWordCounts": [
-        18
+        6,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -6206,7 +7058,9 @@
       "chapter": 8,
       "verse": 58,
       "phraseWordCounts": [
-        15
+        4,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6219,7 +7073,11 @@
       "chapter": 8,
       "verse": 59,
       "phraseWordCounts": [
-        29
+        9,
+        4,
+        6,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -6235,7 +7093,8 @@
       "chapter": 9,
       "verse": 1,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6248,7 +7107,9 @@
       "chapter": 9,
       "verse": 2,
       "phraseWordCounts": [
-        19
+        6,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -6266,7 +7127,8 @@
       "chapter": 9,
       "verse": 3,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [
         {
@@ -6284,7 +7146,10 @@
       "chapter": 9,
       "verse": 4,
       "phraseWordCounts": [
-        23
+        10,
+        4,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6295,7 +7160,8 @@
       "chapter": 9,
       "verse": 5,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6306,7 +7172,11 @@
       "chapter": 9,
       "verse": 6,
       "phraseWordCounts": [
-        29
+        6,
+        5,
+        6,
+        9,
+        3
       ],
       "annotations": [
         {
@@ -6326,7 +7196,11 @@
       "chapter": 9,
       "verse": 7,
       "phraseWordCounts": [
-        25
+        5,
+        7,
+        4,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -6342,7 +7216,9 @@
       "chapter": 9,
       "verse": 8,
       "phraseWordCounts": [
-        22
+        3,
+        11,
+        8
       ],
       "annotations": [
         {
@@ -6366,7 +7242,9 @@
       "chapter": 9,
       "verse": 9,
       "phraseWordCounts": [
-        16
+        5,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -6388,7 +7266,12 @@
       "chapter": 9,
       "verse": 11,
       "phraseWordCounts": [
-        35
+        4,
+        6,
+        8,
+        8,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -6404,7 +7287,8 @@
       "chapter": 9,
       "verse": 12,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 8,
@@ -6431,7 +7315,8 @@
       "chapter": 9,
       "verse": 14,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6442,7 +7327,10 @@
       "chapter": 9,
       "verse": 15,
       "phraseWordCounts": [
-        29
+        13,
+        4,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6455,7 +7343,12 @@
       "chapter": 9,
       "verse": 16,
       "phraseWordCounts": [
-        39
+        6,
+        6,
+        7,
+        6,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6466,7 +7359,9 @@
       "chapter": 9,
       "verse": 17,
       "phraseWordCounts": [
-        24
+        7,
+        11,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6477,7 +7372,8 @@
       "chapter": 9,
       "verse": 18,
       "phraseWordCounts": [
-        29
+        17,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6488,7 +7384,9 @@
       "chapter": 9,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        5,
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6499,7 +7397,9 @@
       "chapter": 9,
       "verse": 20,
       "phraseWordCounts": [
-        19
+        6,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6510,7 +7410,10 @@
       "chapter": 9,
       "verse": 21,
       "phraseWordCounts": [
-        31
+        11,
+        9,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -6526,7 +7429,10 @@
       "chapter": 9,
       "verse": 22,
       "phraseWordCounts": [
-        32
+        10,
+        6,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -6562,7 +7468,10 @@
       "chapter": 9,
       "verse": 24,
       "phraseWordCounts": [
-        25
+        9,
+        4,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6575,7 +7484,9 @@
       "chapter": 9,
       "verse": 25,
       "phraseWordCounts": [
-        27
+        4,
+        11,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6588,7 +7499,9 @@
       "chapter": 9,
       "verse": 26,
       "phraseWordCounts": [
-        18
+        6,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -6599,7 +7512,10 @@
       "chapter": 9,
       "verse": 27,
       "phraseWordCounts": [
-        28
+        3,
+        9,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6610,7 +7526,9 @@
       "chapter": 9,
       "verse": 28,
       "phraseWordCounts": [
-        15
+        6,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -6630,7 +7548,9 @@
       "chapter": 9,
       "verse": 29,
       "phraseWordCounts": [
-        19
+        7,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -6641,7 +7561,10 @@
       "chapter": 9,
       "verse": 30,
       "phraseWordCounts": [
-        28
+        7,
+        6,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -6657,7 +7580,10 @@
       "chapter": 9,
       "verse": 31,
       "phraseWordCounts": [
-        24
+        9,
+        8,
+        4,
+        3
       ],
       "annotations": [
         {
@@ -6677,7 +7603,9 @@
       "chapter": 9,
       "verse": 32,
       "phraseWordCounts": [
-        20
+        4,
+        10,
+        6
       ],
       "annotations": [
         {
@@ -6693,7 +7621,8 @@
       "chapter": 9,
       "verse": 33,
       "phraseWordCounts": [
-        11
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6704,7 +7633,10 @@
       "chapter": 9,
       "verse": 34,
       "phraseWordCounts": [
-        22
+        6,
+        6,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -6722,7 +7654,10 @@
       "chapter": 9,
       "verse": 35,
       "phraseWordCounts": [
-        26
+        8,
+        6,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6735,7 +7670,9 @@
       "chapter": 9,
       "verse": 36,
       "phraseWordCounts": [
-        14
+        4,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6748,7 +7685,9 @@
       "chapter": 9,
       "verse": 37,
       "phraseWordCounts": [
-        19
+        5,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6774,7 +7713,10 @@
       "chapter": 9,
       "verse": 39,
       "phraseWordCounts": [
-        28
+        3,
+        8,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6787,7 +7729,10 @@
       "chapter": 9,
       "verse": 40,
       "phraseWordCounts": [
-        20
+        9,
+        3,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6798,7 +7743,11 @@
       "chapter": 9,
       "verse": 41,
       "phraseWordCounts": [
-        23
+        4,
+        4,
+        5,
+        6,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -6809,7 +7758,10 @@
       "chapter": 10,
       "verse": 1,
       "phraseWordCounts": [
-        30
+        6,
+        10,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -6840,7 +7792,10 @@
       "chapter": 10,
       "verse": 3,
       "phraseWordCounts": [
-        23
+        5,
+        6,
+        8,
+        4
       ],
       "annotations": [
         {
@@ -6868,7 +7823,10 @@
       "chapter": 10,
       "verse": 4,
       "phraseWordCounts": [
-        22
+        8,
+        4,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -6884,7 +7842,9 @@
       "chapter": 10,
       "verse": 5,
       "phraseWordCounts": [
-        23
+        9,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -6908,7 +7868,9 @@
       "chapter": 10,
       "verse": 6,
       "phraseWordCounts": [
-        16
+        4,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -6924,7 +7886,9 @@
       "chapter": 10,
       "verse": 7,
       "phraseWordCounts": [
-        19
+        6,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -6937,7 +7901,9 @@
       "chapter": 10,
       "verse": 8,
       "phraseWordCounts": [
-        17
+        6,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -6957,7 +7923,10 @@
       "chapter": 10,
       "verse": 9,
       "phraseWordCounts": [
-        22
+        4,
+        5,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -6975,7 +7944,11 @@
       "chapter": 10,
       "verse": 10,
       "phraseWordCounts": [
-        30
+        8,
+        3,
+        3,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -6997,7 +7970,8 @@
       "chapter": 10,
       "verse": 11,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -7010,7 +7984,11 @@
       "chapter": 10,
       "verse": 12,
       "phraseWordCounts": [
-        35
+        3,
+        6,
+        7,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -7050,7 +8028,8 @@
       "chapter": 10,
       "verse": 13,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [
         {
@@ -7078,7 +8057,9 @@
       "chapter": 10,
       "verse": 14,
       "phraseWordCounts": [
-        16
+        5,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -7089,7 +8070,9 @@
       "chapter": 10,
       "verse": 15,
       "phraseWordCounts": [
-        20
+        5,
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7100,7 +8083,10 @@
       "chapter": 10,
       "verse": 16,
       "phraseWordCounts": [
-        31
+        11,
+        5,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -7120,7 +8106,9 @@
       "chapter": 10,
       "verse": 17,
       "phraseWordCounts": [
-        17
+        5,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7131,7 +8119,11 @@
       "chapter": 10,
       "verse": 18,
       "phraseWordCounts": [
-        36
+        6,
+        7,
+        7,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7144,7 +8136,8 @@
       "chapter": 10,
       "verse": 19,
       "phraseWordCounts": [
-        13
+        9,
+        4
       ],
       "annotations": [
         {
@@ -7160,7 +8153,9 @@
       "chapter": 10,
       "verse": 20,
       "phraseWordCounts": [
-        18
+        5,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -7176,7 +8171,9 @@
       "chapter": 10,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        2,
+        11,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7187,7 +8184,8 @@
       "chapter": 10,
       "verse": 22,
       "phraseWordCounts": [
-        13
+        9,
+        4
       ],
       "annotations": [
         {
@@ -7229,7 +8227,9 @@
       "chapter": 10,
       "verse": 24,
       "phraseWordCounts": [
-        25
+        9,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -7251,7 +8251,10 @@
       "chapter": 10,
       "verse": 25,
       "phraseWordCounts": [
-        25
+        3,
+        8,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7264,7 +8267,9 @@
       "chapter": 10,
       "verse": 26,
       "phraseWordCounts": [
-        17
+        5,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -7277,7 +8282,9 @@
       "chapter": 10,
       "verse": 27,
       "phraseWordCounts": [
-        13
+        5,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7290,7 +8297,9 @@
       "chapter": 10,
       "verse": 28,
       "phraseWordCounts": [
-        20
+        6,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -7308,7 +8317,9 @@
       "chapter": 10,
       "verse": 29,
       "phraseWordCounts": [
-        25
+        8,
+        4,
+        13
       ],
       "annotations": [
         {
@@ -7350,7 +8361,9 @@
       "chapter": 10,
       "verse": 32,
       "phraseWordCounts": [
-        22
+        3,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -7366,7 +8379,11 @@
       "chapter": 10,
       "verse": 33,
       "phraseWordCounts": [
-        26
+        5,
+        9,
+        3,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -7382,7 +8399,9 @@
       "chapter": 10,
       "verse": 34,
       "phraseWordCounts": [
-        17
+        3,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -7398,7 +8417,9 @@
       "chapter": 10,
       "verse": 35,
       "phraseWordCounts": [
-        18
+        5,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -7414,7 +8435,11 @@
       "chapter": 10,
       "verse": 36,
       "phraseWordCounts": [
-        26
+        5,
+        9,
+        3,
+        3,
+        6
       ],
       "annotations": [
         {
@@ -7434,7 +8459,8 @@
       "chapter": 10,
       "verse": 37,
       "phraseWordCounts": [
-        14
+        10,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7445,7 +8471,11 @@
       "chapter": 10,
       "verse": 38,
       "phraseWordCounts": [
-        29
+        4,
+        6,
+        3,
+        12,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7456,7 +8486,8 @@
       "chapter": 10,
       "verse": 39,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -7472,7 +8503,9 @@
       "chapter": 10,
       "verse": 40,
       "phraseWordCounts": [
-        21
+        8,
+        9,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7483,7 +8516,9 @@
       "chapter": 10,
       "verse": 41,
       "phraseWordCounts": [
-        23
+        7,
+        4,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7505,7 +8540,9 @@
       "chapter": 11,
       "verse": 1,
       "phraseWordCounts": [
-        17
+        6,
+        3,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -7518,7 +8555,10 @@
       "chapter": 11,
       "verse": 2,
       "phraseWordCounts": [
-        23
+        8,
+        3,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7529,7 +8569,8 @@
       "chapter": 11,
       "verse": 3,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -7545,7 +8586,10 @@
       "chapter": 11,
       "verse": 4,
       "phraseWordCounts": [
-        28
+        6,
+        6,
+        6,
+        10
       ],
       "annotations": [
         {
@@ -7578,7 +8622,8 @@
       "chapter": 11,
       "verse": 6,
       "phraseWordCounts": [
-        19
+        8,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7589,7 +8634,8 @@
       "chapter": 11,
       "verse": 7,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7600,7 +8646,9 @@
       "chapter": 11,
       "verse": 8,
       "phraseWordCounts": [
-        19
+        5,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -7616,7 +8664,10 @@
       "chapter": 11,
       "verse": 9,
       "phraseWordCounts": [
-        28
+        10,
+        6,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -7632,7 +8683,8 @@
       "chapter": 11,
       "verse": 10,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [
         {
@@ -7648,7 +8700,10 @@
       "chapter": 11,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        4,
+        7,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -7668,7 +8723,8 @@
       "chapter": 11,
       "verse": 12,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [
         {
@@ -7684,7 +8740,8 @@
       "chapter": 11,
       "verse": 13,
       "phraseWordCounts": [
-        18
+        6,
+        12
       ],
       "annotations": [
         {
@@ -7719,7 +8776,10 @@
       "chapter": 11,
       "verse": 15,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7730,7 +8790,10 @@
       "chapter": 11,
       "verse": 16,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7741,7 +8804,8 @@
       "chapter": 11,
       "verse": 17,
       "phraseWordCounts": [
-        16
+        4,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7763,7 +8827,9 @@
       "chapter": 11,
       "verse": 19,
       "phraseWordCounts": [
-        19
+        9,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -7787,7 +8853,9 @@
       "chapter": 11,
       "verse": 20,
       "phraseWordCounts": [
-        22
+        11,
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7798,7 +8866,9 @@
       "chapter": 11,
       "verse": 21,
       "phraseWordCounts": [
-        17
+        5,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7811,7 +8881,8 @@
       "chapter": 11,
       "verse": 22,
       "phraseWordCounts": [
-        15
+        11,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7837,7 +8908,9 @@
       "chapter": 11,
       "verse": 24,
       "phraseWordCounts": [
-        18
+        4,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -7850,7 +8923,11 @@
       "chapter": 11,
       "verse": 25,
       "phraseWordCounts": [
-        23
+        4,
+        7,
+        5,
+        4,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -7863,7 +8940,9 @@
       "chapter": 11,
       "verse": 26,
       "phraseWordCounts": [
-        14
+        7,
+        3,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7876,7 +8955,10 @@
       "chapter": 11,
       "verse": 27,
       "phraseWordCounts": [
-        24
+        4,
+        9,
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7889,7 +8971,11 @@
       "chapter": 11,
       "verse": 28,
       "phraseWordCounts": [
-        27
+        7,
+        4,
+        7,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -7905,7 +8991,8 @@
       "chapter": 11,
       "verse": 29,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7916,7 +9003,8 @@
       "chapter": 11,
       "verse": 30,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7927,7 +9015,11 @@
       "chapter": 11,
       "verse": 31,
       "phraseWordCounts": [
-        36
+        10,
+        3,
+        11,
+        3,
+        9
       ],
       "annotations": [
         {
@@ -7943,7 +9035,12 @@
       "chapter": 11,
       "verse": 32,
       "phraseWordCounts": [
-        31
+        7,
+        3,
+        6,
+        3,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7956,7 +9053,10 @@
       "chapter": 11,
       "verse": 33,
       "phraseWordCounts": [
-        22
+        6,
+        8,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -7974,7 +9074,10 @@
       "chapter": 11,
       "verse": 34,
       "phraseWordCounts": [
-        16
+        3,
+        5,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8007,7 +9110,10 @@
       "chapter": 11,
       "verse": 37,
       "phraseWordCounts": [
-        23
+        5,
+        4,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -8023,7 +9129,8 @@
       "chapter": 11,
       "verse": 38,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [
         {
@@ -8043,7 +9150,10 @@
       "chapter": 11,
       "verse": 39,
       "phraseWordCounts": [
-        32
+        6,
+        11,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -8059,7 +9169,9 @@
       "chapter": 11,
       "verse": 40,
       "phraseWordCounts": [
-        22
+        4,
+        11,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8070,7 +9182,10 @@
       "chapter": 11,
       "verse": 41,
       "phraseWordCounts": [
-        32
+        6,
+        9,
+        8,
+        9
       ],
       "annotations": [
         {
@@ -8086,7 +9201,9 @@
       "chapter": 11,
       "verse": 42,
       "phraseWordCounts": [
-        28
+        8,
+        12,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8097,7 +9214,9 @@
       "chapter": 11,
       "verse": 43,
       "phraseWordCounts": [
-        16
+        7,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -8115,7 +9234,11 @@
       "chapter": 11,
       "verse": 44,
       "phraseWordCounts": [
-        31
+        7,
+        6,
+        8,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -8149,7 +9272,10 @@
       "chapter": 11,
       "verse": 45,
       "phraseWordCounts": [
-        20
+        5,
+        5,
+        7,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -8160,7 +9286,8 @@
       "chapter": 11,
       "verse": 46,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8171,7 +9298,10 @@
       "chapter": 11,
       "verse": 47,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -8187,7 +9317,10 @@
       "chapter": 11,
       "verse": 48,
       "phraseWordCounts": [
-        25
+        7,
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -8203,7 +9336,10 @@
       "chapter": 11,
       "verse": 49,
       "phraseWordCounts": [
-        18
+        5,
+        5,
+        3,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8214,7 +9350,9 @@
       "chapter": 11,
       "verse": 50,
       "phraseWordCounts": [
-        26
+        10,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -8230,7 +9368,9 @@
       "chapter": 11,
       "verse": 51,
       "phraseWordCounts": [
-        25
+        10,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -8246,7 +9386,9 @@
       "chapter": 11,
       "verse": 52,
       "phraseWordCounts": [
-        23
+        6,
+        13,
+        4
       ],
       "annotations": [
         {
@@ -8262,7 +9404,8 @@
       "chapter": 11,
       "verse": 53,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8273,7 +9416,10 @@
       "chapter": 11,
       "verse": 54,
       "phraseWordCounts": [
-        30
+        9,
+        10,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -8289,7 +9435,9 @@
       "chapter": 11,
       "verse": 55,
       "phraseWordCounts": [
-        23
+        8,
+        12,
+        3
       ],
       "annotations": [
         {
@@ -8305,7 +9453,9 @@
       "chapter": 11,
       "verse": 56,
       "phraseWordCounts": [
-        26
+        4,
+        10,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8316,7 +9466,10 @@
       "chapter": 11,
       "verse": 57,
       "phraseWordCounts": [
-        28
+        12,
+        7,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8327,7 +9480,10 @@
       "chapter": 12,
       "verse": 1,
       "phraseWordCounts": [
-        24
+        6,
+        4,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8340,7 +9496,10 @@
       "chapter": 12,
       "verse": 2,
       "phraseWordCounts": [
-        22
+        6,
+        3,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -8356,7 +9515,11 @@
       "chapter": 12,
       "verse": 3,
       "phraseWordCounts": [
-        34
+        11,
+        5,
+        7,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -8386,7 +9549,9 @@
       "chapter": 12,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        5,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8399,7 +9564,9 @@
       "chapter": 12,
       "verse": 5,
       "phraseWordCounts": [
-        16
+        7,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8412,7 +9579,11 @@
       "chapter": 12,
       "verse": 6,
       "phraseWordCounts": [
-        31
+        3,
+        7,
+        6,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -8430,7 +9601,9 @@
       "chapter": 12,
       "verse": 7,
       "phraseWordCounts": [
-        16
+        3,
+        3,
+        10
       ],
       "annotations": [
         {
@@ -8448,7 +9621,8 @@
       "chapter": 12,
       "verse": 8,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8461,7 +9635,10 @@
       "chapter": 12,
       "verse": 9,
       "phraseWordCounts": [
-        34
+        12,
+        8,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8483,7 +9660,8 @@
       "chapter": 12,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        11,
+        4
       ],
       "annotations": [
         {
@@ -8499,7 +9677,8 @@
       "chapter": 12,
       "verse": 12,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8512,7 +9691,10 @@
       "chapter": 12,
       "verse": 13,
       "phraseWordCounts": [
-        30
+        11,
+        4,
+        11,
+        4
       ],
       "annotations": [
         {
@@ -8534,7 +9716,9 @@
       "chapter": 12,
       "verse": 14,
       "phraseWordCounts": [
-        16
+        9,
+        3,
+        4
       ],
       "annotations": [
         {
@@ -8556,7 +9740,9 @@
       "chapter": 12,
       "verse": 15,
       "phraseWordCounts": [
-        14
+        4,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -8590,7 +9776,10 @@
       "chapter": 12,
       "verse": 16,
       "phraseWordCounts": [
-        33
+        9,
+        5,
+        10,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8601,7 +9790,10 @@
       "chapter": 12,
       "verse": 17,
       "phraseWordCounts": [
-        23
+        3,
+        12,
+        6,
+        2
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8612,7 +9804,8 @@
       "chapter": 12,
       "verse": 18,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8623,7 +9816,9 @@
       "chapter": 12,
       "verse": 19,
       "phraseWordCounts": [
-        20
+        6,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -8639,7 +9834,8 @@
       "chapter": 12,
       "verse": 20,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8650,7 +9846,10 @@
       "chapter": 12,
       "verse": 21,
       "phraseWordCounts": [
-        21
+        5,
+        6,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8661,7 +9860,8 @@
       "chapter": 12,
       "verse": 22,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8672,7 +9872,9 @@
       "chapter": 12,
       "verse": 23,
       "phraseWordCounts": [
-        17
+        5,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8683,7 +9885,11 @@
       "chapter": 12,
       "verse": 24,
       "phraseWordCounts": [
-        28
+        6,
+        11,
+        3,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -8717,7 +9923,9 @@
       "chapter": 12,
       "verse": 25,
       "phraseWordCounts": [
-        23
+        8,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8730,7 +9938,12 @@
       "chapter": 12,
       "verse": 26,
       "phraseWordCounts": [
-        27
+        4,
+        4,
+        4,
+        6,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -8750,7 +9963,10 @@
       "chapter": 12,
       "verse": 27,
       "phraseWordCounts": [
-        25
+        5,
+        5,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -8776,7 +9992,10 @@
       "chapter": 12,
       "verse": 28,
       "phraseWordCounts": [
-        21
+        4,
+        7,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8789,7 +10008,9 @@
       "chapter": 12,
       "verse": 29,
       "phraseWordCounts": [
-        22
+        9,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -8805,7 +10026,9 @@
       "chapter": 12,
       "verse": 30,
       "phraseWordCounts": [
-        16
+        4,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8816,7 +10039,8 @@
       "chapter": 12,
       "verse": 31,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8827,7 +10051,8 @@
       "chapter": 12,
       "verse": 32,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [
         {
@@ -8858,7 +10083,11 @@
       "chapter": 12,
       "verse": 34,
       "phraseWordCounts": [
-        34
+        4,
+        11,
+        5,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -8874,7 +10103,12 @@
       "chapter": 12,
       "verse": 35,
       "phraseWordCounts": [
-        36
+        5,
+        9,
+        6,
+        4,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -8892,7 +10126,11 @@
       "chapter": 12,
       "verse": 36,
       "phraseWordCounts": [
-        27
+        5,
+        4,
+        7,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -8910,7 +10148,8 @@
       "chapter": 12,
       "verse": 37,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8921,7 +10160,10 @@
       "chapter": 12,
       "verse": 38,
       "phraseWordCounts": [
-        30
+        10,
+        3,
+        6,
+        11
       ],
       "annotations": [
         {
@@ -8948,7 +10190,11 @@
       "chapter": 12,
       "verse": 40,
       "phraseWordCounts": [
-        31
+        5,
+        4,
+        7,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -8976,7 +10222,9 @@
       "chapter": 12,
       "verse": 41,
       "phraseWordCounts": [
-        13
+        4,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8987,7 +10235,10 @@
       "chapter": 12,
       "verse": 42,
       "phraseWordCounts": [
-        28
+        9,
+        5,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -9005,7 +10256,8 @@
       "chapter": 12,
       "verse": 43,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [
         {
@@ -9027,7 +10279,10 @@
       "chapter": 12,
       "verse": 44,
       "phraseWordCounts": [
-        21
+        6,
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9049,7 +10304,9 @@
       "chapter": 12,
       "verse": 46,
       "phraseWordCounts": [
-        19
+        9,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9062,7 +10319,11 @@
       "chapter": 12,
       "verse": 47,
       "phraseWordCounts": [
-        29
+        6,
+        4,
+        5,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9073,7 +10334,9 @@
       "chapter": 12,
       "verse": 48,
       "phraseWordCounts": [
-        28
+        10,
+        5,
+        13
       ],
       "annotations": [
         {
@@ -9089,7 +10352,9 @@
       "chapter": 12,
       "verse": 49,
       "phraseWordCounts": [
-        28
+        9,
+        10,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9100,7 +10365,10 @@
       "chapter": 12,
       "verse": 50,
       "phraseWordCounts": [
-        23
+        9,
+        4,
+        7,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9111,7 +10379,11 @@
       "chapter": 13,
       "verse": 1,
       "phraseWordCounts": [
-        40
+        7,
+        8,
+        10,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -9129,7 +10401,9 @@
       "chapter": 13,
       "verse": 2,
       "phraseWordCounts": [
-        21
+        4,
+        12,
+        5
       ],
       "annotations": [
         {
@@ -9147,7 +10421,8 @@
       "chapter": 13,
       "verse": 3,
       "phraseWordCounts": [
-        24
+        12,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9160,7 +10435,8 @@
       "chapter": 13,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -9182,7 +10458,10 @@
       "chapter": 13,
       "verse": 5,
       "phraseWordCounts": [
-        27
+        8,
+        7,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -9212,7 +10491,9 @@
       "chapter": 13,
       "verse": 6,
       "phraseWordCounts": [
-        17
+        6,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -9228,7 +10509,9 @@
       "chapter": 13,
       "verse": 7,
       "phraseWordCounts": [
-        21
+        6,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -9239,7 +10522,11 @@
       "chapter": 13,
       "verse": 8,
       "phraseWordCounts": [
-        25
+        4,
+        6,
+        3,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9250,7 +10537,9 @@
       "chapter": 13,
       "verse": 9,
       "phraseWordCounts": [
-        17
+        5,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -9261,7 +10550,12 @@
       "chapter": 13,
       "verse": 10,
       "phraseWordCounts": [
-        27
+        4,
+        4,
+        6,
+        4,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -9281,7 +10575,9 @@
       "chapter": 13,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        7,
+        3,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9292,7 +10588,11 @@
       "chapter": 13,
       "verse": 12,
       "phraseWordCounts": [
-        27
+        7,
+        3,
+        4,
+        4,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9303,7 +10603,9 @@
       "chapter": 13,
       "verse": 13,
       "phraseWordCounts": [
-        14
+        6,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9314,7 +10616,9 @@
       "chapter": 13,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        7,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -9332,7 +10636,8 @@
       "chapter": 13,
       "verse": 15,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [
         {
@@ -9348,7 +10653,9 @@
       "chapter": 13,
       "verse": 16,
       "phraseWordCounts": [
-        26
+        6,
+        8,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -9361,7 +10668,8 @@
       "chapter": 13,
       "verse": 17,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9372,7 +10680,10 @@
       "chapter": 13,
       "verse": 18,
       "phraseWordCounts": [
-        34
+        8,
+        6,
+        7,
+        13
       ],
       "annotations": [
         {
@@ -9392,7 +10703,9 @@
       "chapter": 13,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        7,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9403,7 +10716,9 @@
       "chapter": 13,
       "verse": 20,
       "phraseWordCounts": [
-        24
+        6,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -9419,7 +10734,11 @@
       "chapter": 13,
       "verse": 21,
       "phraseWordCounts": [
-        27
+        6,
+        5,
+        4,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9430,7 +10749,8 @@
       "chapter": 13,
       "verse": 22,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -9446,7 +10766,8 @@
       "chapter": 13,
       "verse": 23,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -9462,7 +10783,8 @@
       "chapter": 13,
       "verse": 24,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [
         {
@@ -9478,7 +10800,9 @@
       "chapter": 13,
       "verse": 25,
       "phraseWordCounts": [
-        14
+        6,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -9494,7 +10818,11 @@
       "chapter": 13,
       "verse": 26,
       "phraseWordCounts": [
-        35
+        14,
+        5,
+        5,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -9514,7 +10842,9 @@
       "chapter": 13,
       "verse": 27,
       "phraseWordCounts": [
-        19
+        9,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -9541,7 +10871,11 @@
       "chapter": 13,
       "verse": 29,
       "phraseWordCounts": [
-        32
+        3,
+        6,
+        6,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9552,7 +10886,9 @@
       "chapter": 13,
       "verse": 30,
       "phraseWordCounts": [
-        15
+        6,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9563,7 +10899,9 @@
       "chapter": 13,
       "verse": 31,
       "phraseWordCounts": [
-        21
+        8,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9574,7 +10912,9 @@
       "chapter": 13,
       "verse": 32,
       "phraseWordCounts": [
-        17
+        6,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9585,7 +10925,11 @@
       "chapter": 13,
       "verse": 33,
       "phraseWordCounts": [
-        35
+        11,
+        4,
+        7,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9596,7 +10940,10 @@
       "chapter": 13,
       "verse": 34,
       "phraseWordCounts": [
-        23
+        7,
+        5,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9609,7 +10956,8 @@
       "chapter": 13,
       "verse": 35,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9622,7 +10970,11 @@
       "chapter": 13,
       "verse": 36,
       "phraseWordCounts": [
-        28
+        5,
+        5,
+        3,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -9635,7 +10987,9 @@
       "chapter": 13,
       "verse": 37,
       "phraseWordCounts": [
-        21
+        4,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9648,7 +11002,10 @@
       "chapter": 13,
       "verse": 38,
       "phraseWordCounts": [
-        30
+        3,
+        9,
+        6,
+        12
       ],
       "annotations": [
         {
@@ -9670,7 +11027,9 @@
       "chapter": 14,
       "verse": 1,
       "phraseWordCounts": [
-        14
+        6,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9683,7 +11042,10 @@
       "chapter": 14,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        7,
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -9705,7 +11067,10 @@
       "chapter": 14,
       "verse": 3,
       "phraseWordCounts": [
-        28
+        10,
+        9,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -9723,7 +11088,8 @@
       "chapter": 14,
       "verse": 4,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9736,7 +11102,9 @@
       "chapter": 14,
       "verse": 5,
       "phraseWordCounts": [
-        20
+        4,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9749,7 +11117,11 @@
       "chapter": 14,
       "verse": 6,
       "phraseWordCounts": [
-        22
+        4,
+        4,
+        5,
+        6,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9762,7 +11134,10 @@
       "chapter": 14,
       "verse": 7,
       "phraseWordCounts": [
-        23
+        5,
+        7,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9773,7 +11148,9 @@
       "chapter": 14,
       "verse": 8,
       "phraseWordCounts": [
-        15
+        4,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9784,7 +11161,10 @@
       "chapter": 14,
       "verse": 9,
       "phraseWordCounts": [
-        37
+        4,
+        15,
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9797,7 +11177,10 @@
       "chapter": 14,
       "verse": 10,
       "phraseWordCounts": [
-        40
+        15,
+        7,
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9808,7 +11191,8 @@
       "chapter": 14,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        13,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9819,7 +11203,11 @@
       "chapter": 14,
       "verse": 12,
       "phraseWordCounts": [
-        34
+        6,
+        5,
+        9,
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 12,
@@ -9832,7 +11220,9 @@
       "chapter": 14,
       "verse": 13,
       "phraseWordCounts": [
-        20
+        7,
+        4,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9843,7 +11233,8 @@
       "chapter": 14,
       "verse": 14,
       "phraseWordCounts": [
-        11
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9867,7 +11258,9 @@
       "chapter": 14,
       "verse": 16,
       "phraseWordCounts": [
-        20
+        6,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9880,7 +11273,11 @@
       "chapter": 14,
       "verse": 17,
       "phraseWordCounts": [
-        31
+        4,
+        5,
+        8,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9893,7 +11290,8 @@
       "chapter": 14,
       "verse": 18,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [
         {
@@ -9911,7 +11309,11 @@
       "chapter": 14,
       "verse": 19,
       "phraseWordCounts": [
-        24
+        4,
+        8,
+        5,
+        3,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -9922,7 +11324,9 @@
       "chapter": 14,
       "verse": 20,
       "phraseWordCounts": [
-        20
+        12,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -9933,7 +11337,11 @@
       "chapter": 14,
       "verse": 21,
       "phraseWordCounts": [
-        35
+        8,
+        6,
+        11,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -9949,7 +11357,9 @@
       "chapter": 14,
       "verse": 22,
       "phraseWordCounts": [
-        22
+        6,
+        11,
+        5
       ],
       "annotations": [
         {
@@ -9965,7 +11375,12 @@
       "chapter": 14,
       "verse": 23,
       "phraseWordCounts": [
-        33
+        6,
+        4,
+        5,
+        6,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -9976,7 +11391,11 @@
       "chapter": 14,
       "verse": 24,
       "phraseWordCounts": [
-        26
+        6,
+        5,
+        6,
+        6,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -9987,7 +11406,8 @@
       "chapter": 14,
       "verse": 25,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -10003,7 +11423,11 @@
       "chapter": 14,
       "verse": 26,
       "phraseWordCounts": [
-        32
+        6,
+        8,
+        6,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -10021,7 +11445,11 @@
       "chapter": 14,
       "verse": 27,
       "phraseWordCounts": [
-        32
+        5,
+        6,
+        10,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -10034,7 +11462,11 @@
       "chapter": 14,
       "verse": 28,
       "phraseWordCounts": [
-        39
+        7,
+        9,
+        7,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10045,7 +11477,9 @@
       "chapter": 14,
       "verse": 29,
       "phraseWordCounts": [
-        19
+        9,
+        7,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10056,7 +11490,9 @@
       "chapter": 14,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        8,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -10072,7 +11508,10 @@
       "chapter": 14,
       "verse": 31,
       "phraseWordCounts": [
-        27
+        11,
+        7,
+        3,
+        6
       ],
       "annotations": [
         {
@@ -10088,7 +11527,8 @@
       "chapter": 15,
       "verse": 1,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [
         {
@@ -10110,7 +11550,9 @@
       "chapter": 15,
       "verse": 2,
       "phraseWordCounts": [
-        26
+        12,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -10136,7 +11578,8 @@
       "chapter": 15,
       "verse": 3,
       "phraseWordCounts": [
-        14
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10147,7 +11590,11 @@
       "chapter": 15,
       "verse": 4,
       "phraseWordCounts": [
-        29
+        7,
+        8,
+        6,
+        3,
+        5
       ],
       "annotations": [
         {
@@ -10169,7 +11616,10 @@
       "chapter": 15,
       "verse": 5,
       "phraseWordCounts": [
-        27
+        8,
+        9,
+        3,
+        7
       ],
       "annotations": [
         {
@@ -10187,7 +11637,10 @@
       "chapter": 15,
       "verse": 6,
       "phraseWordCounts": [
-        31
+        7,
+        10,
+        10,
+        4
       ],
       "annotations": [
         {
@@ -10211,7 +11664,10 @@
       "chapter": 15,
       "verse": 7,
       "phraseWordCounts": [
-        24
+        5,
+        6,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10222,7 +11678,9 @@
       "chapter": 15,
       "verse": 8,
       "phraseWordCounts": [
-        17
+        6,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10235,7 +11693,9 @@
       "chapter": 15,
       "verse": 9,
       "phraseWordCounts": [
-        14
+        5,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -10246,7 +11706,10 @@
       "chapter": 15,
       "verse": 10,
       "phraseWordCounts": [
-        24
+        5,
+        6,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10257,7 +11720,9 @@
       "chapter": 15,
       "verse": 11,
       "phraseWordCounts": [
-        21
+        7,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 9,
@@ -10270,7 +11735,8 @@
       "chapter": 15,
       "verse": 12,
       "phraseWordCounts": [
-        14
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10283,7 +11749,8 @@
       "chapter": 15,
       "verse": 13,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -10305,7 +11772,8 @@
       "chapter": 15,
       "verse": 14,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -10323,7 +11791,11 @@
       "chapter": 15,
       "verse": 15,
       "phraseWordCounts": [
-        39
+        7,
+        11,
+        6,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -10341,7 +11813,12 @@
       "chapter": 15,
       "verse": 16,
       "phraseWordCounts": [
-        38
+        5,
+        7,
+        7,
+        6,
+        9,
+        4
       ],
       "annotations": [
         {
@@ -10374,7 +11851,8 @@
       "chapter": 15,
       "verse": 18,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10385,7 +11863,11 @@
       "chapter": 15,
       "verse": 19,
       "phraseWordCounts": [
-        33
+        6,
+        6,
+        8,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -10401,7 +11883,12 @@
       "chapter": 15,
       "verse": 20,
       "phraseWordCounts": [
-        35
+        8,
+        8,
+        4,
+        5,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -10417,7 +11904,9 @@
       "chapter": 15,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        9,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -10433,7 +11922,9 @@
       "chapter": 15,
       "verse": 22,
       "phraseWordCounts": [
-        23
+        9,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -10460,7 +11951,11 @@
       "chapter": 15,
       "verse": 24,
       "phraseWordCounts": [
-        32
+        9,
+        5,
+        5,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -10471,7 +11966,9 @@
       "chapter": 15,
       "verse": 25,
       "phraseWordCounts": [
-        21
+        9,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -10487,7 +11984,10 @@
       "chapter": 15,
       "verse": 26,
       "phraseWordCounts": [
-        28
+        5,
+        9,
+        9,
+        5
       ],
       "annotations": [
         {
@@ -10503,7 +12003,8 @@
       "chapter": 15,
       "verse": 27,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10514,7 +12015,8 @@
       "chapter": 16,
       "verse": 1,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 9,
@@ -10525,7 +12027,9 @@
       "chapter": 16,
       "verse": 2,
       "phraseWordCounts": [
-        24
+        8,
+        5,
+        11
       ],
       "annotations": [
         {
@@ -10549,7 +12053,8 @@
       "chapter": 16,
       "verse": 3,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10560,7 +12065,11 @@
       "chapter": 16,
       "verse": 4,
       "phraseWordCounts": [
-        38
+        7,
+        5,
+        9,
+        12,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10571,7 +12080,9 @@
       "chapter": 16,
       "verse": 5,
       "phraseWordCounts": [
-        20
+        10,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -10587,7 +12098,8 @@
       "chapter": 16,
       "verse": 6,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -10598,7 +12110,12 @@
       "chapter": 16,
       "verse": 7,
       "phraseWordCounts": [
-        39
+        6,
+        9,
+        7,
+        7,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -10616,7 +12133,10 @@
       "chapter": 16,
       "verse": 8,
       "phraseWordCounts": [
-        18
+        5,
+        7,
+        3,
+        3
       ],
       "annotations": [
         {
@@ -10651,7 +12171,8 @@
       "chapter": 16,
       "verse": 10,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -10687,7 +12208,8 @@
       "chapter": 16,
       "verse": 12,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10698,7 +12220,11 @@
       "chapter": 16,
       "verse": 13,
       "phraseWordCounts": [
-        40
+        9,
+        7,
+        9,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -10716,7 +12242,9 @@
       "chapter": 16,
       "verse": 14,
       "phraseWordCounts": [
-        17
+        4,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10729,7 +12257,9 @@
       "chapter": 16,
       "verse": 15,
       "phraseWordCounts": [
-        22
+        8,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10740,7 +12270,9 @@
       "chapter": 16,
       "verse": 16,
       "phraseWordCounts": [
-        25
+        9,
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -10751,7 +12283,11 @@
       "chapter": 16,
       "verse": 17,
       "phraseWordCounts": [
-        42
+        8,
+        8,
+        9,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -10767,7 +12303,9 @@
       "chapter": 16,
       "verse": 18,
       "phraseWordCounts": [
-        20
+        3,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -10783,7 +12321,11 @@
       "chapter": 16,
       "verse": 19,
       "phraseWordCounts": [
-        42
+        9,
+        5,
+        9,
+        9,
+        10
       ],
       "annotations": [
         {
@@ -10807,7 +12349,10 @@
       "chapter": 16,
       "verse": 20,
       "phraseWordCounts": [
-        30
+        12,
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -10827,7 +12372,11 @@
       "chapter": 16,
       "verse": 21,
       "phraseWordCounts": [
-        43
+        9,
+        5,
+        11,
+        6,
+        12
       ],
       "annotations": [
         {
@@ -10851,7 +12400,10 @@
       "chapter": 16,
       "verse": 22,
       "phraseWordCounts": [
-        25
+        5,
+        6,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10864,7 +12416,10 @@
       "chapter": 16,
       "verse": 23,
       "phraseWordCounts": [
-        27
+        9,
+        6,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10877,7 +12432,9 @@
       "chapter": 16,
       "verse": 24,
       "phraseWordCounts": [
-        20
+        9,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -10890,7 +12447,10 @@
       "chapter": 16,
       "verse": 25,
       "phraseWordCounts": [
-        35
+        10,
+        5,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -10918,7 +12478,8 @@
       "chapter": 16,
       "verse": 26,
       "phraseWordCounts": [
-        24
+        9,
+        15
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10929,7 +12490,9 @@
       "chapter": 16,
       "verse": 27,
       "phraseWordCounts": [
-        20
+        6,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -10940,7 +12503,10 @@
       "chapter": 16,
       "verse": 28,
       "phraseWordCounts": [
-        22
+        6,
+        6,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10951,7 +12517,9 @@
       "chapter": 16,
       "verse": 29,
       "phraseWordCounts": [
-        17
+        5,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -10971,7 +12539,9 @@
       "chapter": 16,
       "verse": 30,
       "phraseWordCounts": [
-        28
+        9,
+        9,
+        10
       ],
       "annotations": [
         {
@@ -11002,7 +12572,11 @@
       "chapter": 16,
       "verse": 32,
       "phraseWordCounts": [
-        35
+        9,
+        9,
+        5,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -11013,7 +12587,11 @@
       "chapter": 16,
       "verse": 33,
       "phraseWordCounts": [
-        31
+        7,
+        7,
+        7,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -11039,7 +12617,11 @@
       "chapter": 17,
       "verse": 1,
       "phraseWordCounts": [
-        27
+        4,
+        6,
+        7,
+        3,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11052,7 +12634,8 @@
       "chapter": 17,
       "verse": 2,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11063,7 +12646,9 @@
       "chapter": 17,
       "verse": 3,
       "phraseWordCounts": [
-        21
+        5,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11076,7 +12661,8 @@
       "chapter": 17,
       "verse": 4,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11089,7 +12675,9 @@
       "chapter": 17,
       "verse": 5,
       "phraseWordCounts": [
-        21
+        4,
+        5,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11102,7 +12690,12 @@
       "chapter": 17,
       "verse": 6,
       "phraseWordCounts": [
-        31
+        5,
+        8,
+        4,
+        3,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11113,7 +12706,8 @@
       "chapter": 17,
       "verse": 7,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11124,7 +12718,11 @@
       "chapter": 17,
       "verse": 8,
       "phraseWordCounts": [
-        36
+        8,
+        5,
+        5,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -11140,7 +12738,10 @@
       "chapter": 17,
       "verse": 9,
       "phraseWordCounts": [
-        23
+        4,
+        7,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11151,7 +12752,9 @@
       "chapter": 17,
       "verse": 10,
       "phraseWordCounts": [
-        15
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11162,7 +12765,12 @@
       "chapter": 17,
       "verse": 11,
       "phraseWordCounts": [
-        39
+        8,
+        6,
+        5,
+        6,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11173,7 +12781,11 @@
       "chapter": 17,
       "verse": 12,
       "phraseWordCounts": [
-        39
+        8,
+        6,
+        8,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -11189,7 +12801,9 @@
       "chapter": 17,
       "verse": 13,
       "phraseWordCounts": [
-        23
+        6,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11200,7 +12814,10 @@
       "chapter": 17,
       "verse": 14,
       "phraseWordCounts": [
-        27
+        6,
+        6,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11213,7 +12830,8 @@
       "chapter": 17,
       "verse": 15,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -11226,7 +12844,8 @@
       "chapter": 17,
       "verse": 16,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11255,7 +12874,8 @@
       "chapter": 17,
       "verse": 18,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11266,7 +12886,8 @@
       "chapter": 17,
       "verse": 19,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -11282,7 +12903,8 @@
       "chapter": 17,
       "verse": 20,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -11295,7 +12917,10 @@
       "chapter": 17,
       "verse": 21,
       "phraseWordCounts": [
-        33
+        6,
+        10,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11308,7 +12933,8 @@
       "chapter": 17,
       "verse": 22,
       "phraseWordCounts": [
-        21
+        11,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11321,7 +12947,10 @@
       "chapter": 17,
       "verse": 23,
       "phraseWordCounts": [
-        35
+        7,
+        8,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -11339,7 +12968,9 @@
       "chapter": 17,
       "verse": 24,
       "phraseWordCounts": [
-        38
+        17,
+        11,
+        10
       ],
       "annotations": [
         {
@@ -11355,7 +12986,10 @@
       "chapter": 17,
       "verse": 25,
       "phraseWordCounts": [
-        22
+        3,
+        6,
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -11366,7 +13000,10 @@
       "chapter": 17,
       "verse": 26,
       "phraseWordCounts": [
-        28
+        8,
+        4,
+        12,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11377,7 +13014,11 @@
       "chapter": 18,
       "verse": 1,
       "phraseWordCounts": [
-        27
+        6,
+        6,
+        4,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -11397,7 +13038,10 @@
       "chapter": 18,
       "verse": 2,
       "phraseWordCounts": [
-        17
+        5,
+        4,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -11417,7 +13061,9 @@
       "chapter": 18,
       "verse": 3,
       "phraseWordCounts": [
-        23
+        8,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -11441,7 +13087,10 @@
       "chapter": 18,
       "verse": 4,
       "phraseWordCounts": [
-        20
+        5,
+        5,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -11457,7 +13106,10 @@
       "chapter": 18,
       "verse": 5,
       "phraseWordCounts": [
-        23
+        6,
+        7,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -11473,7 +13125,8 @@
       "chapter": 18,
       "verse": 6,
       "phraseWordCounts": [
-        18
+        9,
+        8
       ],
       "annotations": [
         {
@@ -11489,7 +13142,9 @@
       "chapter": 18,
       "verse": 7,
       "phraseWordCounts": [
-        15
+        5,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11500,7 +13155,9 @@
       "chapter": 18,
       "verse": 8,
       "phraseWordCounts": [
-        20
+        10,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11511,7 +13168,9 @@
       "chapter": 18,
       "verse": 9,
       "phraseWordCounts": [
-        19
+        6,
+        3,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11522,7 +13181,10 @@
       "chapter": 18,
       "verse": 10,
       "phraseWordCounts": [
-        25
+        6,
+        8,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -11554,7 +13216,10 @@
       "chapter": 18,
       "verse": 11,
       "phraseWordCounts": [
-        23
+        5,
+        6,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -11578,7 +13243,10 @@
       "chapter": 18,
       "verse": 12,
       "phraseWordCounts": [
-        19
+        5,
+        3,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -11600,7 +13268,9 @@
       "chapter": 18,
       "verse": 13,
       "phraseWordCounts": [
-        21
+        8,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -11616,7 +13286,8 @@
       "chapter": 18,
       "verse": 14,
       "phraseWordCounts": [
-        20
+        12,
+        8
       ],
       "annotations": [
         {
@@ -11632,7 +13303,11 @@
       "chapter": 18,
       "verse": 15,
       "phraseWordCounts": [
-        30
+        5,
+        5,
+        9,
+        4,
+        7
       ],
       "annotations": [
         {
@@ -11650,7 +13325,12 @@
       "chapter": 18,
       "verse": 16,
       "phraseWordCounts": [
-        32
+        7,
+        4,
+        7,
+        6,
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11661,7 +13341,9 @@
       "chapter": 18,
       "verse": 17,
       "phraseWordCounts": [
-        27
+        11,
+        11,
+        5
       ],
       "annotations": [
         {
@@ -11683,7 +13365,12 @@
       "chapter": 18,
       "verse": 18,
       "phraseWordCounts": [
-        30
+        5,
+        7,
+        6,
+        4,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -11699,7 +13386,8 @@
       "chapter": 18,
       "verse": 19,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11710,7 +13398,11 @@
       "chapter": 18,
       "verse": 20,
       "phraseWordCounts": [
-        30
+        3,
+        6,
+        9,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11721,7 +13413,9 @@
       "chapter": 18,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        5,
+        11,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11732,7 +13426,10 @@
       "chapter": 18,
       "verse": 22,
       "phraseWordCounts": [
-        31
+        7,
+        7,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -11743,7 +13440,10 @@
       "chapter": 18,
       "verse": 23,
       "phraseWordCounts": [
-        21
+        3,
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -11770,7 +13470,10 @@
       "chapter": 18,
       "verse": 25,
       "phraseWordCounts": [
-        30
+        7,
+        5,
+        10,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11783,7 +13486,9 @@
       "chapter": 18,
       "verse": 26,
       "phraseWordCounts": [
-        28
+        8,
+        9,
+        11
       ],
       "annotations": [
         {
@@ -11819,7 +13524,11 @@
       "chapter": 18,
       "verse": 28,
       "phraseWordCounts": [
-        35
+        9,
+        5,
+        9,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -11835,7 +13544,8 @@
       "chapter": 18,
       "verse": 29,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [
         {
@@ -11851,7 +13561,9 @@
       "chapter": 18,
       "verse": 30,
       "phraseWordCounts": [
-        21
+        6,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -11867,7 +13579,10 @@
       "chapter": 18,
       "verse": 31,
       "phraseWordCounts": [
-        32
+        5,
+        10,
+        6,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -11878,7 +13593,9 @@
       "chapter": 18,
       "verse": 32,
       "phraseWordCounts": [
-        18
+        8,
+        3,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11889,7 +13606,9 @@
       "chapter": 18,
       "verse": 33,
       "phraseWordCounts": [
-        19
+        6,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11900,7 +13619,9 @@
       "chapter": 18,
       "verse": 34,
       "phraseWordCounts": [
-        18
+        3,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -11911,7 +13632,9 @@
       "chapter": 18,
       "verse": 35,
       "phraseWordCounts": [
-        22
+        6,
+        12,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11922,7 +13645,12 @@
       "chapter": 18,
       "verse": 36,
       "phraseWordCounts": [
-        38
+        2,
+        7,
+        7,
+        4,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -11940,7 +13668,13 @@
       "chapter": 18,
       "verse": 37,
       "phraseWordCounts": [
-        53
+        5,
+        5,
+        10,
+        6,
+        10,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11953,7 +13687,12 @@
       "chapter": 18,
       "verse": 38,
       "phraseWordCounts": [
-        32
+        4,
+        3,
+        6,
+        7,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -11966,7 +13705,9 @@
       "chapter": 18,
       "verse": 39,
       "phraseWordCounts": [
-        29
+        5,
+        10,
+        14
       ],
       "annotations": [
         {
@@ -11984,7 +13725,9 @@
       "chapter": 18,
       "verse": 40,
       "phraseWordCounts": [
-        16
+        6,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -12022,7 +13765,9 @@
       "chapter": 19,
       "verse": 2,
       "phraseWordCounts": [
-        22
+        8,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -12054,7 +13799,9 @@
       "chapter": 19,
       "verse": 3,
       "phraseWordCounts": [
-        15
+        3,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -12070,7 +13817,10 @@
       "chapter": 19,
       "verse": 4,
       "phraseWordCounts": [
-        28
+        5,
+        4,
+        8,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12081,7 +13831,10 @@
       "chapter": 19,
       "verse": 5,
       "phraseWordCounts": [
-        21
+        4,
+        9,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -12115,7 +13868,12 @@
       "chapter": 19,
       "verse": 6,
       "phraseWordCounts": [
-        34
+        9,
+        4,
+        4,
+        4,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -12126,7 +13884,10 @@
       "chapter": 19,
       "verse": 7,
       "phraseWordCounts": [
-        25
+        4,
+        4,
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12137,7 +13898,8 @@
       "chapter": 19,
       "verse": 8,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12148,7 +13910,10 @@
       "chapter": 19,
       "verse": 9,
       "phraseWordCounts": [
-        20
+        6,
+        4,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12159,7 +13924,10 @@
       "chapter": 19,
       "verse": 10,
       "phraseWordCounts": [
-        27
+        5,
+        6,
+        11,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12170,7 +13938,11 @@
       "chapter": 19,
       "verse": 11,
       "phraseWordCounts": [
-        31
+        2,
+        9,
+        8,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12181,7 +13953,12 @@
       "chapter": 19,
       "verse": 12,
       "phraseWordCounts": [
-        33
+        8,
+        6,
+        6,
+        5,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -12201,7 +13978,11 @@
       "chapter": 19,
       "verse": 13,
       "phraseWordCounts": [
-        29
+        6,
+        4,
+        7,
+        8,
+        4
       ],
       "annotations": [
         {
@@ -12225,7 +14006,10 @@
       "chapter": 19,
       "verse": 14,
       "phraseWordCounts": [
-        23
+        9,
+        5,
+        6,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12236,7 +14020,12 @@
       "chapter": 19,
       "verse": 15,
       "phraseWordCounts": [
-        31
+        4,
+        8,
+        4,
+        5,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -12254,7 +14043,8 @@
       "chapter": 19,
       "verse": 16,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12267,7 +14057,9 @@
       "chapter": 19,
       "verse": 17,
       "phraseWordCounts": [
-        22
+        5,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -12293,7 +14085,10 @@
       "chapter": 19,
       "verse": 18,
       "phraseWordCounts": [
-        18
+        4,
+        5,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -12315,7 +14110,11 @@
       "chapter": 19,
       "verse": 19,
       "phraseWordCounts": [
-        23
+        5,
+        6,
+        4,
+        3,
+        5
       ],
       "annotations": [
         {
@@ -12337,7 +14136,9 @@
       "chapter": 19,
       "verse": 20,
       "phraseWordCounts": [
-        28
+        8,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -12365,7 +14166,9 @@
       "chapter": 19,
       "verse": 21,
       "phraseWordCounts": [
-        30
+        10,
+        8,
+        12
       ],
       "annotations": [
         {
@@ -12392,7 +14195,11 @@
       "chapter": 19,
       "verse": 23,
       "phraseWordCounts": [
-        37
+        8,
+        7,
+        9,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -12432,7 +14239,13 @@
       "chapter": 19,
       "verse": 24,
       "phraseWordCounts": [
-        46
+        5,
+        5,
+        9,
+        8,
+        6,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -12464,7 +14277,10 @@
       "chapter": 19,
       "verse": 25,
       "phraseWordCounts": [
-        22
+        8,
+        6,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -12484,7 +14300,10 @@
       "chapter": 19,
       "verse": 26,
       "phraseWordCounts": [
-        23
+        6,
+        8,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12495,7 +14314,10 @@
       "chapter": 19,
       "verse": 27,
       "phraseWordCounts": [
-        21
+        6,
+        3,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12506,7 +14328,10 @@
       "chapter": 19,
       "verse": 28,
       "phraseWordCounts": [
-        19
+        3,
+        7,
+        6,
+        3
       ],
       "annotations": [
         {
@@ -12522,7 +14347,10 @@
       "chapter": 19,
       "verse": 29,
       "phraseWordCounts": [
-        28
+        10,
+        8,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -12558,7 +14386,10 @@
       "chapter": 19,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        8,
+        5,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -12580,7 +14411,11 @@
       "chapter": 19,
       "verse": 31,
       "phraseWordCounts": [
-        43
+        7,
+        12,
+        7,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -12600,7 +14435,9 @@
       "chapter": 19,
       "verse": 32,
       "phraseWordCounts": [
-        20
+        4,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -12616,7 +14453,9 @@
       "chapter": 19,
       "verse": 33,
       "phraseWordCounts": [
-        19
+        6,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -12636,7 +14475,8 @@
       "chapter": 19,
       "verse": 34,
       "phraseWordCounts": [
-        18
+        11,
+        7
       ],
       "annotations": [
         {
@@ -12656,7 +14496,10 @@
       "chapter": 19,
       "verse": 35,
       "phraseWordCounts": [
-        26
+        7,
+        5,
+        9,
+        5
       ],
       "annotations": [
         {
@@ -12672,7 +14515,9 @@
       "chapter": 19,
       "verse": 36,
       "phraseWordCounts": [
-        19
+        5,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -12688,7 +14533,8 @@
       "chapter": 19,
       "verse": 37,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -12704,7 +14550,12 @@
       "chapter": 19,
       "verse": 38,
       "phraseWordCounts": [
-        42
+        5,
+        7,
+        5,
+        11,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -12726,7 +14577,9 @@
       "chapter": 19,
       "verse": 39,
       "phraseWordCounts": [
-        23
+        10,
+        9,
+        4
       ],
       "annotations": [
         {
@@ -12756,7 +14609,9 @@
       "chapter": 19,
       "verse": 40,
       "phraseWordCounts": [
-        26
+        7,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -12782,7 +14637,10 @@
       "chapter": 19,
       "verse": 41,
       "phraseWordCounts": [
-        27
+        8,
+        4,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12795,7 +14653,9 @@
       "chapter": 19,
       "verse": 42,
       "phraseWordCounts": [
-        16
+        5,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -12813,7 +14673,10 @@
       "chapter": 20,
       "verse": 1,
       "phraseWordCounts": [
-        32
+        8,
+        7,
+        5,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12826,7 +14689,11 @@
       "chapter": 20,
       "verse": 2,
       "phraseWordCounts": [
-        40
+        8,
+        8,
+        4,
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12837,7 +14704,9 @@
       "chapter": 20,
       "verse": 3,
       "phraseWordCounts": [
-        14
+        4,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12848,7 +14717,9 @@
       "chapter": 20,
       "verse": 4,
       "phraseWordCounts": [
-        17
+        5,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -12864,7 +14735,9 @@
       "chapter": 20,
       "verse": 5,
       "phraseWordCounts": [
-        19
+        7,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -12884,7 +14757,9 @@
       "chapter": 20,
       "verse": 6,
       "phraseWordCounts": [
-        19
+        6,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -12900,7 +14775,9 @@
       "chapter": 20,
       "verse": 7,
       "phraseWordCounts": [
-        23
+        9,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -12924,7 +14801,10 @@
       "chapter": 20,
       "verse": 8,
       "phraseWordCounts": [
-        18
+        4,
+        6,
+        3,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12935,7 +14815,8 @@
       "chapter": 20,
       "verse": 9,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12962,7 +14843,9 @@
       "chapter": 20,
       "verse": 11,
       "phraseWordCounts": [
-        20
+        8,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12973,7 +14856,9 @@
       "chapter": 20,
       "verse": 12,
       "phraseWordCounts": [
-        25
+        8,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -12991,7 +14876,11 @@
       "chapter": 20,
       "verse": 13,
       "phraseWordCounts": [
-        31
+        5,
+        5,
+        4,
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13004,7 +14893,9 @@
       "chapter": 20,
       "verse": 14,
       "phraseWordCounts": [
-        22
+        6,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -13017,7 +14908,13 @@
       "chapter": 20,
       "verse": 15,
       "phraseWordCounts": [
-        43
+        4,
+        5,
+        4,
+        10,
+        7,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -13041,7 +14938,9 @@
       "chapter": 20,
       "verse": 16,
       "phraseWordCounts": [
-        17
+        5,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -13057,7 +14956,12 @@
       "chapter": 20,
       "verse": 17,
       "phraseWordCounts": [
-        44
+        4,
+        5,
+        9,
+        9,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -13075,7 +14979,8 @@
       "chapter": 20,
       "verse": 18,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -13088,7 +14993,13 @@
       "chapter": 20,
       "verse": 19,
       "phraseWordCounts": [
-        43
+        6,
+        7,
+        10,
+        5,
+        7,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -13106,7 +15017,10 @@
       "chapter": 20,
       "verse": 20,
       "phraseWordCounts": [
-        23
+        5,
+        8,
+        5,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13119,7 +15033,10 @@
       "chapter": 20,
       "verse": 21,
       "phraseWordCounts": [
-        19
+        6,
+        3,
+        6,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13130,7 +15047,10 @@
       "chapter": 20,
       "verse": 22,
       "phraseWordCounts": [
-        18
+        6,
+        4,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -13146,7 +15066,10 @@
       "chapter": 20,
       "verse": 23,
       "phraseWordCounts": [
-        21
+        7,
+        4,
+        7,
+        3
       ],
       "annotations": [
         {
@@ -13174,7 +15097,9 @@
       "chapter": 20,
       "verse": 24,
       "phraseWordCounts": [
-        16
+        5,
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13185,7 +15110,13 @@
       "chapter": 20,
       "verse": 25,
       "phraseWordCounts": [
-        49
+        7,
+        5,
+        5,
+        11,
+        10,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -13215,7 +15146,11 @@
       "chapter": 20,
       "verse": 26,
       "phraseWordCounts": [
-        29
+        9,
+        4,
+        6,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -13235,7 +15170,12 @@
       "chapter": 20,
       "verse": 27,
       "phraseWordCounts": [
-        31
+        5,
+        4,
+        5,
+        5,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -13261,7 +15201,8 @@
       "chapter": 20,
       "verse": 28,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13272,7 +15213,11 @@
       "chapter": 20,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        4,
+        6,
+        3,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13285,7 +15230,9 @@
       "chapter": 20,
       "verse": 30,
       "phraseWordCounts": [
-        20
+        7,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -13307,7 +15254,10 @@
       "chapter": 20,
       "verse": 31,
       "phraseWordCounts": [
-        27
+        4,
+        9,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -13320,7 +15270,9 @@
       "chapter": 21,
       "verse": 1,
       "phraseWordCounts": [
-        22
+        7,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13333,7 +15285,11 @@
       "chapter": 21,
       "verse": 2,
       "phraseWordCounts": [
-        23
+        6,
+        5,
+        4,
+        6,
+        2
       ],
       "annotations": [
         {
@@ -13349,7 +15305,12 @@
       "chapter": 21,
       "verse": 3,
       "phraseWordCounts": [
-        34
+        5,
+        4,
+        4,
+        6,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -13367,7 +15328,9 @@
       "chapter": 21,
       "verse": 4,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -13385,7 +15348,9 @@
       "chapter": 21,
       "verse": 5,
       "phraseWordCounts": [
-        14
+        5,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -13396,7 +15361,11 @@
       "chapter": 21,
       "verse": 6,
       "phraseWordCounts": [
-        40
+        5,
+        10,
+        5,
+        13,
+        6
       ],
       "annotations": [
         {
@@ -13414,7 +15383,12 @@
       "chapter": 21,
       "verse": 7,
       "phraseWordCounts": [
-        39
+        6,
+        7,
+        10,
+        6,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -13442,7 +15416,10 @@
       "chapter": 21,
       "verse": 8,
       "phraseWordCounts": [
-        26
+        9,
+        7,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -13470,7 +15447,10 @@
       "chapter": 21,
       "verse": 9,
       "phraseWordCounts": [
-        23
+        9,
+        7,
+        5,
+        2
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13481,7 +15461,8 @@
       "chapter": 21,
       "verse": 10,
       "phraseWordCounts": [
-        14
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13494,7 +15475,11 @@
       "chapter": 21,
       "verse": 11,
       "phraseWordCounts": [
-        29
+        10,
+        4,
+        4,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -13526,7 +15511,11 @@
       "chapter": 21,
       "verse": 12,
       "phraseWordCounts": [
-        25
+        4,
+        4,
+        8,
+        3,
+        6
       ],
       "annotations": [
         {
@@ -13548,7 +15537,9 @@
       "chapter": 21,
       "verse": 13,
       "phraseWordCounts": [
-        16
+        7,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13559,7 +15550,9 @@
       "chapter": 21,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        6,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -13572,7 +15565,14 @@
       "chapter": 21,
       "verse": 15,
       "phraseWordCounts": [
-        41
+        6,
+        5,
+        4,
+        7,
+        4,
+        8,
+        4,
+        3
       ],
       "annotations": [
         {
@@ -13598,7 +15598,13 @@
       "chapter": 21,
       "verse": 16,
       "phraseWordCounts": [
-        35
+        8,
+        4,
+        4,
+        4,
+        8,
+        4,
+        3
       ],
       "annotations": [
         {
@@ -13614,7 +15620,16 @@
       "chapter": 21,
       "verse": 17,
       "phraseWordCounts": [
-        53
+        7,
+        4,
+        4,
+        11,
+        4,
+        5,
+        5,
+        6,
+        4,
+        3
       ],
       "annotations": [
         {
@@ -13634,7 +15649,13 @@
       "chapter": 21,
       "verse": 18,
       "phraseWordCounts": [
-        42
+        6,
+        4,
+        8,
+        5,
+        6,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -13662,7 +15683,11 @@
       "chapter": 21,
       "verse": 19,
       "phraseWordCounts": [
-        23
+        3,
+        8,
+        6,
+        4,
+        2
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -13673,7 +15698,10 @@
       "chapter": 21,
       "verse": 20,
       "phraseWordCounts": [
-        31
+        4,
+        7,
+        10,
+        10
       ],
       "annotations": [
         {
@@ -13697,7 +15725,9 @@
       "chapter": 21,
       "verse": 21,
       "phraseWordCounts": [
-        12
+        3,
+        3,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13708,7 +15738,10 @@
       "chapter": 21,
       "verse": 22,
       "phraseWordCounts": [
-        21
+        4,
+        9,
+        5,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -13719,7 +15752,11 @@
       "chapter": 21,
       "verse": 23,
       "phraseWordCounts": [
-        41
+        8,
+        6,
+        13,
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -13730,7 +15767,10 @@
       "chapter": 21,
       "verse": 24,
       "phraseWordCounts": [
-        21
+        4,
+        5,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -13743,7 +15783,10 @@
       "chapter": 21,
       "verse": 25,
       "phraseWordCounts": [
-        35
+        10,
+        8,
+        12,
+        5
       ],
       "annotations": [
         {

--- a/tools/evaluate_phrases.py
+++ b/tools/evaluate_phrases.py
@@ -17,8 +17,8 @@ Checks (deterministic, run on every verse):
   threshold → almost certainly a split that was never applied.
 - No phrase ends in a perception/speech verb (``know``, ``see``,
   ``tell``, …) immediately followed by a phrase starting with
-  ``that`` / ``what`` / ``how`` / ``whether`` / ``if`` — that splits
-  a verb from its content clause, which is one rhetorical unit.
+  ``that`` / ``what`` / ``how`` / ``whether`` — that splits a verb
+  from its content clause, which is one rhetorical unit.
 - ``ftvWordCount`` is in range when set.
 
 The optional ``--llm-judge`` flag adds a Claude-Haiku quality check
@@ -47,6 +47,7 @@ from phrase_splitter import (  # noqa: E402
     normalize_reference,
     severity_rank,
 )
+from phrase_splitter.helpers import normalise_word  # noqa: E402
 from phrase_splitter.apibible import (  # noqa: E402
     DEFAULT_DB_PATH,
     DEFAULT_NKJV_ID,
@@ -65,14 +66,10 @@ WORD_MAX = 12
 # from a break.
 MISSING_SPLIT_THRESHOLD = 10
 
-# Verbs of perception / speech that commonly take a ``that``-clause
-# (or ``what`` / ``how`` / ``whether`` / ``if``) as their direct
-# object. Splitting between such a verb and its content clause breaks
-# a single rhetorical/cognitive unit and should be flagged. The
-# heuristic is intentionally narrow — it only matches when the
-# *last word of one phrase* is one of these verbs and the *first word*
-# of the next phrase is one of the listed complementisers. See
-# ``references/quality-criteria.md`` for the rationale.
+# Verbs of perception / speech that take a content clause as their direct
+# object — see ``references/quality-criteria.md``. ``if`` is excluded
+# from the complementiser set because conditional ``if`` dominates the
+# rare ``know if`` complementiser reading in scripture.
 CONTENT_CLAUSE_VERBS = frozenset({
     "know", "knew", "known", "knows",
     "see", "saw", "seen", "sees",
@@ -91,23 +88,11 @@ CONTENT_CLAUSE_VERBS = frozenset({
     "realize", "realized", "realizes",
     "learn", "learned", "learns",
 })
-# ``if`` is excluded — it's almost always a conditional in scripture
-# rather than the rare ``know if`` complementiser, and including it
-# produced more false positives than true positives in practice.
-CONTENT_CLAUSE_COMPLEMENTISERS = frozenset({
-    "that", "what", "how", "whether",
-})
+CONTENT_CLAUSE_COMPLEMENTISERS = frozenset({"that", "what", "how", "whether"})
 
-# When the boundary itself carries a stronger break signal — a colon
-# (introducing direct/reported speech, e.g. ``say: If any brother…``)
-# or an open quote (direct speech, e.g. ``say, "How…"``) — the
-# heuristic backs off, because the verb is being read with its
-# *quoted* object rather than a content clause.
+# Stronger reported-speech breaks where the heuristic backs off —
+# ``say: If any brother…`` and ``say, "How…"`` aren't content clauses.
 _QUOTE_OPENERS = ("\"", "“", "‘", "'")
-
-
-def _strip_punct(word: str) -> str:
-    return word.strip(",.?!;:\"'“”‘’()[]")
 
 
 def check_verse(ref: str, verse: Dict[str, Any], tokens: List[str]) -> List[Dict[str, str]]:
@@ -147,43 +132,37 @@ def check_verse(ref: str, verse: Dict[str, Any], tokens: List[str]) -> List[Dict
         })
 
     cursor = 0
-    phrase_slices: List[str] = []
+    phrase_first: List[str] = []
+    phrase_last: List[str] = []
     for i, count in enumerate(pwc):
-        slice_text = " ".join(tokens[cursor : cursor + count])
-        phrase_slices.append(slice_text)
+        chunk = tokens[cursor : cursor + count]
         cursor += count
+        phrase_first.append(chunk[0] if chunk else "")
+        phrase_last.append(chunk[-1] if chunk else "")
         is_edge = i == 0 or i == len(pwc) - 1
         if count < WORD_MIN:
             sev = "medium" if is_edge else "high"
             issues.append({
                 "severity": sev,
-                "reason": f"phrase {i+1} has {count} word{'s' if count != 1 else ''}: {_clip(slice_text)}",
+                "reason": f"phrase {i+1} has {count} word{'s' if count != 1 else ''}: {_clip(' '.join(chunk))}",
             })
         elif count > WORD_MAX:
             issues.append({
                 "severity": "high",
-                "reason": f"phrase {i+1} has {count} words: {_clip(slice_text)}",
+                "reason": f"phrase {i+1} has {count} words: {_clip(' '.join(chunk))}",
             })
 
-    # Verb-clause split: phrase ends in a perception/speech verb and
-    # the next phrase starts with that/what/how/whether. Skip the
-    # colon and open-quote cases where the boundary is itself a
-    # stronger reported-speech break.
-    for i in range(len(phrase_slices) - 1):
-        words = phrase_slices[i].split()
-        next_phrase = phrase_slices[i + 1]
-        next_words = next_phrase.split()
-        if not words or not next_words:
+    for i in range(len(pwc) - 1):
+        last_raw = phrase_last[i]
+        next_raw = phrase_first[i + 1]
+        if not last_raw or not next_raw:
             continue
-        last_raw = words[-1]
-        last = _strip_punct(last_raw).lower()
-        nxt = _strip_punct(next_words[0]).lower()
+        last = normalise_word(last_raw)
+        nxt = normalise_word(next_raw)
         if last not in CONTENT_CLAUSE_VERBS or nxt not in CONTENT_CLAUSE_COMPLEMENTISERS:
             continue
-        if last_raw.endswith(":"):
-            continue  # ``say: If any brother…`` — colon breaks first
-        if next_phrase.lstrip().startswith(_QUOTE_OPENERS):
-            continue  # ``say, "How…`` — direct-speech quotation
+        if last_raw.endswith(":") or next_raw.startswith(_QUOTE_OPENERS):
+            continue
         issues.append({
             "severity": "high",
             "reason": (

--- a/tools/evaluate_phrases.py
+++ b/tools/evaluate_phrases.py
@@ -15,6 +15,10 @@ Checks (deterministic, run on every verse):
   be shorter (an intro / closing stub).
 - Single-phrase verse whose token count exceeds the missing-split
   threshold → almost certainly a split that was never applied.
+- No phrase ends in a perception/speech verb (``know``, ``see``,
+  ``tell``, …) immediately followed by a phrase starting with
+  ``that`` / ``what`` / ``how`` / ``whether`` / ``if`` — that splits
+  a verb from its content clause, which is one rhetorical unit.
 - ``ftvWordCount`` is in range when set.
 
 The optional ``--llm-judge`` flag adds a Claude-Haiku quality check
@@ -61,6 +65,50 @@ WORD_MAX = 12
 # from a break.
 MISSING_SPLIT_THRESHOLD = 10
 
+# Verbs of perception / speech that commonly take a ``that``-clause
+# (or ``what`` / ``how`` / ``whether`` / ``if``) as their direct
+# object. Splitting between such a verb and its content clause breaks
+# a single rhetorical/cognitive unit and should be flagged. The
+# heuristic is intentionally narrow — it only matches when the
+# *last word of one phrase* is one of these verbs and the *first word*
+# of the next phrase is one of the listed complementisers. See
+# ``references/quality-criteria.md`` for the rationale.
+CONTENT_CLAUSE_VERBS = frozenset({
+    "know", "knew", "known", "knows",
+    "see", "saw", "seen", "sees",
+    "hear", "heard", "hears",
+    "tell", "told", "tells",
+    "say", "said", "says",
+    "believe", "believed", "believes",
+    "think", "thought", "thinks",
+    "understand", "understood", "understands",
+    "remember", "remembered", "remembers",
+    "perceive", "perceived", "perceives",
+    "consider", "considered", "considers",
+    "declare", "declared", "declares",
+    "suppose", "supposed", "supposes",
+    "recognize", "recognized", "recognizes",
+    "realize", "realized", "realizes",
+    "learn", "learned", "learns",
+})
+# ``if`` is excluded — it's almost always a conditional in scripture
+# rather than the rare ``know if`` complementiser, and including it
+# produced more false positives than true positives in practice.
+CONTENT_CLAUSE_COMPLEMENTISERS = frozenset({
+    "that", "what", "how", "whether",
+})
+
+# When the boundary itself carries a stronger break signal — a colon
+# (introducing direct/reported speech, e.g. ``say: If any brother…``)
+# or an open quote (direct speech, e.g. ``say, "How…"``) — the
+# heuristic backs off, because the verb is being read with its
+# *quoted* object rather than a content clause.
+_QUOTE_OPENERS = ("\"", "“", "‘", "'")
+
+
+def _strip_punct(word: str) -> str:
+    return word.strip(",.?!;:\"'“”‘’()[]")
+
 
 def check_verse(ref: str, verse: Dict[str, Any], tokens: List[str]) -> List[Dict[str, str]]:
     """Return a list of ``{severity, reason, ...}`` for one structural
@@ -99,8 +147,10 @@ def check_verse(ref: str, verse: Dict[str, Any], tokens: List[str]) -> List[Dict
         })
 
     cursor = 0
+    phrase_slices: List[str] = []
     for i, count in enumerate(pwc):
         slice_text = " ".join(tokens[cursor : cursor + count])
+        phrase_slices.append(slice_text)
         cursor += count
         is_edge = i == 0 or i == len(pwc) - 1
         if count < WORD_MIN:
@@ -114,6 +164,33 @@ def check_verse(ref: str, verse: Dict[str, Any], tokens: List[str]) -> List[Dict
                 "severity": "high",
                 "reason": f"phrase {i+1} has {count} words: {_clip(slice_text)}",
             })
+
+    # Verb-clause split: phrase ends in a perception/speech verb and
+    # the next phrase starts with that/what/how/whether. Skip the
+    # colon and open-quote cases where the boundary is itself a
+    # stronger reported-speech break.
+    for i in range(len(phrase_slices) - 1):
+        words = phrase_slices[i].split()
+        next_phrase = phrase_slices[i + 1]
+        next_words = next_phrase.split()
+        if not words or not next_words:
+            continue
+        last_raw = words[-1]
+        last = _strip_punct(last_raw).lower()
+        nxt = _strip_punct(next_words[0]).lower()
+        if last not in CONTENT_CLAUSE_VERBS or nxt not in CONTENT_CLAUSE_COMPLEMENTISERS:
+            continue
+        if last_raw.endswith(":"):
+            continue  # ``say: If any brother…`` — colon breaks first
+        if next_phrase.lstrip().startswith(_QUOTE_OPENERS):
+            continue  # ``say, "How…`` — direct-speech quotation
+        issues.append({
+            "severity": "high",
+            "reason": (
+                f"verb-clause split between phrase {i+1} (…{last!r}) and "
+                f"phrase {i+2} ({nxt!r}…) — keep verb with its content clause"
+            ),
+        })
 
     ftv = verse.get("ftvWordCount")
     if ftv is not None:

--- a/tools/evaluate_phrases.py
+++ b/tools/evaluate_phrases.py
@@ -52,6 +52,9 @@ from phrase_splitter.apibible import (  # noqa: E402
 )
 
 WORD_MIN = 3
+# Soft ceiling above which the auditor flags a phrase as too long. There is
+# no validator cap in split_phrases.py — long phrases are a quality flag for
+# human review, not a hard error.
 WORD_MAX = 12
 # A single-phrase verse longer than this is almost certainly a missed
 # split. Tunable; 10 words is roughly the point where reciters benefit

--- a/tools/phrase_splitter/prompts.py
+++ b/tools/phrase_splitter/prompts.py
@@ -17,9 +17,12 @@ that ushers in a new thought.
 
 Rules:
 
-- 3 to 12 words per phrase. A short final phrase (1-2 words) is fine
-  when it carries trailing punctuation like ``...and Him crucified.``;
-  short fragments in the middle of a verse are not.
+- Target 3 to 10 words per phrase; up to ~12 is fine. A short final
+  phrase (1-2 words) is fine when it carries trailing punctuation like
+  ``...and Him crucified.``; short fragments in the middle of a verse
+  are not. A phrase may run longer than 12 when the clause is genuinely
+  continuous and has no natural break — prefer the natural unit over
+  forcing an awkward split.
 - Break at clause and phrase boundaries. Strong cues:
   - after a comma, semicolon, or colon
   - before a connector that starts a new clause: ``and``, ``but``,
@@ -31,9 +34,10 @@ Rules:
 - Never strand a 1-2 word fragment in the middle of the verse (e.g.
   ``"But one"`` followed by the rest of the sentence). Keep small
   introductory phrases with the clause they introduce.
-- Never exceed about 12 words in a single phrase. When a clause is
-  long, look for an internal comma, a relative pronoun (``who``,
-  ``which``, ``that``), or a connective and break there.
+- When a clause is long (over ~12 words), look for an internal comma,
+  a relative pronoun (``who``, ``which``, ``that``), or a connective
+  and break there. If no such break exists, the long phrase is
+  acceptable — naturalness over arbitrary cutoffs.
 - Preserve every character exactly, including HTML tags such as
   ``<b>...</b>``, ``<i>...</i>``, ``<b><i>...</i></b>``, and ``<span
   ...>...</span>``. Treat a tagged span as one indivisible unit —

--- a/tools/phrase_splitter/prompts.py
+++ b/tools/phrase_splitter/prompts.py
@@ -15,6 +15,12 @@ the verse aloud — break where a careful reader would breathe, at the
 start of a new clause, between parallel items, or after a connective
 that ushers in a new thought.
 
+**Guiding principle:** keep splits small, but completeness of thought
+matters more than size. Every phrase should be a self-contained
+unit of meaning. A 9-word phrase that finishes a thought is better
+than 4 + 5 that severs it. When in doubt between a shorter awkward
+split and a longer natural one, choose the natural one.
+
 Rules:
 
 - Target 3 to 10 words per phrase; up to ~12 is fine. A short final
@@ -31,6 +37,17 @@ Rules:
     list to the preceding phrase
   - between parallel items: ``not many wise / not many mighty / not
     many noble`` should be three sibling phrases
+- **Never split a verb from its content clause.** ``that`` (and
+  ``what``, ``how``, ``whether``, ``if``) after a verb of perception
+  or speech — ``know``, ``see``, ``tell``, ``say``, ``believe``,
+  ``think``, ``hear``, ``understand``, ``remember``, ``perceive`` — is
+  introducing the object of that verb, not a new clause for
+  recitation. ``"Do you not know"`` / ``"that we shall judge angels?"``
+  is a bad break; the rhetorical question is one unit. Same for
+  ``"I declare to you"`` / ``"that flesh and blood cannot inherit..."``.
+- **Keep rhetorical questions whole.** A question stem (``"Do you not
+  know that..."``, ``"Are you not aware that..."``) belongs with its
+  content. Split *after* the question mark, not inside it.
 - Never strand a 1-2 word fragment in the middle of the verse (e.g.
   ``"But one"`` followed by the rest of the sentence). Keep small
   introductory phrases with the clause they introduce.
@@ -80,6 +97,12 @@ Output:
     ["deliver such a one to Satan for the destruction of the flesh,",
      "that his spirit may be saved in the day of the Lord Jesus."]
 
+Input:
+    Do you not know that we shall judge angels? How much more, things that pertain to this life?
+Output:
+    ["Do you not know that we shall judge angels?",
+     "How much more, things that pertain to this life?"]
+
 Now split this verse. Reply with a single JSON array of strings on one
 line, nothing else.
 
@@ -94,6 +117,11 @@ split has already passed deterministic checks (it rejoins to the original
 text and every phrase is within the word-count bounds). Your job is to
 catch lingering quality issues that need a human eye.
 
+**Guiding principle:** small phrases are good, but completeness of
+thought matters more than size. Every phrase should be a self-contained
+unit of meaning. A short split that severs a single thought across two
+phrases is worse than a longer split that keeps it whole.
+
 Look for:
 
 - Awkward breakpoints — a split that interrupts a tight idiom or a
@@ -103,6 +131,14 @@ Look for:
   mighty / not many noble`` should be three phrases)
 - Lopsided distribution — one phrase carrying most of the verse while
   the rest are stubs
+- **Verb separated from its content clause** — ``that`` / ``what`` /
+  ``how`` / ``whether`` / ``if`` after ``know``, ``see``, ``tell``,
+  ``say``, ``believe``, ``think``, ``hear``, ``understand``,
+  ``remember``, ``perceive`` introduces the *object* of the verb, not
+  a new clause. ``"Do you not know"`` / ``"that we shall judge
+  angels?"`` is a bad break — the rhetorical question is one unit.
+- Mid-question breaks — a rhetorical question stem split from its
+  content. Keep the question whole; split *after* the question mark.
 - Anything that would feel jarring when reciting the verse aloud
 
 Verse: {ref}

--- a/tools/split_phrases.py
+++ b/tools/split_phrases.py
@@ -53,7 +53,12 @@ from phrase_splitter.apibible import (  # noqa: E402
 )
 
 WORD_MIN_HARD = 1
-WORD_MAX_HARD = 12
+# No upper word-count cap in the validator: the soft target ceiling lives in
+# quality-criteria.md (≈10, audit warning at >12), but recitation phrases for
+# continuous clauses without a natural internal break can legitimately exceed
+# that. ``apply`` enforces only structural invariants (sum matches canonical
+# tokens, phrases non-empty); phrase length is a quality judgement the LLM
+# split / human reviewer makes, not a hard-coded cutoff.
 
 
 def _collect_refs(
@@ -137,8 +142,6 @@ def _validate(ref: str, phrases: List[str], canonical_tokens: int) -> List[str]:
         counts.append(wc)
         if wc < WORD_MIN_HARD:
             errors.append(f"phrase {i+1} has 0 words")
-        elif wc > WORD_MAX_HARD:
-            errors.append(f"phrase {i+1} has {wc} words (max {WORD_MAX_HARD})")
     total = sum(counts)
     if total != canonical_tokens:
         errors.append(


### PR DESCRIPTION
## Summary

- Commit the `phrase-splitter` skill to the repo (under `.claude/skills/phrase-splitter/`) with workflow, quality criteria, prompt-design notes, and stable subagent entry-point wrappers.
- Resplit all 553 verses of year 3 (`data/3-corinthians.json`): rewrite 347 verses, fix 30 sum-drift cases, add fresh splits for 141 placeholder verses in 2 Cor 7–13, and merge 9 verb-clause splits into single units.
- Split year 4 (`data/4-john.json`) from scratch — 814 verses across all 21 chapters, all previously single-phrase placeholders.
- Tooling refinements: drop the validator's hard word-count cap (naturalness over arbitrary cutoff); add a deterministic verb-clause-split check to the auditor so future passes catch `know that…` / `say that…` severing automatically; consolidate the `_strip_punct` helper into the existing `normalise_word`.

## Commits

| Commit | Purpose |
| --- | --- |
| \`e0427e4\` | Track the phrase-splitter skill in the repo |
| \`c5c3e32\` | Generalise the skill workflow for any year deck |
| \`29756ab\` | Drop the validator's hard phrase-length cap |
| \`4171e49\` | Resplit year 3 (Corinthians) — 347 verses |
| \`5610554\` | Auditor flags verb-clause splits + lead with completeness-of-thought |
| \`7a4942c\` | Merge 9 verb-clause splits in year 3 |
| \`9f02c8d\` | Stable subagent wrapper docs (splitter / judge) |
| \`8e25605\` | Split year 4 (John) — 814 verses |
| \`e032d38\` | Tighten auditor + wrapper docs (post-simplify pass) |

## Quality signal

Post-apply audit:

- Year 3: 41 flags remaining — all judgement-call long phrases (continuous content clauses), parallel-structure 2-word phrases, or one known false-positive verb-clause hit (1 Cor 14:9, where `understand` is an infinitive complement, not a content-clause head).
- Year 4: 62 flags remaining — same shape; 3 known false-positive verb-clause hits (passive verbs / parallel rhetorical questions).

All proposals validated against canonical api.bible NKJV tokens before apply; rejoin invariant holds for every verse.

## Test plan

- [ ] \`python3 tools/evaluate_phrases.py data/3-corinthians.json\` — flags should match the post-apply state described above.
- [ ] \`python3 tools/evaluate_phrases.py data/4-john.json\` — same.
- [ ] Spot-check a few verses with the new \`verb-clause split\` reason in the report to confirm the heuristic.
- [ ] Confirm no regressions in runtime rendering (deck \`phraseWordCounts\` indexes the same api.bible token stream as before).