### PR TITLE
fix: bump to 0.1.2; drop pnpm version pin

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -72,8 +72,6 @@ jobs:
           workspaces: crates/wasm
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-vv-router.yml
+++ b/.github/workflows/deploy-vv-router.yml
@@ -46,8 +46,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -47,8 +47,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,14 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-05-20
+
+### Fixed
+
+* CI: `pnpm/action-setup@v4` errored on redundant version pin (both `with: version: 10` and
+  `package.json`'s `packageManager: pnpm@10.7.0`). Dropped the `with` arg; 0.1.1 never reached
+  production because of this, so 0.1.2 is the first successful deploy.
+
 ## [0.1.1] — 2026-05-20
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/vv-router/CHANGELOG.md
+++ b/deploy/vv-router/CHANGELOG.md
@@ -13,6 +13,13 @@ app-level changes don't need a bump here.
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-05-20
+
+### Fixed
+
+* CI: same `pnpm/action-setup@v4` version-conflict fix as the other deployables (see top-level
+  `CHANGELOG.md`). 0.1.2 is the first successful deploy of the Worker.
+
 ## [0.1.1] — 2026-05-20
 
 ### Added

--- a/deploy/vv-router/package.json
+++ b/deploy/vv-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/vv-router",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,18 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-05-20
+
+### Fixed
+
+* CI: same `pnpm/action-setup@v4` version-conflict fix as the other deployables. 0.1.2 is the first
+  successful API deploy to the VPS.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.1 (CI-only fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.1 (CI-only fix)
+
 ## [0.1.1] — 2026-05-20
 
 ### Added

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Problem

The first deploy (PR #35 merge at `dafcd06`) failed all three workflows with:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.7.0 in the package.json with the key "packageManager"
```

`pnpm/action-setup@v4` now refuses to resolve when both the action's `with: version: 10` and the root `package.json`'s `packageManager: pnpm@10.7.0` are set. They agreed on the major in our case, but the action treats any redundancy as ambiguous.

## Fix

- Drop `with: version: 10` from all three deploy workflows. `packageManager` in `package.json` is the canonical pin.
- Bump web + api + vv-router to **0.1.2** so the merge of this PR triggers the deploys via the existing `paths` filter + version-bump check (no manual `workflow_dispatch` needed).

0.1.1 stays documented in each CHANGELOG as the attempted release that never shipped; 0.1.2 is the first successful deploy.

## Expected post-merge

Three deploy workflows fire in parallel:

- `deploy-web.yml` → CF Pages, tag `web@0.1.2`
- `deploy-vv-router.yml` → CF Worker, tag `vv-router@0.1.2`
- `deploy-api.yml` → VPS rsync + restart + health check, tags `api@0.1.2`, plus `core@0.1.0` + `wasm@0.1.0` (first time they're tagged since they ship inside the API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)