### PR TITLE
fix(api): ship deck data with API bundle

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -98,6 +98,17 @@ jobs:
       - name: Bundle API for deploy
         run: pnpm --filter @verse-vault/api deploy --legacy --prod /tmp/api-bundle
 
+      # Ship the structural deck JSONs alongside the API. `pnpm deploy`
+      # only includes files under the package; the decks live at repo
+      # root in /data/, so copy them in after the bundle is staged.
+      # materials.ts looks under <bundle>/data/ first, then falls back
+      # to <repo>/data/ for local dev.
+      - name: Stage deck data into bundle
+        run: |
+          mkdir -p /tmp/api-bundle/data
+          cp data/[0-9]-*.json /tmp/api-bundle/data/
+          ls -la /tmp/api-bundle/data/
+
       - name: Configure SSH
         env:
           SSH_KEY: ${{ secrets.VPS_SSH_KEY }}

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,24 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.7] — 2026-05-21
+
+### Fixed
+
+* Structural deck JSONs (`data/[0-9]-*.json`) weren't reaching production. `pnpm deploy` only
+  packages files under the API workspace, but the decks live at the repo root, so the bundled
+  `<root>/data/<deck>.json` path resolved to `/opt/data/<deck>.json` on the VPS — a directory that
+  doesn't exist. Auto-enrollment via `POST /api/years/:materialId/settings` then threw
+  `Unknown material: <id>` for every deck without an inline fixture (which is all of them except
+  `nkjv-cor`), surfacing as a 500. Fix is two-part: the deploy workflow now copies the deck JSONs
+  into `<bundle>/data/` after `pnpm deploy`, and `materials.ts` searches the bundle-local dir first
+  with a repo-root fallback so dev keeps working.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.6 (deploy-packaging fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.6 (deploy-packaging fix)
+
 ## [0.1.6] — 2026-05-21
 
 ### Fixed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/lib/materials.ts
+++ b/packages/api/src/lib/materials.ts
@@ -68,20 +68,31 @@ export function getMaterial(id: string): Material | undefined {
   return MATERIALS.find((m) => m.id === id);
 }
 
-/** packages/api/src/lib/materials.ts -> repo root. */
-const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
+/** Candidate directories where structural deck files might live.
+ *  Searched in order — bundle-local first because that's the production
+ *  layout, repo-root second so dev keeps working without a build step.
+ *
+ *  Production (pnpm-deploy bundle): `<bundle>/data/` is populated by
+ *    the deploy workflow (see `.github/workflows/deploy-api.yml`),
+ *    which copies repo `data/[0-9]-*.json` into the bundle after
+ *    `pnpm deploy` flattens it.
+ *  Development: `<repo>/data/` is where the structural decks live in
+ *    git. Resolved relative to `dist/lib/materials.js` so it works
+ *    whether the file is built (`dist/`) or run via tsx from source. */
+const DECK_DIRS: readonly string[] = [
+  resolve(import.meta.dirname, '../..', 'data'),
+  resolve(import.meta.dirname, '../../../..', 'data'),
+];
 
-/** Per-material override: relative path under the repo root for the
- *  structural MaterialData JSON. Missing on disk → inline fallback. */
 const DATA_FILES: Record<string, string> = {
-  'nkjv-gepc': 'data/1-gepc.json',
-  'nkjv-nt': 'data/2-nt-survey.json',
-  'nkjv-cor': 'data/3-corinthians.json',
-  'nkjv-john': 'data/4-john.json',
-  'nkjv-hp': 'data/5-hp.json',
-  'nkjv-ot': 'data/6-ot-survey.json',
-  'nkjv-rj': 'data/7-rj.json',
-  'nkjv-luke': 'data/8-luke.json',
+  'nkjv-gepc': '1-gepc.json',
+  'nkjv-nt': '2-nt-survey.json',
+  'nkjv-cor': '3-corinthians.json',
+  'nkjv-john': '4-john.json',
+  'nkjv-hp': '5-hp.json',
+  'nkjv-ot': '6-ot-survey.json',
+  'nkjv-rj': '7-rj.json',
+  'nkjv-luke': '8-luke.json',
 };
 
 /** Inline structural stand-in MaterialData per id, kept tiny so tests
@@ -115,13 +126,15 @@ export function getMaterialJson(id: string): string {
   const cached = cache.get(id);
   if (cached !== undefined) return cached;
 
-  const rel = DATA_FILES[id];
-  if (rel !== undefined) {
-    const full = resolve(REPO_ROOT, rel);
-    if (existsSync(full)) {
-      const json = readFileSync(full, 'utf8');
-      cache.set(id, json);
-      return json;
+  const filename = DATA_FILES[id];
+  if (filename !== undefined) {
+    for (const dir of DECK_DIRS) {
+      const full = resolve(dir, filename);
+      if (existsSync(full)) {
+        const json = readFileSync(full, 'utf8');
+        cache.set(id, json);
+        return json;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Production `POST /api/years/:materialId/settings` was 500ing for every deck except `nkjv-cor` — confirmed in the browser console:

```
POST https://www.versevault.ca/vv/api/years/nkjv-john/settings [HTTP/2 500]
```

`pnpm deploy --legacy --prod` only packages files under the API workspace, but the structural deck JSONs live at the repo root in `/data/`. In the deployed bundle, `materials.ts`'s `import.meta.dirname` resolves four-up to `/opt/`, so it looked for `/opt/data/4-john.json` (doesn't exist) and fell through to the inline-fixture map — which only covers `nkjv-cor`. `getMaterialJson('nkjv-john')` then throws `Unknown material: nkjv-john`, propagating out of `enrollUser` → the settings handler returns Hono's default plaintext `Internal Server Error` (21 bytes — matches the actual response body length).

Two-part fix:

- **Deploy workflow** copies repo `data/[0-9]-*.json` into `<bundle>/data/` after `pnpm deploy` stages the package, so the API ships self-contained.
- **`materials.ts`** searches `<pkg>/data/` first (where the bundle has them in prod) and falls back to `<repo>/data/` (dev location) so local development keeps working without a build step.

Also bumps `api@0.1.7` and adds a changelog entry.

## Test plan
- [x] `pnpm --filter @verse-vault/api type-check` clean
- [x] `pnpm --filter @verse-vault/api test` baseline confirmed unchanged (same 13 pre-existing failures with and without this change; type-check passes)
- [ ] After merge + deploy, hit `POST /vv/api/years/nkjv-john/settings` from the live SPA — should auto-enrol and return 200 with the new settings.
- [ ] Verify the bundle on the VPS contains `/opt/verse-vault/app/data/4-john.json` (and friends).