### PR TITLE
fix(deploy): append env-var line when missing

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -366,10 +366,16 @@ prompt_secret() {
 
 	# Escape sed-meaningful chars defensively. Typical OAuth + API keys
 	# don't contain these but better safe. Replaces the line whether it's
-	# currently #VAR=, VAR=, or VAR=oldvalue.
+	# currently #VAR=, VAR=, or VAR=oldvalue. Appends when no such line
+	# exists — older env files that pre-date a template addition silently
+	# no-op'd a pure substitution, so the value never actually landed.
 	local esc
 	esc=$(printf '%s' "$value" | sed 's|[&\\|]|\\&|g')
-	sed -i -E "s|^#?${var}=.*|${var}=${esc}|" "$ENV_FILE"
+	if grep -qE "^#?${var}=" "$ENV_FILE"; then
+		sed -i -E "s|^#?${var}=.*|${var}=${esc}|" "$ENV_FILE"
+	else
+		printf '%s=%s\n' "$var" "$value" >> "$ENV_FILE"
+	fi
 	echo "  -> $var written"
 	return 0
 }


### PR DESCRIPTION
## Summary

`provision.sh`'s `prompt_secret` writes new values via sed substitution. That only rewrites a line that already exists — if the env file pre-dates a template addition (or was hand-trimmed), the substitution silently no-ops and the friendly `"-> $var written"` echo lies.

Hit on a real VPS where `/etc/verse-vault.env` was missing the `#BIBLE_API_KEY=` placeholder from the heredoc, so re-running provision.sh prompted for `BIBLE_API_KEY`, accepted a value, and changed nothing on disk. Same gap for `NKJV_BIBLE_ID`, `GOOGLE_CLIENT_ID/SECRET`, `RENDER_DIALECT`.

## Fix

Grep for the line first; if absent, append. The grep accepts the commented form (`#?VAR=`) so the existing substitution path still handles the heredoc-populated case.

## Test plan

- [ ] Manual: cherry-pick onto a test VPS with an env file missing `BIBLE_API_KEY` entirely. Re-run `provision.sh`. Confirm the entered value lands in `/etc/verse-vault.env`.
- [ ] Re-run `provision.sh` against an env file that already has `#BIBLE_API_KEY=` commented out. Confirm the entered value replaces that line (existing behaviour, regression check).
- [ ] Re-run `provision.sh` against an env file that already has `BIBLE_API_KEY=oldvalue`. Confirm Keep/change/remove prompt still fires; choosing "change" updates the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)