### PR TITLE
fix(api): strip path from Better Auth baseURL (0.1.5)

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,22 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-05-21
+
+### Fixed
+
+* 0.1.4's `basePath: '/api/auth'` option turned out to be a no-op for path matching — Better Auth's
+  request router derives the match prefix directly from `new URL(baseURL).pathname`, ignoring the
+  `basePath` option in this code path. With production `baseURL = https://www.versevault.ca/vv`, the
+  match prefix became `/vv` and every incoming `/api/auth/*` request still 404'd. Pass just
+  `new URL(env.baseUrl).origin` (i.e. drop the `/vv` path component) to Better Auth so the match
+  prefix is empty and `/api/auth/*` is matched directly.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.4 (auth-only fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.4 (auth-only fix)
+
 ## [0.1.4] — 2026-05-20
 
 ### Fixed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -20,12 +20,19 @@ export function createAuth(db: DB, env: AuthEnv) {
     ? [env.webOrigin]
     : [env.webOrigin, 'http://localhost:5173', 'http://localhost:5180'];
 
+  // Better Auth derives its request-matching basePath from
+  // `new URL(baseURL).pathname` — so any path component in env.baseUrl
+  // (e.g. `/vv` in prod, where the SPA is mounted under a subpath) becomes
+  // part of what Better Auth expects every request URL to start with. The
+  // API actually receives requests at `/api/auth/*` because vv-router
+  // strips `/vv` before forwarding. Pass just the origin so the match path
+  // stays empty and `/api/auth/*` is matched directly. We still keep
+  // env.baseUrl as the source of truth for the public-facing URL (used
+  // elsewhere for things like OAuth-flow URL construction).
+  const betterAuthBaseURL = new URL(env.baseUrl).origin;
+
   return betterAuth({
-    baseURL: env.baseUrl,
-    // Path the API actually receives requests on (vv-router strips the `/vv`
-    // prefix before forwarding to the Tunnel, so Better Auth must not derive
-    // its match path from baseURL's `/vv/...` path component).
-    basePath: '/api/auth',
+    baseURL: betterAuthBaseURL,
     secret: env.secret,
     database: drizzleAdapter(db, { provider: 'sqlite', schema }),
     trustedOrigins,


### PR DESCRIPTION
## Summary

0.1.4's `basePath: '/api/auth'` option was a no-op. Better Auth's request matcher uses `new URL(baseURL).pathname` directly and ignores the `basePath` option in that code path. With production `baseURL = https://www.versevault.ca/vv`, the matcher expected every request URL to start with `/vv` — but vv-router strips `/vv` before forwarding, so the API receives `/api/auth/*` and the match never fired. Every `/api/auth/*` request still 404'd post-0.1.4 deploy.

Confirmed via curl after the 0.1.4 deploy landed:

```
$ curl -o /dev/null -w '%{http_code}\n' https://vv-api.versevault.ca/api/auth/get-session
404
$ curl -o /dev/null -w '%{http_code}\n' https://www.versevault.ca/vv/api/auth/get-session
404
```

The other two bugs from PR #38 (bare `/vv` falling through to qzr-sheet, web client using a dead env var) are confirmed fixed in 0.1.4 — only the API-side path matching remained broken.

## Fix

Pass `new URL(env.baseUrl).origin` (just `https://www.versevault.ca`) to Better Auth instead of the full `env.baseUrl`. Match prefix becomes empty; `/api/auth/*` matches directly.

`env.baseUrl` is unchanged elsewhere — it's still the source of truth for the public-facing URL used in CORS / OAuth flows.

## Versions

- `@verse-vault/api`: 0.1.4 → 0.1.5

## Test plan

- [ ] CI deploy succeeds
- [ ] `curl https://vv-api.versevault.ca/api/auth/get-session` returns JSON (not 404)
- [ ] `curl https://www.versevault.ca/vv/api/auth/get-session` returns JSON via the Worker
- [ ] Sign-in flow works end-to-end in a real browser

## Follow-up (not in this PR)

OAuth callback URL is generated by Better Auth as `${baseURL}/api/auth/callback/google`. With the new origin-only `baseURL`, that resolves to `https://www.versevault.ca/api/auth/callback/google` — which falls under the qzr-api Worker's route, not vv-router. Configuring Google OAuth in production will need a callback-URL override or a Worker-route adjustment. Email/password works without it.