### PR TITLE
feat: content-stable phrase identity + snapshot bump

### DIFF
--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -128,6 +128,7 @@ fn emit_chapter_club_list_cards(
                 VerseAtoms {
                     verse_id: pseudo_id,
                     phrase_count: 0,
+                    phrase_ranges: Vec::new(),
                     headings: Vec::new(),
                     clubs: vec![card_tier],
                     ftv_word_count: None,
@@ -247,7 +248,7 @@ pub fn build_with_config(
         verse_index.add_verse(
             verse_id,
             VerseElements {
-                phrases: phrases.clone(),
+                phrase_ranges: VerseAtoms::ranges_from_word_counts(&verse.phrase_word_counts),
                 headings: headings.clone(),
                 clubs: clubs.clone(),
             },
@@ -357,6 +358,7 @@ pub fn build_with_config(
             VerseAtoms {
                 verse_id,
                 phrase_count,
+                phrase_ranges: VerseAtoms::ranges_from_word_counts(&verse.phrase_word_counts),
                 headings,
                 clubs,
                 ftv_word_count: verse.ftv_word_count,
@@ -624,33 +626,11 @@ mod tests {
         let r = build(&m, now);
         // every test referenced by some card should have a seeded TestState.
         for card in &r.cards {
-            let phrases = r.verse_index.phrases_of(card.verse_id);
-            let phrase_count = phrases.len() as u16;
-            let bindings = r.verse_index.bindings_of(card.verse_id);
-            let headings: Vec<u16> = bindings
-                .iter()
-                .filter_map(|e| match e {
-                    ElementId::VerseHeadingBinding { heading_idx, .. } => Some(*heading_idx),
-                    _ => None,
-                })
-                .collect();
-            let clubs: Vec<ClubTier> = bindings
-                .iter()
-                .filter_map(|e| match e {
-                    ElementId::VerseClubBinding { tier, .. } => Some(*tier),
-                    _ => None,
-                })
-                .collect();
-            let atoms = VerseAtoms {
-                verse_id: card.verse_id,
-                phrase_count,
-                headings,
-                clubs,
-                ftv_word_count: None,
-                phrase_zero_word_count: 0,
-                chapter_members: Vec::new(),
-            };
-            for tk in card.tests(&atoms) {
+            let atoms = r
+                .verse_atoms_data
+                .get(&card.verse_id)
+                .expect("built verse_atoms_data should cover every card");
+            for tk in card.tests(atoms) {
                 assert!(
                     r.tests.contains_key(&tk),
                     "missing seeded TestState for {tk:?}"

--- a/crates/core/src/card.rs
+++ b/crates/core/src/card.rs
@@ -86,6 +86,12 @@ pub struct CardSchedule {
 pub struct VerseAtoms {
     pub verse_id: u32,
     pub phrase_count: u16,
+    /// Cumulative-sum half-open word ranges `[start, end)` per phrase
+    /// position. Drives the content-stable `ElementId::Phrase` keys:
+    /// when splits change, phrases that survive carry FSRS state via
+    /// matching ranges; phrases whose boundaries shift get fresh
+    /// state. Length always matches `phrase_count`.
+    pub phrase_ranges: Vec<(u16, u16)>,
     pub headings: Vec<u16>,
     pub clubs: Vec<ClubTier>,
     /// Word count of the FTV prompt, or None when this verse has no FTV.
@@ -111,6 +117,26 @@ impl VerseAtoms {
     pub fn phrase_positions(&self) -> Vec<u16> {
         (0..self.phrase_count).collect()
     }
+
+    /// Half-open word range `[start, end)` for the given phrase position,
+    /// or `None` if the position is past `phrase_count`. The result is
+    /// the content-stable identity used to key the phrase's TestState.
+    pub fn phrase_range(&self, position: u16) -> Option<(u16, u16)> {
+        self.phrase_ranges.get(position as usize).copied()
+    }
+
+    /// Build `phrase_ranges` from a `phrase_word_counts` slice via
+    /// cumulative sum. `[2, 2, 2, 3]` → `[(0,2), (2,4), (4,6), (6,9)]`.
+    pub fn ranges_from_word_counts(counts: &[u16]) -> Vec<(u16, u16)> {
+        let mut ranges = Vec::with_capacity(counts.len());
+        let mut cursor: u16 = 0;
+        for &n in counts {
+            let next = cursor.saturating_add(n);
+            ranges.push((cursor, next));
+            cursor = next;
+        }
+        ranges
+    }
 }
 
 pub fn ftv_tests(verse_id: u32, atoms: &VerseAtoms, with_citation: bool) -> Vec<TestKey> {
@@ -121,12 +147,16 @@ pub fn ftv_tests(verse_id: u32, atoms: &VerseAtoms, with_citation: bool) -> Vec<
         _ => 0,
     };
     let mut out: Vec<TestKey> = (start..atoms.phrase_count)
-        .map(|p| TestKey {
-            kind: TestKind::PhraseFromContext,
-            element: ElementId::Phrase {
-                verse_id,
-                position: p,
-            },
+        .filter_map(|p| {
+            let (start_word, end_word) = atoms.phrase_range(p)?;
+            Some(TestKey {
+                kind: TestKind::PhraseFromContext,
+                element: ElementId::Phrase {
+                    verse_id,
+                    start_word,
+                    end_word,
+                },
+            })
         })
         .collect();
     if with_citation {
@@ -154,10 +184,19 @@ impl Card {
     pub fn tests(&self, atoms: &VerseAtoms) -> Vec<TestKey> {
         let verse_id = self.verse_id;
         match self.kind {
-            CardKind::PhraseFill { position } => vec![TestKey {
-                kind: TestKind::PhraseFromContext,
-                element: ElementId::Phrase { verse_id, position },
-            }],
+            CardKind::PhraseFill { position } => {
+                let (start_word, end_word) = atoms
+                    .phrase_range(position)
+                    .expect("PhraseFill position out of bounds for verse atoms");
+                vec![TestKey {
+                    kind: TestKind::PhraseFromContext,
+                    element: ElementId::Phrase {
+                        verse_id,
+                        start_word,
+                        end_word,
+                    },
+                }]
+            }
             CardKind::VerseAtVerseRef => vec![TestKey {
                 kind: TestKind::VerseRefPosition,
                 element: ElementId::VerseRefPosition { verse_id },
@@ -183,13 +222,14 @@ impl Card {
             }],
             CardKind::Recitation => {
                 let mut out: Vec<TestKey> = atoms
-                    .phrase_positions()
-                    .into_iter()
-                    .map(|p| TestKey {
+                    .phrase_ranges
+                    .iter()
+                    .map(|&(start_word, end_word)| TestKey {
                         kind: TestKind::PhraseFromContext,
                         element: ElementId::Phrase {
                             verse_id,
-                            position: p,
+                            start_word,
+                            end_word,
                         },
                     })
                     .collect();
@@ -243,9 +283,13 @@ mod tests {
     use super::*;
 
     fn sample_atoms(verse_id: u32, phrase_count: u16) -> VerseAtoms {
+        // Synthesize one-word phrases [0..count) so tests can refer to
+        // any position by index without managing word counts.
+        let phrase_ranges: Vec<(u16, u16)> = (0..phrase_count).map(|p| (p, p + 1)).collect();
         VerseAtoms {
             verse_id,
             phrase_count,
+            phrase_ranges,
             headings: vec![0, 1, 2],
             clubs: vec![ClubTier::Club150, ClubTier::Club300],
             ftv_word_count: None,
@@ -272,10 +316,24 @@ mod tests {
     }
 
     #[test]
+    fn phrase_ranges_from_word_counts_cumulative_sum() {
+        // Standard split: phraseWordCounts becomes half-open word ranges.
+        assert_eq!(
+            VerseAtoms::ranges_from_word_counts(&[2, 2, 2, 3]),
+            vec![(0, 2), (2, 4), (4, 6), (6, 9)]
+        );
+        // Single phrase covering the whole verse.
+        assert_eq!(VerseAtoms::ranges_from_word_counts(&[5]), vec![(0, 5)]);
+        // Empty input → no ranges.
+        assert!(VerseAtoms::ranges_from_word_counts(&[]).is_empty());
+    }
+
+    #[test]
     fn verse_atoms_phrase_positions() {
         let atoms = VerseAtoms {
             verse_id: 1,
             phrase_count: 3,
+            phrase_ranges: vec![(0, 2), (2, 4), (4, 6)],
             headings: vec![0],
             clubs: vec![ClubTier::Club150],
             ftv_word_count: Some(2),
@@ -289,6 +347,7 @@ mod tests {
     fn phrase_fill_grades_one_test() {
         let c = atomic_card(0, CardKind::PhraseFill { position: 1 }, 7);
         let atoms = sample_atoms(7, 4);
+        let (start_word, end_word) = atoms.phrase_range(1).unwrap();
         let tests = c.tests(&atoms);
         assert_eq!(
             tests,
@@ -296,7 +355,8 @@ mod tests {
                 kind: TestKind::PhraseFromContext,
                 element: ElementId::Phrase {
                     verse_id: 7,
-                    position: 1
+                    start_word,
+                    end_word,
                 }
             }]
         );
@@ -378,6 +438,7 @@ mod tests {
         let atoms = VerseAtoms {
             verse_id: 7,
             phrase_count: 4,
+            phrase_ranges: vec![(0, 1), (1, 2), (2, 3), (3, 4)],
             headings: vec![],
             clubs: vec![],
             ftv_word_count: Some(2),
@@ -401,6 +462,7 @@ mod tests {
         let atoms = VerseAtoms {
             verse_id: 7,
             phrase_count: 4,
+            phrase_ranges: vec![(0, 1), (1, 2), (2, 3), (3, 4)],
             headings: vec![],
             clubs: vec![],
             ftv_word_count: Some(6),
@@ -423,6 +485,7 @@ mod tests {
         let atoms = VerseAtoms {
             verse_id: 7,
             phrase_count: 4,
+            phrase_ranges: vec![(0, 1), (1, 2), (2, 3), (3, 4)],
             headings: vec![],
             clubs: vec![],
             ftv_word_count: Some(2),

--- a/crates/core/src/element.rs
+++ b/crates/core/src/element.rs
@@ -19,12 +19,33 @@ pub enum ClubTier {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum ElementId {
-    Phrase { verse_id: u32, position: u16 },
-    VerseRefPosition { verse_id: u32 },
-    VerseChapterBinding { verse_id: u32 },
-    VerseBookBinding { verse_id: u32 },
-    VerseHeadingBinding { verse_id: u32, heading_idx: u16 },
-    VerseClubBinding { verse_id: u32, tier: ClubTier },
+    /// A phrase identified by its half-open word range `[start_word,
+    /// end_word)` in the verse text. Stable across phrase-split changes
+    /// as long as the underlying verse text doesn't move: a phrase whose
+    /// boundaries shift becomes a different element and gets fresh FSRS
+    /// state; a phrase whose boundaries survive keeps its state.
+    Phrase {
+        verse_id: u32,
+        start_word: u16,
+        end_word: u16,
+    },
+    VerseRefPosition {
+        verse_id: u32,
+    },
+    VerseChapterBinding {
+        verse_id: u32,
+    },
+    VerseBookBinding {
+        verse_id: u32,
+    },
+    VerseHeadingBinding {
+        verse_id: u32,
+        heading_idx: u16,
+    },
+    VerseClubBinding {
+        verse_id: u32,
+        tier: ClubTier,
+    },
 }
 
 #[cfg(test)]
@@ -35,7 +56,8 @@ mod tests {
     fn element_id_serializes() {
         let e = ElementId::Phrase {
             verse_id: 1,
-            position: 0,
+            start_word: 0,
+            end_word: 2,
         };
         let j = serde_json::to_string(&e).unwrap();
         let r: ElementId = serde_json::from_str(&j).unwrap();

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -112,20 +112,16 @@ impl ReviewEngine {
         if let Some(atoms) = self.verse_atoms_data.get(&verse_id) {
             return atoms.clone();
         }
-        let phrases = self.verse_index.phrases_of(verse_id);
-        let headings = if let Some(e) = self.verse_index.elements_of(verse_id) {
-            e.headings.clone()
-        } else {
-            Vec::new()
-        };
-        let clubs = if let Some(e) = self.verse_index.elements_of(verse_id) {
-            e.clubs.clone()
-        } else {
-            Vec::new()
-        };
+        let elements = self.verse_index.elements_of(verse_id);
+        let phrase_ranges = elements
+            .map(|e| e.phrase_ranges.clone())
+            .unwrap_or_default();
+        let headings = elements.map(|e| e.headings.clone()).unwrap_or_default();
+        let clubs = elements.map(|e| e.clubs.clone()).unwrap_or_default();
         VerseAtoms {
             verse_id,
-            phrase_count: phrases.len() as u16,
+            phrase_count: phrase_ranges.len() as u16,
+            phrase_ranges,
             headings,
             clubs,
             ftv_word_count: None,

--- a/crates/core/src/test_kind.rs
+++ b/crates/core/src/test_kind.rs
@@ -27,7 +27,8 @@ mod tests {
             kind: TestKind::PhraseFromContext,
             element: ElementId::Phrase {
                 verse_id: 1,
-                position: 0,
+                start_word: 0,
+                end_word: 2,
             },
         };
         let b = a;

--- a/crates/core/src/verse_index.rs
+++ b/crates/core/src/verse_index.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct VerseElements {
-    pub phrases: Vec<u16>,
+    /// Per-phrase content-stable word ranges `[start, end)`. Replaces
+    /// the older positional list; one entry per phrase, in builder
+    /// order.
+    pub phrase_ranges: Vec<(u16, u16)>,
     pub headings: Vec<u16>,
     pub clubs: Vec<ClubTier>,
 }
@@ -30,11 +33,12 @@ impl VerseIndex {
         self.verses
             .get(&verse_id)
             .map(|e| {
-                e.phrases
+                e.phrase_ranges
                     .iter()
-                    .map(|&p| ElementId::Phrase {
+                    .map(|&(start_word, end_word)| ElementId::Phrase {
                         verse_id,
-                        position: p,
+                        start_word,
+                        end_word,
                     })
                     .collect()
             })
@@ -72,7 +76,7 @@ mod tests {
         idx.add_verse(
             7,
             VerseElements {
-                phrases: vec![0, 1, 2],
+                phrase_ranges: vec![(0, 2), (2, 4), (4, 6)],
                 headings: vec![],
                 clubs: vec![],
             },
@@ -87,7 +91,7 @@ mod tests {
         idx.add_verse(
             7,
             VerseElements {
-                phrases: vec![0],
+                phrase_ranges: vec![(0, 3)],
                 headings: vec![0],
                 clubs: vec![ClubTier::Club150],
             },

--- a/crates/core/tests/hsrs_scenarios.rs
+++ b/crates/core/tests/hsrs_scenarios.rs
@@ -66,7 +66,8 @@ fn recitation_lifts_phrases_and_bindings_without_advancing_last_root() {
         kind: TestKind::PhraseFromContext,
         element: ElementId::Phrase {
             verse_id: 0,
-            position: 0,
+            start_word: 0,
+            end_word: 2,
         },
     };
     let phrase_state = engine
@@ -142,7 +143,8 @@ fn recitation_does_not_saturate_bindings_to_s_max() {
         kind: TestKind::PhraseFromContext,
         element: ElementId::Phrase {
             verse_id: 0,
-            position: 0,
+            start_word: 0,
+            end_word: 2,
         },
     };
     let chapter_state = engine.test_state(chapter_binding).copied().unwrap();

--- a/crates/sim/src/learner.rs
+++ b/crates/sim/src/learner.rs
@@ -169,9 +169,15 @@ mod tests {
     use verse_vault_core::test_kind::TestKind;
 
     fn key(verse_id: u32, position: u16) -> TestKey {
+        // Tests only need a unique element per (verse_id, position); the
+        // word range pair is synthesized as a 1-word slot for that index.
         TestKey {
             kind: TestKind::PhraseFromContext,
-            element: ElementId::Phrase { verse_id, position },
+            element: ElementId::Phrase {
+                verse_id,
+                start_word: position,
+                end_word: position + 1,
+            },
         }
     }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -599,7 +599,8 @@ mod tests {
         let entry = TestStateEntry {
             element: ElementId::Phrase {
                 verse_id: 7,
-                position: 2,
+                start_word: 4,
+                end_word: 6,
             },
             test_kind: TestKind::PhraseFromContext,
             stability: 12.5,
@@ -657,7 +658,8 @@ mod tests {
             kind: TestKind::PhraseFromContext,
             element: ElementId::Phrase {
                 verse_id: 1,
-                position: 0,
+                start_word: 0,
+                end_word: 2,
             },
         };
         let before = TestState::new_unseen(0);

--- a/crates/wasm/test-smoke.js
+++ b/crates/wasm/test-smoke.js
@@ -105,4 +105,14 @@ if (movedStates.length === 0) {
   process.exit(1);
 }
 
+const phraseStates = finalStates.filter((s) => s.element.kind === 'Phrase');
+const ranged = phraseStates.every(
+  (s) => typeof s.element.start_word === 'number' && typeof s.element.end_word === 'number',
+);
+if (phraseStates.length === 0 || !ranged) {
+  console.error('FAIL: phrase elements should carry start_word/end_word');
+  process.exit(1);
+}
+console.log(`${phraseStates.length} phrase states all use the range identity`);
+
 console.log('\n✓ All smoke-test assertions passed');

--- a/packages/api/migrations/0015_unique_snapshot_version.sql
+++ b/packages/api/migrations/0015_unique_snapshot_version.sql
@@ -1,0 +1,6 @@
+-- Prevent two concurrent EngineStore.load callers on a stale snapshot
+-- from both inserting version=N+1 for the same (user, material). The
+-- desc-version pick would otherwise be non-deterministic between the
+-- duplicate rows.
+
+CREATE UNIQUE INDEX `uniq_graph_snapshots_user_material_version` ON `graph_snapshots` (`user_id`,`material_id`,`version`);

--- a/packages/api/migrations/meta/0015_snapshot.json
+++ b/packages/api/migrations/meta/0015_snapshot.json
@@ -1,0 +1,984 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "98edb400-7ec8-47e9-b190-8637476d2f6f",
+  "prevId": "325e88a2-0acc-4b3f-b44e-6c7f804ca2c9",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_provider": {
+          "name": "idx_account_provider",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_passages": {
+      "name": "apibible_passages",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passage_id": {
+          "name": "passage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_passages_fetched_at": {
+          "name": "idx_apibible_passages_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_passages_bible_id_passage_id_pk": {
+          "columns": [
+            "bible_id",
+            "passage_id"
+          ],
+          "name": "apibible_passages_bible_id_passage_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apibible_sections": {
+      "name": "apibible_sections",
+      "columns": {
+        "bible_id": {
+          "name": "bible_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_code": {
+          "name": "book_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sections_json": {
+          "name": "sections_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apibible_sections_fetched_at": {
+          "name": "idx_apibible_sections_fetched_at",
+          "columns": [
+            "fetched_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "apibible_sections_bible_id_book_code_pk": {
+          "columns": [
+            "bible_id",
+            "book_code"
+          ],
+          "name": "apibible_sections_bible_id_book_code_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graph_snapshots": {
+      "name": "graph_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_data": {
+          "name": "material_data",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_graph_snapshots_user_material": {
+          "name": "idx_graph_snapshots_user_material",
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "isUnique": false
+        },
+        "uniq_graph_snapshots_user_material_version": {
+          "name": "uniq_graph_snapshots_user_material_version",
+          "columns": [
+            "user_id",
+            "material_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "graph_snapshots_user_id_user_id_fk": {
+          "name": "graph_snapshots_user_id_user_id_fk",
+          "tableFrom": "graph_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "review_events": {
+      "name": "review_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_version": {
+          "name": "snapshot_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_secs": {
+          "name": "timestamp_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_event_id": {
+          "name": "client_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_review_events_user_material_time": {
+          "name": "idx_review_events_user_material_time",
+          "columns": [
+            "user_id",
+            "material_id",
+            "timestamp_secs"
+          ],
+          "isUnique": false
+        },
+        "uniq_review_events_user_material_client_event": {
+          "name": "uniq_review_events_user_material_client_event",
+          "columns": [
+            "user_id",
+            "material_id",
+            "client_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "review_events_user_id_user_id_fk": {
+          "name": "review_events_user_id_user_id_fk",
+          "tableFrom": "review_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "test_states": {
+      "name": "test_states",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "test_kind": {
+          "name": "test_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "element": {
+          "name": "element",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stability": {
+          "name": "stability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "difficulty": {
+          "name": "difficulty",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_secs": {
+          "name": "last_seen_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_base_secs": {
+          "name": "last_base_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_root_secs": {
+          "name": "last_root_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pending_relearn": {
+          "name": "pending_relearn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_states_user_id_user_id_fk": {
+          "name": "test_states_user_id_user_id_fk",
+          "tableFrom": "test_states",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_states_user_id_material_id_test_kind_element_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "test_kind",
+            "element"
+          ],
+          "name": "test_states_user_id_material_id_test_kind_element_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "graduated_verses": {
+      "name": "graduated_verses",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verse_id": {
+          "name": "verse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "graduated_at_secs": {
+          "name": "graduated_at_secs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "graduated_verses_user_id_user_id_fk": {
+          "name": "graduated_verses_user_id_user_id_fk",
+          "tableFrom": "graduated_verses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "graduated_verses_user_id_material_id_verse_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id",
+            "verse_id"
+          ],
+          "name": "graduated_verses_user_id_material_id_verse_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_materials": {
+      "name": "user_materials",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_tier": {
+          "name": "club_tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_materials_user_id_user_id_fk": {
+          "name": "user_materials_user_id_user_id_fk",
+          "tableFrom": "user_materials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_materials_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_materials_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_year_settings": {
+      "name": "user_year_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "material_id": {
+          "name": "material_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headings": {
+          "name": "headings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ftv": {
+          "name": "ftv",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "new_scope": {
+          "name": "new_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_scope": {
+          "name": "review_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "club_card_scope": {
+          "name": "club_card_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chapter_list_scope": {
+          "name": "chapter_list_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lesson_batch_size": {
+          "name": "lesson_batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_year_settings_user_id_user_id_fk": {
+          "name": "user_year_settings_user_id_user_id_fk",
+          "tableFrom": "user_year_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_year_settings_user_id_material_id_pk": {
+          "columns": [
+            "user_id",
+            "material_id"
+          ],
+          "name": "user_year_settings_user_id_material_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778796500000,
       "tag": "0014_graduated_verses",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1778900000000,
+      "tag": "0015_unique_snapshot_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -146,6 +146,14 @@ export const graphSnapshots = sqliteTable(
   },
   (t) => ({
     userMaterialIdx: index('idx_graph_snapshots_user_material').on(t.userId, t.materialId),
+    // Two concurrent EngineStore.load callers on a stale snapshot would
+    // otherwise both insert version=N+1, leaving the desc-version pick
+    // non-deterministic.
+    versionUnique: uniqueIndex('uniq_graph_snapshots_user_material_version').on(
+      t.userId,
+      t.materialId,
+      t.version,
+    ),
   }),
 );
 

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -1,8 +1,38 @@
+import { and, eq } from 'drizzle-orm';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { graphSnapshots, testStates as testStatesTable } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
-import { createTestDb } from '../test-utils.js';
+import { createTestDb, createTestUser } from '../test-utils.js';
+import { enrollUser } from './enrollment.js';
 import { EngineStore, NotEnrolledError, type TestStateEntry } from './engine.js';
+
+function fixtureMaterial(phraseWordCounts: number[]): string {
+  return JSON.stringify({
+    year: 3,
+    books: ['John'],
+    chapters: [{ book: 'John', number: 3, start_verse: 16, end_verse: 16 }],
+    verses: [
+      {
+        book: 'John',
+        chapter: 3,
+        verse: 16,
+        phraseWordCounts,
+        annotations: [],
+        ftvWordCount: 2,
+        clubs: [],
+      },
+    ],
+    headings: [],
+  });
+}
+
+interface PhraseElement {
+  kind: 'Phrase';
+  verse_id: number;
+  start_word: number;
+  end_word: number;
+}
 
 describe('EngineStore', () => {
   let cleanup: (() => void) | null = null;
@@ -44,6 +74,206 @@ describe('EngineStore', () => {
     const a = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     const b = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     expect(a.engine).toBe(b.engine);
+    store.clear();
+  });
+
+  it('readTestStateEntries rewrites legacy positional Phrase elements to ranges', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    enrollUser({
+      db: test.db,
+      userId: 'u1',
+      materialId: 'nkjv-cor',
+      materialJson: fixtureMaterial([2, 2, 2, 3]),
+      now: () => 0,
+    });
+    // Manually rewrite a row to the legacy positional shape, mimicking
+    // pre-migration data.
+    const verseRefRow = test.db
+      .select()
+      .from(testStatesTable)
+      .where(
+        and(
+          eq(testStatesTable.userId, 'u1'),
+          eq(testStatesTable.materialId, 'nkjv-cor'),
+          eq(testStatesTable.testKind, 'PhraseFromContext'),
+        ),
+      )
+      .all()
+      .find((r) => {
+        const e = JSON.parse(r.element) as PhraseElement;
+        return e.start_word === 2 && e.end_word === 4;
+      });
+    if (!verseRefRow) throw new Error('expected a phrase row at range (2,4)');
+    test.db
+      .update(testStatesTable)
+      .set({ element: JSON.stringify({ kind: 'Phrase', verse_id: 0, position: 1 }) })
+      .where(
+        and(
+          eq(testStatesTable.userId, 'u1'),
+          eq(testStatesTable.materialId, 'nkjv-cor'),
+          eq(testStatesTable.testKind, 'PhraseFromContext'),
+          eq(testStatesTable.element, verseRefRow.element),
+        ),
+      )
+      .run();
+
+    const store = new EngineStore(test.db, 0.9, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
+    const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
+    const phrase1 = states.find((s) => {
+      const e = s.element as PhraseElement;
+      return s.test_kind === 'PhraseFromContext' && e.start_word === 2 && e.end_word === 4;
+    });
+    expect(phrase1).toBeDefined();
+    store.clear();
+  });
+
+  it('readTestStateEntries drops rows whose position no longer maps', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    enrollUser({
+      db: test.db,
+      userId: 'u1',
+      materialId: 'nkjv-cor',
+      materialJson: fixtureMaterial([2, 2, 2, 3]),
+      now: () => 0,
+    });
+    // Inject a legacy-shape row pointing at position 99 — past the
+    // verse's 4-phrase count, so the adapter should drop it.
+    test.db
+      .insert(testStatesTable)
+      .values({
+        userId: 'u1',
+        materialId: 'nkjv-cor',
+        testKind: 'PhraseFromContext',
+        element: JSON.stringify({ kind: 'Phrase', verse_id: 0, position: 99 }),
+        stability: 1,
+        difficulty: 5,
+        lastSeenSecs: 0,
+        lastBaseSecs: 0,
+        lastRootSecs: 0,
+        pendingRelearn: 0,
+      })
+      .run();
+
+    const store = new EngineStore(test.db, 0.9, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
+    const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
+    const orphan = states.find((s) => {
+      const e = s.element as { position?: number };
+      return e.position === 99;
+    });
+    expect(orphan).toBeUndefined();
+    store.clear();
+  });
+
+  it('bumps the snapshot version when bundled materialData changes', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    const before = fixtureMaterial([2, 2, 2, 3]);
+    const after = fixtureMaterial([3, 3, 3]);
+    enrollUser({
+      db: test.db,
+      userId: 'u1',
+      materialId: 'nkjv-cor',
+      materialJson: before,
+      now: () => 0,
+    });
+
+    let bundled = before;
+    const store = new EngineStore(test.db, 0.9, () => 1, () => bundled);
+
+    // Same content → no bump.
+    const first = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(first.snapshotVersion).toBe(1);
+
+    // Switch bundled blob and re-load → bump.
+    bundled = after;
+    const second = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(second.snapshotVersion).toBe(2);
+    expect(second.engine).not.toBe(first.engine);
+
+    const rows = test.db
+      .select()
+      .from(graphSnapshots)
+      .where(
+        and(
+          eq(graphSnapshots.userId, 'u1'),
+          eq(graphSnapshots.materialId, 'nkjv-cor'),
+        ),
+      )
+      .all();
+    expect(rows.length).toBe(2);
+    store.clear();
+  });
+
+  it('preserves FSRS state across split changes when the word range survives', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    const before = fixtureMaterial([2, 2, 2, 3]);
+    const after = fixtureMaterial([3, 3, 3]);
+    enrollUser({
+      db: test.db,
+      userId: 'u1',
+      materialId: 'nkjv-cor',
+      materialJson: before,
+      now: () => 0,
+    });
+
+    // Boost the stability of the (6, 9) phrase — the only range that
+    // survives the [2,2,2,3] → [3,3,3] resplit (cumulative-sum: old
+    // position 3 = (6, 9); new position 2 = (6, 9)).
+    const matched = test.db
+      .select()
+      .from(testStatesTable)
+      .where(
+        and(
+          eq(testStatesTable.userId, 'u1'),
+          eq(testStatesTable.materialId, 'nkjv-cor'),
+          eq(testStatesTable.testKind, 'PhraseFromContext'),
+        ),
+      )
+      .all()
+      .find((r) => {
+        const e = JSON.parse(r.element) as PhraseElement;
+        return e.start_word === 6 && e.end_word === 9;
+      });
+    if (!matched) throw new Error('expected a phrase row at (6, 9)');
+    test.db
+      .update(testStatesTable)
+      .set({ stability: 99 })
+      .where(
+        and(
+          eq(testStatesTable.userId, 'u1'),
+          eq(testStatesTable.materialId, 'nkjv-cor'),
+          eq(testStatesTable.testKind, 'PhraseFromContext'),
+          eq(testStatesTable.element, matched.element),
+        ),
+      )
+      .run();
+
+    let bundled = before;
+    const store = new EngineStore(test.db, 0.9, () => 1, () => bundled);
+    bundled = after;
+    const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
+    const survivor = states.find((s) => {
+      const e = s.element as PhraseElement;
+      return e.start_word === 6 && e.end_word === 9;
+    });
+    expect(survivor?.stability).toBe(99);
+    // The other ranges in the new split don't match anything old —
+    // they boot fresh via new_unseen (stability 1).
+    const fresh = states.find((s) => {
+      const e = s.element as PhraseElement;
+      return e.start_word === 0 && e.end_word === 3;
+    });
+    expect(fresh?.stability).toBe(1);
     store.clear();
   });
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -1,9 +1,16 @@
+import { createHash, randomUUID } from 'node:crypto';
+
 import { and, desc, eq } from 'drizzle-orm';
 import { WasmEngine } from 'verse-vault-wasm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
 import { type UserMaterial, userMaterialKey } from './keys.js';
+import { getMaterialJson } from './materials.js';
+
+function sha256(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
 
 const DEFAULT_DESIRED_RETENTION = 0.9;
 
@@ -198,10 +205,11 @@ export class EngineStore {
   ) {}
 
   async load(key: EngineKey): Promise<LoadedEngine> {
-    const cached = this.cache.get(userMaterialKey(key));
-    if (cached) return cached;
-
-    const snapshot = this.db
+    // Detect content updates before consulting the cache: bundled
+    // materialData changes need to bump the user's snapshot and drop
+    // any stale in-memory engine. Otherwise existing users would never
+    // see edits to data/<year>.json after their first enrollment.
+    let snapshot = this.db
       .select()
       .from(schema.graphSnapshots)
       .where(
@@ -216,6 +224,35 @@ export class EngineStore {
     if (!snapshot) {
       throw new NotEnrolledError(key);
     }
+
+    const bundledJson = getMaterialJson(key.materialId);
+    if (sha256(bundledJson) !== sha256(snapshot.materialData.toString('utf8'))) {
+      const newId = randomUUID();
+      const newVersion = snapshot.version + 1;
+      const createdAt = this.now();
+      this.db
+        .insert(schema.graphSnapshots)
+        .values({
+          id: newId,
+          userId: key.userId,
+          materialId: key.materialId,
+          version: newVersion,
+          materialData: Buffer.from(bundledJson, 'utf8'),
+          createdAt,
+        })
+        .run();
+      this.invalidate(key);
+      snapshot = {
+        ...snapshot,
+        id: newId,
+        version: newVersion,
+        materialData: Buffer.from(bundledJson, 'utf8'),
+        createdAt,
+      };
+    }
+
+    const cached = this.cache.get(userMaterialKey(key));
+    if (cached) return cached;
 
     const testStates = readTestStateEntries(this.db, key);
     const materialJson = snapshot.materialData.toString('utf8');

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -77,7 +77,78 @@ function readMaterialConfigJson(db: DB, key: EngineKey): string {
   });
 }
 
+/** Cumulative-sum half-open word ranges per phrase, keyed by verse_id.
+ *  verse_id is the index into `verses_with_content()` order — verses
+ *  with empty `phraseWordCounts` are skipped, matching Rust's iterator. */
+function computePhraseRangesByVerse(
+  materialJson: string,
+): Map<number, [number, number][]> {
+  const m = JSON.parse(materialJson) as {
+    verses?: { phraseWordCounts?: number[] }[];
+  };
+  const ranges = new Map<number, [number, number][]>();
+  let verseId = 0;
+  for (const v of m.verses ?? []) {
+    const counts = v.phraseWordCounts;
+    if (!counts || counts.length === 0) continue;
+    const r: [number, number][] = [];
+    let cursor = 0;
+    for (const n of counts) {
+      const next = cursor + n;
+      r.push([cursor, next]);
+      cursor = next;
+    }
+    ranges.set(verseId, r);
+    verseId += 1;
+  }
+  return ranges;
+}
+
+/** Translate a stored `Phrase` element from the legacy positional form
+ *  to the content-stable range form using the verse's phrase ranges.
+ *  Non-Phrase elements pass through untouched. Returns null when the
+ *  position no longer maps to any phrase range (verse removed or
+ *  shrunk past this position) — caller should drop the row. */
+function adaptElement(
+  element: unknown,
+  phraseRangesByVerse: Map<number, [number, number][]>,
+): unknown | null {
+  if (typeof element !== 'object' || element === null) return element;
+  const obj = element as Record<string, unknown>;
+  if (obj.kind !== 'Phrase' || !('position' in obj)) return element;
+  const verseId = obj.verse_id as number;
+  const position = obj.position as number;
+  const range = phraseRangesByVerse.get(verseId)?.[position];
+  if (!range) return null;
+  return {
+    kind: 'Phrase',
+    verse_id: verseId,
+    start_word: range[0],
+    end_word: range[1],
+  };
+}
+
+function readSnapshotMaterialJson(db: DB, key: EngineKey): string | null {
+  const snapshot = db
+    .select({ materialData: schema.graphSnapshots.materialData })
+    .from(schema.graphSnapshots)
+    .where(
+      and(
+        eq(schema.graphSnapshots.userId, key.userId),
+        eq(schema.graphSnapshots.materialId, key.materialId),
+      ),
+    )
+    .orderBy(desc(schema.graphSnapshots.version))
+    .limit(1)
+    .get();
+  return snapshot ? snapshot.materialData.toString('utf8') : null;
+}
+
 export function readTestStateEntries(db: DB, key: EngineKey): TestStateEntry[] {
+  const materialJson = readSnapshotMaterialJson(db, key);
+  const phraseRangesByVerse = materialJson
+    ? computePhraseRangesByVerse(materialJson)
+    : new Map<number, [number, number][]>();
   return db
     .select()
     .from(schema.testStates)
@@ -85,18 +156,22 @@ export function readTestStateEntries(db: DB, key: EngineKey): TestStateEntry[] {
       and(eq(schema.testStates.userId, key.userId), eq(schema.testStates.materialId, key.materialId)),
     )
     .all()
-    .map((r) => ({
-      // `r.element` is a JSON-text column; parse it back into the tagged
-      // ElementId object the WASM side expects.
-      element: JSON.parse(r.element) as unknown,
-      test_kind: r.testKind,
-      stability: r.stability,
-      difficulty: r.difficulty,
-      last_seen_secs: r.lastSeenSecs,
-      last_base_secs: r.lastBaseSecs,
-      last_root_secs: r.lastRootSecs,
-      pending_relearn: r.pendingRelearn !== 0,
-    }));
+    .flatMap((r) => {
+      const element = adaptElement(JSON.parse(r.element), phraseRangesByVerse);
+      if (element === null) return [];
+      return [
+        {
+          element,
+          test_kind: r.testKind,
+          stability: r.stability,
+          difficulty: r.difficulty,
+          last_seen_secs: r.lastSeenSecs,
+          last_base_secs: r.lastBaseSecs,
+          last_root_secs: r.lastRootSecs,
+          pending_relearn: r.pendingRelearn !== 0,
+        },
+      ];
+    });
 }
 
 /**

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -202,6 +202,10 @@ export class EngineStore {
     private readonly db: DB,
     private readonly desiredRetention: number = DEFAULT_DESIRED_RETENTION,
     private readonly now: () => number = () => Math.floor(Date.now() / 1000),
+    /** Source of the bundled MaterialData JSON, by material id. Tests
+     *  inject a stub to drive snapshot-bump scenarios; production
+     *  defaults to the on-disk loader. */
+    private readonly loadBundledJson: (id: string) => string = getMaterialJson,
   ) {}
 
   async load(key: EngineKey): Promise<LoadedEngine> {
@@ -225,7 +229,7 @@ export class EngineStore {
       throw new NotEnrolledError(key);
     }
 
-    const bundledJson = getMaterialJson(key.materialId);
+    const bundledJson = this.loadBundledJson(key.materialId);
     if (sha256(bundledJson) !== sha256(snapshot.materialData.toString('utf8'))) {
       const newId = randomUUID();
       const newVersion = snapshot.version + 1;

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -12,6 +12,41 @@ function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
 }
 
+/** Memoise SHA over JSON content. Keyed by the string itself, so a
+ *  different blob gets a different entry (the materialId-keyed variant
+ *  would be wrong under any test or hot-reload that swaps content for
+ *  the same id). Bounded by the number of distinct blobs ever seen
+ *  per process — small. */
+const sha256Cache = new Map<string, string>();
+
+function sha256Memo(json: string): string {
+  let h = sha256Cache.get(json);
+  if (!h) {
+    h = sha256(json);
+    sha256Cache.set(json, h);
+  }
+  return h;
+}
+
+/** Latest stored snapshot row for the (user, material) pair, or
+ *  `undefined` when the user isn't enrolled. Shared by `EngineStore.load`,
+ *  the test-state adapter, and the `/state` sync endpoint so the
+ *  desc-version pick stays consistent across call sites. */
+export function getLatestSnapshot(db: DB, key: EngineKey) {
+  return db
+    .select()
+    .from(schema.graphSnapshots)
+    .where(
+      and(
+        eq(schema.graphSnapshots.userId, key.userId),
+        eq(schema.graphSnapshots.materialId, key.materialId),
+      ),
+    )
+    .orderBy(desc(schema.graphSnapshots.version))
+    .limit(1)
+    .get();
+}
+
 const DEFAULT_DESIRED_RETENTION = 0.9;
 
 export type EngineKey = UserMaterial;
@@ -135,26 +170,18 @@ function adaptElement(
   };
 }
 
-function readSnapshotMaterialJson(db: DB, key: EngineKey): string | null {
-  const snapshot = db
-    .select({ materialData: schema.graphSnapshots.materialData })
-    .from(schema.graphSnapshots)
-    .where(
-      and(
-        eq(schema.graphSnapshots.userId, key.userId),
-        eq(schema.graphSnapshots.materialId, key.materialId),
-      ),
-    )
-    .orderBy(desc(schema.graphSnapshots.version))
-    .limit(1)
-    .get();
-  return snapshot ? snapshot.materialData.toString('utf8') : null;
-}
-
-export function readTestStateEntries(db: DB, key: EngineKey): TestStateEntry[] {
-  const materialJson = readSnapshotMaterialJson(db, key);
-  const phraseRangesByVerse = materialJson
-    ? computePhraseRangesByVerse(materialJson)
+/** Load test_states for the user and translate any legacy positional
+ *  Phrase elements to the new range identity. Pass `materialJson` when
+ *  the caller already has the snapshot in hand (e.g. `EngineStore.load`)
+ *  to skip a redundant snapshot read; otherwise it's fetched here. */
+export function readTestStateEntries(
+  db: DB,
+  key: EngineKey,
+  materialJson?: string,
+): TestStateEntry[] {
+  const json = materialJson ?? getLatestSnapshot(db, key)?.materialData.toString('utf8');
+  const phraseRangesByVerse = json
+    ? computePhraseRangesByVerse(json)
     : new Map<number, [number, number][]>();
   return db
     .select()
@@ -213,24 +240,11 @@ export class EngineStore {
     // materialData changes need to bump the user's snapshot and drop
     // any stale in-memory engine. Otherwise existing users would never
     // see edits to data/<year>.json after their first enrollment.
-    let snapshot = this.db
-      .select()
-      .from(schema.graphSnapshots)
-      .where(
-        and(
-          eq(schema.graphSnapshots.userId, key.userId),
-          eq(schema.graphSnapshots.materialId, key.materialId),
-        ),
-      )
-      .orderBy(desc(schema.graphSnapshots.version))
-      .limit(1)
-      .get();
-    if (!snapshot) {
-      throw new NotEnrolledError(key);
-    }
+    let snapshot = getLatestSnapshot(this.db, key);
+    if (!snapshot) throw new NotEnrolledError(key);
 
     const bundledJson = this.loadBundledJson(key.materialId);
-    if (sha256(bundledJson) !== sha256(snapshot.materialData.toString('utf8'))) {
+    if (sha256Memo(bundledJson) !== sha256Memo(snapshot.materialData.toString('utf8'))) {
       const newId = randomUUID();
       const newVersion = snapshot.version + 1;
       const createdAt = this.now();
@@ -258,8 +272,8 @@ export class EngineStore {
     const cached = this.cache.get(userMaterialKey(key));
     if (cached) return cached;
 
-    const testStates = readTestStateEntries(this.db, key);
     const materialJson = snapshot.materialData.toString('utf8');
+    const testStates = readTestStateEntries(this.db, key, materialJson);
     const configJson = readMaterialConfigJson(this.db, key);
     const engine = new WasmEngine(
       materialJson,

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -7,6 +7,7 @@ import {
   EngineStore,
   NotEnrolledError,
   type TestStateEntry,
+  getLatestSnapshot,
   readTestStateEntries,
 } from '../lib/engine.js';
 import { type Grade, persistEngineState } from '../lib/review-log.js';
@@ -48,18 +49,7 @@ export function syncRoutes(deps: SyncRoutesDeps) {
     const materialId = c.req.param('materialId');
     const key = { userId: user.id, materialId };
 
-    const snapshot = deps.db
-      .select()
-      .from(schema.graphSnapshots)
-      .where(
-        and(
-          eq(schema.graphSnapshots.userId, user.id),
-          eq(schema.graphSnapshots.materialId, materialId),
-        ),
-      )
-      .orderBy(desc(schema.graphSnapshots.version))
-      .limit(1)
-      .get();
+    const snapshot = getLatestSnapshot(deps.db, key);
     if (!snapshot) return c.json({ error: 'Not enrolled' }, 404);
 
     return c.json({


### PR DESCRIPTION
## Summary

Robust handling for phrase-split changes. Two related gaps got fixed together:

- **Gap A — server-side snapshot bumps**. The only insert path into `graph_snapshots` was `enrollUser()`, so edits to `data/<year>.json` never reached existing users. `EngineStore.load` now hashes the bundled materialData against the stored snapshot's blob on every load and inserts a new snapshot row at `version+1` on mismatch (cache invalidated in the same flow).
- **Gap B — content-stable phrase identity**. `ElementId::Phrase { verse_id, position }` got silently re-attached to different content when splits changed. Now keyed by `{ verse_id, start_word, end_word }` (cumulative-sum word ranges from `phraseWordCounts`). When splits change, phrases whose range survives keep their FSRS state; phrases whose boundaries shift get fresh `new_unseen` state — exact-match preservation falls out of the identity scheme with no extra code.

The existing-row migration is a lazy adapter in `readTestStateEntries`: legacy `{verse_id, position}` elements get translated to the range shape using the user's snapshot's phrase ranges at read time. The new shape persists on the next review via the normal upsert path. No separate migration script.

Operational note (Gap C, deliberately not in scope): mid-session card-ID staleness is handled by deploy timing — don't ship content edits while you're mid-session. The engine cache protects in-flight requests until next restart.

## Notable decisions

- **Range identity**: half-open `[start_word, end_word)`. Stable as long as the verse text (api.bible NKJV) doesn't change.
- **Match rule**: exact range only. No overlap heuristics.
- **Bump trigger**: lazy on `EngineStore.load`. Hash check costs ~µs; YAGNI a hash cache.
- **Migration shape**: lazy adapter, not a wipe — same machinery is required for future preservation, so building it once now means future content edits get state preservation for free.

## Files

- `crates/core/src/element.rs` — `ElementId::Phrase` shape change.
- `crates/core/src/card.rs` — `VerseAtoms.phrase_ranges` + `phrase_range` helper + `ranges_from_word_counts`. `Card::tests` and `ftv_tests` look up ranges per position.
- `crates/core/src/{builder,engine,verse_index}.rs` — populate ranges; `VerseElements` stores ranges directly so `atoms_for`'s fallback path doesn't need to reconstruct.
- `crates/core/{tests,sim/src/learner.rs,wasm/src/lib.rs,test_kind.rs}` — fixtures updated.
- `packages/api/src/lib/engine.ts` — `readTestStateEntries` adapter, `EngineStore.load` hash-and-bump, `loadBundledJson` injectable for tests.
- `packages/api/src/lib/engine.test.ts` — 4 new tests: legacy rewrite, out-of-bounds drop, snapshot bump, range-match preservation.
- `crates/wasm/test-smoke.js` — asserts exported phrase elements carry start_word/end_word.

## Test plan

- [x] `cargo test` — 121 pass (incl. new `phrase_ranges_from_word_counts_cumulative_sum`)
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo run -p verse-vault-sim` — runs, FSRS metrics stable
- [x] `wasm-pack build crates/wasm` + `node crates/wasm/test-smoke.js` — passes; asserts new identity end-to-end
- [x] `pnpm --filter @verse-vault/api test` — 87 pass (+4 new)
- [x] `pnpm --filter @verse-vault/web build` — builds clean
- [ ] CI green