### PR TITLE
chore: release api@0.1.8 + web@0.1.7

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,18 +9,53 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.7] — 2026-05-21
+
 ### Added
 
-* **Fat-client engine**: ReviewView, MemorizeView, and MaterialView now drive the WASM engine
-  locally. Each grade runs `engine.replay_event` in-browser and queues an event to IndexedDB; the
-  background flush ships them to `POST /api/sync/:materialId/events` on a 5 s debounce + on tab
+* **Fat-client engine.** ReviewView, MemorizeView, MaterialView, and StatsView now drive the WASM
+  engine locally. Each grade runs `engine.replay_event` in-browser and queues an event to IndexedDB;
+  the background flush ships them to `POST /api/sync/:materialId/events` on a 5 s debounce + on tab
   hide. No more network round-trip per card. Per-card render output caches in IDB (MAUA-compliant
   30-day TTL); the engine sources next-card decisions locally so review feels instant.
 * `verse-vault-wasm-web` workspace package (wasm-pack `--target bundler` output) — same Rust source
   as the API's nodejs target, different JS shim. Vite emits the .wasm asset (~117 KB gzipped) as
   part of the build.
-* `useEngine` composable + `engineStore` module-singleton that own per-material `WasmEngine`
-  instances across navigations. Multi-material capable for MemorizeView's cross-year sessions.
+* `useEngine` composable + `engineStore` module-singleton owning per-material `WasmEngine` instances
+  across navigations. Multi-material capable for MemorizeView's cross-year sessions.
+* `getSyncState` + `postSyncEvents` methods on the API client wrapping the new server endpoints.
+* `MaterialConfig` (newScope, reviewScope, clubCardScope, chapterListScope, headings, ftv) now
+  threads through to the client engine; `MaterialView.onSave` invalidates the cached engine + render
+  cache for the affected material so the next view visit rebuilds with fresh settings.
+
+### Fixed
+
+* `StatsView` no longer hardcodes `MATERIAL_ID = 'nkjv-cor'` — fetches stats per enrolled year via
+  `getYears` and renders one card per year, sorted by total reviews. Single-year failures degrade
+  gracefully via `Promise.allSettled` rather than blanking the whole page.
+* Stale-merge `needsConfirm` responses no longer trigger an unbounded re-POST loop. The
+  `engineStore` module now tracks a per-material `staleGate`; flushes for gated materials no-op
+  until a `confirmMerge: true` flush succeeds or `clearStaleGate(materialId)` is called by the
+  discard path.
+* Render cache skips IDB writes when the server returns `composed: null` (the BIBLE_API_KEY-unset
+  fallback path), so a misconfigured first request can't wedge the cache with empty composed HTML
+  for the full 30-day TTL.
+
+### Build
+
+* `tools/build-wasm-web.sh` runs `wasm-pack build crates/wasm --target bundler --out-dir pkg-web`
+  and renames the output package to `verse-vault-wasm-web` so both bundler + nodejs targets can
+  coexist in the pnpm workspace.
+* `vite-plugin-wasm` + `vite-plugin-top-level-await` handle the bundler-target import; build target
+  bumped to `es2022` to compile the wasm-bindgen TLA shim cleanly.
+* `.github/workflows/deploy-web.yml` installs the Rust toolchain + wasm-pack before `pnpm install`
+  so the workspace `verse-vault-wasm-web` package exists when pnpm resolves the apps/web dependency.
+
+### Documentation
+
+* New top-level `NOTICE.md` carries the NKJV citation in the Starter-plan canonical form + the
+  API.Bible attribution surface. `README.md` gains a "Third-party content" section pointing at it.
+* MAUA URL fixes — see `packages/api/CHANGELOG.md` 0.1.8 for the matching server-side cleanup.
 
 ### Bundled algorithm contract
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,57 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.8] — 2026-05-21
+
+### Added
+
+* **Kinded sync events.** `POST /api/sync/:materialId/events` now accepts a discriminated event
+  union: `{ kind: 'review', cardId, grade }` or `{ kind: 'graduate', verseId }`. Untyped events
+  default to `kind: 'review'` so existing online-review callers keep working unchanged. Graduate
+  events route through `engine.graduate_verse()` + a `graduatedVerses` upsert in the same
+  transaction as the review-event log writes — closes the graduate-while-offline hole the previous
+  thin-client `POST /api/cards/memorize/graduate` route was the only path for.
+* **Out-of-order rebuild.** When a batch arrives with `timestampSecs` earlier than what's already
+  applied for the same card, the server now triggers `EngineStore.rebuildFromEvents`: drops the
+  cached engine, instantiates a fresh one from baseline, applies all graduations, replays every row
+  in `reviewEvents` in `(timestampSecs, clientEventId)` order, and writes the resulting `testStates`
+  back atomically. Response gains a `rebuilt: boolean` field so multi-device clients can replace
+  their local state wholesale instead of merging. Fixes silent FSRS drift for any user with
+  phone+laptop offline review sessions that synced in the "wrong" order.
+* **Stale-merge preflight.** When a batch's oldest event predates more than 10 already-applied
+  server events (`STALE_MERGE_THRESHOLD`), the response is a `{ needsConfirm: true, staleSummary }`
+  envelope instead of an immediate merge. Client re-POSTs with `confirmMerge: true` to proceed.
+  Stops months-old offline reviews from silently dragging FSRS stability down on accounts the user
+  has continued to study elsewhere.
+* **Clock-skew guard.** Events with `timestampSecs > server_now + 24h` are rejected with 400. A
+  device with a broken RTC could otherwise wedge the user's timeline arbitrarily — the rebuild path
+  would replay those events at year-2099 positions.
+
+### Fixed
+
+* Sync POST handler now wraps the `db.transaction` in try/catch and calls
+  `deps.engines.invalidate(key)` on failure. The handler calls `engine.replay_event` /
+  `engine.graduate_verse` BEFORE the transaction, so a SQLite write failure used to leave the cached
+  engine ahead of `reviewEvents` + `graduatedVerses` until process restart. Real impact is small
+  (production SQLite writes rarely throw, and `graduatedVerses` inserts are `onConflictDoNothing`),
+  but the divergence was real and self-healing only across restarts.
+
+### Documentation
+
+* MAUA reference URLs (`docs.api.bible/guides/terms-of-use` → 404) replaced with the canonical
+  `api.bible/terms-and-conditions#acceptable_use` clause across the schema comment, cache class
+  docstring, render.ts header, `docs/persistence.md`, and `tools/README.md`.
+* `EngineStore.rebuildFromEvents` ordering rationale corrected: `replay_event` is
+  lifecycle-agnostic; graduations run first for parity with `EngineStore.load` (which also
+  constructs the engine then applies graduations), not because `replay_event` requires Active state.
+* New `NOTICE.md` carries the NKJV citation in the Starter-plan canonical form, plus the API.Bible
+  attribution surface. `README.md` gains a "Third-party content" section pointing at it.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.7 (sync-protocol additive; no core changes)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.7 (same)
+
 ## [0.1.7] — 2026-05-21
 
 ### Fixed

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Coordinated release for the fat-client + sync-protocol extensions that landed via #46 (`2454237 chore: merge feat/web-fat-client`).

## Bumps

| Package | From | To | Trigger |
|---|---|---|---|
| `@verse-vault/api` | 0.1.7 | 0.1.8 | `.github/workflows/deploy-api.yml` (VPS rsync + restart) |
| `@verse-vault/web` | 0.1.6 | 0.1.7 | `.github/workflows/deploy-web.yml` (Cloudflare Pages) |

Both bumps land in the same PR so the matching contract releases together. Contract crates (`verse-vault-core@0.1.0`, `verse-vault-wasm@0.1.0`) unchanged — additive protocol with backward-compat for untyped events.

## What's shipping

**`@verse-vault/api` 0.1.8** — sync protocol extensions:
- Kinded events (`review` | `graduate`) with legacy-untyped fallback to `review`
- Out-of-order rebuild via `EngineStore.rebuildFromEvents` + `rebuilt: boolean` in response
- Stale-merge preflight with `needsConfirm` envelope when batch predates >10 server events
- Clock-skew guard rejecting events with `timestampSecs > now + 24h`
- Engine invalidate on sync-txn failure
- MAUA URL fixes + new `NOTICE.md`

**`@verse-vault/web` 0.1.7** — fat-client cutover:
- All four engine-consuming views (Review/Memorize/Material/Stats) drive a local `WasmEngine`
- IndexedDB-backed offline queue, lazy render cache, MaterialConfig threading
- Code-review fixes from PR #46: stale-merge flush gate, render-null skip, StatsView `Promise.allSettled`
- Vite + wasm bundler target via `tools/build-wasm-web.sh`

Full per-package details in the changelog entries.

## Test plan

- [ ] `pnpm --filter @verse-vault/api test` — 95/95 passing (verified locally before push).
- [ ] `pnpm --filter @verse-vault/web build` — produces 293 KB wasm asset + 17 KB engineStore chunk.
- [ ] On merge: confirm `deploy-api.yml` and `deploy-web.yml` both fire.
- [ ] Post-deploy: smoke `https://vv-api.versevault.ca/health` returns 200; load `https://www.versevault.ca/vv/`, sign in, exercise review/memorize/material/stats.
- [ ] Post-deploy: confirm `journalctl -u verse-vault` shows clean boot with no missing-env warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)