### PR TITLE
fix(auth+routing): unbreak /vv in production (0.1.4)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,15 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-05-20
+
+### Fixed
+
+* Better Auth client's `baseURL` came from `VITE_API_URL` (legacy env var) and fell back to
+  `http://localhost:3000` in production because CI only sets `VITE_API_BASE`. The deployed SPA was
+  therefore calling `localhost` for every auth request. Switched to deriving the auth base from
+  `VITE_API_BASE` (the same env var the API client reads) by stripping the trailing `/api`.
+
 ## [0.1.3] — 2026-05-20
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,5 +1,15 @@
 import { createAppAuthClient } from '@/lib/authClient'
 
-const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000'
+// Better Auth's baseURL is the URL prefix in front of `/api/auth/*` — i.e.
+// the API base with the `/api` suffix stripped. In dev that's just the API
+// origin (`http://localhost:3000`). In prod the SPA sees the API through the
+// vv-router at `/vv/api`, so the auth base is `/vv` (browser resolves it
+// against `www.versevault.ca`). VITE_API_URL is the legacy flat-URL form,
+// kept as a fallback.
+const apiBase =
+  import.meta.env.VITE_API_BASE ??
+  import.meta.env.VITE_API_URL ??
+  'http://localhost:3000'
+const authBaseURL = apiBase.replace(/\/api$/, '')
 
-export const { authClient, useAuth } = createAppAuthClient(apiUrl)
+export const { authClient, useAuth } = createAppAuthClient(authBaseURL)

--- a/deploy/vv-router/CHANGELOG.md
+++ b/deploy/vv-router/CHANGELOG.md
@@ -13,6 +13,16 @@ app-level changes don't need a bump here.
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-05-21
+
+### Fixed
+
+* Bare `/vv` (no trailing slash) wasn't matched by the single `/vv/*` Worker route, so the request
+  fell through to the qzr-sheet Pages catch-all at `/*`. qzr-sheet's SPA loaded, its Vue Router
+  didn't know `/vv`, and the user was bounced to apex — looking like "going to `/vv` redirects to
+  the apex." Added a second route pattern (`/vv` exactly) and a 301 in the Worker that sends `/vv` →
+  `/vv/` so the SPA always loads under its proper base path.
+
 ## [0.1.3] — 2026-05-20
 
 ### Fixed

--- a/deploy/vv-router/package.json
+++ b/deploy/vv-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/vv-router",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/deploy/vv-router/src/index.ts
+++ b/deploy/vv-router/src/index.ts
@@ -22,9 +22,21 @@ export default {
     const url = new URL(request.url);
 
     if (!url.pathname.startsWith(PREFIX)) {
-      // Worker route is /vv/*, so anything that lands here without the
-      // prefix is a routing misconfiguration. Surface it loudly.
+      // Worker route is /vv and /vv/*, so anything that lands here without
+      // the prefix is a routing misconfiguration. Surface it loudly.
       return new Response('vv-router: path outside /vv prefix', { status: 500 });
+    }
+
+    // Bare /vv (no trailing slash) → redirect to /vv/. Without this, the SPA
+    // would load with `<base href="/vv/">` while the browser URL was `/vv`,
+    // and Vue Router's path normalisation would lose the prefix. Also, if we
+    // forwarded the bare /vv to Pages as `/`, the Pages SPA would render but
+    // any relative-path navigation from there would drop out of the /vv
+    // subpath entirely.
+    if (url.pathname === PREFIX) {
+      const redirectTo = new URL(url);
+      redirectTo.pathname = PREFIX + '/';
+      return Response.redirect(redirectTo.toString(), 301);
     }
 
     const rest = url.pathname.slice(PREFIX.length) || '/';

--- a/deploy/vv-router/wrangler.toml
+++ b/deploy/vv-router/wrangler.toml
@@ -2,9 +2,16 @@ name = "vv-router"
 main = "src/index.ts"
 compatibility_date = "2026-05-01"
 
-# Mount under /vv/* on the apex. Caddy isn't involved — Cloudflare evaluates
-# Worker routes longest-prefix-first, so this co-exists with qzr-api's
-# /api/* route and the qzr-sheet Pages catch-all at /*.
+# Mount under /vv on the apex. Cloudflare evaluates Worker routes
+# longest-prefix-first, so this co-exists with qzr-api's /api/* route and the
+# qzr-sheet Pages catch-all at /*. Two patterns: `/vv` matches the bare prefix
+# (so the Worker — not the qzr-sheet Pages fallback — handles a no-trailing-
+# slash visit and redirects to `/vv/`), and `/vv/*` matches everything under
+# it.
+[[routes]]
+pattern = "www.versevault.ca/vv"
+zone_name = "versevault.ca"
+
 [[routes]]
 pattern = "www.versevault.ca/vv/*"
 zone_name = "versevault.ca"

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,21 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-05-20
+
+### Fixed
+
+* Better Auth's path matcher derived its basePath from `baseURL`, which in production is
+  `https://www.versevault.ca/vv` (the SPA-facing URL). The Tunnel-fronted API actually receives
+  requests at `/api/auth/*` (vv-router strips the `/vv` prefix before forwarding), so the derived
+  match path `/vv/api/auth/*` never matched and every `/api/auth/*` request 404'd. Pinned
+  `basePath: '/api/auth'` explicitly so the match is independent of `baseURL`'s path component.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.3 (auth-only fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.3 (auth-only fix)
+
 ## [0.1.3] — 2026-05-20
 
 ### Fixed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -22,6 +22,10 @@ export function createAuth(db: DB, env: AuthEnv) {
 
   return betterAuth({
     baseURL: env.baseUrl,
+    // Path the API actually receives requests on (vv-router strips the `/vv`
+    // prefix before forwarding to the Tunnel, so Better Auth must not derive
+    // its match path from baseURL's `/vv/...` path component).
+    basePath: '/api/auth',
     secret: env.secret,
     database: drizzleAdapter(db, { provider: 'sqlite', schema }),
     trustedOrigins,


### PR DESCRIPTION
## Summary

Three production-only bugs caught while smoke-testing the 0.1.3 stack. **User-visible symptom: visiting `versevault.ca/vv` bounced to the qzr-sheet home at apex** — and even if you got past that, every `/api/auth/*` call 404'd, and the SPA's auth client was actually calling `localhost` from production.

### Bug 1 — vv-router: bare `/vv` (no trailing slash) fell through to qzr-sheet

The Worker route was `www.versevault.ca/vv/*` only. CF's `/*` pattern requires *something* after the slash, so a request to exactly `/vv` did NOT match the Worker. It fell through to the Pages catch-all at `/*` — i.e. qzr-sheet. qzr-sheet's Vue Router didn't recognise `/vv` and bounced the user to its own home route, making it look like `/vv` redirected to the apex.

Confirmed by curl: `www.versevault.ca/vv` returned qzr-sheet's index.html (`<title>qzr-sheet</title>`), while `www.versevault.ca/vv/` correctly returned verse-vault's.

Fix: add a second route pattern (`www.versevault.ca/vv` exactly), and 301 the bare `/vv` to `/vv/` from inside the Worker so the SPA always loads under its proper base path.

### Bug 2 — server: Better Auth derives basePath from baseURL

`auth.ts` set `baseURL: env.baseUrl` (= `https://www.versevault.ca/vv`, the SPA-facing URL) and let Better Auth derive `basePath` from it — yielding `/vv/api/auth` as the expected match path. But the Tunnel-fronted API actually receives requests at `/api/auth/*` because `vv-router` strips the `/vv` prefix before forwarding. Every auth request 404'd.

Fix: pin `basePath: '/api/auth'` explicitly so the match path is independent of `baseURL`'s path component. `baseURL` is still used for cookie domain, OAuth callbacks, and absolute URLs in emails — those need the SPA-facing host.

### Bug 3 — web: auth client reads dead env var, falls back to localhost

`composables/useAuth.ts` still read `VITE_API_URL` (legacy) and fell back to `http://localhost:3000`. CI only sets `VITE_API_BASE` (`/vv/api`), so the deployed SPA's Better Auth client was calling `localhost` for every auth request. Mixed-content errors in the browser console were the real symptom.

Fix: derive the auth baseURL from `VITE_API_BASE` by stripping the trailing `/api`. Dev keeps the same behaviour via the `VITE_API_URL` fallback chain.

## Versions

- `@verse-vault/web`: 0.1.3 → 0.1.4
- `@verse-vault/api`: 0.1.3 → 0.1.4
- `@verse-vault/vv-router`: 0.1.3 → 0.1.4
- Algorithm contract unchanged (`core@0.1.0`, `wasm@0.1.0`)

## Test plan

- [ ] All three CI deploys succeed (no pnpm-v10 regressions); tags `web@0.1.4`, `api@0.1.4`, `vv-router@0.1.4` land
- [ ] `curl https://www.versevault.ca/vv` (no trailing slash) returns 301 → `/vv/`
- [ ] `curl https://www.versevault.ca/vv/` returns the verse-vault SPA (title `verse-vault`, NOT `qzr-sheet`)
- [ ] `curl https://vv-api.versevault.ca/api/auth/get-session` returns JSON, not 404
- [ ] `curl https://www.versevault.ca/vv/api/auth/get-session` returns JSON via the Worker
- [ ] Sign-in flow works end-to-end in a real browser