### PR TITLE
feat: memorize/review split + relearning lane

### DIFF
--- a/.claude/skills/phrase-splitter/references/quality-criteria.md
+++ b/.claude/skills/phrase-splitter/references/quality-criteria.md
@@ -18,8 +18,10 @@ natural one. All the rules below are in service of this principle, not above it.
   review. There is no validator cap: a phrase can exceed 12 when a clause is genuinely continuous
   and has no natural internal breakpoint (e.g.
   `"that his spirit may be saved in the day of the Lord Jesus."`). The lower bound allows 1+ to
-  admit short trailing closures like `"and Him crucified."`. Prefer naturalness over hitting the
-  target.
+  admit short _rhetorical or completive_ tails like `"and Him crucified."` or `"be the glory."` —
+  closing flourishes that stand on their own. A short tail is **not** licensed when it is a
+  grammatical fragment severed from a mid-verse clause (e.g. `"that was made."` chopped off
+  `"nothing was made that was made."`). Prefer naturalness over hitting the target.
 * **HTML tag balance.** Every `<b>`, `<i>`, `<span ...>` open must close inside the same phrase.
   Never split inside a tag.
 
@@ -44,6 +46,13 @@ natural one. All the rules below are in service of this principle, not above it.
 * **Keep rhetorical questions whole.** A question stem (`"Do you not know that..."`,
   `"Are you not aware that..."`) belongs with its content. Split _after_ the question mark, not
   inside it.
+* **Keep restrictive relative clauses attached to their antecedent.** When `that`, `who`, or `which`
+  follows a noun _without_ a preceding comma, it is a restrictive relative — it defines or restricts
+  the noun and reads as one unit with no pause. Don't break before it. `"nothing was made"` /
+  `"that was made."` is bad: the `that`-clause restrictively modifies "nothing". Same shape:
+  `"the bread"` / `"which I will give"`, `"the man"` / `"who came to Jesus"`. A _non-restrictive_
+  relative is the opposite — the preceding comma is a real pause and a valid break:
+  `"...Nicodemus, / who came to Jesus by night,"` is fine.
 * **Don't lop-side.** A verse split into one 15-word phrase and one 3-word phrase is worse than two
   9-word phrases. Aim for relatively even chunks while still respecting clause boundaries.
 * **Single-phrase verses.** Anything over ~10 words should split somewhere. Anything under ~8 can
@@ -53,8 +62,10 @@ natural one. All the rules below are in service of this principle, not above it.
 
 * A single-word opener like `"Moreover,"` or `"Therefore,"` at position 0. Stylistic, often
   deliberate in memorisation aids. Flagged `medium` by the evaluator, not `high`.
-* A short final phrase like `"are called."` or `"and Him crucified."` that carries closing
-  punctuation. Same treatment — `medium`, not blocking.
+* A short final phrase like `"are called."` or `"and Him crucified."` that is a rhetorical or
+  completive tail — a closing flourish, not a grammatical fragment chopped off a mid-verse clause.
+  Same treatment — `medium`, not blocking. (`"that was made."` lopped off `"nothing was made"`
+  doesn't qualify — see the restrictive-relative example below.)
 * A pair of short intro phrases like `"Therefore," / "my beloved,"`. Often the natural break is to
   merge them into one `"Therefore, my beloved,"` phrase, but both forms are defensible — the
   evaluator will surface this as `high` (middle 2-word phrase) for human review.
@@ -95,6 +106,25 @@ Bad (1 Cor 12:11):
 ```
 ["But one and the same Spirit works all these things,",
  "<b>distributing</b> to each one individually as He wills."]
+```
+
+### Restrictive relative clause
+
+Bad (John 1:3):
+
+```
+["All things were made through Him,",
+ "and without Him nothing was made",
+ "that was made."]
+```
+
+The `"that was made"` clause is a restrictive relative modifying `"nothing"` — no comma precedes it,
+and there's no natural pause between `"nothing was made"` and `"that was made"`. The emphatic
+doubling reads as one breath. Break only at the real pause (the comma after `"Him,"`):
+
+```
+["All things were made through Him,",
+ "and without Him nothing was made that was made."]
 ```
 
 ### Parallel structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,6 @@ characters** including the type/scope prefix. Body wrapped at ~72 cols, focuses 
 
 * Slight preference for writing tests before features.
 * Redundant inline comments are not helpful. Comments that simply say "what" is happening when the
-  code is obvious should be extremely brief or omitted. Prefer comments that explain "why" or
-  complex logic. Docstrings should be brief and focused on info that is not obvious from the
-  signature and would be useful to consumers.
+  code is obvious should be brief or perhaps even omitted. Prefer comments that explain "why" or
+  clarify complex logic. Docstrings should be brief and focused on info that is not obvious from the
+  signature and would be useful to consumers. (but don't be too picky about removing comments)

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,13 +1,31 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { RouterLink, RouterView, useRouter } from 'vue-router'
+import { computed, ref, watch } from 'vue'
+import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 
+import { api } from '@/api'
 import { useAuth } from '@/composables/useAuth'
 
 const { session, signOut } = useAuth()
 const router = useRouter()
+const route = useRoute()
 
 const user = computed(() => session.value?.data?.user ?? null)
+const newToMemorize = ref<number>(0)
+
+async function refreshMemorizeCount() {
+  if (!user.value) return
+  try {
+    const res = await api.getYears()
+    newToMemorize.value = res.years.reduce((sum, y) => sum + y.newCardCount, 0)
+  } catch {
+    // Don't fail nav rendering on a count fetch error; leave at 0.
+  }
+}
+
+// Refresh on auth change and after every navigation — graduations and
+// material-picker writes both move this number.
+watch(user, refreshMemorizeCount, { immediate: true })
+watch(() => route.fullPath, refreshMemorizeCount)
 
 async function onSignOut() {
   signOut()
@@ -20,7 +38,11 @@ async function onSignOut() {
     <header class="site-header">
       <RouterLink to="/" class="brand">verse-vault</RouterLink>
       <nav v-if="user" class="nav">
-        <RouterLink to="/session">Session</RouterLink>
+        <RouterLink to="/review">Review</RouterLink>
+        <RouterLink to="/memorize" class="memorize-link">
+          Memorize
+          <span v-if="newToMemorize > 0" class="pill">{{ newToMemorize }}</span>
+        </RouterLink>
         <RouterLink to="/material">Material</RouterLink>
         <RouterLink to="/stats">Stats</RouterLink>
         <span class="who">{{ user.email }}</span>
@@ -72,6 +94,22 @@ async function onSignOut() {
 .nav :deep(a.router-link-active) {
   color: var(--color-accent);
   background: var(--color-accent-soft);
+}
+
+.memorize-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.pill {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  line-height: 1.4;
 }
 
 .who {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -129,6 +129,10 @@ export interface MemorizeSessionVerse {
   verseId: number
   /** Every per-verse card to drill, in builder order. */
   cardIds: number[]
+  /** Card id of the verse's Recitation, when emitted. Used as the
+   *  anchor render for the session-opening + closing walkthroughs so
+   *  the verse displays without a PhraseFill's phrase-0 highlight. */
+  recitationCardId: number | null
 }
 
 export interface MemorizeSessionResponse {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -117,6 +117,8 @@ export interface YearView {
   enrolled: boolean
   settings: YearSettings
   clubs: Record<ClubTier, ClubView>
+  /** Total `New` cards in the engine — drives the "N to memorize" pill. */
+  newCardCount: number
 }
 
 export interface YearsResponse {
@@ -125,7 +127,9 @@ export interface YearsResponse {
 
 export interface ApiClient {
   enroll(materialId: string): Promise<{ snapshotId: string; version: number }>
-  getNextCard(materialId: string): Promise<{ cardId: number | null }>
+  getNextReviewCard(materialId: string): Promise<{ cardId: number | null }>
+  getNextMemorizeCard(materialId: string): Promise<{ cardId: number | null }>
+  graduateVerse(materialId: string, verseId: number): Promise<{ graduated: number }>
   getCardRender(materialId: string, cardId: number): Promise<CardRender>
   submitReview(materialId: string, cardId: number, grade: Grade): Promise<ReviewResponse>
   getStats(materialId: string): Promise<StatsResponse>
@@ -159,8 +163,12 @@ export function createApiClient(apiUrl: string): ApiClient {
   return {
     enroll: (materialId) =>
       request('POST', '/api/materials/enroll', { materialId }),
-    getNextCard: (materialId) =>
-      request('GET', `/api/cards/next?materialId=${encodeURIComponent(materialId)}`),
+    getNextReviewCard: (materialId) =>
+      request('GET', `/api/cards/review/next?materialId=${encodeURIComponent(materialId)}`),
+    getNextMemorizeCard: (materialId) =>
+      request('GET', `/api/cards/memorize/next?materialId=${encodeURIComponent(materialId)}`),
+    graduateVerse: (materialId, verseId) =>
+      request('POST', '/api/cards/memorize/graduate', { materialId, verseId }),
     getCardRender: (materialId, cardId) =>
       request('GET', `/api/cards/${cardId}?materialId=${encodeURIComponent(materialId)}`),
     submitReview: (materialId, cardId, grade) =>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -125,13 +125,11 @@ export interface YearsResponse {
   years: YearView[]
 }
 
-export type MemorizeStep =
-  | { kind: 'PhraseFill'; cardId: number; position: number }
-  | { kind: 'Recitation'; cardId: number }
-
 export interface MemorizeProgressionResponse {
   verseId: number | null
-  progression: MemorizeStep[]
+  /** Every per-verse card to drill in memorize, in builder order. The
+   *  client cycles them in a drill loop until each gets graded Good. */
+  cardIds: number[]
 }
 
 export interface ApiClient {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -125,10 +125,19 @@ export interface YearsResponse {
   years: YearView[]
 }
 
+export type MemorizeStep =
+  | { kind: 'PhraseFill'; cardId: number; position: number }
+  | { kind: 'Recitation'; cardId: number }
+
+export interface MemorizeProgressionResponse {
+  verseId: number | null
+  progression: MemorizeStep[]
+}
+
 export interface ApiClient {
   enroll(materialId: string): Promise<{ snapshotId: string; version: number }>
   getNextReviewCard(materialId: string): Promise<{ cardId: number | null }>
-  getNextMemorizeCard(materialId: string): Promise<{ cardId: number | null }>
+  getNextMemorizeProgression(materialId: string): Promise<MemorizeProgressionResponse>
   graduateVerse(materialId: string, verseId: number): Promise<{ graduated: number }>
   getCardRender(materialId: string, cardId: number): Promise<CardRender>
   submitReview(materialId: string, cardId: number, grade: Grade): Promise<ReviewResponse>
@@ -165,7 +174,7 @@ export function createApiClient(apiUrl: string): ApiClient {
       request('POST', '/api/materials/enroll', { materialId }),
     getNextReviewCard: (materialId) =>
       request('GET', `/api/cards/review/next?materialId=${encodeURIComponent(materialId)}`),
-    getNextMemorizeCard: (materialId) =>
+    getNextMemorizeProgression: (materialId) =>
       request('GET', `/api/cards/memorize/next?materialId=${encodeURIComponent(materialId)}`),
     graduateVerse: (materialId, verseId) =>
       request('POST', '/api/cards/memorize/graduate', { materialId, verseId }),

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -71,6 +71,7 @@ export interface TestState {
   last_seen_secs: number
   last_base_secs: number
   last_root_secs: number
+  pending_relearn: boolean
 }
 
 export interface ReviewResponse {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -125,17 +125,20 @@ export interface YearsResponse {
   years: YearView[]
 }
 
-export interface MemorizeProgressionResponse {
-  verseId: number | null
-  /** Every per-verse card to drill in memorize, in builder order. The
-   *  client cycles them in a drill loop until each gets graded Good. */
+export interface MemorizeSessionVerse {
+  verseId: number
+  /** Every per-verse card to drill, in builder order. */
   cardIds: number[]
+}
+
+export interface MemorizeSessionResponse {
+  verses: MemorizeSessionVerse[]
 }
 
 export interface ApiClient {
   enroll(materialId: string): Promise<{ snapshotId: string; version: number }>
   getNextReviewCard(materialId: string): Promise<{ cardId: number | null }>
-  getNextMemorizeProgression(materialId: string): Promise<MemorizeProgressionResponse>
+  getMemorizeSession(materialId: string, max: number): Promise<MemorizeSessionResponse>
   graduateVerse(materialId: string, verseId: number): Promise<{ graduated: number }>
   getCardRender(materialId: string, cardId: number): Promise<CardRender>
   submitReview(materialId: string, cardId: number, grade: Grade): Promise<ReviewResponse>
@@ -172,8 +175,11 @@ export function createApiClient(apiUrl: string): ApiClient {
       request('POST', '/api/materials/enroll', { materialId }),
     getNextReviewCard: (materialId) =>
       request('GET', `/api/cards/review/next?materialId=${encodeURIComponent(materialId)}`),
-    getNextMemorizeProgression: (materialId) =>
-      request('GET', `/api/cards/memorize/next?materialId=${encodeURIComponent(materialId)}`),
+    getMemorizeSession: (materialId, max) =>
+      request(
+        'GET',
+        `/api/cards/memorize/session?materialId=${encodeURIComponent(materialId)}&max=${max}`,
+      ),
     graduateVerse: (materialId, verseId) =>
       request('POST', '/api/cards/memorize/graduate', { materialId, verseId }),
     getCardRender: (materialId, cardId) =>

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -5,7 +5,8 @@ import { authClient } from '@/composables/useAuth'
 const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/', redirect: '/session' },
+    { path: '/', redirect: '/review' },
+    { path: '/session', redirect: '/review' },
     {
       path: '/signin',
       name: 'signin',
@@ -13,9 +14,14 @@ const router = createRouter({
       meta: { public: true },
     },
     {
-      path: '/session',
-      name: 'session',
-      component: () => import('@/views/SessionView.vue'),
+      path: '/review',
+      name: 'review',
+      component: () => import('@/views/ReviewView.vue'),
+    },
+    {
+      path: '/memorize',
+      name: 'memorize',
+      component: () => import('@/views/MemorizeView.vue'),
     },
     {
       path: '/stats',
@@ -43,7 +49,7 @@ router.beforeEach(async (to) => {
   const signedIn = !!result?.data?.user
   if (to.meta.public) {
     if (signedIn && to.name === 'signin') {
-      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/session'
+      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/review'
       return redirect
     }
     return true

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -85,6 +85,15 @@ const selected = computed<YearCard | null>(() => {
   return cards.value.find((c) => c.view.materialId === id) ?? null
 })
 
+/** A year reads as "studying" iff at least one of `newScope` or
+ *  `reviewScope` is on. Provisioned-but-all-paused years (e.g. the
+ *  user touched the year once then turned everything off) display the
+ *  same as never-touched years: no enrolled marker, no card counts. */
+function isStudying(c: YearCard): boolean {
+  if (!c.view.enrolled) return false
+  return c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off'
+}
+
 async function refresh() {
   loading.value = true
   error.value = null
@@ -102,9 +111,6 @@ async function refresh() {
     if (cards.value.length === 0) {
       selectedMaterialId.value = null
     } else if (!cards.value.some((c) => c.view.materialId === selectedMaterialId.value)) {
-      const isStudying = (c: YearCard) =>
-        c.view.enrolled &&
-        (c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off')
       const next =
         cards.value.find(isStudying) ?? cards.value.find((c) => c.view.enrolled) ?? cards.value[0]
       selectedMaterialId.value = next?.view.materialId ?? null
@@ -176,7 +182,7 @@ onMounted(refresh)
             'year-tab',
             {
               'tab-active': c.view.materialId === selectedMaterialId,
-              'tab-unenrolled': !c.view.enrolled,
+              'tab-unenrolled': !isStudying(c),
             },
           ]"
           :aria-selected="c.view.materialId === selectedMaterialId"
@@ -185,7 +191,7 @@ onMounted(refresh)
         >
           <span class="tab-title">{{ tabTitle(c.view.title) }}</span>
           <span
-            v-if="c.view.enrolled"
+            v-if="isStudying(c)"
             class="tab-marker tab-marker-enrolled"
             aria-hidden="true"
           />
@@ -195,12 +201,12 @@ onMounted(refresh)
         v-if="selected"
         :key="selected.view.materialId"
         class="year-card"
-        :class="{ 'year-card-unenrolled': !selected.view.enrolled }"
+        :class="{ 'year-card-unenrolled': !isStudying(selected) }"
       >
         <header class="year-header">
           <div class="year-title-row">
             <h3>{{ selected.view.title }}</h3>
-            <span v-if="!selected.view.enrolled" class="enrollment-badge">Not enrolled</span>
+            <span v-if="!isStudying(selected)" class="enrollment-badge">Not enrolled</span>
           </div>
           <p class="year-description">{{ selected.view.description }}</p>
           <div class="tier-summary">
@@ -211,7 +217,7 @@ onMounted(refresh)
               :class="`tier-status-${selected.view.clubs[tier].status}`"
             >
               <span class="tier-pill-name">{{ TIER_LABELS[tier] }}</span>
-              <span v-if="selected.view.enrolled" class="tier-pill-count">
+              <span v-if="isStudying(selected)" class="tier-pill-count">
                 {{ selected.view.clubs[tier].cardCount }}
               </span>
               <span :class="`status-chip status-${selected.view.clubs[tier].status}`">

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -95,13 +95,18 @@ async function refresh() {
       draft: { ...view.settings },
       saving: false,
     }))
-    // Re-resolve the active tab after the list changes: prefer the user's
-    // first enrolled year so the picker opens on a populated panel rather
-    // than a "Not enrolled" empty state.
+    // Re-resolve the active tab after the list changes. Prefer the year
+    // the user is actively studying (any scope above off) so the picker
+    // opens on a working panel; otherwise fall back to any enrolled year,
+    // and finally to the first listed.
     if (cards.value.length === 0) {
       selectedMaterialId.value = null
     } else if (!cards.value.some((c) => c.view.materialId === selectedMaterialId.value)) {
-      const next = cards.value.find((c) => c.view.enrolled) ?? cards.value[0]
+      const isStudying = (c: YearCard) =>
+        c.view.enrolled &&
+        (c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off')
+      const next =
+        cards.value.find(isStudying) ?? cards.value.find((c) => c.view.enrolled) ?? cards.value[0]
       selectedMaterialId.value = next?.view.materialId ?? null
     }
   } catch (err) {

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -75,6 +75,7 @@ async function buildSession() {
         materialId: y.materialId,
         verseId: v.verseId,
         cardIds: v.cardIds,
+        recitationCardId: v.recitationCardId,
         anchor: null,
         graduated: false,
       })
@@ -83,12 +84,14 @@ async function buildSession() {
   verses.value = collected
 
   // Pre-fetch each verse's anchor render so reading_start has the
-  // verse text ready without per-step round trips.
+  // verse text ready without per-step round trips. Prefer the
+  // Recitation card so the verse displays as a plain reading prompt,
+  // not as a PhraseFill (which would highlight phrase 0).
   await Promise.all(
     collected.map(async (v) => {
-      const first = v.cardIds[0]
-      if (first === undefined) return
-      v.anchor = await api.getCardRender(v.materialId, first)
+      const anchorId = v.recitationCardId ?? v.cardIds[0]
+      if (anchorId === undefined || anchorId === null) return
+      v.anchor = await api.getCardRender(v.materialId, anchorId)
     }),
   )
 

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -4,16 +4,15 @@ import { computed, onMounted, ref } from 'vue'
 import {
   ApiError,
   type CardRender,
-  MATERIAL_ID,
   type MemorizeStep,
   api,
 } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
-// TODO: pull from year settings; hardcoded to the default lesson batch
-// size while the picker plumbing isn't wired into this view yet.
-const BATCH_SIZE = 3
-
+// Resolved at mount from /years — the first material with new cards.
+// Picker writes to /years (status, scopes) change this between sessions.
+const materialId = ref<string | null>(null)
+const lessonBatchSize = ref(3)
 const verseId = ref<number | null>(null)
 const progression = ref<MemorizeStep[]>([])
 const stepIndex = ref(0)
@@ -31,12 +30,30 @@ const isLastStep = computed(
   () => totalSteps.value > 0 && stepIndex.value === totalSteps.value - 1,
 )
 
+async function resolveMaterial() {
+  // Pick the first year with new cards available. /api/years exposes
+  // newCardCount per year; the picker writes (scopes / status) decide
+  // what counts. If none, the view shows the empty state.
+  const res = await api.getYears()
+  const target = res.years.find((y) => y.enrolled && y.newCardCount > 0)
+  if (target) {
+    materialId.value = target.materialId
+    lessonBatchSize.value = target.settings.lessonBatchSize
+    return true
+  }
+  return false
+}
+
 async function loadVerse() {
+  if (!materialId.value) {
+    empty.value = true
+    return
+  }
   loading.value = true
   error.value = null
   card.value = null
   try {
-    const res = await api.getNextMemorizeProgression(MATERIAL_ID)
+    const res = await api.getNextMemorizeProgression(materialId.value)
     if (res.verseId === null || res.progression.length === 0) {
       verseId.value = null
       progression.value = []
@@ -56,10 +73,10 @@ async function loadVerse() {
 
 async function loadStepCard() {
   const step = currentStep.value
-  if (!step) return
+  if (!step || !materialId.value) return
   loading.value = true
   try {
-    card.value = await api.getCardRender(MATERIAL_ID, step.cardId)
+    card.value = await api.getCardRender(materialId.value, step.cardId)
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -76,13 +93,13 @@ async function nextStep() {
   }
   // Last step: graduate the verse and either fetch the next verse or
   // show the done state.
-  if (verseId.value === null) return
+  if (verseId.value === null || !materialId.value) return
   submitting.value = true
   error.value = null
   try {
-    await api.graduateVerse(MATERIAL_ID, verseId.value)
+    await api.graduateVerse(materialId.value, verseId.value)
     graduatedCount.value += 1
-    if (graduatedCount.value >= BATCH_SIZE) {
+    if (graduatedCount.value >= lessonBatchSize.value) {
       verseId.value = null
       progression.value = []
       card.value = null
@@ -94,15 +111,6 @@ async function nextStep() {
     error.value = formatError(err)
   } finally {
     submitting.value = false
-  }
-}
-
-async function ensureEnrolled() {
-  try {
-    await api.enroll(MATERIAL_ID)
-  } catch (err) {
-    if (err instanceof ApiError && err.status === 409) return
-    throw err
   }
 }
 
@@ -122,10 +130,16 @@ const buttonLabel = computed(() => (isLastStep.value ? 'Got it — graduate' : '
 
 onMounted(async () => {
   try {
-    await ensureEnrolled()
+    loading.value = true
+    const found = await resolveMaterial()
+    if (!found) {
+      empty.value = true
+      return
+    }
     await loadVerse()
   } catch (err) {
     error.value = formatError(err)
+  } finally {
     loading.value = false
   }
 })
@@ -153,7 +167,7 @@ onMounted(async () => {
 
     <div v-else-if="card" class="card">
       <div class="meta">
-        Verse {{ graduatedCount + 1 }} of {{ BATCH_SIZE }} ·
+        Verse {{ graduatedCount + 1 }} of {{ lessonBatchSize }} ·
         Step {{ stepIndex + 1 }} of {{ totalSteps }} · {{ stepLabel }}
       </div>
       <CardPrompt :card="card" :revealed="true" />

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -1,23 +1,25 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 
-import {
-  ApiError,
-  type CardRender,
-  type MemorizeStep,
-  api,
-} from '@/api'
+import { type CardRender, type MemorizeStep, api } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
-// Resolved at mount from /years — the first material with new cards.
-// Picker writes to /years (status, scopes) change this between sessions.
-const materialId = ref<string | null>(null)
-const lessonBatchSize = ref(3)
+// Per-year cap built at mount from /years. Each enrolled year with new
+// cards contributes min(newCardCount, lessonBatchSize) verses; the
+// session walks the queue front-to-back. The future mem-schedule work
+// will replace this aggregate-quota model with something smarter.
+interface YearQuota {
+  materialId: string
+  remaining: number
+}
+
+const queue = ref<YearQuota[]>([])
 const verseId = ref<number | null>(null)
 const progression = ref<MemorizeStep[]>([])
 const stepIndex = ref(0)
 const card = ref<CardRender | null>(null)
 const graduatedCount = ref(0)
+const totalTarget = ref(0)
 const done = ref(false)
 const empty = ref(false)
 const error = ref<string | null>(null)
@@ -29,35 +31,37 @@ const totalSteps = computed(() => progression.value.length)
 const isLastStep = computed(
   () => totalSteps.value > 0 && stepIndex.value === totalSteps.value - 1,
 )
+const currentMaterialId = computed(() => queue.value[0]?.materialId ?? null)
 
-async function resolveMaterial() {
-  // Pick the first year with new cards available. /api/years exposes
-  // newCardCount per year; the picker writes (scopes / status) decide
-  // what counts. If none, the view shows the empty state.
+async function buildQueue(): Promise<boolean> {
   const res = await api.getYears()
-  const target = res.years.find((y) => y.enrolled && y.newCardCount > 0)
-  if (target) {
-    materialId.value = target.materialId
-    lessonBatchSize.value = target.settings.lessonBatchSize
-    return true
+  const quotas: YearQuota[] = []
+  for (const y of res.years) {
+    if (!y.enrolled || y.settings.newScope === 'off' || y.newCardCount === 0) continue
+    quotas.push({
+      materialId: y.materialId,
+      remaining: Math.min(y.newCardCount, y.settings.lessonBatchSize),
+    })
   }
-  return false
+  queue.value = quotas
+  totalTarget.value = quotas.reduce((sum, q) => sum + q.remaining, 0)
+  return quotas.length > 0
 }
 
 async function loadVerse() {
-  if (!materialId.value) {
-    empty.value = true
+  if (!currentMaterialId.value) {
+    empty.value = !done.value
     return
   }
   loading.value = true
   error.value = null
   card.value = null
   try {
-    const res = await api.getNextMemorizeProgression(materialId.value)
+    const res = await api.getNextMemorizeProgression(currentMaterialId.value)
     if (res.verseId === null || res.progression.length === 0) {
-      verseId.value = null
-      progression.value = []
-      empty.value = true
+      // This year ran out before its quota — drop it and move on.
+      queue.value.shift()
+      await loadVerse()
       return
     }
     verseId.value = res.verseId
@@ -73,10 +77,10 @@ async function loadVerse() {
 
 async function loadStepCard() {
   const step = currentStep.value
-  if (!step || !materialId.value) return
+  if (!step || !currentMaterialId.value) return
   loading.value = true
   try {
-    card.value = await api.getCardRender(materialId.value, step.cardId)
+    card.value = await api.getCardRender(currentMaterialId.value, step.cardId)
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -91,15 +95,18 @@ async function nextStep() {
     await loadStepCard()
     return
   }
-  // Last step: graduate the verse and either fetch the next verse or
-  // show the done state.
-  if (verseId.value === null || !materialId.value) return
+  // Last step for this verse: graduate, decrement the current year's
+  // quota, and move on. Pop the year when it hits zero.
+  const active = queue.value[0]
+  if (verseId.value === null || !active) return
   submitting.value = true
   error.value = null
   try {
-    await api.graduateVerse(materialId.value, verseId.value)
+    await api.graduateVerse(active.materialId, verseId.value)
     graduatedCount.value += 1
-    if (graduatedCount.value >= lessonBatchSize.value) {
+    active.remaining -= 1
+    if (active.remaining <= 0) queue.value.shift()
+    if (queue.value.length === 0) {
       verseId.value = null
       progression.value = []
       card.value = null
@@ -131,7 +138,7 @@ const buttonLabel = computed(() => (isLastStep.value ? 'Got it — graduate' : '
 onMounted(async () => {
   try {
     loading.value = true
-    const found = await resolveMaterial()
+    const found = await buildQueue()
     if (!found) {
       empty.value = true
       return
@@ -167,7 +174,7 @@ onMounted(async () => {
 
     <div v-else-if="card" class="card">
       <div class="meta">
-        Verse {{ graduatedCount + 1 }} of {{ lessonBatchSize }} ·
+        Verse {{ graduatedCount + 1 }} of {{ totalTarget }} ·
         Step {{ stepIndex + 1 }} of {{ totalSteps }} · {{ stepLabel }}
       </div>
       <CardPrompt :card="card" :revealed="true" />

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -44,11 +44,17 @@ const currentReadingVerse = computed<SessionVerse | null>(() =>
 const onLastReading = computed(() => readingIndex.value === verses.value.length - 1)
 const currentDrill = computed<DrillEntry | null>(() => drillQueue.value[0] ?? null)
 
-function shuffled<T>(arr: T[]): T[] {
-  const out = [...arr]
-  for (let i = out.length - 1; i > 0; i -= 1) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[out[i]!, out[j]!] = [out[j]!, out[i]!]
+/** Interleave per-verse card lists so verses appear in random order
+ *  but each verse's cards stay in their builder order. Equivalent to:
+ *  at each step, pick a random non-empty verse and pop its next card. */
+function interleaveByVerse(byVerse: DrillEntry[][]): DrillEntry[] {
+  const pools: DrillEntry[][] = byVerse.map((c) => [...c]).filter((c) => c.length > 0)
+  const out: DrillEntry[] = []
+  while (pools.length > 0) {
+    const i = Math.floor(Math.random() * pools.length)
+    const next = pools[i]!.shift()!
+    out.push(next)
+    if (pools[i]!.length === 0) pools.splice(i, 1)
   }
   return out
 }
@@ -86,14 +92,14 @@ async function buildSession() {
     }),
   )
 
-  // Build the drill queue: verses in shuffled order, cards within each
-  // verse stay in builder order.
-  const drill: DrillEntry[] = []
-  for (const v of shuffled(collected)) {
-    for (const cardId of v.cardIds) {
-      drill.push({ materialId: v.materialId, verseId: v.verseId, cardId })
-    }
-  }
+  // Build the drill queue. Per-verse card lists stay in builder order;
+  // interleaving picks a random non-empty verse for each step so the
+  // user moves between verses constantly without ever seeing a verse's
+  // card 2 before card 1 on the initial pass.
+  const byVerse: DrillEntry[][] = collected.map((v) =>
+    v.cardIds.map((cardId) => ({ materialId: v.materialId, verseId: v.verseId, cardId })),
+  )
+  const drill = interleaveByVerse(byVerse)
   drillQueue.value = drill
   totalDrillCards.value = drill.length
 }

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -4,15 +4,19 @@ import { onMounted, ref } from 'vue'
 import {
   ApiError,
   type CardRender,
-  type Grade,
   MATERIAL_ID,
   api,
 } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
+// TODO: pull from year settings; hardcoded to the default lesson batch
+// size while the picker plumbing isn't wired into this view yet.
+const BATCH_SIZE = 3
+
 const card = ref<CardRender | null>(null)
-const revealed = ref(false)
+const graduatedCount = ref(0)
 const done = ref(false)
+const empty = ref(false)
 const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
@@ -21,14 +25,12 @@ async function loadNext() {
   loading.value = true
   error.value = null
   try {
-    const { cardId } = await api.getNextCard(MATERIAL_ID)
+    const { cardId } = await api.getNextMemorizeCard(MATERIAL_ID)
     if (cardId === null) {
       card.value = null
-      done.value = true
+      empty.value = true
     } else {
       card.value = await api.getCardRender(MATERIAL_ID, cardId)
-      revealed.value = false
-      done.value = false
     }
   } catch (err) {
     error.value = formatError(err)
@@ -37,19 +39,19 @@ async function loadNext() {
   }
 }
 
-async function submit(grade: Grade) {
+async function graduate() {
   if (!card.value || submitting.value) return
   submitting.value = true
   error.value = null
   try {
-    const res = await api.submitReview(MATERIAL_ID, card.value.cardId, grade)
-    if (res.nextCardId === null) {
+    await api.graduateVerse(MATERIAL_ID, card.value.verseId)
+    graduatedCount.value += 1
+    if (graduatedCount.value >= BATCH_SIZE) {
       card.value = null
       done.value = true
-    } else {
-      card.value = await api.getCardRender(MATERIAL_ID, res.nextCardId)
-      revealed.value = false
+      return
     }
+    await loadNext()
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -61,7 +63,6 @@ async function ensureEnrolled() {
   try {
     await api.enroll(MATERIAL_ID)
   } catch (err) {
-    // 409 = already enrolled, expected on subsequent loads.
     if (err instanceof ApiError && err.status === 409) return
     throw err
   }
@@ -84,50 +85,38 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="session">
+  <div class="memorize">
     <div v-if="error" class="banner banner-error">{{ error }}</div>
 
     <div v-if="loading && !card" class="status">Loading…</div>
 
     <div v-else-if="done" class="done">
-      <h2>Session complete</h2>
-      <p>Nothing else is due right now.</p>
-      <RouterLink to="/stats" class="link-button">View stats →</RouterLink>
+      <h2>Memorized {{ graduatedCount }} verse{{ graduatedCount === 1 ? '' : 's' }}</h2>
+      <p>Start another batch when you're ready, or move on to review.</p>
+      <RouterLink to="/review" class="link-button">Review now →</RouterLink>
+    </div>
+
+    <div v-else-if="empty" class="done">
+      <h2>Nothing to memorize</h2>
+      <p>Activate a club in <RouterLink to="/material">/material</RouterLink> to introduce new verses.</p>
     </div>
 
     <div v-else-if="card" class="card">
-      <CardPrompt :card="card" :revealed="revealed" />
-
+      <CardPrompt :card="card" :revealed="true" />
+      <div class="meta">
+        Verse {{ graduatedCount + 1 }} of {{ BATCH_SIZE }} this session
+      </div>
       <div class="actions">
-        <button
-          v-if="!revealed"
-          class="reveal"
-          :disabled="submitting"
-          @click="revealed = true"
-        >
-          Reveal answer
+        <button class="graduate" :disabled="submitting" @click="graduate">
+          Got it — next verse
         </button>
-        <div v-else class="grades">
-          <button class="grade grade-again" :disabled="submitting" @click="submit(1)">
-            Again
-          </button>
-          <button class="grade grade-hard" :disabled="submitting" @click="submit(2)">
-            Hard
-          </button>
-          <button class="grade grade-good" :disabled="submitting" @click="submit(3)">
-            Good
-          </button>
-          <button class="grade grade-easy" :disabled="submitting" @click="submit(4)">
-            Easy
-          </button>
-        </div>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.session {
+.memorize {
   width: 100%;
   max-width: 720px;
   display: flex;
@@ -171,9 +160,6 @@ onMounted(async () => {
   font-weight: 500;
 }
 
-/* Layout wrapper only — no surface or border. Stretches to fill the
-   session column so the grade buttons can pin themselves to the
-   bottom while the meta label + flashcard box sit at the top. */
 .card {
   display: flex;
   flex-direction: column;
@@ -181,9 +167,12 @@ onMounted(async () => {
   flex: 1;
 }
 
-/* Push the grade buttons (and the Reveal button before they appear)
-   to the bottom of the .card column. Empty space goes between the
-   flashcard box and the buttons. */
+.meta {
+  text-align: center;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
 .actions {
   display: flex;
   flex-direction: column;
@@ -191,7 +180,7 @@ onMounted(async () => {
   margin-top: auto;
 }
 
-.reveal {
+.graduate {
   padding: 0.75rem 1.5rem;
   background: var(--color-accent);
   color: var(--color-on-accent);
@@ -201,45 +190,7 @@ onMounted(async () => {
   font-size: 1rem;
 }
 
-.reveal:hover:not(:disabled) {
+.graduate:hover:not(:disabled) {
   background: var(--color-accent-hover);
-}
-
-.grades {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.5rem;
-}
-
-.grade {
-  padding: 0.75rem 0.5rem;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.95rem;
-}
-
-.grade-again {
-  background: var(--color-grade-again-bg);
-  color: var(--color-grade-again);
-}
-
-.grade-hard {
-  background: var(--color-grade-hard-bg);
-  color: var(--color-grade-hard);
-}
-
-.grade-good {
-  background: var(--color-grade-good-bg);
-  color: var(--color-grade-good);
-}
-
-.grade-easy {
-  background: var(--color-grade-easy-bg);
-  color: var(--color-grade-easy);
-}
-
-.grade:hover:not(:disabled) {
-  border-color: currentColor;
 }
 </style>

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -11,8 +11,10 @@ type Phase = 'reading_start' | 'drilling' | 'reading_end' | 'done'
 
 interface SessionVerse extends MemorizeSessionVerse {
   materialId: string
-  /** Anchor render — the first card's data, used to show the verse
-   *  text during reading_start and reading_end. */
+  /** Anchor render used during reading_start and reading_end: the
+   *  verse's Recitation when available, falling back to the first
+   *  drill card. Recitation avoids the phrase-0 highlight a PhraseFill
+   *  would impose. */
   anchor: CardRender | null
   graduated: boolean
 }
@@ -45,8 +47,7 @@ const onLastReading = computed(() => readingIndex.value === verses.value.length 
 const currentDrill = computed<DrillEntry | null>(() => drillQueue.value[0] ?? null)
 
 /** Interleave per-verse card lists so verses appear in random order
- *  but each verse's cards stay in their builder order. Equivalent to:
- *  at each step, pick a random non-empty verse and pop its next card. */
+ *  while each verse's cards stay in builder order. */
 function interleaveByVerse(byVerse: DrillEntry[][]): DrillEntry[] {
   const pools: DrillEntry[][] = byVerse.map((c) => [...c]).filter((c) => c.length > 0)
   const out: DrillEntry[] = []
@@ -60,19 +61,26 @@ function interleaveByVerse(byVerse: DrillEntry[][]): DrillEntry[] {
 }
 
 async function buildSession() {
-  // Collect every enrolled year with `New` cards. Each contributes up to
-  // its own lessonBatchSize verses. Random verse order is applied to the
-  // drill queue; reading walkthroughs stay in collection order so the
-  // user reads the same shape twice.
+  // Each enrolled year contributes up to its lessonBatchSize verses.
+  // Reading walkthroughs stay in collection order so opening + closing
+  // reads expose verses in the same shape.
   const yearsRes = await api.getYears()
+  const eligibleYears = yearsRes.years.filter(
+    (y) => y.enrolled && y.settings.newScope !== 'off' && y.newCardCount > 0,
+  )
+  const sessions = await Promise.all(
+    eligibleYears.map((y) =>
+      api
+        .getMemorizeSession(y.materialId, y.settings.lessonBatchSize)
+        .then((s) => ({ materialId: y.materialId, verses: s.verses })),
+    ),
+  )
   const collected: SessionVerse[] = []
-  for (const y of yearsRes.years) {
-    if (!y.enrolled || y.settings.newScope === 'off' || y.newCardCount === 0) continue
-    const session = await api.getMemorizeSession(y.materialId, y.settings.lessonBatchSize)
-    for (const v of session.verses) {
+  for (const { materialId, verses: ys } of sessions) {
+    for (const v of ys) {
       if (v.cardIds.length === 0) continue
       collected.push({
-        materialId: y.materialId,
+        materialId,
         verseId: v.verseId,
         cardIds: v.cardIds,
         recitationCardId: v.recitationCardId,
@@ -83,10 +91,9 @@ async function buildSession() {
   }
   verses.value = collected
 
-  // Pre-fetch each verse's anchor render so reading_start has the
-  // verse text ready without per-step round trips. Prefer the
-  // Recitation card so the verse displays as a plain reading prompt,
-  // not as a PhraseFill (which would highlight phrase 0).
+  // Pre-fetch anchor renders so the reading walkthroughs don't pause
+  // for a round trip per verse. Prefer Recitation to avoid the phrase-0
+  // highlight a PhraseFill render would impose.
   await Promise.all(
     collected.map(async (v) => {
       const anchorId = v.recitationCardId ?? v.cardIds[0]
@@ -95,10 +102,8 @@ async function buildSession() {
     }),
   )
 
-  // Build the drill queue. Per-verse card lists stay in builder order;
-  // interleaving picks a random non-empty verse for each step so the
-  // user moves between verses constantly without ever seeing a verse's
-  // card 2 before card 1 on the initial pass.
+  // Verses interleave; cards within a verse keep builder order on the
+  // initial pass so the user doesn't see card 2 before card 1.
   const byVerse: DrillEntry[][] = collected.map((v) =>
     v.cardIds.map((cardId) => ({ materialId: v.materialId, verseId: v.verseId, cardId })),
   )

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 
-import { type CardRender, type MemorizeStep, api } from '@/api'
+import { type CardRender, api } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
 // Per-year cap built at mount from /years. Each enrolled year with new
@@ -13,11 +13,20 @@ interface YearQuota {
   remaining: number
 }
 
+// Per-verse drill phase: a quick "read the verse" intro, then cycle
+// the verse's cards (Again re-queues, Good removes) until every card
+// has been passed once, then a closing "read it again" before
+// graduating. None of these grades flow to FSRS — memorize stays
+// pure-intro per the planning notes.
+type Phase = 'reading_start' | 'drilling' | 'reading_end'
+
 const queue = ref<YearQuota[]>([])
 const verseId = ref<number | null>(null)
-const progression = ref<MemorizeStep[]>([])
-const stepIndex = ref(0)
+const drillQueue = ref<number[]>([])
 const card = ref<CardRender | null>(null)
+const anchorCard = ref<CardRender | null>(null)
+const phase = ref<Phase>('reading_start')
+const revealed = ref(false)
 const graduatedCount = ref(0)
 const totalTarget = ref(0)
 const done = ref(false)
@@ -26,12 +35,9 @@ const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
 
-const currentStep = computed(() => progression.value[stepIndex.value] ?? null)
-const totalSteps = computed(() => progression.value.length)
-const isLastStep = computed(
-  () => totalSteps.value > 0 && stepIndex.value === totalSteps.value - 1,
-)
 const currentMaterialId = computed(() => queue.value[0]?.materialId ?? null)
+const totalDrillCards = ref(0)
+const remainingDrillCards = computed(() => drillQueue.value.length)
 
 async function buildQueue(): Promise<boolean> {
   const res = await api.getYears()
@@ -56,18 +62,25 @@ async function loadVerse() {
   loading.value = true
   error.value = null
   card.value = null
+  anchorCard.value = null
   try {
     const res = await api.getNextMemorizeProgression(currentMaterialId.value)
-    if (res.verseId === null || res.progression.length === 0) {
+    const firstCardId = res.cardIds[0]
+    if (res.verseId === null || firstCardId === undefined) {
       // This year ran out before its quota — drop it and move on.
       queue.value.shift()
       await loadVerse()
       return
     }
     verseId.value = res.verseId
-    progression.value = res.progression
-    stepIndex.value = 0
-    await loadStepCard()
+    drillQueue.value = [...res.cardIds]
+    totalDrillCards.value = res.cardIds.length
+    phase.value = 'reading_start'
+    revealed.value = true
+    // Anchor render = first card, used to display the verse during the
+    // reading_start/reading_end phases.
+    anchorCard.value = await api.getCardRender(currentMaterialId.value, firstCardId)
+    card.value = anchorCard.value
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -75,12 +88,13 @@ async function loadVerse() {
   }
 }
 
-async function loadStepCard() {
-  const step = currentStep.value
-  if (!step || !currentMaterialId.value) return
+async function loadCurrentDrillCard() {
+  const cardId = drillQueue.value[0]
+  if (cardId === undefined || !currentMaterialId.value) return
   loading.value = true
   try {
-    card.value = await api.getCardRender(currentMaterialId.value, step.cardId)
+    card.value = await api.getCardRender(currentMaterialId.value, cardId)
+    revealed.value = false
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -88,17 +102,38 @@ async function loadStepCard() {
   }
 }
 
-async function nextStep() {
+async function startDrilling() {
+  phase.value = 'drilling'
+  await loadCurrentDrillCard()
+}
+
+function reveal() {
+  revealed.value = true
+}
+
+async function gradeAgain() {
   if (submitting.value) return
-  if (!isLastStep.value) {
-    stepIndex.value += 1
-    await loadStepCard()
+  // Push the current card to the back of the queue so it cycles again.
+  const id = drillQueue.value.shift()
+  if (id !== undefined) drillQueue.value.push(id)
+  await loadCurrentDrillCard()
+}
+
+async function gradeGood() {
+  if (submitting.value) return
+  drillQueue.value.shift()
+  if (drillQueue.value.length === 0) {
+    phase.value = 'reading_end'
+    revealed.value = true
+    card.value = anchorCard.value
     return
   }
-  // Last step for this verse: graduate, decrement the current year's
-  // quota, and move on. Pop the year when it hits zero.
+  await loadCurrentDrillCard()
+}
+
+async function graduate() {
   const active = queue.value[0]
-  if (verseId.value === null || !active) return
+  if (verseId.value === null || !active || submitting.value) return
   submitting.value = true
   error.value = null
   try {
@@ -108,8 +143,8 @@ async function nextStep() {
     if (active.remaining <= 0) queue.value.shift()
     if (queue.value.length === 0) {
       verseId.value = null
-      progression.value = []
       card.value = null
+      anchorCard.value = null
       done.value = true
       return
     }
@@ -125,15 +160,6 @@ function formatError(err: unknown): string {
   if (err instanceof Error) return err.message
   return String(err)
 }
-
-const stepLabel = computed(() => {
-  const step = currentStep.value
-  if (!step) return ''
-  if (step.kind === 'PhraseFill') return `Phrase ${step.position + 1}`
-  return 'Recitation'
-})
-
-const buttonLabel = computed(() => (isLastStep.value ? 'Got it — graduate' : 'Next'))
 
 onMounted(async () => {
   try {
@@ -174,13 +200,50 @@ onMounted(async () => {
 
     <div v-else-if="card" class="card">
       <div class="meta">
-        Verse {{ graduatedCount + 1 }} of {{ totalTarget }} ·
-        Step {{ stepIndex + 1 }} of {{ totalSteps }} · {{ stepLabel }}
+        <template v-if="phase === 'reading_start'">
+          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} · Read it through
+        </template>
+        <template v-else-if="phase === 'drilling'">
+          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} ·
+          {{ totalDrillCards - remainingDrillCards + 1 }} of {{ totalDrillCards }} cards
+        </template>
+        <template v-else>
+          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} · Read it once more
+        </template>
       </div>
-      <CardPrompt :card="card" :revealed="true" />
+      <CardPrompt :card="card" :revealed="revealed" />
       <div class="actions">
-        <button class="advance" :disabled="submitting" @click="nextStep">
-          {{ buttonLabel }}
+        <button
+          v-if="phase === 'reading_start'"
+          class="primary"
+          :disabled="submitting"
+          @click="startDrilling"
+        >
+          Start drilling
+        </button>
+        <button
+          v-else-if="phase === 'drilling' && !revealed"
+          class="primary"
+          :disabled="submitting"
+          @click="reveal"
+        >
+          Reveal answer
+        </button>
+        <div v-else-if="phase === 'drilling' && revealed" class="grades">
+          <button class="grade grade-again" :disabled="submitting" @click="gradeAgain">
+            Again
+          </button>
+          <button class="grade grade-good" :disabled="submitting" @click="gradeGood">
+            Good
+          </button>
+        </div>
+        <button
+          v-else-if="phase === 'reading_end'"
+          class="primary"
+          :disabled="submitting"
+          @click="graduate"
+        >
+          Graduate verse
         </button>
       </div>
     </div>
@@ -252,7 +315,7 @@ onMounted(async () => {
   margin-top: auto;
 }
 
-.advance {
+.primary {
   padding: 0.75rem 1.5rem;
   background: var(--color-accent);
   color: var(--color-on-accent);
@@ -262,7 +325,35 @@ onMounted(async () => {
   font-size: 1rem;
 }
 
-.advance:hover:not(:disabled) {
+.primary:hover:not(:disabled) {
   background: var(--color-accent-hover);
+}
+
+.grades {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+}
+
+.grade {
+  padding: 0.75rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.grade-again {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+
+.grade-good {
+  background: var(--color-grade-good-bg);
+  color: var(--color-grade-good);
+}
+
+.grade:hover:not(:disabled) {
+  border-color: currentColor;
 }
 </style>

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -1,122 +1,132 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 
-import { type CardRender, api } from '@/api'
+import { type CardRender, type MemorizeSessionVerse, api } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
-// Per-year cap built at mount from /years. Each enrolled year with new
-// cards contributes min(newCardCount, lessonBatchSize) verses; the
-// session walks the queue front-to-back. The future mem-schedule work
-// will replace this aggregate-quota model with something smarter.
-interface YearQuota {
+// One session walks three phases: read every verse first, drill every
+// card (shuffled by verse), then walk the verses again and graduate
+// each one. None of this is FSRS-graded — memorize stays pure-intro.
+type Phase = 'reading_start' | 'drilling' | 'reading_end' | 'done'
+
+interface SessionVerse extends MemorizeSessionVerse {
   materialId: string
-  remaining: number
+  /** Anchor render — the first card's data, used to show the verse
+   *  text during reading_start and reading_end. */
+  anchor: CardRender | null
+  graduated: boolean
 }
 
-// Per-verse drill phase: a quick "read the verse" intro, then cycle
-// the verse's cards (Again re-queues, Good removes) until every card
-// has been passed once, then a closing "read it again" before
-// graduating. None of these grades flow to FSRS — memorize stays
-// pure-intro per the planning notes.
-type Phase = 'reading_start' | 'drilling' | 'reading_end'
+interface DrillEntry {
+  materialId: string
+  verseId: number
+  cardId: number
+}
 
-const queue = ref<YearQuota[]>([])
-const verseId = ref<number | null>(null)
-const drillQueue = ref<number[]>([])
-const card = ref<CardRender | null>(null)
-const anchorCard = ref<CardRender | null>(null)
+const verses = ref<SessionVerse[]>([])
 const phase = ref<Phase>('reading_start')
-const revealed = ref(false)
-const graduatedCount = ref(0)
-const totalTarget = ref(0)
-const done = ref(false)
-const empty = ref(false)
+const readingIndex = ref(0)
+const drillQueue = ref<DrillEntry[]>([])
+const totalDrillCards = ref(0)
+const drillCard = ref<CardRender | null>(null)
+const drillRevealed = ref(false)
 const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
 
-const currentMaterialId = computed(() => queue.value[0]?.materialId ?? null)
-const totalDrillCards = ref(0)
+const empty = computed(() => phase.value !== 'done' && verses.value.length === 0)
+const totalVerses = computed(() => verses.value.length)
 const remainingDrillCards = computed(() => drillQueue.value.length)
 
-async function buildQueue(): Promise<boolean> {
-  const res = await api.getYears()
-  const quotas: YearQuota[] = []
-  for (const y of res.years) {
+const currentReadingVerse = computed<SessionVerse | null>(() =>
+  verses.value[readingIndex.value] ?? null,
+)
+const onLastReading = computed(() => readingIndex.value === verses.value.length - 1)
+const currentDrill = computed<DrillEntry | null>(() => drillQueue.value[0] ?? null)
+
+function shuffled<T>(arr: T[]): T[] {
+  const out = [...arr]
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i]!, out[j]!] = [out[j]!, out[i]!]
+  }
+  return out
+}
+
+async function buildSession() {
+  // Collect every enrolled year with `New` cards. Each contributes up to
+  // its own lessonBatchSize verses. Random verse order is applied to the
+  // drill queue; reading walkthroughs stay in collection order so the
+  // user reads the same shape twice.
+  const yearsRes = await api.getYears()
+  const collected: SessionVerse[] = []
+  for (const y of yearsRes.years) {
     if (!y.enrolled || y.settings.newScope === 'off' || y.newCardCount === 0) continue
-    quotas.push({
-      materialId: y.materialId,
-      remaining: Math.min(y.newCardCount, y.settings.lessonBatchSize),
-    })
-  }
-  queue.value = quotas
-  totalTarget.value = quotas.reduce((sum, q) => sum + q.remaining, 0)
-  return quotas.length > 0
-}
-
-async function loadVerse() {
-  if (!currentMaterialId.value) {
-    empty.value = !done.value
-    return
-  }
-  loading.value = true
-  error.value = null
-  card.value = null
-  anchorCard.value = null
-  try {
-    const res = await api.getNextMemorizeProgression(currentMaterialId.value)
-    const firstCardId = res.cardIds[0]
-    if (res.verseId === null || firstCardId === undefined) {
-      // This year ran out before its quota — drop it and move on.
-      queue.value.shift()
-      await loadVerse()
-      return
+    const session = await api.getMemorizeSession(y.materialId, y.settings.lessonBatchSize)
+    for (const v of session.verses) {
+      if (v.cardIds.length === 0) continue
+      collected.push({
+        materialId: y.materialId,
+        verseId: v.verseId,
+        cardIds: v.cardIds,
+        anchor: null,
+        graduated: false,
+      })
     }
-    verseId.value = res.verseId
-    drillQueue.value = [...res.cardIds]
-    totalDrillCards.value = res.cardIds.length
-    phase.value = 'reading_start'
-    revealed.value = true
-    // Anchor render = first card, used to display the verse during the
-    // reading_start/reading_end phases.
-    anchorCard.value = await api.getCardRender(currentMaterialId.value, firstCardId)
-    card.value = anchorCard.value
-  } catch (err) {
-    error.value = formatError(err)
-  } finally {
-    loading.value = false
   }
-}
+  verses.value = collected
 
-async function loadCurrentDrillCard() {
-  const cardId = drillQueue.value[0]
-  if (cardId === undefined || !currentMaterialId.value) return
-  loading.value = true
-  try {
-    card.value = await api.getCardRender(currentMaterialId.value, cardId)
-    revealed.value = false
-  } catch (err) {
-    error.value = formatError(err)
-  } finally {
-    loading.value = false
+  // Pre-fetch each verse's anchor render so reading_start has the
+  // verse text ready without per-step round trips.
+  await Promise.all(
+    collected.map(async (v) => {
+      const first = v.cardIds[0]
+      if (first === undefined) return
+      v.anchor = await api.getCardRender(v.materialId, first)
+    }),
+  )
+
+  // Build the drill queue: verses in shuffled order, cards within each
+  // verse stay in builder order.
+  const drill: DrillEntry[] = []
+  for (const v of shuffled(collected)) {
+    for (const cardId of v.cardIds) {
+      drill.push({ materialId: v.materialId, verseId: v.verseId, cardId })
+    }
   }
+  drillQueue.value = drill
+  totalDrillCards.value = drill.length
 }
 
 async function startDrilling() {
   phase.value = 'drilling'
-  await loadCurrentDrillCard()
+  drillRevealed.value = false
+  await loadDrillCard()
 }
 
-function reveal() {
-  revealed.value = true
+async function loadDrillCard() {
+  const entry = currentDrill.value
+  if (!entry) return
+  loading.value = true
+  try {
+    drillCard.value = await api.getCardRender(entry.materialId, entry.cardId)
+    drillRevealed.value = false
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function revealDrill() {
+  drillRevealed.value = true
 }
 
 async function gradeAgain() {
   if (submitting.value) return
-  // Push the current card to the back of the queue so it cycles again.
-  const id = drillQueue.value.shift()
-  if (id !== undefined) drillQueue.value.push(id)
-  await loadCurrentDrillCard()
+  const entry = drillQueue.value.shift()
+  if (entry) drillQueue.value.push(entry)
+  await loadDrillCard()
 }
 
 async function gradeGood() {
@@ -124,37 +134,49 @@ async function gradeGood() {
   drillQueue.value.shift()
   if (drillQueue.value.length === 0) {
     phase.value = 'reading_end'
-    revealed.value = true
-    card.value = anchorCard.value
+    readingIndex.value = 0
     return
   }
-  await loadCurrentDrillCard()
+  await loadDrillCard()
 }
 
-async function graduate() {
-  const active = queue.value[0]
-  if (verseId.value === null || !active || submitting.value) return
+function advanceReadingStart() {
+  if (onLastReading.value) {
+    void startDrilling()
+    return
+  }
+  readingIndex.value += 1
+}
+
+async function graduateCurrentReadingEnd() {
+  const v = currentReadingVerse.value
+  if (!v || submitting.value) return
   submitting.value = true
   error.value = null
   try {
-    await api.graduateVerse(active.materialId, verseId.value)
-    graduatedCount.value += 1
-    active.remaining -= 1
-    if (active.remaining <= 0) queue.value.shift()
-    if (queue.value.length === 0) {
-      verseId.value = null
-      card.value = null
-      anchorCard.value = null
-      done.value = true
+    await api.graduateVerse(v.materialId, v.verseId)
+    v.graduated = true
+    if (onLastReading.value) {
+      phase.value = 'done'
       return
     }
-    await loadVerse()
+    readingIndex.value += 1
   } catch (err) {
     error.value = formatError(err)
   } finally {
     submitting.value = false
   }
 }
+
+function skipCurrentReadingEnd() {
+  if (onLastReading.value) {
+    phase.value = 'done'
+    return
+  }
+  readingIndex.value += 1
+}
+
+const graduatedCount = computed(() => verses.value.filter((v) => v.graduated).length)
 
 function formatError(err: unknown): string {
   if (err instanceof Error) return err.message
@@ -164,12 +186,8 @@ function formatError(err: unknown): string {
 onMounted(async () => {
   try {
     loading.value = true
-    const found = await buildQueue()
-    if (!found) {
-      empty.value = true
-      return
-    }
-    await loadVerse()
+    await buildSession()
+    if (verses.value.length === 0) return
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -182,11 +200,11 @@ onMounted(async () => {
   <div class="memorize">
     <div v-if="error" class="banner banner-error">{{ error }}</div>
 
-    <div v-if="loading && !card" class="status">Loading…</div>
+    <div v-if="loading && verses.length === 0" class="status">Loading…</div>
 
-    <div v-else-if="done" class="done">
+    <div v-else-if="phase === 'done'" class="done">
       <h2>Memorized {{ graduatedCount }} verse{{ graduatedCount === 1 ? '' : 's' }}</h2>
-      <p>Start another batch when you're ready, or move on to review.</p>
+      <p>Start another session when you're ready, or move on to review.</p>
       <RouterLink to="/review" class="link-button">Review now →</RouterLink>
     </div>
 
@@ -198,38 +216,38 @@ onMounted(async () => {
       </p>
     </div>
 
-    <div v-else-if="card" class="card">
+    <!-- Reading walkthrough (used at both ends of the session). -->
+    <div
+      v-else-if="phase === 'reading_start' && currentReadingVerse?.anchor"
+      class="card"
+    >
       <div class="meta">
-        <template v-if="phase === 'reading_start'">
-          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} · Read it through
-        </template>
-        <template v-else-if="phase === 'drilling'">
-          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} ·
-          {{ totalDrillCards - remainingDrillCards + 1 }} of {{ totalDrillCards }} cards
-        </template>
-        <template v-else>
-          Verse {{ graduatedCount + 1 }} of {{ totalTarget }} · Read it once more
-        </template>
+        Read it through · Verse {{ readingIndex + 1 }} of {{ totalVerses }}
       </div>
-      <CardPrompt :card="card" :revealed="revealed" />
+      <CardPrompt :card="currentReadingVerse.anchor" :revealed="true" />
+      <div class="actions">
+        <button class="primary" :disabled="submitting" @click="advanceReadingStart">
+          {{ onLastReading ? 'Start drilling' : 'Next verse' }}
+        </button>
+      </div>
+    </div>
+
+    <div v-else-if="phase === 'drilling' && drillCard" class="card">
+      <div class="meta">
+        Drilling · {{ totalDrillCards - remainingDrillCards + 1 }} of
+        {{ totalDrillCards }} cards
+      </div>
+      <CardPrompt :card="drillCard" :revealed="drillRevealed" />
       <div class="actions">
         <button
-          v-if="phase === 'reading_start'"
+          v-if="!drillRevealed"
           class="primary"
           :disabled="submitting"
-          @click="startDrilling"
-        >
-          Start drilling
-        </button>
-        <button
-          v-else-if="phase === 'drilling' && !revealed"
-          class="primary"
-          :disabled="submitting"
-          @click="reveal"
+          @click="revealDrill"
         >
           Reveal answer
         </button>
-        <div v-else-if="phase === 'drilling' && revealed" class="grades">
+        <div v-else class="grades">
           <button class="grade grade-again" :disabled="submitting" @click="gradeAgain">
             Again
           </button>
@@ -237,14 +255,34 @@ onMounted(async () => {
             Good
           </button>
         </div>
-        <button
-          v-else-if="phase === 'reading_end'"
-          class="primary"
-          :disabled="submitting"
-          @click="graduate"
-        >
-          Graduate verse
-        </button>
+      </div>
+    </div>
+
+    <div
+      v-else-if="phase === 'reading_end' && currentReadingVerse?.anchor"
+      class="card"
+    >
+      <div class="meta">
+        Read it once more · Verse {{ readingIndex + 1 }} of {{ totalVerses }}
+      </div>
+      <CardPrompt :card="currentReadingVerse.anchor" :revealed="true" />
+      <div class="actions">
+        <div class="grades">
+          <button
+            class="grade grade-again"
+            :disabled="submitting"
+            @click="skipCurrentReadingEnd"
+          >
+            Not yet
+          </button>
+          <button
+            class="grade grade-good"
+            :disabled="submitting"
+            @click="graduateCurrentReadingEnd"
+          >
+            Graduate
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 import {
   ApiError,
   type CardRender,
   MATERIAL_ID,
+  type MemorizeStep,
   api,
 } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
@@ -13,6 +14,9 @@ import CardPrompt from '@/components/CardPrompt.vue'
 // size while the picker plumbing isn't wired into this view yet.
 const BATCH_SIZE = 3
 
+const verseId = ref<number | null>(null)
+const progression = ref<MemorizeStep[]>([])
+const stepIndex = ref(0)
 const card = ref<CardRender | null>(null)
 const graduatedCount = ref(0)
 const done = ref(false)
@@ -21,17 +25,28 @@ const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
 
-async function loadNext() {
+const currentStep = computed(() => progression.value[stepIndex.value] ?? null)
+const totalSteps = computed(() => progression.value.length)
+const isLastStep = computed(
+  () => totalSteps.value > 0 && stepIndex.value === totalSteps.value - 1,
+)
+
+async function loadVerse() {
   loading.value = true
   error.value = null
+  card.value = null
   try {
-    const { cardId } = await api.getNextMemorizeCard(MATERIAL_ID)
-    if (cardId === null) {
-      card.value = null
+    const res = await api.getNextMemorizeProgression(MATERIAL_ID)
+    if (res.verseId === null || res.progression.length === 0) {
+      verseId.value = null
+      progression.value = []
       empty.value = true
-    } else {
-      card.value = await api.getCardRender(MATERIAL_ID, cardId)
+      return
     }
+    verseId.value = res.verseId
+    progression.value = res.progression
+    stepIndex.value = 0
+    await loadStepCard()
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -39,19 +54,42 @@ async function loadNext() {
   }
 }
 
-async function graduate() {
-  if (!card.value || submitting.value) return
+async function loadStepCard() {
+  const step = currentStep.value
+  if (!step) return
+  loading.value = true
+  try {
+    card.value = await api.getCardRender(MATERIAL_ID, step.cardId)
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function nextStep() {
+  if (submitting.value) return
+  if (!isLastStep.value) {
+    stepIndex.value += 1
+    await loadStepCard()
+    return
+  }
+  // Last step: graduate the verse and either fetch the next verse or
+  // show the done state.
+  if (verseId.value === null) return
   submitting.value = true
   error.value = null
   try {
-    await api.graduateVerse(MATERIAL_ID, card.value.verseId)
+    await api.graduateVerse(MATERIAL_ID, verseId.value)
     graduatedCount.value += 1
     if (graduatedCount.value >= BATCH_SIZE) {
+      verseId.value = null
+      progression.value = []
       card.value = null
       done.value = true
       return
     }
-    await loadNext()
+    await loadVerse()
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -73,10 +111,19 @@ function formatError(err: unknown): string {
   return String(err)
 }
 
+const stepLabel = computed(() => {
+  const step = currentStep.value
+  if (!step) return ''
+  if (step.kind === 'PhraseFill') return `Phrase ${step.position + 1}`
+  return 'Recitation'
+})
+
+const buttonLabel = computed(() => (isLastStep.value ? 'Got it — graduate' : 'Next'))
+
 onMounted(async () => {
   try {
     await ensureEnrolled()
-    await loadNext()
+    await loadVerse()
   } catch (err) {
     error.value = formatError(err)
     loading.value = false
@@ -98,17 +145,21 @@ onMounted(async () => {
 
     <div v-else-if="empty" class="done">
       <h2>Nothing to memorize</h2>
-      <p>Activate a club in <RouterLink to="/material">/material</RouterLink> to introduce new verses.</p>
+      <p>
+        Activate a club in <RouterLink to="/material">/material</RouterLink> to introduce new
+        verses.
+      </p>
     </div>
 
     <div v-else-if="card" class="card">
-      <CardPrompt :card="card" :revealed="true" />
       <div class="meta">
-        Verse {{ graduatedCount + 1 }} of {{ BATCH_SIZE }} this session
+        Verse {{ graduatedCount + 1 }} of {{ BATCH_SIZE }} ·
+        Step {{ stepIndex + 1 }} of {{ totalSteps }} · {{ stepLabel }}
       </div>
+      <CardPrompt :card="card" :revealed="true" />
       <div class="actions">
-        <button class="graduate" :disabled="submitting" @click="graduate">
-          Got it — next verse
+        <button class="advance" :disabled="submitting" @click="nextStep">
+          {{ buttonLabel }}
         </button>
       </div>
     </div>
@@ -180,7 +231,7 @@ onMounted(async () => {
   margin-top: auto;
 }
 
-.graduate {
+.advance {
   padding: 0.75rem 1.5rem;
   background: var(--color-accent);
   color: var(--color-on-accent);
@@ -190,7 +241,7 @@ onMounted(async () => {
   font-size: 1rem;
 }
 
-.graduate:hover:not(:disabled) {
+.advance:hover:not(:disabled) {
   background: var(--color-accent-hover);
 }
 </style>

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -2,14 +2,13 @@
 import { onMounted, ref } from 'vue'
 
 import {
-  ApiError,
   type CardRender,
   type Grade,
-  MATERIAL_ID,
   api,
 } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
 
+const materialId = ref<string | null>(null)
 const card = ref<CardRender | null>(null)
 const revealed = ref(false)
 const done = ref(false)
@@ -17,16 +16,30 @@ const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
 
+async function resolveMaterial() {
+  // Pick the first enrolled year with review turned on. The scheduler
+  // returns null when nothing's due, which the view handles as the
+  // "session complete" state below.
+  const res = await api.getYears()
+  const target = res.years.find((y) => y.enrolled && y.settings.reviewScope !== 'off')
+  if (target) {
+    materialId.value = target.materialId
+    return true
+  }
+  return false
+}
+
 async function loadNext() {
+  if (!materialId.value) return
   loading.value = true
   error.value = null
   try {
-    const { cardId } = await api.getNextReviewCard(MATERIAL_ID)
+    const { cardId } = await api.getNextReviewCard(materialId.value)
     if (cardId === null) {
       card.value = null
       done.value = true
     } else {
-      card.value = await api.getCardRender(MATERIAL_ID, cardId)
+      card.value = await api.getCardRender(materialId.value, cardId)
       revealed.value = false
       done.value = false
     }
@@ -38,32 +51,22 @@ async function loadNext() {
 }
 
 async function submit(grade: Grade) {
-  if (!card.value || submitting.value) return
+  if (!card.value || submitting.value || !materialId.value) return
   submitting.value = true
   error.value = null
   try {
-    const res = await api.submitReview(MATERIAL_ID, card.value.cardId, grade)
+    const res = await api.submitReview(materialId.value, card.value.cardId, grade)
     if (res.nextCardId === null) {
       card.value = null
       done.value = true
     } else {
-      card.value = await api.getCardRender(MATERIAL_ID, res.nextCardId)
+      card.value = await api.getCardRender(materialId.value, res.nextCardId)
       revealed.value = false
     }
   } catch (err) {
     error.value = formatError(err)
   } finally {
     submitting.value = false
-  }
-}
-
-async function ensureEnrolled() {
-  try {
-    await api.enroll(MATERIAL_ID)
-  } catch (err) {
-    // 409 = already enrolled, expected on subsequent loads.
-    if (err instanceof ApiError && err.status === 409) return
-    throw err
   }
 }
 
@@ -74,10 +77,16 @@ function formatError(err: unknown): string {
 
 onMounted(async () => {
   try {
-    await ensureEnrolled()
+    loading.value = true
+    const found = await resolveMaterial()
+    if (!found) {
+      done.value = true
+      return
+    }
     await loadNext()
   } catch (err) {
     error.value = formatError(err)
+  } finally {
     loading.value = false
   }
 })

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -1,0 +1,245 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+import {
+  ApiError,
+  type CardRender,
+  type Grade,
+  MATERIAL_ID,
+  api,
+} from '@/api'
+import CardPrompt from '@/components/CardPrompt.vue'
+
+const card = ref<CardRender | null>(null)
+const revealed = ref(false)
+const done = ref(false)
+const error = ref<string | null>(null)
+const loading = ref(false)
+const submitting = ref(false)
+
+async function loadNext() {
+  loading.value = true
+  error.value = null
+  try {
+    const { cardId } = await api.getNextReviewCard(MATERIAL_ID)
+    if (cardId === null) {
+      card.value = null
+      done.value = true
+    } else {
+      card.value = await api.getCardRender(MATERIAL_ID, cardId)
+      revealed.value = false
+      done.value = false
+    }
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function submit(grade: Grade) {
+  if (!card.value || submitting.value) return
+  submitting.value = true
+  error.value = null
+  try {
+    const res = await api.submitReview(MATERIAL_ID, card.value.cardId, grade)
+    if (res.nextCardId === null) {
+      card.value = null
+      done.value = true
+    } else {
+      card.value = await api.getCardRender(MATERIAL_ID, res.nextCardId)
+      revealed.value = false
+    }
+  } catch (err) {
+    error.value = formatError(err)
+  } finally {
+    submitting.value = false
+  }
+}
+
+async function ensureEnrolled() {
+  try {
+    await api.enroll(MATERIAL_ID)
+  } catch (err) {
+    // 409 = already enrolled, expected on subsequent loads.
+    if (err instanceof ApiError && err.status === 409) return
+    throw err
+  }
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+onMounted(async () => {
+  try {
+    await ensureEnrolled()
+    await loadNext()
+  } catch (err) {
+    error.value = formatError(err)
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="session">
+    <div v-if="error" class="banner banner-error">{{ error }}</div>
+
+    <div v-if="loading && !card" class="status">Loading…</div>
+
+    <div v-else-if="done" class="done">
+      <h2>Session complete</h2>
+      <p>Nothing else is due right now.</p>
+      <RouterLink to="/stats" class="link-button">View stats →</RouterLink>
+    </div>
+
+    <div v-else-if="card" class="card">
+      <CardPrompt :card="card" :revealed="revealed" />
+
+      <div class="actions">
+        <button
+          v-if="!revealed"
+          class="reveal"
+          :disabled="submitting"
+          @click="revealed = true"
+        >
+          Reveal answer
+        </button>
+        <div v-else class="grades">
+          <button class="grade grade-again" :disabled="submitting" @click="submit(1)">
+            Again
+          </button>
+          <button class="grade grade-hard" :disabled="submitting" @click="submit(2)">
+            Hard
+          </button>
+          <button class="grade grade-good" :disabled="submitting" @click="submit(3)">
+            Good
+          </button>
+          <button class="grade grade-easy" :disabled="submitting" @click="submit(4)">
+            Easy
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.session {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.banner {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.status {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.done {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.done h2 {
+  margin-bottom: 0.5rem;
+}
+
+.link-button {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+/* Layout wrapper only — no surface or border. Stretches to fill the
+   session column so the grade buttons can pin themselves to the
+   bottom while the meta label + flashcard box sit at the top. */
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex: 1;
+}
+
+/* Push the grade buttons (and the Reveal button before they appear)
+   to the bottom of the .card column. Empty space goes between the
+   flashcard box and the buttons. */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+.reveal {
+  padding: 0.75rem 1.5rem;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border: none;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.reveal:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+}
+
+.grades {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.grade {
+  padding: 0.75rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.grade-again {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+
+.grade-hard {
+  background: var(--color-grade-hard-bg);
+  color: var(--color-grade-hard);
+}
+
+.grade-good {
+  background: var(--color-grade-good-bg);
+  color: var(--color-grade-good);
+}
+
+.grade-easy {
+  background: var(--color-grade-easy-bg);
+  color: var(--color-grade-easy);
+}
+
+.grade:hover:not(:disabled) {
+  border-color: currentColor;
+}
+</style>

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -402,6 +402,7 @@ pub fn build_with_config(
 mod tests {
     use super::*;
     use crate::element::ElementId;
+    use crate::material_config::ChapterListScope;
     use crate::test_kind::TestKind;
 
     fn material_one_verse_simple() -> MaterialData {
@@ -858,7 +859,13 @@ mod tests {
             "headings": []
         }"#;
         let m: MaterialData = serde_json::from_str(json).unwrap();
-        let r = build(&m, 0);
+        // chapter_list_scope defaults to Up150 (per ChapterListScope::default),
+        // so the Club300 chapter card needs an explicit Up300 to surface.
+        let cfg = MaterialConfig {
+            chapter_list_scope: ChapterListScope::Up300,
+            ..MaterialConfig::default()
+        };
+        let r = build_with_config(&m, &cfg, 0);
         let chapter_cards: Vec<&Card> = r
             .cards
             .iter()

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -152,7 +152,7 @@ fn emit_chapter_club_list_cards(
                 id: CardId(*next_card_id),
                 kind: CardKind::ChapterClubList { tier: card_tier },
                 verse_id: pseudo_id,
-                state: CardState::Active,
+                state: CardState::New,
             });
             *next_card_id += 1;
         }
@@ -259,7 +259,7 @@ pub fn build_with_config(
                 id: CardId(*next),
                 kind,
                 verse_id,
-                state: CardState::Active,
+                state: CardState::New,
             });
             *next += 1;
         };

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -484,7 +484,13 @@ mod tests {
     #[test]
     fn builder_emits_atomic_cards() {
         let m = material_one_verse_with_heading_and_club();
-        let r = build(&m, 0);
+        // club_card_scope defaults to Off, so VerseInClub cards need an
+        // explicit opt-in for this test to exercise their emission.
+        let cfg = MaterialConfig {
+            club_card_scope: crate::material_config::TierScope::All,
+            ..MaterialConfig::default()
+        };
+        let r = build_with_config(&m, &cfg, 0);
 
         let phrase_fill = r
             .cards

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -168,7 +168,8 @@ impl ReviewEngine {
                 .tests
                 .get(&key)
                 .unwrap_or_else(|| panic!("review: missing TestState for {key:?}"));
-            let after = self.fsrs.update(&before, grade, 1.0, true, now_secs);
+            let mut after = self.fsrs.update(&before, grade, 1.0, true, now_secs);
+            after.pending_relearn = !grade.is_pass();
             self.tests.insert(key, after);
             return ReviewOutcome {
                 updates: vec![TestUpdate {
@@ -192,6 +193,7 @@ impl ReviewEngine {
             .collect();
         let p_total: f32 = probs.iter().product();
         let mut updates: Vec<TestUpdate> = Vec::with_capacity(tests.len());
+        let pending = !grade.is_pass();
         for (key, p_i) in tests.iter().zip(&probs) {
             let weight = if p_total >= 1.0 - 1e-9 {
                 0.0
@@ -202,7 +204,8 @@ impl ReviewEngine {
                 .tests
                 .get(key)
                 .unwrap_or_else(|| panic!("review: missing TestState for {key:?}"));
-            let after = self.fsrs.update(&before, grade, weight, false, now_secs);
+            let mut after = self.fsrs.update(&before, grade, weight, false, now_secs);
+            after.pending_relearn = pending;
             self.tests.insert(*key, after);
             updates.push(TestUpdate {
                 key: *key,
@@ -332,6 +335,48 @@ mod tests {
         });
         let outcome = engine.review(reading_id, Grade::Good, 86400 * 365);
         assert!(outcome.updates.is_empty());
+    }
+
+    #[test]
+    fn atomic_again_sets_pending_relearn_then_good_clears_it() {
+        let mut engine = build_engine();
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        let card = engine.card(card_id).unwrap().clone();
+        let key = card.tests(&engine.atoms_for(card.verse_id))[0];
+
+        engine.review(card_id, Grade::Again, 86400 * 365);
+        assert!(engine.test_state(key).unwrap().pending_relearn);
+
+        // 6h later, FSRS sub-day due time has passed for a fresh-lapse card.
+        engine.review(card_id, Grade::Good, 86400 * 365 + 6 * 3600);
+        assert!(!engine.test_state(key).unwrap().pending_relearn);
+    }
+
+    #[test]
+    fn composite_again_sets_pending_relearn_on_every_contained_test() {
+        let mut engine = build_engine();
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::Recitation))
+            .unwrap()
+            .id;
+        let card = engine.card(card_id).unwrap().clone();
+        let keys = card.tests(&engine.atoms_for(card.verse_id));
+
+        let outcome = engine.review(card_id, Grade::Again, 86400 * 365);
+        assert_eq!(outcome.updates.len(), keys.len());
+        for key in &keys {
+            assert!(
+                engine.test_state(*key).unwrap().pending_relearn,
+                "composite Again must set pending_relearn for {key:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -149,6 +149,14 @@ impl ReviewEngine {
         count
     }
 
+    /// Flip every card in the deck to `Active`. Convenience for tests and
+    /// the sim, which bypass the memorize flow.
+    pub fn graduate_all(&mut self) {
+        for card in self.cards.iter_mut() {
+            card.state = CardState::Active;
+        }
+    }
+
     /// Apply a single grade to a card and return the resulting test
     /// updates.
     ///

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::builder::BuildResult;
-use crate::card::{Card, VerseAtoms};
+use crate::card::{Card, CardState, VerseAtoms};
 use crate::fsrs_bridge::FsrsBridge;
 use crate::render::VerseRender;
 use crate::test_kind::TestKey;
@@ -132,6 +132,21 @@ impl ReviewEngine {
             phrase_zero_word_count: 0,
             chapter_members: Vec::new(),
         }
+    }
+
+    /// Flip every `New` card whose `verse_id` matches to `Active`. Returns
+    /// the number of cards that transitioned. Idempotent: a second call on
+    /// the same verse_id returns 0. The memorize-session graduation step
+    /// uses this to "introduce" every card the verse owns in one go.
+    pub fn graduate_verse(&mut self, verse_id: u32) -> usize {
+        let mut count = 0;
+        for card in self.cards.iter_mut().filter(|c| c.verse_id == verse_id) {
+            if matches!(card.state, CardState::New) {
+                card.state = CardState::Active;
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Apply a single grade to a card and return the resulting test

--- a/crates/core/src/fsrs_bridge.rs
+++ b/crates/core/src/fsrs_bridge.rs
@@ -183,6 +183,7 @@ impl FsrsBridge {
                 } else {
                     state.last_root_secs
                 },
+                pending_relearn: state.pending_relearn,
             };
         }
         let elapsed = state.elapsed_days(now_secs).max(0.0);
@@ -203,6 +204,7 @@ impl FsrsBridge {
             } else {
                 state.last_root_secs
             },
+            pending_relearn: state.pending_relearn,
         }
     }
 
@@ -221,6 +223,7 @@ impl FsrsBridge {
             last_seen_secs: now_secs,
             last_base_secs: now_secs,
             last_root_secs: now_secs,
+            pending_relearn: state.pending_relearn,
         }
     }
 
@@ -370,6 +373,7 @@ mod tests {
             last_seen_secs: now,
             last_base_secs: now,
             last_root_secs: now,
+            pending_relearn: false,
         };
         let after = bridge.update(&ts, Grade::Hard, 1.0, true, now);
         assert!(
@@ -387,6 +391,7 @@ mod tests {
             last_seen_secs: 100,
             last_base_secs: 100,
             last_root_secs: 100,
+            pending_relearn: false,
         };
         let r = bridge.retrievability_of(&ts, 100);
         assert!((r - 1.0).abs() < 0.001);
@@ -401,6 +406,7 @@ mod tests {
             last_seen_secs: 0,
             last_base_secs: 0,
             last_root_secs: 0,
+            pending_relearn: false,
         };
         let due = bridge.due_at(&ts, 0.9);
         let secs_from_base = due - ts.last_base_secs;
@@ -425,6 +431,7 @@ mod tests {
             last_seen_secs: 0,
             last_base_secs: 0,
             last_root_secs: 0,
+            pending_relearn: false,
         };
         let r_before = bridge.retrievability_of(&ts, 86400 * 30);
         assert!(r_before < 0.95, "should have decayed: {r_before}");
@@ -452,6 +459,7 @@ mod tests {
             last_seen_secs: 100,
             last_base_secs: 100,
             last_root_secs: 100,
+            pending_relearn: false,
         };
         let grades = [Grade::Again, Grade::Hard, Grade::Good, Grade::Easy];
         let weights = [0.05_f32, 0.1, 0.3, 0.5, 0.7, 1.0];
@@ -509,6 +517,7 @@ mod tests {
             last_seen_secs: 0,
             last_base_secs: 0,
             last_root_secs: 0,
+            pending_relearn: false,
         }
     }
 
@@ -547,6 +556,7 @@ mod tests {
             last_seen_secs: 0,
             last_base_secs: 0,
             last_root_secs: 0,
+            pending_relearn: false,
         };
         let ms: MemoryState = (&ts).into();
         assert_eq!(ms.stability, 12.0);

--- a/crates/core/src/material_config.rs
+++ b/crates/core/src/material_config.rs
@@ -89,10 +89,17 @@ pub struct MaterialConfig {
     pub new_scope: TierScope,
     #[serde(default)]
     pub review_scope: TierScope,
-    #[serde(default)]
+    #[serde(default = "default_club_card_scope")]
     pub club_card_scope: TierScope,
     #[serde(default)]
     pub chapter_list_scope: ChapterListScope,
+}
+
+/// "Which club is this verse in?" prompts default off: they're high
+/// effort for low signal until the user has memorised enough verses
+/// to actually distinguish clubs. The picker exposes the toggle.
+fn default_club_card_scope() -> TierScope {
+    TierScope::Off
 }
 
 impl Default for MaterialConfig {
@@ -102,7 +109,7 @@ impl Default for MaterialConfig {
             ftv: true,
             new_scope: TierScope::All,
             review_scope: TierScope::All,
-            club_card_scope: TierScope::All,
+            club_card_scope: TierScope::Off,
             chapter_list_scope: ChapterListScope::Up150,
         }
     }
@@ -154,6 +161,9 @@ mod tests {
         assert!(c.ftv);
         assert_eq!(c.new_scope, TierScope::All);
         assert_eq!(c.review_scope, TierScope::All);
+        // Club-card prompts default off; chapter-list defaults to Up150.
+        assert_eq!(c.club_card_scope, TierScope::Off);
+        assert_eq!(c.chapter_list_scope, ChapterListScope::Up150);
         for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
             assert_eq!(c.effective_status(tier), ClubStatus::Active);
         }
@@ -244,14 +254,14 @@ mod tests {
     }
 
     #[test]
-    fn missing_scopes_default_to_widest() {
-        // Older JSON may omit scopes. Tier-scope toggles default to the
-        // widest (All); chapter-list defaults to Up150 since listing every
-        // Club 300 verse in a chapter is rarely useful out of the box.
+    fn missing_scopes_match_default_impl() {
+        // Older JSON may omit scopes. Each defaults to the same value that
+        // `MaterialConfig::default()` uses: new/review at All, club-card
+        // at Off (rarely useful out of the box), chapter-list at Up150.
         let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
         assert_eq!(c.new_scope, TierScope::All);
         assert_eq!(c.review_scope, TierScope::All);
-        assert_eq!(c.club_card_scope, TierScope::All);
+        assert_eq!(c.club_card_scope, TierScope::Off);
         assert_eq!(c.chapter_list_scope, ChapterListScope::Up150);
     }
 }

--- a/crates/core/src/material_config.rs
+++ b/crates/core/src/material_config.rs
@@ -50,8 +50,8 @@ impl TierScope {
 #[serde(rename_all = "camelCase")]
 pub enum ChapterListScope {
     Off,
-    Up150,
     #[default]
+    Up150,
     Up300,
 }
 
@@ -103,7 +103,7 @@ impl Default for MaterialConfig {
             new_scope: TierScope::All,
             review_scope: TierScope::All,
             club_card_scope: TierScope::All,
-            chapter_list_scope: ChapterListScope::Up300,
+            chapter_list_scope: ChapterListScope::Up150,
         }
     }
 }
@@ -245,11 +245,13 @@ mod tests {
 
     #[test]
     fn missing_scopes_default_to_widest() {
-        // Older JSON may omit scopes. Default everything to All / Up300.
+        // Older JSON may omit scopes. Tier-scope toggles default to the
+        // widest (All); chapter-list defaults to Up150 since listing every
+        // Club 300 verse in a chapter is rarely useful out of the box.
         let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
         assert_eq!(c.new_scope, TierScope::All);
         assert_eq!(c.review_scope, TierScope::All);
         assert_eq!(c.club_card_scope, TierScope::All);
-        assert_eq!(c.chapter_list_scope, ChapterListScope::Up300);
+        assert_eq!(c.chapter_list_scope, ChapterListScope::Up150);
     }
 }

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -59,11 +59,29 @@ pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
     engine
         .cards
         .iter()
+        .filter(|c| matches!(c.state, CardState::Active))
         .filter(|c| !engine.is_in_cooldown(c.id, now_secs))
         .filter_map(|c| Some((c.id, engine.card_min_r(c, now_secs)?)))
         .filter(|(_, r)| *r < engine.schedule_params.target_retention)
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
         .map(|(id, _)| id)
+}
+
+/// Pick the next card from the memorize queue: any `New` card. Returns one
+/// canonical card per call; the caller is expected to walk the per-verse
+/// progression client-side (see [`crate::session::Session::new_verse_progression`])
+/// and then graduate the verse via [`ReviewEngine::graduate_verse`].
+///
+/// Cooldown and FSRS due time don't apply — `New` cards have never been
+/// reviewed. Ties broken by `CardId` (insertion order), which means the
+/// memorize queue surfaces cards in the same order the builder emitted
+/// them (early verses first).
+pub fn next_memorize_card(engine: &ReviewEngine, _now_secs: i64) -> Option<CardId> {
+    engine
+        .cards
+        .iter()
+        .find(|c| matches!(c.state, CardState::New))
+        .map(|c| c.id)
 }
 
 /// Pick a card from the relearning priority lane: any `Active` card that has
@@ -158,6 +176,13 @@ mod tests {
         .unwrap()
     }
 
+    fn graduate_all(engine: &mut ReviewEngine) {
+        let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
+        for v in verse_ids {
+            engine.graduate_verse(v);
+        }
+    }
+
     #[test]
     fn next_card_returns_some_when_seeded_unseen_advanced_a_year() {
         let m = sample_material_two_verses();
@@ -165,10 +190,44 @@ mod tests {
         // forgetting curve has had 365 days to decay, so retrievability is
         // far below the 0.9 target and `next_card` should return Some.
         let r = crate::builder::build(&m, 0);
-        let engine = ReviewEngine::new(r, 0.9);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365 + 86400 * 60;
         let pick = next_card(&engine, now);
         assert!(pick.is_some());
+    }
+
+    #[test]
+    fn next_card_skips_new_cards() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        // No graduation: every card is `New`. `next_card` is a review-only
+        // function, so it must return None.
+        assert!(next_card(&engine, 86400 * 400).is_none());
+    }
+
+    #[test]
+    fn next_memorize_card_returns_new_card() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        assert!(next_memorize_card(&engine, 0).is_some());
+    }
+
+    #[test]
+    fn graduate_verse_flips_state_and_unblocks_review() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let count = engine.graduate_verse(0);
+        assert!(count > 0);
+        // Idempotent.
+        assert_eq!(engine.graduate_verse(0), 0);
+        // After graduation /memorize empties for that verse and /review
+        // sees the cards.
+        assert!(next_memorize_card(&engine, 0).is_none());
+        assert!(next_card(&engine, 86400 * 400).is_some());
     }
 
     #[test]
@@ -205,6 +264,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -222,6 +282,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -235,6 +296,28 @@ mod tests {
     }
 
     #[test]
+    fn relearn_lane_skips_new_cards() {
+        // A New card's pending_relearn flag should not surface in the lane:
+        // the lane is review-only.
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        // No graduation: card stays New. Forcibly set pending_relearn anyway.
+        let key = engine.card(card_id).unwrap().tests(&engine.atoms_for(0))[0];
+        engine.tests.get_mut(&key).unwrap().pending_relearn = true;
+        engine.tests.get_mut(&key).unwrap().stability = 0.25;
+        engine.tests.get_mut(&key).unwrap().last_base_secs = now - 86400;
+        assert!(next_relearn_card(&engine, now).is_none());
+    }
+
+    #[test]
     fn relearn_lane_bypasses_sibling_cooldown() {
         // Lapse a card, wait past the FSRS sub-day due time, then re-touch
         // one of its shared tests so the cooldown filter would mask it. The
@@ -243,6 +326,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365;
         let pf_id = engine
             .cards
@@ -263,6 +347,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -284,6 +369,7 @@ mod tests {
         let m = sample_material_two_verses();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
+        graduate_all(&mut engine);
         let now = 86400 * 365 + 86400 * 60;
 
         // Pick two PhraseFill cards from different verses to avoid sibling

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -40,10 +40,19 @@ impl ReviewEngine {
     }
 }
 
-/// Pick the card whose weakest test is furthest below
-/// `schedule_params.target_retention`. Cards at or above target are skipped
-/// (not yet due); cards in sibling cooldown are also skipped. Returns `None`
-/// when no card is both due and out of cooldown.
+/// Pick the next due card, ordered by **descending retrievability** of the
+/// card's weakest test. Cards at or above `schedule_params.target_retention`
+/// are skipped (not yet due); cards in sibling cooldown are skipped. Returns
+/// `None` when no card is both due and out of cooldown.
+///
+/// The high-R-first ordering matches the FSRS-author recommendation for
+/// capacity-limited sessions: well-known-but-due cards are cleared cheaply,
+/// banking their gains, while at-risk cards left for later will be
+/// rescheduled by FSRS regardless. Sims show this minimises retention loss
+/// when the learner doesn't finish their queue; for users who do finish, the
+/// order is irrelevant. See the research note in
+/// `~/.config/claude/plans/crystalline-wishing-garden-agent-ad6777b84ca7f2f08.md`
+/// for sources.
 ///
 /// See `docs/scheduling.md` for the full per-test FSRS scheduling story.
 pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
@@ -53,7 +62,7 @@ pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
         .filter(|c| !engine.is_in_cooldown(c.id, now_secs))
         .filter_map(|c| Some((c.id, engine.card_min_r(c, now_secs)?)))
         .filter(|(_, r)| *r < engine.schedule_params.target_retention)
-        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
         .map(|(id, _)| id)
 }
 
@@ -265,6 +274,35 @@ mod tests {
         // Pass after the FSRS due window — lane should clear.
         engine.review(card_id, Grade::Good, now + 86400);
         assert!(next_relearn_card(&engine, now + 2 * 86400).is_none());
+    }
+
+    #[test]
+    fn next_card_orders_by_descending_retrievability() {
+        // Two cards both below target_retention. The one with the *higher*
+        // R (closer to remembered) should surface first per the FSRS-author-
+        // recommended ordering.
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365 + 86400 * 60;
+
+        // Pick two PhraseFill cards from different verses to avoid sibling
+        // cooldown interactions. Boost one card's stability so its R is
+        // higher (closer to 1) at `now` than the other's.
+        let pfs: Vec<_> = engine
+            .cards
+            .iter()
+            .filter(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .map(|c| (c.id, c.verse_id))
+            .collect();
+        let (high_r_id, _) = pfs.iter().find(|(_, v)| *v == 0).copied().unwrap();
+        let (low_r_id, _) = pfs.iter().find(|(_, v)| *v == 1).copied().unwrap();
+        let high_test = engine.card(high_r_id).unwrap().tests(&engine.atoms_for(0))[0];
+        engine.tests.get_mut(&high_test).unwrap().stability = 100.0; // high R at `now`
+
+        let pick = next_card(&engine, now).expect("a card should be due");
+        assert_eq!(pick, high_r_id, "high-R card must surface before low-R");
+        assert_ne!(pick, low_r_id);
     }
 
     #[test]

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -45,14 +45,11 @@ impl ReviewEngine {
 /// are skipped (not yet due); cards in sibling cooldown are skipped. Returns
 /// `None` when no card is both due and out of cooldown.
 ///
-/// The high-R-first ordering matches the FSRS-author recommendation for
-/// capacity-limited sessions: well-known-but-due cards are cleared cheaply,
-/// banking their gains, while at-risk cards left for later will be
-/// rescheduled by FSRS regardless. Sims show this minimises retention loss
-/// when the learner doesn't finish their queue; for users who do finish, the
-/// order is irrelevant. See the research note in
-/// `~/.config/claude/plans/crystalline-wishing-garden-agent-ad6777b84ca7f2f08.md`
-/// for sources.
+/// High-R-first matches the FSRS-author recommendation for capacity-limited
+/// sessions: well-known-but-due cards clear cheaply and bank their gains,
+/// while at-risk cards left for later get re-scheduled by FSRS regardless.
+/// Sims report ~1–5pp retention edge over ascending-R for non-finishers and
+/// no difference for users who finish their queue.
 ///
 /// See `docs/scheduling.md` for the full per-test FSRS scheduling story.
 pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
@@ -176,13 +173,6 @@ mod tests {
         .unwrap()
     }
 
-    fn graduate_all(engine: &mut ReviewEngine) {
-        let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
-        for v in verse_ids {
-            engine.graduate_verse(v);
-        }
-    }
-
     #[test]
     fn next_card_returns_some_when_seeded_unseen_advanced_a_year() {
         let m = sample_material_two_verses();
@@ -191,7 +181,7 @@ mod tests {
         // far below the 0.9 target and `next_card` should return Some.
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365 + 86400 * 60;
         let pick = next_card(&engine, now);
         assert!(pick.is_some());
@@ -264,7 +254,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -282,7 +272,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -326,7 +316,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365;
         let pf_id = engine
             .cards
@@ -347,7 +337,7 @@ mod tests {
         let m = sample_material_one_verse();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365;
         let card_id = engine
             .cards
@@ -369,7 +359,7 @@ mod tests {
         let m = sample_material_two_verses();
         let r = crate::builder::build(&m, 0);
         let mut engine = ReviewEngine::new(r, 0.9);
-        graduate_all(&mut engine);
+        engine.graduate_all();
         let now = 86400 * 365 + 86400 * 60;
 
         // Pick two PhraseFill cards from different verses to avoid sibling

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -1,4 +1,4 @@
-use crate::card::Card;
+use crate::card::{Card, CardState};
 use crate::engine::ReviewEngine;
 use crate::types::CardId;
 
@@ -54,6 +54,40 @@ pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
         .filter_map(|c| Some((c.id, engine.card_min_r(c, now_secs)?)))
         .filter(|(_, r)| *r < engine.schedule_params.target_retention)
         .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
+        .map(|(id, _)| id)
+}
+
+/// Pick a card from the relearning priority lane: any `Active` card that has
+/// at least one test with `pending_relearn = true` whose FSRS-computed due
+/// time has elapsed. Bypasses the sibling cooldown — a freshly-lapsed card
+/// is exactly what we want the user re-drilling, even if another card in the
+/// session just touched a shared test.
+///
+/// Returns `None` when no lane card is due. Ties broken by earliest due time
+/// (the lapse a learner has been kept waiting longest gets cleared first).
+pub fn next_relearn_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
+    let target = engine.schedule_params.target_retention;
+    engine
+        .cards
+        .iter()
+        .filter(|c| matches!(c.state, CardState::Active))
+        .filter_map(|c| {
+            let atoms = engine.atoms_for(c.verse_id);
+            let earliest_due = c
+                .tests(&atoms)
+                .into_iter()
+                .filter_map(|tk| {
+                    let state = engine.tests.get(&tk)?;
+                    if !state.pending_relearn {
+                        return None;
+                    }
+                    let due = engine.fsrs.due_at(state, target);
+                    (due <= now_secs).then_some(due)
+                })
+                .min()?;
+            Some((c.id, earliest_due))
+        })
+        .min_by_key(|(_, due)| *due)
         .map(|(id, _)| id)
 }
 
@@ -153,6 +187,84 @@ mod tests {
         // cooldown — we don't want the user drilling the same phrase twice
         // back-to-back.
         assert!(engine.is_in_cooldown(pf_id, now + 60));
+    }
+
+    #[test]
+    fn relearn_lane_empty_before_pending_relearn_due_elapsed() {
+        // Grade Again at t=now; the FSRS post-failure interval is ~6h, so the
+        // lane should not surface the card until that interval elapses.
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        engine.review(card_id, Grade::Again, now);
+        // 1 minute later — well before the 6h FSRS sub-day interval.
+        assert!(next_relearn_card(&engine, now + 60).is_none());
+    }
+
+    #[test]
+    fn relearn_lane_surfaces_card_once_fsrs_due_time_elapses() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        engine.review(card_id, Grade::Again, now);
+        // A day later — well past the 6h post-failure interval.
+        assert_eq!(next_relearn_card(&engine, now + 86400), Some(card_id));
+    }
+
+    #[test]
+    fn relearn_lane_bypasses_sibling_cooldown() {
+        // Lapse a card, wait past the FSRS sub-day due time, then re-touch
+        // one of its shared tests so the cooldown filter would mask it. The
+        // lane must still surface it — defeating that mask is the lane's
+        // only job.
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        let pf_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        engine.review(pf_id, Grade::Again, now);
+        let later = now + 86400;
+        let touched_test = engine.card(pf_id).unwrap().tests(&engine.atoms_for(0))[0];
+        engine.tests.get_mut(&touched_test).unwrap().last_seen_secs = later - 60;
+        assert!(engine.is_in_cooldown(pf_id, later));
+        assert_eq!(next_relearn_card(&engine, later), Some(pf_id));
+    }
+
+    #[test]
+    fn relearn_lane_clears_after_passing_grade() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        engine.review(card_id, Grade::Again, now);
+        // Pass after the FSRS due window — lane should clear.
+        engine.review(card_id, Grade::Good, now + 86400);
+        assert!(next_relearn_card(&engine, now + 2 * 86400).is_none());
     }
 
     #[test]

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -103,10 +103,22 @@ impl Session {
         engine.review(card_id, grade, now_secs)
     }
 
-    /// Pick the next card. Cooldown is enforced by `schedule::next_card`
-    /// against `engine.tests[*].last_seen_secs`, which `engine.review`
-    /// updates for every test the just-reviewed card touched.
+    /// Pick the next card to review. Priority order:
+    ///
+    /// 1. **Relearning lane** — any `Active` card whose any test has
+    ///    `pending_relearn = true` and whose FSRS sub-day due time has
+    ///    elapsed. Bypasses the sibling cooldown so a freshly-lapsed card
+    ///    is re-drilled even when another card in the session just touched
+    ///    a shared test.
+    /// 2. **Regular schedule** — `schedule::next_card`, the descending-R
+    ///    review queue with cooldown enforcement.
+    ///
+    /// The FTV queue (`upcoming_cards`) is exposed for the UI to surface
+    /// independently; the scheduler doesn't drain it.
     pub fn next_card<'e>(&self, engine: &'e ReviewEngine, now_secs: i64) -> Option<&'e Card> {
+        if let Some(id) = schedule::next_relearn_card(engine, now_secs) {
+            return engine.card(id);
+        }
         let id = schedule::next_card(engine, now_secs)?;
         engine.card(id)
     }
@@ -256,6 +268,34 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c.kind, CardKind::Ftv { .. }))
         );
+    }
+
+    #[test]
+    fn session_next_card_returns_lane_card_before_regular_schedule() {
+        // Lapse a card and advance time past the FSRS sub-day due. The
+        // session must hand the lane card back before consulting the
+        // descending-R review queue. This is the load-bearing wiring for
+        // /review surfacing freshly-lapsed cards within minutes.
+        let m = sample_material_with_ftv();
+        let r = build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
+        for v in verse_ids {
+            engine.graduate_verse(v);
+        }
+        let pf_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        let now = 86400 * 365;
+        engine.review(pf_id, Grade::Again, now);
+
+        let session = Session::start(&engine, now);
+        let later = now + 86400;
+        let pick = session.next_card(&engine, later).unwrap();
+        assert_eq!(pick.id, pf_id, "lane card must surface ahead of schedule");
     }
 
     #[test]

--- a/crates/core/src/test_state.rs
+++ b/crates/core/src/test_state.rs
@@ -28,6 +28,12 @@ pub struct TestState {
     /// under propagation — that is the load-bearing invariant of HSRS that
     /// keeps propagated tests from masquerading as directly-reviewed ones.
     pub last_root_secs: i64,
+    /// Set to `true` when this test was last graded `Again` and the
+    /// learner hasn't passed it since. The session-level relearning lane
+    /// surfaces such tests' cards once their FSRS due time elapses,
+    /// bypassing the sibling cooldown. Cleared on any non-Again grade.
+    #[serde(default)]
+    pub pending_relearn: bool,
 }
 
 impl TestState {
@@ -42,6 +48,7 @@ impl TestState {
             last_seen_secs: prior,
             last_base_secs: prior,
             last_root_secs: prior,
+            pending_relearn: false,
         }
     }
 

--- a/crates/core/tests/real_data.rs
+++ b/crates/core/tests/real_data.rs
@@ -20,6 +20,13 @@ fn try_load_material() -> Option<MaterialData> {
     Some(serde_json::from_str(&json).expect("fixture parses as MaterialData"))
 }
 
+fn graduate_all(engine: &mut ReviewEngine) {
+    let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
+    for v in verse_ids {
+        engine.graduate_verse(v);
+    }
+}
+
 #[test]
 fn real_data_loads_and_runs_session() {
     let Some(material) = try_load_material() else {
@@ -29,7 +36,8 @@ fn real_data_loads_and_runs_session() {
     let now = 86400 * 365;
     let result = build(&material, now);
     assert!(!result.cards.is_empty(), "expected non-empty card set");
-    let engine = ReviewEngine::new(result, 0.9);
+    let mut engine = ReviewEngine::new(result, 0.9);
+    graduate_all(&mut engine);
     let pick = next_card(&engine, now + 86400 * 400);
     assert!(pick.is_some(), "scheduler should find a due card");
 }
@@ -43,6 +51,7 @@ fn real_data_review_first_due_card() {
     let now = 86400 * 365;
     let result = build(&material, now);
     let mut engine = ReviewEngine::new(result, 0.9);
+    graduate_all(&mut engine);
     let later = now + 86400 * 400;
     let card_id = next_card(&engine, later).expect("expected a due card to review");
     let outcome = engine.review(card_id, Grade::Good, later);

--- a/crates/core/tests/real_data.rs
+++ b/crates/core/tests/real_data.rs
@@ -20,13 +20,6 @@ fn try_load_material() -> Option<MaterialData> {
     Some(serde_json::from_str(&json).expect("fixture parses as MaterialData"))
 }
 
-fn graduate_all(engine: &mut ReviewEngine) {
-    let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
-    for v in verse_ids {
-        engine.graduate_verse(v);
-    }
-}
-
 #[test]
 fn real_data_loads_and_runs_session() {
     let Some(material) = try_load_material() else {
@@ -37,7 +30,7 @@ fn real_data_loads_and_runs_session() {
     let result = build(&material, now);
     assert!(!result.cards.is_empty(), "expected non-empty card set");
     let mut engine = ReviewEngine::new(result, 0.9);
-    graduate_all(&mut engine);
+    engine.graduate_all();
     let pick = next_card(&engine, now + 86400 * 400);
     assert!(pick.is_some(), "scheduler should find a due card");
 }
@@ -51,7 +44,7 @@ fn real_data_review_first_due_card() {
     let now = 86400 * 365;
     let result = build(&material, now);
     let mut engine = ReviewEngine::new(result, 0.9);
-    graduate_all(&mut engine);
+    engine.graduate_all();
     let later = now + 86400 * 400;
     let card_id = next_card(&engine, later).expect("expected a due card to review");
     let outcome = engine.review(card_id, Grade::Good, later);

--- a/crates/sim/src/main.rs
+++ b/crates/sim/src/main.rs
@@ -114,6 +114,12 @@ fn main() {
     let total_cards = result.cards.len();
     let total_tests = result.tests.len();
     let mut engine = ReviewEngine::new(result, 0.9);
+    // Sim doesn't model the memorize step — graduate every verse upfront so
+    // the review scheduler sees all cards. Real users go through /memorize.
+    let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
+    for v in verse_ids {
+        engine.graduate_verse(v);
+    }
     let mut learner = match &learner_params {
         Some(params) => ProbLearner::with_parameters(RNG_SEED, 0.9, params, initial_seed_secs),
         None => ProbLearner::new(RNG_SEED, 0.9, initial_seed_secs),

--- a/crates/sim/src/main.rs
+++ b/crates/sim/src/main.rs
@@ -114,12 +114,9 @@ fn main() {
     let total_cards = result.cards.len();
     let total_tests = result.tests.len();
     let mut engine = ReviewEngine::new(result, 0.9);
-    // Sim doesn't model the memorize step — graduate every verse upfront so
-    // the review scheduler sees all cards. Real users go through /memorize.
-    let verse_ids: Vec<u32> = engine.cards.iter().map(|c| c.verse_id).collect();
-    for v in verse_ids {
-        engine.graduate_verse(v);
-    }
+    // Sim doesn't model the memorize step — graduate every card upfront so
+    // the review scheduler sees them all. Real users go through /memorize.
+    engine.graduate_all();
     let mut learner = match &learner_params {
         Some(params) => ProbLearner::with_parameters(RNG_SEED, 0.9, params, initial_seed_secs),
         None => ProbLearner::new(RNG_SEED, 0.9, initial_seed_secs),

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -13,7 +13,9 @@ use verse_vault_core::element::{ClubTier, ElementId};
 use verse_vault_core::engine::{ReviewEngine, TestUpdate, UpdateKind};
 use verse_vault_core::material_config::MaterialConfig;
 use verse_vault_core::render::{HeadingRender, VerseRender};
-use verse_vault_core::schedule::next_card;
+use verse_vault_core::schedule::{
+    next_card, next_memorize_card as schedule_next_memorize_card, next_relearn_card,
+};
 use verse_vault_core::test_kind::{TestKey, TestKind};
 use verse_vault_core::test_state::TestState;
 use verse_vault_core::types::{CardId, Grade};
@@ -321,10 +323,22 @@ impl WasmEngine {
             .map_err(|e| JsError::new(&format!("export serialise error: {e}")))
     }
 
-    /// Pick the next card to review at `now_secs`, or `None` if every card
-    /// is currently above the target retention threshold.
-    pub fn next_card(&self, now_secs: i64) -> Option<u32> {
+    /// Pick the next card to review at `now_secs`, or `None` if no Active
+    /// card is due. Consults the relearning lane first (freshly-lapsed
+    /// cards past their FSRS sub-day due time, bypassing sibling cooldown)
+    /// then the regular descending-R schedule.
+    pub fn next_review_card(&self, now_secs: i64) -> Option<u32> {
+        if let Some(id) = next_relearn_card(&self.engine, now_secs) {
+            return Some(id.0);
+        }
         next_card(&self.engine, now_secs).map(|c| c.0)
+    }
+
+    /// Pick the next New card for the memorize queue. The caller walks the
+    /// per-verse progression client-side (see `new_verse_progression` on
+    /// the core `Session`) then calls `graduate_verse` to commit.
+    pub fn next_memorize_card(&self, now_secs: i64) -> Option<u32> {
+        schedule_next_memorize_card(&self.engine, now_secs).map(|c| c.0)
     }
 
     /// Flip every `New` card belonging to `verse_id` to `Active`. Returns
@@ -333,6 +347,16 @@ impl WasmEngine {
     /// and confirms.
     pub fn graduate_verse(&mut self, verse_id: u32) -> u32 {
         self.engine.graduate_verse(verse_id) as u32
+    }
+
+    /// Count of `New` cards still awaiting memorize. Drives the
+    /// "N to memorize" nudge in the web UI nav.
+    pub fn new_card_count(&self) -> u32 {
+        self.engine
+            .cards
+            .iter()
+            .filter(|c| matches!(c.state, verse_vault_core::card::CardState::New))
+            .count() as u32
     }
 
     /// Render data for a card: kind, verse_id, plus the verse's render data

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -420,6 +420,12 @@ impl WasmEngine {
         struct Entry {
             verse_id: u32,
             card_ids: Vec<u32>,
+            /// Card id of the verse's Recitation, when emitted. The web
+            /// client uses this to render the whole verse as a plain
+            /// reading prompt during the session's opening + closing
+            /// walkthroughs, avoiding the phrase-0 highlight that a
+            /// PhraseFill render would impose.
+            recitation_card_id: Option<u32>,
         }
         let cards = &self.engine.cards;
 
@@ -480,7 +486,15 @@ impl WasmEngine {
                     session_chapter_lists.remove(&card.id.0);
                 }
             }
-            entries.push(Entry { verse_id, card_ids });
+            let recitation_card_id = cards
+                .iter()
+                .find(|c| c.verse_id == verse_id && matches!(c.kind, CardKind::Recitation))
+                .map(|c| c.id.0);
+            entries.push(Entry {
+                verse_id,
+                card_ids,
+                recitation_card_id,
+            });
         }
 
         serde_json::to_string(&entries)

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -342,22 +342,61 @@ impl WasmEngine {
     }
 
     /// JSON-serialised list of card IDs to drill while memorising the
-    /// verse. Every per-verse card except `ChapterClubList` (anchored to
-    /// a pseudo verse) and `Reading` (synthetic; never emitted) is
-    /// included; the frontend cycles them in a drill loop until each
-    /// gets a passing grade. Builder-insertion order is preserved so
-    /// PhraseFills surface before the citation triple, Recitation, and
-    /// FTV.
+    /// verse. Includes every per-verse card except `ChapterClubList`
+    /// (anchored to a pseudo verse) and `Reading` (synthetic; never
+    /// emitted), with two introduction-aware additions:
+    ///
+    /// * `VerseInHeading` is skipped when another verse under the same
+    ///   heading has already been graduated — once the user has seen the
+    ///   heading via any of its verses, re-drilling it on the next one is
+    ///   redundant.
+    /// * The pseudo-verse `ChapterClubList` card is appended when the
+    ///   verse being memorised is the last `chapter_member` for that
+    ///   (chapter, tier) and the list itself is still `New` — i.e. the
+    ///   chapter's tier is "completed" by this verse so the listing
+    ///   becomes meaningful to drill.
+    ///
+    /// Builder-insertion order is otherwise preserved so PhraseFills
+    /// surface before the citation triple, Recitation, and FTV.
     pub fn memorize_progression(&self, verse_id: u32) -> Result<String, JsError> {
-        use verse_vault_core::card::CardKind;
-        let card_ids: Vec<u32> = self
-            .engine
-            .cards
-            .iter()
-            .filter(|c| c.verse_id == verse_id)
-            .filter(|c| !matches!(c.kind, CardKind::ChapterClubList { .. } | CardKind::Reading))
-            .map(|c| c.id.0)
-            .collect();
+        use verse_vault_core::card::{CardKind, CardState};
+        let cards = &self.engine.cards;
+        let mut card_ids: Vec<u32> = Vec::new();
+
+        for card in cards.iter().filter(|c| c.verse_id == verse_id) {
+            match card.kind {
+                CardKind::ChapterClubList { .. } | CardKind::Reading => continue,
+                CardKind::VerseInHeading { heading_idx } => {
+                    let heading_introduced = cards.iter().any(|other| {
+                        other.verse_id != verse_id
+                            && matches!(other.state, CardState::Active)
+                            && matches!(
+                                other.kind,
+                                CardKind::VerseInHeading { heading_idx: h } if h == heading_idx
+                            )
+                    });
+                    if !heading_introduced {
+                        card_ids.push(card.id.0);
+                    }
+                }
+                _ => card_ids.push(card.id.0),
+            }
+        }
+
+        for card in cards.iter() {
+            let CardKind::ChapterClubList { .. } = card.kind else {
+                continue;
+            };
+            if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            let atoms = self.engine.atoms_for(card.verse_id);
+            let last_member = atoms.chapter_members.last().map(|(v, _)| *v);
+            if last_member == Some(verse_id) {
+                card_ids.push(card.id.0);
+            }
+        }
+
         serde_json::to_string(&card_ids)
             .map_err(|e| JsError::new(&format!("progression serialise error: {e}")))
     }

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -341,66 +341,6 @@ impl WasmEngine {
         schedule_next_memorize_card(&self.engine, now_secs).map(|c| c.0)
     }
 
-    /// JSON-serialised list of card IDs to drill while memorising the
-    /// verse. Includes every per-verse card except `ChapterClubList`
-    /// (anchored to a pseudo verse) and `Reading` (synthetic; never
-    /// emitted), with two introduction-aware additions:
-    ///
-    /// * `VerseInHeading` is skipped when another verse under the same
-    ///   heading has already been graduated — once the user has seen the
-    ///   heading via any of its verses, re-drilling it on the next one is
-    ///   redundant.
-    /// * The pseudo-verse `ChapterClubList` card is appended when the
-    ///   verse being memorised is the last `chapter_member` for that
-    ///   (chapter, tier) and the list itself is still `New` — i.e. the
-    ///   chapter's tier is "completed" by this verse so the listing
-    ///   becomes meaningful to drill.
-    ///
-    /// Builder-insertion order is otherwise preserved so PhraseFills
-    /// surface before the citation triple, Recitation, and FTV.
-    pub fn memorize_progression(&self, verse_id: u32) -> Result<String, JsError> {
-        use verse_vault_core::card::{CardKind, CardState};
-        let cards = &self.engine.cards;
-        let mut card_ids: Vec<u32> = Vec::new();
-
-        for card in cards.iter().filter(|c| c.verse_id == verse_id) {
-            match card.kind {
-                CardKind::ChapterClubList { .. } | CardKind::Reading => continue,
-                CardKind::VerseInHeading { heading_idx } => {
-                    let heading_introduced = cards.iter().any(|other| {
-                        other.verse_id != verse_id
-                            && matches!(other.state, CardState::Active)
-                            && matches!(
-                                other.kind,
-                                CardKind::VerseInHeading { heading_idx: h } if h == heading_idx
-                            )
-                    });
-                    if !heading_introduced {
-                        card_ids.push(card.id.0);
-                    }
-                }
-                _ => card_ids.push(card.id.0),
-            }
-        }
-
-        for card in cards.iter() {
-            let CardKind::ChapterClubList { .. } = card.kind else {
-                continue;
-            };
-            if !matches!(card.state, CardState::New) {
-                continue;
-            }
-            let atoms = self.engine.atoms_for(card.verse_id);
-            let last_member = atoms.chapter_members.last().map(|(v, _)| *v);
-            if last_member == Some(verse_id) {
-                card_ids.push(card.id.0);
-            }
-        }
-
-        serde_json::to_string(&card_ids)
-            .map_err(|e| JsError::new(&format!("progression serialise error: {e}")))
-    }
-
     /// JSON-serialised list of up to `limit` New verses, each paired with
     /// its memorize progression. Used by the web UI to plan a whole
     /// memorize session in one trip — the client can show all verses up

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -35,6 +35,8 @@ pub struct TestStateEntry {
     pub last_seen_secs: i64,
     pub last_base_secs: i64,
     pub last_root_secs: i64,
+    #[serde(default)]
+    pub pending_relearn: bool,
 }
 
 impl TestStateEntry {
@@ -47,6 +49,7 @@ impl TestStateEntry {
             last_seen_secs: state.last_seen_secs,
             last_base_secs: state.last_base_secs,
             last_root_secs: state.last_root_secs,
+            pending_relearn: state.pending_relearn,
         }
     }
 
@@ -61,6 +64,7 @@ impl TestStateEntry {
             last_seen_secs: self.last_seen_secs,
             last_base_secs: self.last_base_secs,
             last_root_secs: self.last_root_secs,
+            pending_relearn: self.pending_relearn,
         };
         (key, state)
     }
@@ -471,6 +475,7 @@ mod tests {
             last_seen_secs: 1_700_000_000,
             last_base_secs: 1_699_000_000,
             last_root_secs: 1_690_000_000,
+            pending_relearn: true,
         };
         let j = serde_json::to_string(&entry).unwrap();
         let r: TestStateEntry = serde_json::from_str(&j).unwrap();
@@ -487,10 +492,31 @@ mod tests {
             last_seen_secs: 100,
             last_base_secs: 90,
             last_root_secs: 80,
+            pending_relearn: false,
         };
         let (key, state) = entry.clone().into_pair();
         let again = TestStateEntry::from_pair(key, &state);
         assert_eq!(entry, again);
+    }
+
+    #[test]
+    fn test_state_entry_missing_pending_relearn_defaults_false() {
+        // Pre-Slice-2 snapshots have no `pending_relearn` field. Make sure
+        // they still deserialize cleanly with the flag defaulting to false.
+        let with_flag = TestStateEntry {
+            element: ElementId::VerseRefPosition { verse_id: 1 },
+            test_kind: TestKind::VerseRefPosition,
+            stability: 3.0,
+            difficulty: 4.0,
+            last_seen_secs: 100,
+            last_base_secs: 90,
+            last_root_secs: 80,
+            pending_relearn: false,
+        };
+        let mut value = serde_json::to_value(&with_flag).unwrap();
+        value.as_object_mut().unwrap().remove("pending_relearn");
+        let entry: TestStateEntry = serde_json::from_value(value).unwrap();
+        assert!(!entry.pending_relearn);
     }
 
     #[test]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -341,45 +341,24 @@ impl WasmEngine {
         schedule_next_memorize_card(&self.engine, now_secs).map(|c| c.0)
     }
 
-    /// JSON-serialised per-verse memorize progression in walk order:
-    /// every PhraseFill for the verse (sorted by position) followed by
-    /// the verse's Recitation card. Shape:
-    /// `[{ "cardId": 0, "kind": "PhraseFill", "position": 0 }, …,
-    ///   { "cardId": 8, "kind": "Recitation" }]`.
-    /// Returns an empty array if no progression cards exist.
+    /// JSON-serialised list of card IDs to drill while memorising the
+    /// verse. Every per-verse card except `ChapterClubList` (anchored to
+    /// a pseudo verse) and `Reading` (synthetic; never emitted) is
+    /// included; the frontend cycles them in a drill loop until each
+    /// gets a passing grade. Builder-insertion order is preserved so
+    /// PhraseFills surface before the citation triple, Recitation, and
+    /// FTV.
     pub fn memorize_progression(&self, verse_id: u32) -> Result<String, JsError> {
         use verse_vault_core::card::CardKind;
-        #[derive(Serialize)]
-        #[serde(tag = "kind", rename_all_fields = "camelCase")]
-        enum Step {
-            PhraseFill { card_id: u32, position: u16 },
-            Recitation { card_id: u32 },
-        }
-        let mut phrase_fills: Vec<(u16, u32)> = self
+        let card_ids: Vec<u32> = self
             .engine
             .cards
             .iter()
             .filter(|c| c.verse_id == verse_id)
-            .filter_map(|c| match c.kind {
-                CardKind::PhraseFill { position } => Some((position, c.id.0)),
-                _ => None,
-            })
+            .filter(|c| !matches!(c.kind, CardKind::ChapterClubList { .. } | CardKind::Reading))
+            .map(|c| c.id.0)
             .collect();
-        phrase_fills.sort_by_key(|(p, _)| *p);
-        let recitation = self
-            .engine
-            .cards
-            .iter()
-            .find(|c| c.verse_id == verse_id && matches!(c.kind, CardKind::Recitation))
-            .map(|c| c.id.0);
-        let mut steps: Vec<Step> = phrase_fills
-            .into_iter()
-            .map(|(position, card_id)| Step::PhraseFill { card_id, position })
-            .collect();
-        if let Some(card_id) = recitation {
-            steps.push(Step::Recitation { card_id });
-        }
-        serde_json::to_string(&steps)
+        serde_json::to_string(&card_ids)
             .map_err(|e| JsError::new(&format!("progression serialise error: {e}")))
     }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -341,6 +341,48 @@ impl WasmEngine {
         schedule_next_memorize_card(&self.engine, now_secs).map(|c| c.0)
     }
 
+    /// JSON-serialised per-verse memorize progression in walk order:
+    /// every PhraseFill for the verse (sorted by position) followed by
+    /// the verse's Recitation card. Shape:
+    /// `[{ "cardId": 0, "kind": "PhraseFill", "position": 0 }, …,
+    ///   { "cardId": 8, "kind": "Recitation" }]`.
+    /// Returns an empty array if no progression cards exist.
+    pub fn memorize_progression(&self, verse_id: u32) -> Result<String, JsError> {
+        use verse_vault_core::card::CardKind;
+        #[derive(Serialize)]
+        #[serde(tag = "kind", rename_all_fields = "camelCase")]
+        enum Step {
+            PhraseFill { card_id: u32, position: u16 },
+            Recitation { card_id: u32 },
+        }
+        let mut phrase_fills: Vec<(u16, u32)> = self
+            .engine
+            .cards
+            .iter()
+            .filter(|c| c.verse_id == verse_id)
+            .filter_map(|c| match c.kind {
+                CardKind::PhraseFill { position } => Some((position, c.id.0)),
+                _ => None,
+            })
+            .collect();
+        phrase_fills.sort_by_key(|(p, _)| *p);
+        let recitation = self
+            .engine
+            .cards
+            .iter()
+            .find(|c| c.verse_id == verse_id && matches!(c.kind, CardKind::Recitation))
+            .map(|c| c.id.0);
+        let mut steps: Vec<Step> = phrase_fills
+            .into_iter()
+            .map(|(position, card_id)| Step::PhraseFill { card_id, position })
+            .collect();
+        if let Some(card_id) = recitation {
+            steps.push(Step::Recitation { card_id });
+        }
+        serde_json::to_string(&steps)
+            .map_err(|e| JsError::new(&format!("progression serialise error: {e}")))
+    }
+
     /// Flip every `New` card belonging to `verse_id` to `Active`. Returns
     /// the number of cards transitioned. Idempotent. Called by the
     /// `/memorize` flow after the learner walks the per-verse progression

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -401,6 +401,92 @@ impl WasmEngine {
             .map_err(|e| JsError::new(&format!("progression serialise error: {e}")))
     }
 
+    /// JSON-serialised list of up to `limit` New verses, each paired with
+    /// its memorize progression. Used by the web UI to plan a whole
+    /// memorize session in one trip — the client can show all verses up
+    /// front, drill across them in any order, and walk back through them
+    /// for graduation.
+    ///
+    /// Same per-card filtering rules as `memorize_progression`, plus an
+    /// extra session-scoped dedupe: a `VerseInHeading` heading is only
+    /// drilled on the first verse that introduces it within this batch,
+    /// and a `ChapterClubList` card only attaches to the single verse
+    /// (per session) whose last-member rule fires.
+    pub fn memorize_session(&self, limit: u32) -> Result<String, JsError> {
+        use std::collections::HashSet;
+        use verse_vault_core::card::{CardKind, CardState};
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Entry {
+            verse_id: u32,
+            card_ids: Vec<u32>,
+        }
+        let cards = &self.engine.cards;
+
+        let mut seen_verses: HashSet<u32> = HashSet::new();
+        let mut verse_order: Vec<u32> = Vec::new();
+        for card in cards.iter() {
+            if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            if seen_verses.insert(card.verse_id) {
+                verse_order.push(card.verse_id);
+                if verse_order.len() >= limit as usize {
+                    break;
+                }
+            }
+        }
+
+        let mut session_headings: HashSet<u16> = HashSet::new();
+        let mut session_chapter_lists: HashSet<u32> = HashSet::new();
+        let mut entries: Vec<Entry> = Vec::with_capacity(verse_order.len());
+
+        for verse_id in verse_order {
+            let mut card_ids: Vec<u32> = Vec::new();
+            for card in cards.iter().filter(|c| c.verse_id == verse_id) {
+                match card.kind {
+                    CardKind::ChapterClubList { .. } | CardKind::Reading => continue,
+                    CardKind::VerseInHeading { heading_idx } => {
+                        let already_introduced = cards.iter().any(|other| {
+                            other.verse_id != verse_id
+                                && matches!(other.state, CardState::Active)
+                                && matches!(
+                                    other.kind,
+                                    CardKind::VerseInHeading { heading_idx: h } if h == heading_idx
+                                )
+                        });
+                        if !already_introduced && session_headings.insert(heading_idx) {
+                            card_ids.push(card.id.0);
+                        }
+                    }
+                    _ => card_ids.push(card.id.0),
+                }
+            }
+            for card in cards.iter() {
+                let CardKind::ChapterClubList { .. } = card.kind else {
+                    continue;
+                };
+                if !matches!(card.state, CardState::New) {
+                    continue;
+                }
+                if !session_chapter_lists.insert(card.id.0) {
+                    continue;
+                }
+                let atoms = self.engine.atoms_for(card.verse_id);
+                if atoms.chapter_members.last().map(|(v, _)| *v) == Some(verse_id) {
+                    card_ids.push(card.id.0);
+                } else {
+                    // Not this verse — un-mark so a later verse can claim it.
+                    session_chapter_lists.remove(&card.id.0);
+                }
+            }
+            entries.push(Entry { verse_id, card_ids });
+        }
+
+        serde_json::to_string(&entries)
+            .map_err(|e| JsError::new(&format!("session serialise error: {e}")))
+    }
+
     /// Flip every `New` card belonging to `verse_id` to `Active`. Returns
     /// the number of cards transitioned. Idempotent. Called by the
     /// `/memorize` flow after the learner walks the per-verse progression

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -327,6 +327,14 @@ impl WasmEngine {
         next_card(&self.engine, now_secs).map(|c| c.0)
     }
 
+    /// Flip every `New` card belonging to `verse_id` to `Active`. Returns
+    /// the number of cards transitioned. Idempotent. Called by the
+    /// `/memorize` flow after the learner walks the per-verse progression
+    /// and confirms.
+    pub fn graduate_verse(&mut self, verse_id: u32) -> u32 {
+        self.engine.graduate_verse(verse_id) as u32
+    }
+
     /// Render data for a card: kind, verse_id, plus the verse's render data
     /// (book / chapter / verse number, full text, phrases, ftv, headings,
     /// clubs). Returns JSON of `CardRenderWire`. Errors when the card id

--- a/crates/wasm/test-smoke.js
+++ b/crates/wasm/test-smoke.js
@@ -36,13 +36,28 @@ if (initialStates.length === 0) {
   process.exit(1);
 }
 
+console.log(`Initial new card count: ${engine.new_card_count()}`);
+if (engine.next_review_card(NOW) !== undefined) {
+  console.error('FAIL: next_review_card should be empty before graduation');
+  process.exit(1);
+}
+
+const memorizeCardId = engine.next_memorize_card(NOW);
+if (memorizeCardId === undefined) {
+  console.error('FAIL: next_memorize_card returned undefined');
+  process.exit(1);
+}
+console.log(`Memorize queue surfaces card ${memorizeCardId}; graduating verse 0...`);
+const graduated = engine.graduate_verse(0);
+console.log(`Graduated ${graduated} cards; new_card_count=${engine.new_card_count()}`);
+
 console.log('Stepping through reviews...');
 let step = 0;
 let now = NOW;
 while (step < 20) {
-  const cardId = engine.next_card(now);
+  const cardId = engine.next_review_card(now);
   if (cardId === undefined) {
-    console.log(`Step ${step}: next_card returned undefined; loop done`);
+    console.log(`Step ${step}: next_review_card returned undefined; loop done`);
     break;
   }
 

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -138,7 +138,7 @@ fn next_card_returns_some_when_due_after_graduation() {
     // surface its cards — without graduation, /review is empty.
     let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
     engine.graduate_verse(0);
-    let pick = engine.next_card(86400 * 365 + 86400 * 60);
+    let pick = engine.next_review_card(86400 * 365 + 86400 * 60);
     assert!(pick.is_some(), "expected a due card");
 }
 
@@ -146,7 +146,7 @@ fn next_card_returns_some_when_due_after_graduation() {
 fn next_card_empty_until_verse_graduates() {
     // Brand-new engine: every card is `New`. /review must be empty.
     let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
-    assert!(engine.next_card(86400 * 365 + 86400 * 60).is_none());
+    assert!(engine.next_review_card(86400 * 365 + 86400 * 60).is_none());
 }
 
 #[test]

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -131,12 +131,22 @@ fn replay_event_invalid_grade_returns_error() {
 }
 
 #[test]
-fn next_card_returns_some_when_due() {
+fn next_card_returns_some_when_due_after_graduation() {
     // Build at t=0; every test seeds with last_base = -365 days. By the time
-    // we ask at +60 days past t=365d, retrievability is well below 0.9.
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    // we ask at +60 days past t=365d, retrievability is well below 0.9. The
+    // verse has to be graduated (memorize → Active) before `next_card` will
+    // surface its cards — without graduation, /review is empty.
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    engine.graduate_verse(0);
     let pick = engine.next_card(86400 * 365 + 86400 * 60);
     assert!(pick.is_some(), "expected a due card");
+}
+
+#[test]
+fn next_card_empty_until_verse_graduates() {
+    // Brand-new engine: every card is `New`. /review must be empty.
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    assert!(engine.next_card(86400 * 365 + 86400 * 60).is_none());
 }
 
 #[test]

--- a/data/4-john.json
+++ b/data/4-john.json
@@ -164,8 +164,7 @@
       "verse": 3,
       "phraseWordCounts": [
         6,
-        6,
-        3
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,

--- a/data/4-john.json
+++ b/data/4-john.json
@@ -295,8 +295,7 @@
       "verse": 12,
       "phraseWordCounts": [
         6,
-        6,
-        5,
+        11,
         7
       ],
       "annotations": [],
@@ -434,8 +433,7 @@
       "verse": 19,
       "phraseWordCounts": [
         7,
-        7,
-        5,
+        12,
         3
       ],
       "annotations": [
@@ -491,8 +489,7 @@
       "phraseWordCounts": [
         5,
         3,
-        6,
-        5,
+        11,
         6
       ],
       "annotations": [],
@@ -563,8 +560,7 @@
       "phraseWordCounts": [
         4,
         4,
-        6,
-        5
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -577,10 +573,8 @@
       "chapter": 1,
       "verse": 27,
       "phraseWordCounts": [
-        7,
-        4,
-        3,
-        6
+        11,
+        9
       ],
       "annotations": [
         {
@@ -625,8 +619,7 @@
       "phraseWordCounts": [
         9,
         3,
-        4,
-        8
+        12
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -640,8 +633,7 @@
       "verse": 30,
       "phraseWordCounts": [
         7,
-        5,
-        5,
+        10,
         5
       ],
       "annotations": [],
@@ -669,8 +661,7 @@
       "verse": 32,
       "phraseWordCounts": [
         5,
-        7,
-        3,
+        10,
         5
       ],
       "annotations": [
@@ -690,12 +681,9 @@
       "verse": 33,
       "phraseWordCounts": [
         5,
-        9,
-        3,
-        7,
-        4,
-        3,
-        6
+        12,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -891,8 +879,7 @@
       "verse": 45,
       "phraseWordCounts": [
         7,
-        10,
-        5,
+        15,
         7
       ],
       "annotations": [],
@@ -1014,8 +1001,7 @@
         5,
         6,
         6,
-        5,
-        8
+        13
       ],
       "annotations": [
         {
@@ -1033,8 +1019,7 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        8,
-        4,
+        12,
         7
       ],
       "annotations": [
@@ -1247,8 +1232,7 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        6,
-        4,
+        10,
         4,
         6
       ],
@@ -1818,8 +1802,8 @@
       "phraseWordCounts": [
         8,
         9,
-        8,
-        7
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -1952,9 +1936,8 @@
       "chapter": 3,
       "verse": 25,
       "phraseWordCounts": [
-        5,
-        8,
-        2
+        10,
+        5
       ],
       "annotations": [
         {
@@ -2141,7 +2124,8 @@
       "chapter": 3,
       "verse": 36,
       "phraseWordCounts": [
-        9,
+        6,
+        3,
         8,
         4,
         8
@@ -2163,7 +2147,8 @@
       "verse": 1,
       "phraseWordCounts": [
         1,
-        18
+        11,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -2292,7 +2277,8 @@
       "chapter": 4,
       "verse": 8,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2528,8 +2514,7 @@
       "verse": 20,
       "phraseWordCounts": [
         6,
-        10,
-        5
+        15
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2594,8 +2579,7 @@
       "verse": 24,
       "phraseWordCounts": [
         3,
-        5,
-        6
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -2673,8 +2657,7 @@
       "chapter": 4,
       "verse": 29,
       "phraseWordCounts": [
-        4,
-        9,
+        13,
         5
       ],
       "annotations": [],
@@ -2717,8 +2700,7 @@
       "verse": 32,
       "phraseWordCounts": [
         5,
-        5,
-        6
+        11
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2792,8 +2774,7 @@
       "phraseWordCounts": [
         6,
         6,
-        9,
-        3
+        12
       ],
       "annotations": [
         {
@@ -2882,9 +2863,9 @@
       "chapter": 4,
       "verse": 39,
       "phraseWordCounts": [
-        8,
-        10,
-        10
+        11,
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2989,10 +2970,8 @@
       "chapter": 4,
       "verse": 46,
       "phraseWordCounts": [
-        8,
-        7,
-        6,
-        6
+        15,
+        12
       ],
       "annotations": [
         {
@@ -3067,10 +3046,8 @@
       "verse": 50,
       "phraseWordCounts": [
         4,
-        3,
-        3,
         6,
-        5,
+        11,
         5
       ],
       "annotations": [],
@@ -3099,11 +3076,9 @@
       "chapter": 4,
       "verse": 52,
       "phraseWordCounts": [
-        7,
-        4,
+        11,
         5,
-        5,
-        4
+        9
       ],
       "annotations": [
         {
@@ -3137,8 +3112,7 @@
       "chapter": 4,
       "verse": 53,
       "phraseWordCounts": [
-        11,
-        6,
+        17,
         3,
         4,
         4
@@ -3439,8 +3413,7 @@
       "chapter": 5,
       "verse": 13,
       "phraseWordCounts": [
-        6,
-        6,
+        12,
         4,
         6
       ],
@@ -3673,8 +3646,7 @@
       "verse": 26,
       "phraseWordCounts": [
         8,
-        6,
-        5
+        11
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -3968,8 +3940,7 @@
       "phraseWordCounts": [
         4,
         6,
-        6,
-        6
+        12
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4049,8 +4020,7 @@
       "verse": 2,
       "phraseWordCounts": [
         6,
-        5,
-        8
+        13
       ],
       "annotations": [
         {
@@ -4126,8 +4096,7 @@
       "verse": 7,
       "phraseWordCounts": [
         3,
-        6,
-        5,
+        11,
         9
       ],
       "annotations": [
@@ -4160,8 +4129,7 @@
       "chapter": 6,
       "verse": 9,
       "phraseWordCounts": [
-        5,
-        9,
+        14,
         7
       ],
       "annotations": [
@@ -4265,8 +4233,7 @@
       "verse": 13,
       "phraseWordCounts": [
         5,
-        7,
-        5,
+        12,
         9
       ],
       "annotations": [
@@ -4291,9 +4258,8 @@
       "chapter": 6,
       "verse": 14,
       "phraseWordCounts": [
-        13,
-        5,
-        7
+        12,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4411,8 +4377,7 @@
       "verse": 21,
       "phraseWordCounts": [
         8,
-        8,
-        4
+        12
       ],
       "annotations": [
         {
@@ -4614,8 +4579,7 @@
       "chapter": 6,
       "verse": 33,
       "phraseWordCounts": [
-        7,
-        5,
+        12,
         6
       ],
       "annotations": [],
@@ -4731,8 +4695,7 @@
       "phraseWordCounts": [
         6,
         3,
-        4,
-        5
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5053,8 +5016,7 @@
       "chapter": 6,
       "verse": 62,
       "phraseWordCounts": [
-        11,
-        4
+        15
       ],
       "annotations": [
         {
@@ -5118,8 +5080,8 @@
       "chapter": 6,
       "verse": 66,
       "phraseWordCounts": [
-        7,
-        8
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5228,8 +5190,7 @@
       "phraseWordCounts": [
         6,
         7,
-        8,
-        4
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5335,8 +5296,7 @@
       "phraseWordCounts": [
         7,
         8,
-        2,
-        6
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5361,8 +5321,7 @@
       "phraseWordCounts": [
         10,
         5,
-        6,
-        4
+        10
       ],
       "annotations": [
         {
@@ -5688,10 +5647,9 @@
       "chapter": 7,
       "verse": 31,
       "phraseWordCounts": [
-        8,
-        6,
-        7,
-        5
+        10,
+        4,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5873,7 +5831,8 @@
       "chapter": 7,
       "verse": 42,
       "phraseWordCounts": [
-        14,
+        9,
+        5,
         6,
         3
       ],
@@ -6081,8 +6040,8 @@
       "chapter": 8,
       "verse": 3,
       "phraseWordCounts": [
-        8,
         5,
+        8,
         9
       ],
       "annotations": [
@@ -6242,7 +6201,8 @@
       "chapter": 8,
       "verse": 10,
       "phraseWordCounts": [
-        13,
+        6,
+        7,
         4,
         7,
         5
@@ -6353,8 +6313,7 @@
       "chapter": 8,
       "verse": 17,
       "phraseWordCounts": [
-        7,
-        8
+        15
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6366,8 +6325,7 @@
       "verse": 18,
       "phraseWordCounts": [
         8,
-        6,
-        4
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6497,8 +6455,7 @@
       "phraseWordCounts": [
         11,
         7,
-        8,
-        5
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6743,8 +6700,7 @@
       "verse": 40,
       "phraseWordCounts": [
         7,
-        8,
-        5,
+        13,
         5
       ],
       "annotations": [],
@@ -7215,8 +7171,7 @@
       "chapter": 9,
       "verse": 8,
       "phraseWordCounts": [
-        3,
-        11,
+        14,
         8
       ],
       "annotations": [
@@ -7329,7 +7284,8 @@
         13,
         4,
         6,
-        6
+        3,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7345,8 +7301,7 @@
         6,
         6,
         7,
-        6,
-        7,
+        13,
         7
       ],
       "annotations": [],
@@ -7371,7 +7326,8 @@
       "chapter": 9,
       "verse": 18,
       "phraseWordCounts": [
-        17,
+        8,
+        9,
         12
       ],
       "annotations": [],
@@ -7780,7 +7736,8 @@
       "chapter": 10,
       "verse": 2,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7868,8 +7825,7 @@
       "verse": 6,
       "phraseWordCounts": [
         4,
-        7,
-        5
+        12
       ],
       "annotations": [
         {
@@ -8434,11 +8390,9 @@
       "chapter": 10,
       "verse": 36,
       "phraseWordCounts": [
-        5,
-        9,
+        14,
         3,
-        3,
-        6
+        9
       ],
       "annotations": [
         {
@@ -8939,8 +8893,7 @@
       "chapter": 11,
       "verse": 26,
       "phraseWordCounts": [
-        7,
-        3,
+        10,
         4
       ],
       "annotations": [],
@@ -9169,8 +9122,7 @@
       "verse": 40,
       "phraseWordCounts": [
         4,
-        11,
-        7
+        18
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9271,8 +9223,7 @@
       "chapter": 11,
       "verse": 45,
       "phraseWordCounts": [
-        5,
-        5,
+        10,
         7,
         3
       ],
@@ -9349,8 +9300,7 @@
       "chapter": 11,
       "verse": 50,
       "phraseWordCounts": [
-        10,
-        8,
+        18,
         8
       ],
       "annotations": [
@@ -9386,8 +9336,7 @@
       "verse": 52,
       "phraseWordCounts": [
         6,
-        13,
-        4
+        17
       ],
       "annotations": [
         {
@@ -9497,8 +9446,7 @@
       "phraseWordCounts": [
         6,
         3,
-        6,
-        7
+        13
       ],
       "annotations": [
         {
@@ -9517,8 +9465,7 @@
         11,
         5,
         7,
-        5,
-        6
+        11
       ],
       "annotations": [
         {
@@ -9563,8 +9510,7 @@
       "chapter": 12,
       "verse": 5,
       "phraseWordCounts": [
-        7,
-        4,
+        11,
         5
       ],
       "annotations": [],
@@ -9872,8 +9818,7 @@
       "verse": 23,
       "phraseWordCounts": [
         5,
-        4,
-        8
+        12
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -9923,8 +9868,7 @@
       "verse": 25,
       "phraseWordCounts": [
         8,
-        9,
-        6
+        15
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10304,8 +10248,7 @@
       "verse": 46,
       "phraseWordCounts": [
         9,
-        5,
-        5
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -10318,8 +10261,7 @@
       "chapter": 12,
       "verse": 47,
       "phraseWordCounts": [
-        6,
-        4,
+        10,
         5,
         9,
         5
@@ -10333,9 +10275,11 @@
       "chapter": 12,
       "verse": 48,
       "phraseWordCounts": [
-        10,
+        4,
+        6,
         5,
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -10379,8 +10323,7 @@
       "verse": 1,
       "phraseWordCounts": [
         7,
-        8,
-        10,
+        18,
         9,
         6
       ],
@@ -10459,8 +10402,7 @@
       "phraseWordCounts": [
         8,
         7,
-        7,
-        5
+        12
       ],
       "annotations": [
         {
@@ -10550,8 +10492,7 @@
       "verse": 10,
       "phraseWordCounts": [
         4,
-        4,
-        6,
+        10,
         4,
         4,
         5
@@ -10682,7 +10623,8 @@
         8,
         6,
         7,
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -10765,8 +10707,8 @@
       "chapter": 13,
       "verse": 23,
       "phraseWordCounts": [
-        7,
-        7
+        11,
+        3
       ],
       "annotations": [
         {
@@ -10820,8 +10762,7 @@
         14,
         5,
         5,
-        6,
-        4
+        10
       ],
       "annotations": [
         {
@@ -11161,9 +11102,11 @@
       "verse": 9,
       "phraseWordCounts": [
         4,
-        15,
+        7,
+        8,
         9,
-        9
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -11176,7 +11119,8 @@
       "chapter": 14,
       "verse": 10,
       "phraseWordCounts": [
-        15,
+        10,
+        5,
         7,
         8,
         10
@@ -11390,11 +11334,9 @@
       "chapter": 14,
       "verse": 24,
       "phraseWordCounts": [
-        6,
-        5,
-        6,
-        6,
-        3
+        11,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -11950,11 +11892,11 @@
       "chapter": 15,
       "verse": 24,
       "phraseWordCounts": [
-        9,
+        7,
+        7,
         5,
         5,
-        8,
-        5
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -12478,7 +12420,8 @@
       "verse": 26,
       "phraseWordCounts": [
         9,
-        15
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12634,7 +12577,8 @@
       "verse": 2,
       "phraseWordCounts": [
         9,
-        14
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -12705,8 +12649,8 @@
       "chapter": 17,
       "verse": 7,
       "phraseWordCounts": [
-        7,
-        8
+        4,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -12717,8 +12661,7 @@
       "chapter": 17,
       "verse": 8,
       "phraseWordCounts": [
-        8,
-        5,
+        13,
         5,
         10,
         8
@@ -12967,7 +12910,8 @@
       "chapter": 17,
       "verse": 24,
       "phraseWordCounts": [
-        17,
+        10,
+        7,
         11,
         10
       ],
@@ -13086,8 +13030,7 @@
       "chapter": 18,
       "verse": 4,
       "phraseWordCounts": [
-        5,
-        5,
+        10,
         6,
         4
       ],
@@ -13167,8 +13110,7 @@
       "chapter": 18,
       "verse": 9,
       "phraseWordCounts": [
-        6,
-        3,
+        9,
         10
       ],
       "annotations": [],
@@ -13217,8 +13159,7 @@
       "phraseWordCounts": [
         5,
         6,
-        6,
-        6
+        12
       ],
       "annotations": [
         {
@@ -13268,8 +13209,7 @@
       "verse": 13,
       "phraseWordCounts": [
         8,
-        7,
-        6
+        13
       ],
       "annotations": [
         {
@@ -13285,8 +13225,8 @@
       "chapter": 18,
       "verse": 14,
       "phraseWordCounts": [
-        12,
-        8
+        8,
+        12
       ],
       "annotations": [
         {
@@ -13327,8 +13267,7 @@
         7,
         4,
         7,
-        6,
-        4,
+        10,
         4
       ],
       "annotations": [],
@@ -13364,12 +13303,10 @@
       "chapter": 18,
       "verse": 18,
       "phraseWordCounts": [
-        5,
-        7,
-        6,
+        14,
         4,
-        5,
-        3
+        4,
+        8
       ],
       "annotations": [
         {
@@ -13592,8 +13529,7 @@
       "chapter": 18,
       "verse": 32,
       "phraseWordCounts": [
-        8,
-        3,
+        11,
         7
       ],
       "annotations": [],
@@ -13704,8 +13640,7 @@
       "chapter": 18,
       "verse": 39,
       "phraseWordCounts": [
-        5,
-        10,
+        15,
         14
       ],
       "annotations": [
@@ -13956,8 +13891,7 @@
         6,
         6,
         5,
-        5,
-        3
+        8
       ],
       "annotations": [
         {
@@ -15363,7 +15297,8 @@
         5,
         10,
         5,
-        13,
+        3,
+        10,
         6
       ],
       "annotations": [
@@ -15751,10 +15686,9 @@
       "chapter": 21,
       "verse": 23,
       "phraseWordCounts": [
-        8,
-        6,
-        13,
-        9,
+        14,
+        12,
+        10,
         5
       ],
       "annotations": [],
@@ -15766,8 +15700,7 @@
       "chapter": 21,
       "verse": 24,
       "phraseWordCounts": [
-        4,
-        5,
+        9,
         4,
         8
       ],
@@ -15784,8 +15717,8 @@
       "phraseWordCounts": [
         10,
         8,
-        12,
-        5
+        16,
+        1
       ],
       "annotations": [
         {

--- a/packages/api/migrations/0013_relearn_and_wipe.sql
+++ b/packages/api/migrations/0013_relearn_and_wipe.sql
@@ -1,0 +1,18 @@
+-- Add `pending_relearn` to `test_states` (relearning priority lane state).
+-- Wipe every per-user table so the builder's switch from CardState::Active
+-- to CardState::New takes effect: all existing decks were built before the
+-- switch and have stale Active-state cards in their snapshots. Pre-deploy,
+-- no production users; the next sync replays a freshly-built deck.
+-- Each DELETE is a no-op on an empty fresh DB.
+
+ALTER TABLE `test_states` ADD COLUMN `pending_relearn` INTEGER NOT NULL DEFAULT 0;
+--> statement-breakpoint
+DELETE FROM `test_states`;
+--> statement-breakpoint
+DELETE FROM `graph_snapshots`;
+--> statement-breakpoint
+DELETE FROM `review_events`;
+--> statement-breakpoint
+DELETE FROM `user_year_settings`;
+--> statement-breakpoint
+DELETE FROM `user_materials`;

--- a/packages/api/migrations/0014_graduated_verses.sql
+++ b/packages/api/migrations/0014_graduated_verses.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `graduated_verses` (
+	`user_id` text NOT NULL,
+	`material_id` text NOT NULL,
+	`verse_id` integer NOT NULL,
+	`graduated_at_secs` integer NOT NULL,
+	PRIMARY KEY(`user_id`, `material_id`, `verse_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/packages/api/migrations/meta/0013_snapshot.json
+++ b/packages/api/migrations/meta/0013_snapshot.json
@@ -1,0 +1,914 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9920da57-3055-4920-a01e-ec7f171deeb7",
+  "prevId": "08427fc9-2b6c-4108-b7a5-4954aaa40256",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_passages": {
+      "name": "apibible_passages",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passage_id": {
+          "name": "passage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_passages_fetched_at": {
+          "name": "idx_apibible_passages_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_passages_bible_id_passage_id_pk": {
+          "columns": [
+            "bible_id",
+            "passage_id"
+          ],
+          "name": "apibible_passages_bible_id_passage_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_sections": {
+      "name": "apibible_sections",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_code": {
+          "name": "book_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_sections_fetched_at": {
+          "name": "idx_apibible_sections_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_sections_bible_id_book_code_pk": {
+          "columns": [
+            "bible_id",
+            "book_code"
+          ],
+          "name": "apibible_sections_bible_id_book_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graph_snapshots": {
+      "name": "graph_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_data": {
+          "name": "material_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_graph_snapshots_user_material": {
+          "name": "idx_graph_snapshots_user_material",
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "graph_snapshots_user_id_user_id_fk": {
+          "name": "graph_snapshots_user_id_user_id_fk",
+          "tableFrom": "graph_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_events": {
+      "name": "review_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_version": {
+          "name": "snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_secs": {
+          "name": "timestamp_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_event_id": {
+          "name": "client_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_review_events_user_material_time": {
+          "name": "idx_review_events_user_material_time",
+          "columns": [
+            "user_id",
+            "material_id",
+            "timestamp_secs"
+          ],
+          "isUnique": false
+        },
+        "uniq_review_events_user_material_client_event": {
+          "name": "uniq_review_events_user_material_client_event",
+          "columns": [
+            "user_id",
+            "material_id",
+            "client_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "review_events_user_id_user_id_fk": {
+          "name": "review_events_user_id_user_id_fk",
+          "tableFrom": "review_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_states": {
+      "name": "test_states",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_kind": {
+          "name": "test_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_secs": {
+          "name": "last_seen_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_base_secs": {
+          "name": "last_base_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_root_secs": {
+          "name": "last_root_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_relearn": {
+          "name": "pending_relearn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_states_user_id_user_id_fk": {
+          "name": "test_states_user_id_user_id_fk",
+          "tableFrom": "test_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_states_user_id_material_id_test_kind_element_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "test_kind",
+            "element"
+          ],
+          "name": "test_states_user_id_material_id_test_kind_element_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_materials": {
+      "name": "user_materials",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_tier": {
+          "name": "club_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_materials_user_id_user_id_fk": {
+          "name": "user_materials_user_id_user_id_fk",
+          "tableFrom": "user_materials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_materials_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_materials_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_year_settings": {
+      "name": "user_year_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headings": {
+          "name": "headings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ftv": {
+          "name": "ftv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_scope": {
+          "name": "new_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_scope": {
+          "name": "review_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_card_scope": {
+          "name": "club_card_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapter_list_scope": {
+          "name": "chapter_list_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_batch_size": {
+          "name": "lesson_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_year_settings_user_id_user_id_fk": {
+          "name": "user_year_settings_user_id_user_id_fk",
+          "tableFrom": "user_year_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_year_settings_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_year_settings_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/0014_snapshot.json
+++ b/packages/api/migrations/meta/0014_snapshot.json
@@ -1,0 +1,975 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "325e88a2-0acc-4b3f-b44e-6c7f804ca2c9",
+  "prevId": "9920da57-3055-4920-a01e-ec7f171deeb7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_passages": {
+      "name": "apibible_passages",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passage_id": {
+          "name": "passage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_passages_fetched_at": {
+          "name": "idx_apibible_passages_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_passages_bible_id_passage_id_pk": {
+          "columns": [
+            "bible_id",
+            "passage_id"
+          ],
+          "name": "apibible_passages_bible_id_passage_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_sections": {
+      "name": "apibible_sections",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_code": {
+          "name": "book_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_sections_fetched_at": {
+          "name": "idx_apibible_sections_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_sections_bible_id_book_code_pk": {
+          "columns": [
+            "bible_id",
+            "book_code"
+          ],
+          "name": "apibible_sections_bible_id_book_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graph_snapshots": {
+      "name": "graph_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_data": {
+          "name": "material_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_graph_snapshots_user_material": {
+          "name": "idx_graph_snapshots_user_material",
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "graph_snapshots_user_id_user_id_fk": {
+          "name": "graph_snapshots_user_id_user_id_fk",
+          "tableFrom": "graph_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_events": {
+      "name": "review_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_version": {
+          "name": "snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_secs": {
+          "name": "timestamp_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_event_id": {
+          "name": "client_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_review_events_user_material_time": {
+          "name": "idx_review_events_user_material_time",
+          "columns": [
+            "user_id",
+            "material_id",
+            "timestamp_secs"
+          ],
+          "isUnique": false
+        },
+        "uniq_review_events_user_material_client_event": {
+          "name": "uniq_review_events_user_material_client_event",
+          "columns": [
+            "user_id",
+            "material_id",
+            "client_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "review_events_user_id_user_id_fk": {
+          "name": "review_events_user_id_user_id_fk",
+          "tableFrom": "review_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_states": {
+      "name": "test_states",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_kind": {
+          "name": "test_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_secs": {
+          "name": "last_seen_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_base_secs": {
+          "name": "last_base_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_root_secs": {
+          "name": "last_root_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_relearn": {
+          "name": "pending_relearn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_states_user_id_user_id_fk": {
+          "name": "test_states_user_id_user_id_fk",
+          "tableFrom": "test_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_states_user_id_material_id_test_kind_element_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "test_kind",
+            "element"
+          ],
+          "name": "test_states_user_id_material_id_test_kind_element_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graduated_verses": {
+      "name": "graduated_verses",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verse_id": {
+          "name": "verse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graduated_at_secs": {
+          "name": "graduated_at_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graduated_verses_user_id_user_id_fk": {
+          "name": "graduated_verses_user_id_user_id_fk",
+          "tableFrom": "graduated_verses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "graduated_verses_user_id_material_id_verse_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "verse_id"
+          ],
+          "name": "graduated_verses_user_id_material_id_verse_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_materials": {
+      "name": "user_materials",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_tier": {
+          "name": "club_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_materials_user_id_user_id_fk": {
+          "name": "user_materials_user_id_user_id_fk",
+          "tableFrom": "user_materials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_materials_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_materials_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_year_settings": {
+      "name": "user_year_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headings": {
+          "name": "headings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ftv": {
+          "name": "ftv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_scope": {
+          "name": "new_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_scope": {
+          "name": "review_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_card_scope": {
+          "name": "club_card_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapter_list_scope": {
+          "name": "chapter_list_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_batch_size": {
+          "name": "lesson_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_year_settings_user_id_user_id_fk": {
+          "name": "user_year_settings_user_id_user_id_fk",
+          "tableFrom": "user_year_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_year_settings_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_year_settings_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1778796400000,
       "tag": "0013_relearn_and_wipe",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1778796500000,
+      "tag": "0014_graduated_verses",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778710000000,
       "tag": "0012_rename_material_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1778796400000,
+      "tag": "0013_relearn_and_wipe",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -204,6 +204,11 @@ export const testStates = sqliteTable(
     lastSeenSecs: integer('last_seen_secs').notNull(),
     lastBaseSecs: integer('last_base_secs').notNull(),
     lastRootSecs: integer('last_root_secs').notNull(),
+    // Set by the engine when the card was last graded Again and the learner
+    // hasn't passed it since; cleared on any non-Again grade. The session's
+    // relearning lane re-surfaces these cards once their FSRS sub-day due
+    // time has elapsed, bypassing the sibling cooldown.
+    pendingRelearn: integer('pending_relearn').notNull().default(0),
   },
   (t) => ({
     pk: primaryKey({ columns: [t.userId, t.materialId, t.testKind, t.element] }),

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -215,6 +215,25 @@ export const testStates = sqliteTable(
   }),
 );
 
+// Per-user verse-graduation log. Drives the engine's `CardState::Active`
+// flip after a user walks the memorize progression for a verse. Cards
+// rebuilt from MaterialData start as `New`; on engine load we apply
+// `graduate_verse(verseId)` for every row in this table.
+export const graduatedVerses = sqliteTable(
+  'graduated_verses',
+  {
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    materialId: text('material_id').notNull(),
+    verseId: integer('verse_id').notNull(),
+    graduatedAtSecs: integer('graduated_at_secs').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.materialId, t.verseId] }),
+  }),
+);
+
 // Cached api.bible content. Per the API.Bible Minimum Acceptable Use
 // Agreement, cached entries must be refreshed within 30 days of fetch.
 // `ApibibleCache` enforces both via TTL-on-read and prune-on-load.

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -153,6 +153,22 @@ export class EngineStore {
       BigInt(this.now()),
     );
 
+    // Cards built from MaterialData start as `New`; apply every recorded
+    // graduation so the in-memory engine matches the user's actual progress.
+    const graduated = this.db
+      .select({ verseId: schema.graduatedVerses.verseId })
+      .from(schema.graduatedVerses)
+      .where(
+        and(
+          eq(schema.graduatedVerses.userId, key.userId),
+          eq(schema.graduatedVerses.materialId, key.materialId),
+        ),
+      )
+      .all();
+    for (const { verseId } of graduated) {
+      engine.graduate_verse(verseId);
+    }
+
     const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
     this.cache.set(userMaterialKey(key), loaded);
     return loaded;

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -38,6 +38,9 @@ export interface TestStateEntry {
   last_seen_secs: number;
   last_base_secs: number;
   last_root_secs: number;
+  /** Sticky after a card was graded Again; the relearning lane re-surfaces
+   *  these tests' cards. Cleared on any non-Again grade. */
+  pending_relearn: boolean;
 }
 
 /**
@@ -92,6 +95,7 @@ export function readTestStateEntries(db: DB, key: EngineKey): TestStateEntry[] {
       last_seen_secs: r.lastSeenSecs,
       last_base_secs: r.lastBaseSecs,
       last_root_secs: r.lastRootSecs,
+      pending_relearn: r.pendingRelearn !== 0,
     }));
 }
 

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -68,6 +68,7 @@ export function writeTestStates(
       lastSeenSecs: s.last_seen_secs,
       lastBaseSecs: s.last_base_secs,
       lastRootSecs: s.last_root_secs,
+      pendingRelearn: s.pending_relearn ? 1 : 0,
     }));
     const stmt = tx.insert(schema.testStates).values(values);
     if (opts.onConflict) {
@@ -85,6 +86,7 @@ export function writeTestStates(
             lastSeenSecs: sql`excluded.last_seen_secs`,
             lastBaseSecs: sql`excluded.last_base_secs`,
             lastRootSecs: sql`excluded.last_root_secs`,
+            pendingRelearn: sql`excluded.pending_relearn`,
           },
         })
         .run();

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -94,7 +94,7 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
       if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
       throw err;
     }
-    const cardId = loaded.engine.next_card(BigInt(now()));
+    const cardId = loaded.engine.next_review_card(BigInt(now()));
     return c.json({ cardId: cardId ?? null });
   });
 
@@ -206,7 +206,7 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
         });
       });
 
-      const nextCardId = loaded.engine.next_card(BigInt(nowSecs));
+      const nextCardId = loaded.engine.next_review_card(BigInt(nowSecs));
       return c.json({
         updates,
         nextCardId: nextCardId ?? null,

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -112,11 +112,11 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     }
     const cardId = loaded.engine.next_memorize_card(BigInt(now()));
     if (cardId === undefined) {
-      return c.json({ verseId: null, progression: [] });
+      return c.json({ verseId: null, cardIds: [] });
     }
     const card = JSON.parse(loaded.engine.get_card_render(cardId)) as { verseId: number };
-    const progression = JSON.parse(loaded.engine.memorize_progression(card.verseId)) as unknown[];
-    return c.json({ verseId: card.verseId, progression });
+    const cardIds = JSON.parse(loaded.engine.memorize_progression(card.verseId)) as number[];
+    return c.json({ verseId: card.verseId, cardIds });
   });
 
   app.get('/:cardId{[0-9]+}', async (c) => {

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
+import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
@@ -263,8 +264,26 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const nowSecs = now();
     return deps.engines.withLock(key, async () => {
       const count = loaded.engine.graduate_verse(verseId);
-      // Persist regardless of in-memory count (e.g. cache re-loaded with
-      // graduation already applied still wants the row stable).
+      if (count === 0) {
+        // Two cases collapse to a zero count: (a) already-graduated
+        // verses replayed by engine load — idempotent, row exists; and
+        // (b) verseId doesn't belong to this material's deck at all.
+        // The graduated_verses table is the source of truth that
+        // distinguishes them.
+        const existing = deps.db
+          .select({ verseId: graduatedVerses.verseId })
+          .from(graduatedVerses)
+          .where(
+            and(
+              eq(graduatedVerses.userId, user.id),
+              eq(graduatedVerses.materialId, materialId),
+              eq(graduatedVerses.verseId, verseId),
+            ),
+          )
+          .get();
+        if (!existing) return c.json({ error: 'Unknown verse' }, 404);
+        return c.json({ graduated: 0 });
+      }
       deps.db
         .insert(graduatedVerses)
         .values({ userId: user.id, materialId, verseId, graduatedAtSecs: nowSecs })

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -99,9 +99,11 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     return c.json({ cardId: cardId ?? null });
   });
 
-  app.get('/memorize/next', async (c) => {
+  app.get('/memorize/session', async (c) => {
     const materialId = c.req.query('materialId');
     if (!materialId) return c.json({ error: 'materialId required' }, 400);
+    const maxRaw = Number(c.req.query('max') ?? '1');
+    const max = Number.isFinite(maxRaw) ? Math.max(1, Math.min(50, Math.floor(maxRaw))) : 1;
     const user = getUser(c);
     let loaded;
     try {
@@ -110,13 +112,11 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
       if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
       throw err;
     }
-    const cardId = loaded.engine.next_memorize_card(BigInt(now()));
-    if (cardId === undefined) {
-      return c.json({ verseId: null, cardIds: [] });
-    }
-    const card = JSON.parse(loaded.engine.get_card_render(cardId)) as { verseId: number };
-    const cardIds = JSON.parse(loaded.engine.memorize_progression(card.verseId)) as number[];
-    return c.json({ verseId: card.verseId, cardIds });
+    const verses = JSON.parse(loaded.engine.memorize_session(max)) as {
+      verseId: number;
+      cardIds: number[];
+    }[];
+    return c.json({ verses });
   });
 
   app.get('/:cardId{[0-9]+}', async (c) => {

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
+import { graduatedVerses } from '../db/schema.js';
 import { ApibibleCache } from '../lib/apibible-cache.js';
 import { EngineStore, NotEnrolledError, type TestStateEntry } from '../lib/engine.js';
 import { bookCodeOf } from '../lib/book-codes.js';
@@ -83,7 +84,7 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
 
   app.use('*', requireAuth());
 
-  app.get('/next', async (c) => {
+  app.get('/review/next', async (c) => {
     const materialId = c.req.query('materialId');
     if (!materialId) return c.json({ error: 'materialId required' }, 400);
     const user = getUser(c);
@@ -95,6 +96,21 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
       throw err;
     }
     const cardId = loaded.engine.next_review_card(BigInt(now()));
+    return c.json({ cardId: cardId ?? null });
+  });
+
+  app.get('/memorize/next', async (c) => {
+    const materialId = c.req.query('materialId');
+    if (!materialId) return c.json({ error: 'materialId required' }, 400);
+    const user = getUser(c);
+    let loaded;
+    try {
+      loaded = await deps.engines.load({ userId: user.id, materialId });
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
+    const cardId = loaded.engine.next_memorize_card(BigInt(now()));
     return c.json({ cardId: cardId ?? null });
   });
 
@@ -211,6 +227,45 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
         updates,
         nextCardId: nextCardId ?? null,
       });
+    });
+  });
+
+  app.post('/memorize/graduate', async (c) => {
+    let body: { materialId?: string; verseId?: number };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (typeof body.materialId !== 'string') {
+      return c.json({ error: 'materialId required' }, 400);
+    }
+    if (typeof body.verseId !== 'number' || !Number.isInteger(body.verseId)) {
+      return c.json({ error: 'verseId required (integer)' }, 400);
+    }
+    const user = getUser(c);
+    const materialId = body.materialId;
+    const verseId = body.verseId;
+    const key = { userId: user.id, materialId };
+    let loaded;
+    try {
+      loaded = await deps.engines.load(key);
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
+
+    const nowSecs = now();
+    return deps.engines.withLock(key, async () => {
+      const count = loaded.engine.graduate_verse(verseId);
+      // Persist regardless of in-memory count (e.g. cache re-loaded with
+      // graduation already applied still wants the row stable).
+      deps.db
+        .insert(graduatedVerses)
+        .values({ userId: user.id, materialId, verseId, graduatedAtSecs: nowSecs })
+        .onConflictDoNothing()
+        .run();
+      return c.json({ graduated: count });
     });
   });
 

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -111,7 +111,12 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
       throw err;
     }
     const cardId = loaded.engine.next_memorize_card(BigInt(now()));
-    return c.json({ cardId: cardId ?? null });
+    if (cardId === undefined) {
+      return c.json({ verseId: null, progression: [] });
+    }
+    const card = JSON.parse(loaded.engine.get_card_render(cardId)) as { verseId: number };
+    const progression = JSON.parse(loaded.engine.memorize_progression(card.verseId)) as unknown[];
+    return c.json({ verseId: card.verseId, progression });
   });
 
   app.get('/:cardId{[0-9]+}', async (c) => {

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -16,6 +16,7 @@ interface TestStateWire {
   last_seen_secs: number;
   last_base_secs: number;
   last_root_secs: number;
+  pending_relearn?: boolean;
 }
 
 interface StateResponse {

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -87,7 +87,7 @@ describe('years routes', () => {
       ftv: true,
       newScope: 'all',
       reviewScope: 'all',
-      clubCardScope: 'all',
+      clubCardScope: 'off',
       chapterListScope: 'up150',
       lessonBatchSize: 3,
     });

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -88,7 +88,7 @@ describe('years routes', () => {
       newScope: 'all',
       reviewScope: 'all',
       clubCardScope: 'all',
-      chapterListScope: 'up300',
+      chapterListScope: 'up150',
       lessonBatchSize: 3,
     });
     for (const tier of ['150', '300', 'full'] as const) {

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -139,7 +139,7 @@ const ENROLLED_DEFAULTS: YearSettings = {
   ftv: true,
   newScope: 'all',
   reviewScope: 'all',
-  clubCardScope: 'all',
+  clubCardScope: 'off',
   chapterListScope: 'up150',
   lessonBatchSize: DEFAULT_LESSON_BATCH_SIZE,
 };

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -57,6 +57,9 @@ interface YearView {
   enrolled: boolean;
   settings: YearSettings;
   clubs: Record<ClubTier, ClubView>;
+  /** Count of cards still in `CardState::New` — drives the
+   *  "N to memorize" nudge in the web nav. */
+  newCardCount: number;
 }
 
 interface SettingsBody {
@@ -206,10 +209,12 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
       // no graph_snapshot yet. Card counts stay at zero until the user
       // enables a scope (which auto-enrolls on save).
       let counts: ClubCounts = {};
+      let newCardCount = 0;
       if (enrolled) {
         try {
           const loaded = await deps.engines.load({ userId: user.id, materialId: material.id });
           counts = JSON.parse(loaded.engine.card_count_by_club()) as ClubCounts;
+          newCardCount = loaded.engine.new_card_count();
         } catch (err) {
           // Don't fail the whole picker render if one year's engine can't
           // build — degrade that row to zero counts and log so it's
@@ -243,6 +248,7 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
         enrolled,
         settings,
         clubs,
+        newCardCount,
       });
     }
 

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -140,7 +140,7 @@ const ENROLLED_DEFAULTS: YearSettings = {
   newScope: 'all',
   reviewScope: 'all',
   clubCardScope: 'all',
-  chapterListScope: 'up300',
+  chapterListScope: 'up150',
   lessonBatchSize: DEFAULT_LESSON_BATCH_SIZE,
 };
 

--- a/tools/phrase_splitter/prompts.py
+++ b/tools/phrase_splitter/prompts.py
@@ -24,11 +24,16 @@ split and a longer natural one, choose the natural one.
 Rules:
 
 - Target 3 to 10 words per phrase; up to ~12 is fine. A short final
-  phrase (1-2 words) is fine when it carries trailing punctuation like
-  ``...and Him crucified.``; short fragments in the middle of a verse
-  are not. A phrase may run longer than 12 when the clause is genuinely
-  continuous and has no natural break — prefer the natural unit over
-  forcing an awkward split.
+  phrase (1-3 words) is fine when it is a *rhetorical or completive
+  tail* like ``...and Him crucified.`` or ``...be the glory.`` — a
+  closing flourish that stands on its own. It is **not** fine when it
+  is a grammatical fragment severed from a mid-verse clause. ``nothing
+  was made`` / ``that was made.`` is bad even though the tail ends in
+  a period — the relative clause was chopped off, not closed off.
+  Short fragments in the middle of a verse are never fine. A phrase
+  may run longer than 12 when the clause is genuinely continuous and
+  has no natural break — prefer the natural unit over forcing an
+  awkward split.
 - Break at clause and phrase boundaries. Strong cues:
   - after a comma, semicolon, or colon
   - before a connector that starts a new clause: ``and``, ``but``,
@@ -48,6 +53,17 @@ Rules:
 - **Keep rhetorical questions whole.** A question stem (``"Do you not
   know that..."``, ``"Are you not aware that..."``) belongs with its
   content. Split *after* the question mark, not inside it.
+- **Keep restrictive relative clauses attached to their antecedent.**
+  When ``that``, ``who``, or ``which`` follows a noun *without* a
+  preceding comma, it is a restrictive relative — it defines or
+  restricts the noun and reads as one unit with no pause. Don't break
+  before it. ``"nothing was made"`` / ``"that was made."`` is bad: the
+  ``that``-clause restrictively modifies ``"nothing"``. Same shape:
+  ``"the bread"`` / ``"which I will give"``, ``"the man"`` / ``"who
+  came to Jesus"`` — keep them whole. A *non-restrictive* relative
+  (preceded by a comma) is the opposite — the comma is a real pause
+  and a valid break point: ``"...Nicodemus, / who came to Jesus by
+  night,"`` is fine.
 - Never strand a 1-2 word fragment in the middle of the verse (e.g.
   ``"But one"`` followed by the rest of the sentence). Keep small
   introductory phrases with the clause they introduce.
@@ -103,6 +119,12 @@ Output:
     ["Do you not know that we shall judge angels?",
      "How much more, things that pertain to this life?"]
 
+Input:
+    All things were made through Him, and without Him nothing was made that was made.
+Output:
+    ["All things were made through Him,",
+     "and without Him nothing was made that was made."]
+
 Now split this verse. Reply with a single JSON array of strings on one
 line, nothing else.
 
@@ -139,6 +161,16 @@ Look for:
   angels?"`` is a bad break — the rhetorical question is one unit.
 - Mid-question breaks — a rhetorical question stem split from its
   content. Keep the question whole; split *after* the question mark.
+- **Restrictive relative clause split from its antecedent** — ``that``
+  / ``who`` / ``which`` following a noun *without* a preceding comma
+  is restrictive and reads as one unit. ``"nothing was made"`` /
+  ``"that was made."`` is bad; the relative clause restrictively
+  modifies ``"nothing"`` with no pause. (A non-restrictive relative
+  preceded by a comma is a valid break.)
+- **Severed grammatical tail** — a short final phrase that is a
+  grammatical fragment chopped off a mid-verse clause, not a
+  rhetorical or completive ending. ``"that was made."`` as a
+  standalone tail is severed; ``"and Him crucified."`` is completive.
 - Anything that would feel jarring when reciting the verse aloud
 
 Verse: {ref}


### PR DESCRIPTION
## Summary

Slice 2 of the material-picker plan. Splits the existing `/session` UX into two distinct flows and adds the supporting engine + persistence:

- **`/memorize`** — session-level flow that reads every verse first, drills every per-verse card (verses interleaved, cards in builder order), then walks back through the verses for graduation. Cards stay `New` until the user finishes a verse's drill and confirms.
- **`/review`** — existing card-grading flow, but now filtered to `Active` cards and ordered by **descending retrievability** (FSRS-author-recommended for capacity-limited sessions). Cards graded `Again` set a `pending_relearn` flag.
- **Relearning priority lane** — a session-level queue surfaces freshly-lapsed cards once their FSRS sub-day due time elapses, bypassing the 30-min sibling cooldown.
- **Material-picker integration** — `/material` defaults to the year the user is actively studying; all-paused years display as `Not enrolled` even when a `user_materials` row exists; `chapter_list_scope` defaults to `up150` and `club_card_scope` defaults to `off`.

Three layers:
- **Core**: `CardState::{New, Active}`, `pending_relearn` on `TestState`, `graduate_verse` / `graduate_all` on `ReviewEngine`, `next_relearn_card` / `next_memorize_card` schedulers, descending-R sort, session priority order.
- **API**: migration 0013 (add `pending_relearn` column + wipe pre-Slice-2 per-user rows), migration 0014 (`graduated_verses` table), split `/cards/next` into `/cards/review/next` + `/cards/memorize/session` + `/cards/memorize/graduate`, `/years` extended with `newCardCount`. `graduate` returns 404 on unknown verseId.
- **Web**: `SessionView` → `ReviewView`, new `MemorizeView` with 3-phase state machine, nav pill for new cards, MaterialView default-tab + display fixes, dynamic material resolution (no more hardcoded `MATERIAL_ID`).

Tangential commits on the branch: `b781d57`, `f863a15`, `79d74cc` are phrase-splitter tool tweaks that landed alongside the picker work — included here so the branch stays a single integration. They don't touch Slice 2 code paths.

## Notable decisions

- **Memorize stays pure-intro.** `Again` / `Good` during the drill are local queue-control only — no FSRS state mutates until graduation. Rationale: the progression is heavily scaffolded (each step shows the verse with one phrase blanked), so grades there would be a contaminated signal. FSRS cold-starts at first appearance in `/review`.
- **Descending-R ordering.** Matches Jarrett Ye's FSRS sims for capacity-limited sessions; for users who finish their queue daily, order is irrelevant.
- **Heading + chapter-list intro rules.** `VerseInHeading` only surfaces on the first verse under each heading (deduped within a memorize session and against already-graduated state). `ChapterClubList` attaches to the verse that completes the chapter's tier.

## Deliberately deferred

- **Per-user `lessonBatchSize` aggregation across years** is the placeholder shape until the mem-schedule work; comment marks it.
- **Split-staleness protection** — if the bundled content changes mid-session, the pre-fetched `cardIds` could go stale. Cosmetic to severe (FSRS state attached to `Phrase { verse_id, position }` semantically drifts when splits change). Needs its own focused branch.
- **`atoms_for` clones `VerseAtoms` per scheduler call** — flagged but the fix touches every scheduler caller; better as part of the mem-schedule rework.
- **`App.vue` refetches `/years` on every navigation** — needs a shared store / event bus to fix properly.
- **API integration tests for the new `/cards/*` routes** — wasm smoke test and manual browser walkthrough cover them today.

## Test plan

- [x] `cargo test` — 120 pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo run -p verse-vault-sim` — runs, FSRS metrics stable
- [x] `wasm-pack build crates/wasm` + `node crates/wasm/test-smoke.js` — passes; exercises `next_review_card`, `next_memorize_card`, `graduate_verse`, `new_card_count`
- [x] `pnpm --filter @verse-vault/api test` — 83 pass
- [x] `pnpm --filter @verse-vault/web build` — builds clean
- [x] Browser walkthrough: `/memorize` walks the 3-phase session correctly; `/review` surfaces lane cards before regular schedule; nav pill updates after graduation; material picker defaults to actively-studied year
- [ ] CI green