### PR TITLE
fix(web): make Better Auth client baseURL absolute (0.1.5)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,15 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.5] — 2026-05-21
+
+### Fixed
+
+* 0.1.4 stripped `/api` off `VITE_API_BASE` to derive the Better Auth client `baseURL`, yielding
+  `/vv` in production. Better Auth's `createAuthClient` validates that string with `new URL(...)`,
+  which rejects relative paths (`Invalid base URL: /vv`) and the SPA crashed on first render.
+  Resolve the relative path against `window.location.origin` before passing it in.
+
 ## [0.1.4] — 2026-05-20
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -3,13 +3,17 @@ import { createAppAuthClient } from '@/lib/authClient'
 // Better Auth's baseURL is the URL prefix in front of `/api/auth/*` — i.e.
 // the API base with the `/api` suffix stripped. In dev that's just the API
 // origin (`http://localhost:3000`). In prod the SPA sees the API through the
-// vv-router at `/vv/api`, so the auth base is `/vv` (browser resolves it
-// against `www.versevault.ca`). VITE_API_URL is the legacy flat-URL form,
-// kept as a fallback.
+// vv-router at `/vv/api`, so the stripped base is `/vv` — but Better Auth's
+// client validates baseURL via `new URL(...)` which rejects relative paths,
+// so resolve relative results against `window.location.origin`. VITE_API_URL
+// is the legacy flat-URL form, kept as a fallback.
 const apiBase =
   import.meta.env.VITE_API_BASE ??
   import.meta.env.VITE_API_URL ??
   'http://localhost:3000'
-const authBaseURL = apiBase.replace(/\/api$/, '')
+const stripped = apiBase.replace(/\/api$/, '')
+const authBaseURL = stripped.startsWith('/')
+  ? window.location.origin + stripped
+  : stripped
 
 export const { authClient, useAuth } = createAppAuthClient(authBaseURL)


### PR DESCRIPTION
## Summary

0.1.4 stripped `/api` off `VITE_API_BASE` to derive the Better Auth client `baseURL`, yielding `/vv` in production. Better Auth's `createAuthClient` validates that string via `new URL(...)`, which throws on a relative path:

```
Uncaught BetterAuthError: Invalid base URL: /vv. Please provide a valid base URL.
Caused by: TypeError: URL constructor: /vv is not a valid URL.
```

SPA crashed at first render — the auth client construct runs at module init time, before anything else mounts.

## Fix

Resolve the relative stripped-base against `window.location.origin` before handing it to Better Auth: `/vv` → `https://www.versevault.ca/vv`. Absolute inputs (dev's `http://localhost:3000`) pass through unchanged.

## Versions

- `@verse-vault/web`: 0.1.4 → 0.1.5

## Test plan

- [ ] CI deploy succeeds
- [ ] Loading `https://www.versevault.ca/vv/` doesn't throw `Invalid base URL`
- [ ] Sign-in flow works end-to-end