### PR TITLE
chore: release @verse-vault/api 0.1.9 + ci fix

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -81,11 +81,20 @@ jobs:
       - name: Install wasm-pack
         run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
 
-      - name: Install workspace deps
-        run: pnpm install --frozen-lockfile
-
+      # Build both wasm-pack outputs BEFORE pnpm install — pnpm resolves
+      # the full workspace at install time, and `apps/web` depends on
+      # `verse-vault-wasm-web@workspace:*` (the bundler target). With
+      # pkg-web/ missing, pnpm errors out with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND
+      # even though the API bundle itself only needs the nodejs target.
+      # Cost is two wasm-pack runs (~3 s each); cheap enough to mirror.
       - name: Build WASM (nodejs target)
         run: wasm-pack build crates/wasm --target nodejs --out-dir pkg
+
+      - name: Build WASM (bundler target)
+        run: bash tools/build-wasm-web.sh
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
 
       - name: Build API (tsc)
         run: pnpm --filter @verse-vault/api... build

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,23 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.9] — 2026-05-21
+
+### Fixed
+
+* CI: `deploy-api.yml`'s `pnpm install --frozen-lockfile` failed at the "Bundle API for deploy" step
+  with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` because apps/web (resolved as part of the workspace)
+  depends on `verse-vault-wasm-web@workspace:*`, and the bundler wasm-pack output at
+  `crates/wasm/pkg-web/` is gitignored — not built before install ran. Mirror the deploy-web
+  pattern: build both wasm-pack targets (nodejs + bundler) before `pnpm install`. 0.1.8's deploy
+  never reached the VPS; 0.1.9 is the first successful deploy of the fat-client sync-protocol
+  extensions documented in 0.1.8's entry below.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged from 0.1.8 (CI-only fix)
+* `verse-vault-wasm@0.1.0` — unchanged from 0.1.8 (CI-only fix)
+
 ## [0.1.8] — 2026-05-21
 
 ### Added

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
api@0.1.8 deploy failed at "Bundle API for deploy" ([run 26253041140](https://github.com/TommyAmberson/verse-vault/actions/runs/26253041140)). Root cause: `pnpm install` at workspace root resolves apps/web's `verse-vault-wasm-web@workspace:*` dependency, but the bundler wasm-pack output at the gitignored `crates/wasm/pkg-web/` wasn't built before install ran. pnpm errored with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.

Two commits:

1. **`fbd8e26` fix(ci):** build both wasm-pack targets (nodejs + bundler) BEFORE `pnpm install` in `deploy-api.yml`. Mirrors the deploy-web pattern. ~3 s overhead.

2. **`bcdb3a4` chore: release 0.1.9:** bump `packages/api/package.json` 0.1.8 → 0.1.9 + a thin CHANGELOG entry. Follows the precedent from 0.1.2/0.1.3/0.1.5 (each failed deploy gets a fresh version rather than a `workflow_dispatch` retry against the same number — keeps git tags 1:1 with deploys). 0.1.8's entry stays in the changelog as the historical record of what the bundle was supposed to contain.

Merging this auto-fires the `deploy-api.yml` workflow on master push, no manual dispatch needed.

## Production state

- Web 0.1.7 is live (deploy succeeded; fat-client serving from versevault.ca/vv).
- API 0.1.7 is still running on the VPS (0.1.8 never made it past CI).
- Backward compat holds for review events. Graduate events from MemorizeView will 400 on the old API's validator until 0.1.9 lands.

## Test plan

- [ ] Merge → `deploy-api.yml` fires automatically.
- [ ] Bundle step completes (was the failing step).
- [ ] rsync to VPS + systemd restart + `/health` returns 200.
- [ ] `api@0.1.9` tag gets pushed on success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)