### PR TITLE
fix(url-handling): unbreak prod (api paths, CORS, OAuth) (0.1.6)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -58,10 +58,13 @@ jobs:
       - name: Build
         env:
           # Subpath layout: SPA serves from www.versevault.ca/vv/, API calls
-          # go to /vv/api/*. Flip both to root values when we move off the
-          # subpath (see docs/deployment.md "Future: cutting over to subdomains").
+          # go through the same prefix. VITE_API_BASE is the origin-relative
+          # prefix (subpath only, NOT including `/api`); api.ts paths begin
+          # with `/api/`, so the final URLs become `/vv/api/*`. Flip both to
+          # root values when we move off the subpath (see docs/deployment.md
+          # "Future: cutting over to subdomains").
           VITE_BASE_PATH: /vv/
-          VITE_API_BASE: /vv/api
+          VITE_API_BASE: /vv
         run: pnpm --filter @verse-vault/web build
 
       # Using pnpm dlx wrangler instead of cloudflare/wrangler-action@v3:

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,22 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-05-21
+
+### Fixed
+
+* Production-only URL plumbing audit. Two issues:
+  1. **API client double-pathed every request.** `VITE_API_BASE` was `/vv/api`, but every path
+     passed to the api client already starts with `/api/` — so the final URLs became
+     `/vv/api/api/cards/...` and 404'd the entire (non-auth) API surface in production. Confirmed by
+     curl: `/vv/api/api/me` → 404, `/vv/api/me` → 401.
+  2. **Better Auth client's `withPath` skips the `/api/auth` auto-append** when the baseURL has any
+     path component (and `/vv` counts), so route calls were landing at `/vv/sign-up/email` (405)
+     instead of `/vv/api/auth/sign-up/email`.
+
+  Fix: `VITE_API_BASE` is now the subpath-only prefix (`/vv`) without `/api`. The api client adds
+  `/api/...` itself, and `useAuth.ts` adds `/api/auth` explicitly for Better Auth.
+
 ## [0.1.5] — 2026-05-21
 
 ### Fixed

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -212,9 +212,11 @@ export class ApiError extends Error {
 /** Singleton instance configured against the Vite-injected API URL.
  *  Falls back to the local dev server when no override is provided.
  *
- *  `VITE_API_BASE` is the new path-aware setting (e.g. `/vv/api` when
- *  co-hosting under versevault.ca). `VITE_API_URL` is the legacy
- *  full-origin form, kept for any existing dev setups that set it. */
+ *  `VITE_API_BASE` is an origin-relative subpath prefix that does NOT
+ *  include `/api` (e.g. `/vv` when co-hosting under
+ *  www.versevault.ca/vv/). Paths passed to `request()` start with `/api/`,
+ *  so the final URL is `${VITE_API_BASE}/api/...`. `VITE_API_URL` is the
+ *  legacy absolute-origin form, kept for any existing dev setups. */
 export const api = createApiClient(
   import.meta.env.VITE_API_BASE ?? import.meta.env.VITE_API_URL ?? 'http://localhost:3000',
 )

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,19 +1,19 @@
 import { createAppAuthClient } from '@/lib/authClient'
 
-// Better Auth's baseURL is the URL prefix in front of `/api/auth/*` — i.e.
-// the API base with the `/api` suffix stripped. In dev that's just the API
-// origin (`http://localhost:3000`). In prod the SPA sees the API through the
-// vv-router at `/vv/api`, so the stripped base is `/vv` — but Better Auth's
-// client validates baseURL via `new URL(...)` which rejects relative paths,
-// so resolve relative results against `window.location.origin`. VITE_API_URL
-// is the legacy flat-URL form, kept as a fallback.
+// Better Auth's client auto-appends `/api/auth` to baseURL only when the
+// URL has no path component (see `withPath` / `checkHasPath` in
+// better-auth/utils/url). In our subpath deployment VITE_API_BASE is `/vv`,
+// which already has a path, so the auto-append is skipped — we add the
+// `/api/auth` suffix ourselves. Better Auth also validates baseURL via
+// `new URL(...)`, which rejects relative inputs, so we absolutize against
+// `window.location.origin` when VITE_API_BASE is origin-relative.
+// VITE_API_URL is the legacy absolute-origin form, kept as a fallback.
 const apiBase =
   import.meta.env.VITE_API_BASE ??
   import.meta.env.VITE_API_URL ??
   'http://localhost:3000'
-const stripped = apiBase.replace(/\/api$/, '')
-const authBaseURL = stripped.startsWith('/')
-  ? window.location.origin + stripped
-  : stripped
+const authBaseURL = apiBase.startsWith('/')
+  ? `${window.location.origin}${apiBase}/api/auth`
+  : `${apiBase}/api/auth`
 
 export const { authClient, useAuth } = createAppAuthClient(authBaseURL)

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,27 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.6] — 2026-05-21
+
+### Fixed
+
+* `trustedOrigins` and the Hono CORS allow-list both compared the configured `WEB_BASE_URL` verbatim
+  against the browser's `Origin` header. In production `WEB_BASE_URL` is
+  `https://www.versevault.ca/vv` (with subpath), but the browser always sends Origin as
+  scheme+host+port only (`https://www.versevault.ca`). The mismatch would have 403'd every POST
+  through Better Auth once the path issues were fixed — strip the path from `env.webOrigin` at the
+  comparison sites so the equality holds.
+* Pin Google OAuth's `redirectURI` to `${env.baseUrl}/api/auth/callback/google`. Better Auth's
+  default redirect URI is `${baseURL}/callback/google`, which with our stripped origin-only
+  `baseURL` resolves to `https://<origin>/callback/google` — missing `/api/auth/` and routed to the
+  sibling qzr-api Worker instead of vv-router. The explicit override matches the URL `provision.sh`
+  already tells users to register in the Google OAuth client.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.5 (auth-only fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.5 (auth-only fix)
+
 ## [0.1.5] — 2026-05-21
 
 ### Fixed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -42,6 +42,10 @@ export function createApp(deps: AppDeps) {
 
   app.use('*', logger());
   const isProd = process.env.NODE_ENV === 'production';
+  // Browser-sent Origin headers are scheme+host+port only. Strip any path
+  // (e.g. `/vv` for subpath deployments) from the configured webOrigin so
+  // the equality check works.
+  const webOrigin = new URL(deps.authEnv.webOrigin).origin;
   app.use(
     '*',
     cors({
@@ -50,7 +54,7 @@ export function createApp(deps: AppDeps) {
       // API without a coordinated WEB_BASE_URL. In production only the
       // configured webOrigin is allowed.
       origin: (origin) => {
-        if (origin === deps.authEnv.webOrigin) return origin;
+        if (origin === webOrigin) return origin;
         if (
           !isProd &&
           origin &&

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -13,12 +13,18 @@ export interface AuthEnv {
 
 export function createAuth(db: DB, env: AuthEnv) {
   const isProd = process.env.NODE_ENV === 'production';
+  // Browsers send Origin headers as scheme+host+port only — never a path.
+  // env.webOrigin may include a subpath in prod (e.g.
+  // `https://www.versevault.ca/vv`), but matching against trustedOrigins
+  // needs the bare origin. Strip the path here once and reuse below.
+  const webOrigin = new URL(env.webOrigin).origin;
+
   // In dev, trust any localhost port the thin client might land on (Vite
   // falls back through 5180/5181/… when ports collide). Production sticks
   // to the single configured origin.
   const trustedOrigins = isProd
-    ? [env.webOrigin]
-    : [env.webOrigin, 'http://localhost:5173', 'http://localhost:5180'];
+    ? [webOrigin]
+    : [webOrigin, 'http://localhost:5173', 'http://localhost:5180'];
 
   // Better Auth derives its request-matching basePath from
   // `new URL(baseURL).pathname` — so any path component in env.baseUrl
@@ -37,7 +43,22 @@ export function createAuth(db: DB, env: AuthEnv) {
     database: drizzleAdapter(db, { provider: 'sqlite', schema }),
     trustedOrigins,
     emailAndPassword: { enabled: true },
-    socialProviders: env.googleOAuth ? { google: env.googleOAuth } : {},
+    socialProviders: env.googleOAuth
+      ? {
+          google: {
+            ...env.googleOAuth,
+            // Better Auth's auto-generated redirect URI is
+            // `${baseURL}/callback/google`. With our stripped origin-only
+            // baseURL that resolves to https://<origin>/callback/google —
+            // wrong on two fronts: it's missing `/api/auth/`, and the path
+            // would hit the sibling qzr-api Worker, not vv-router → API.
+            // Pin the redirect URI to a URL that goes through vv-router and
+            // matches the value provision.sh tells the user to register in
+            // the Google OAuth client.
+            redirectURI: `${env.baseUrl}/api/auth/callback/google`,
+          },
+        }
+      : {},
     account: {
       accountLinking: {
         // Google verifies email addresses — safe to auto-link with the


### PR DESCRIPTION
## Summary

Comprehensive fix from a full URL-handling audit (Better Auth source, qzr-sheet's working setup, our current state end-to-end). Earlier PRs (#38, #39, #40, closed #41) chipped at individual symptoms — this one fixes the underlying mismatches in one shot.

## Bugs caught by the audit

### Web — Bug A: API client double-paths every request

CI sets `VITE_API_BASE=/vv/api`, but every path passed to `api.request()` already starts with `/api/`. So the final URLs in production were `/vv/api/api/cards/...`, `/vv/api/api/me`, etc., 404'ing the entire non-auth API surface. Confirmed by curl:

```
$ curl -o /dev/null -w '%{http_code}' https://www.versevault.ca/vv/api/api/me
404
$ curl -o /dev/null -w '%{http_code}' https://www.versevault.ca/vv/api/me
401   # what the API actually responds to
```

The auth flow happened to work in isolation because Better Auth constructs its own URLs separately.

### Web — Bug B: Better Auth client never appends `/api/auth`

Better Auth's `withPath(url, "/api/auth")` only appends when `checkHasPath(url)` is false — i.e. when the URL has no path component. `/vv` counts as a path, so the auto-append is skipped and route calls landed at `/vv/sign-up/email` (405) instead of `/vv/api/auth/sign-up/email`.

### API — Bug C: `trustedOrigins` and CORS allow-list don't match the browser's `Origin`

Browsers send `Origin` as scheme+host+port only — never a path. But `WEB_BASE_URL=https://www.versevault.ca/vv` (with subpath) was being compared verbatim. Equality always failed. Once the path bugs above were fixed, Better Auth's origin-check would have 403'd every POST.

### API — Bug D: OAuth callback URL routes to the wrong Worker

Better Auth auto-generates `redirectURI = ${baseURL}/callback/${provider}`. With our stripped origin-only `baseURL`, that became `https://www.versevault.ca/callback/google` — missing `/api/auth/`, and worse, the path matches qzr-api's Worker route (`www.versevault.ca/api/*`), not vv-router. OAuth would have silently broken once anyone wired up Google in production.

## Fixes

| Bug | Change |
|---|---|
| A | `VITE_API_BASE: /vv/api` → `/vv` (subpath only). `api.ts` paths add the `/api/` themselves. |
| B | `useAuth.ts` appends `/api/auth` explicitly; absolutizes via `window.location.origin`. |
| C | `trustedOrigins` and Hono CORS in the API both strip the path from `env.webOrigin` via `new URL(...).origin`. |
| D | `socialProviders.google.redirectURI` pinned to `${env.baseUrl}/api/auth/callback/google`, matching what `provision.sh` already tells users to register in the Google OAuth client. |

## Conventions going forward (from the audit's qzr-sheet reference)

- `VITE_API_BASE`: origin-relative subpath prefix WITHOUT `/api`. `/vv` in prod, unset in dev.
- API client paths start with `/api/`. Final URL = `${VITE_API_BASE}/api/...`.
- Better Auth client `baseURL` = `${apiBase}/api/auth` (we add the suffix; `withPath` won't).
- Server's Better Auth `baseURL` = origin only (path stripped from `env.baseUrl`). `webOrigin` likewise stripped for CORS/trustedOrigins.

## Versions

- `@verse-vault/web`: 0.1.5 → 0.1.6
- `@verse-vault/api`: 0.1.5 → 0.1.6
- Algorithm contract unchanged (`core@0.1.0`, `wasm@0.1.0`)

## Test plan

- [ ] Both CI deploys succeed; `web@0.1.6` and `api@0.1.6` tags land
- [ ] `curl https://www.versevault.ca/vv/api/me` → 401 (was 401 before; sanity check)
- [ ] `curl https://www.versevault.ca/vv/api/cards/review/next?materialId=nkjv-cor` → 401 (was 404)
- [ ] `curl https://www.versevault.ca/vv/api/auth/get-session` → 200 `null`
- [ ] Sign-up and sign-in flow works end-to-end in a real browser (incognito to bypass cached state)
- [ ] After sign-in, the SPA's regular API calls (`/api/cards/...`, etc.) succeed