### PR TITLE
fix(web): include /api/auth in Better Auth client baseURL (0.1.6)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,17 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-05-21
+
+### Fixed
+
+* Better Auth's client `withPath()` helper only appends `/api/auth` to `baseURL` when there is no
+  path component on the URL. With the production `baseURL = https://www.versevault.ca/vv`, the `/vv`
+  path already counted as "has path," so nothing was appended and route calls hit
+  `/vv/sign-up/email` → 405 (the Worker forwards the path to the Pages SPA, which doesn't accept
+  POSTs). Hand Better Auth the full auth-route prefix explicitly: `${apiBase}/auth` when `apiBase`
+  already ends with `/api`, otherwise `${apiBase}/api/auth`.
+
 ## [0.1.5] — 2026-05-21
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,19 +1,20 @@
 import { createAppAuthClient } from '@/lib/authClient'
 
-// Better Auth's baseURL is the URL prefix in front of `/api/auth/*` — i.e.
-// the API base with the `/api` suffix stripped. In dev that's just the API
-// origin (`http://localhost:3000`). In prod the SPA sees the API through the
-// vv-router at `/vv/api`, so the stripped base is `/vv` — but Better Auth's
-// client validates baseURL via `new URL(...)` which rejects relative paths,
-// so resolve relative results against `window.location.origin`. VITE_API_URL
-// is the legacy flat-URL form, kept as a fallback.
+// Better Auth's client appends `/api/auth` to baseURL — but only when
+// baseURL has no path component (see `withPath` in better-auth/utils/url).
+// Once there's a path (`/vv` in prod), nothing is appended and route calls
+// land at `/vv/sign-up/email` instead of `/vv/api/auth/sign-up/email`.
+// So we hand it the full auth route prefix explicitly and resolve to an
+// absolute URL (Better Auth validates via `new URL(...)`, which rejects
+// relative paths). VITE_API_URL is the legacy flat-URL form, kept as a
+// fallback.
 const apiBase =
   import.meta.env.VITE_API_BASE ??
   import.meta.env.VITE_API_URL ??
   'http://localhost:3000'
-const stripped = apiBase.replace(/\/api$/, '')
-const authBaseURL = stripped.startsWith('/')
-  ? window.location.origin + stripped
-  : stripped
+const withAuth = apiBase.endsWith('/api') ? `${apiBase}/auth` : `${apiBase}/api/auth`
+const authBaseURL = withAuth.startsWith('/')
+  ? window.location.origin + withAuth
+  : withAuth
 
 export const { authClient, useAuth } = createAppAuthClient(authBaseURL)


### PR DESCRIPTION
## Summary

The browser POST to sign up landed at `/vv/sign-up/email` and 405'd — missing the `/api/auth/` segment entirely.

Why: Better Auth's client uses `withPath(url, "/api/auth")` to construct its base, but `withPath` only appends `/api/auth` when the URL has **no path component**:

```js
function withPath(url, path = "/api/auth") {
  if (checkHasPath(url)) return url;   // <- skips append if /vv is already there
  return `${trimmedUrl}${path}`;
}
```

With production `baseURL = https://www.versevault.ca/vv`, `checkHasPath` sees the `/vv` and returns the URL as-is. Route calls then become `${base}/sign-up/email` — no `/api/auth` in the path. That's the path the SPA actually sent (and got 405 from, because vv-router forwarded it to Pages, which doesn't accept POSTs).

## Fix

Hand Better Auth the full auth-route prefix explicitly: `${apiBase}/auth` when `apiBase` already ends with `/api` (prod: `/vv/api` → `/vv/api/auth`), otherwise `${apiBase}/api/auth` (dev: `http://localhost:3000` → `http://localhost:3000/api/auth`). Resolve to absolute via `window.location.origin` if relative.

## Versions

- `@verse-vault/web`: 0.1.5 → 0.1.6

## Test plan

- [ ] CI deploy succeeds
- [ ] Sign-up POST lands at `/vv/api/auth/sign-up/email` (not `/vv/sign-up/email`)
- [ ] Sign-in flow works end-to-end