### PR TITLE
feat(web): stale-merge modal + attribution + cleanups + docs

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -181,6 +181,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+          # actions/checkout@v4 doesn't fetch tags; without this,
+          # tag_if_missing's `git rev-parse` only sees tags created in
+          # this run. Existing remote tags (e.g. core@0.1.0 from prior
+          # deploys) look missing → push tries again → remote rejects.
+          # Pull them once so the local check matches reality.
+          git fetch --tags --quiet origin
+
           tag_if_missing() {
             local tag=$1
             local subject=$2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,8 +121,12 @@ dprint check          # formatting for docs (also runs via lint-staged)
 
 Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `style`, `revert`, `perf`, `build`.
 
-Scopes: `core`, `wasm`, `sim`, `api`, `web`, `desktop`, `cli`, `tools`, `docs`. Omit the scope for
-cross-cutting changes (e.g. `chore: bump version to 0.2.0`).
+Scopes: `core`, `wasm`, `sim`, `api`, `web`, `desktop`, `cli`, `tools`, `docs`, `ci`, `deploy`. Each
+corresponds to a top-level workspace member or root-level directory (`crates/<scope>`,
+`packages/<scope>`, `apps/<scope>`, plus `docs/`, `.github/workflows/` → `ci`, `deploy/` →
+`deploy`). Omit the scope for cross-cutting changes (e.g. `chore: bump version to 0.2.0`). Use bare
+`docs:` (no sub-scope) for doc-only edits — sub-scoping by doc-area (`docs(arch)`,
+`docs(server-api)`, etc.) sprawls fast and isn't enforced.
 
 Subject in lowercase, no trailing period, imperative mood ("add X", not "added X"), and **≤ 50
 characters** including the type/scope prefix. Body wrapped at ~72 cols, focuses on the why.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,12 @@ dprint check          # formatting for docs (also runs via lint-staged)
   `chore: merge <branch-name>`. For local merges, set this via `git merge --no-ff -m "..."`. For
   PRs, pass `--subject "chore: merge <branch>"` to `gh pr merge` (or edit before confirming) —
   GitHub's default `Merge pull request #N from …` template doesn't conform.
+* **master is branch-protected.** GitHub blocks merge until: (a) the three required CI checks
+  (`rust`, `typos`, `dprint`) pass on the PR head, and (b) the PR branch is up-to-date with master
+  (forces a refresh-from-master when something else lands between PR open + merge). Net effect: the
+  merge commit's content is always equivalent to a SHA that CI already validated, so the deploy
+  workflows that fire on master push can't race a broken merge. Owner can `--admin` bypass
+  (`gh pr merge <N> --admin --merge ...`) for true hotfixes; do that consciously, not by default.
 
 ### Rewriting history
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,16 @@ Core algorithm and simulation framework in development. See `docs/` for the full
 ```
 crates/
   core/     Rust library — graph, FSRS, credit assignment, scheduling (no I/O)
+  wasm/     wasm-bindgen wrappers; nodejs target for the API, bundler for the web
   sim/      Simulation binary — validates algorithm against synthetic data
-docs/       Design docs — graph model, review algorithm, scheduling, validation
+packages/
+  api/      Hono + Better Auth + Drizzle + better-sqlite3 server (Node 22)
+apps/
+  web/      Vue 3 + Vite SPA running the WASM engine in-browser (fat client)
+data/       Structural deck JSONs (committed) + gitignored content + caches
+deploy/     systemd unit, provision script, vv-router worker, tunnel config
+docs/       Design docs — architecture, memory model, persistence, deployment
+tools/      Python content pipeline + the wasm-pack bundler build script
 ```
 
 ## Build

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,29 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Added
+
+* **Stale-merge confirmation modal.** New `StaleMergeModal.vue` component reads
+  `useEngine().staleSummary` and renders Sync / Discard / Cancel. Rendered as an overlay from
+  ReviewView and MemorizeView when the server flags a batch as stale. The composable surface
+  (`confirmMerge`, `discardStale`) existed in 0.1.7 but no view consumed it; flushes for affected
+  materials silently no-op'd via the `staleGate` until this UI shipped.
+* **MAUA attribution footer.** Site-wide footer in `App.vue` carrying the canonical NKJV citation
+  and a `https://api.bible` link, visible on every route. Required by the API.Bible Starter-plan
+  terms and previously only present in `NOTICE.md` (not surfaced to end users).
+
+### Refactored
+
+* `apps/web/src/lib/engine/persistence.ts` centralises IDB store names in a single `STORE` const +
+  `BY_MATERIAL_ID_INDEX` constant. Inline string literals across the helper functions are typo-prone
+  — TypeScript catches them at the type layer now. No emitted-string change.
+
+### Performance
+
+* `MaterialView.onSave` no longer invalidates the cached engine + render cache when only
+  `lessonBatchSize` (a session-size knob the engine doesn't consume) changed. Previously every
+  settings save wiped a full deck's lazy-cached renders.
+
 ## [0.1.7] — 2026-05-21
 
 ### Added

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -52,6 +52,21 @@ async function onSignOut() {
     <main class="site-main">
       <RouterView />
     </main>
+    <!-- API.Bible Starter-plan attribution: a visible citation +
+         hyperlink to api.bible is required by their terms. The NKJV
+         copyright line is the canonical Thomas Nelson citation
+         (mirrored in NOTICE.md). -->
+    <footer class="site-footer">
+      <p>
+        Scripture quotations marked NKJV are taken from the New King James
+        Version®. Copyright © 1982 by Thomas Nelson. Used by permission.
+        All rights reserved.
+      </p>
+      <p>
+        Scripture text served via
+        <a href="https://api.bible" target="_blank" rel="noopener">API.Bible</a>.
+      </p>
+    </footer>
   </div>
 </template>
 
@@ -135,5 +150,31 @@ async function onSignOut() {
   display: flex;
   justify-content: center;
   padding: 2rem 1rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--color-border);
+  padding: 1rem 1.5rem;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.site-footer p {
+  margin: 0;
+}
+
+.site-footer p + p {
+  margin-top: 0.25rem;
+}
+
+.site-footer a {
+  color: var(--color-muted);
+  text-decoration: underline;
+}
+
+.site-footer a:hover {
+  color: var(--color-text);
 }
 </style>

--- a/apps/web/src/components/StaleMergeModal.vue
+++ b/apps/web/src/components/StaleMergeModal.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import type { StaleSummary } from '@/composables/useEngine'
+
+const props = defineProps<{
+  summary: StaleSummary
+  /** Disables both action buttons while a confirm/discard call is in
+   *  flight, so the user can't double-tap. */
+  busy?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'confirm'): void
+  (e: 'discard'): void
+  (e: 'cancel'): void
+}>()
+
+const oldestDate = computed(() =>
+  new Date(props.summary.oldestQueuedTs * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }),
+)
+</script>
+
+<template>
+  <div class="overlay" role="dialog" aria-modal="true" aria-labelledby="stale-title">
+    <div class="modal">
+      <h2 id="stale-title">Sync offline reviews from {{ oldestDate }}?</h2>
+      <p>
+        You have <strong>{{ summary.queuedCount }}</strong> offline
+        review{{ summary.queuedCount === 1 ? '' : 's' }} queued from before
+        <strong>{{ summary.serverEventsSince }}</strong> server-side
+        review{{ summary.serverEventsSince === 1 ? '' : 's' }}. Merging will
+        rebuild this deck's card history to include them. Discarding throws
+        them away.
+      </p>
+      <div class="actions">
+        <button
+          type="button"
+          class="btn discard"
+          :disabled="busy"
+          @click="emit('discard')"
+        >
+          Discard
+        </button>
+        <button
+          type="button"
+          class="btn cancel"
+          :disabled="busy"
+          @click="emit('cancel')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="btn sync"
+          :disabled="busy"
+          @click="emit('confirm')"
+        >
+          Sync
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 480px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.modal p {
+  margin: 0;
+  color: var(--color-muted);
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.discard {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+
+.cancel {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-muted);
+}
+
+.sync {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+</style>

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -227,6 +227,16 @@ export function useEngine() {
     }
   }
 
+  /** Dismiss the stale-merge prompt without acting on it. Clears the
+   *  gate so the next flush re-surfaces the modal rather than
+   *  silently no-op'ing. */
+  function cancelStale() {
+    const stale = staleSummary.value
+    if (!stale) return
+    engineStore.clearStaleGate(stale.materialId)
+    staleSummary.value = null
+  }
+
   /** Drop the queued events the server flagged stale on the affected
    *  material. The user explicitly chose to throw them away. */
   async function discardStale() {
@@ -262,6 +272,7 @@ export function useEngine() {
     flush: flushAll,
     confirmMerge,
     discardStale,
+    cancelStale,
   }
 }
 

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -38,6 +38,20 @@ const DB_VERSION = 1
  *  `CACHE_TTL_SECS` in `packages/api/src/lib/apibible-cache.ts`. */
 export const RENDER_TTL_SECS = 30 * 24 * 60 * 60
 
+/** Object-store names + the shared `byMaterialId` index name in one
+ *  place. Inline string literals across the helper functions are
+ *  typo-prone; centralising lets TypeScript catch typos and lets a
+ *  grep for a store name find every site. */
+const STORE = {
+  Snapshots: 'snapshots',
+  TestStates: 'testStates',
+  EventQueue: 'eventQueue',
+  EventQueueOrphans: 'eventQueueOrphans',
+  Renders: 'renders',
+} as const
+
+const BY_MATERIAL_ID_INDEX = 'byMaterialId'
+
 let dbPromise: Promise<IDBDatabase> | null = null
 
 /** Open (or cache) the singleton DB. Subsequent calls return the same
@@ -48,30 +62,30 @@ export function openDb(): Promise<IDBDatabase> {
     const req = indexedDB.open(DB_NAME, DB_VERSION)
     req.onupgradeneeded = () => {
       const db = req.result
-      if (!db.objectStoreNames.contains('snapshots')) {
-        db.createObjectStore('snapshots', { keyPath: 'materialId' })
+      if (!db.objectStoreNames.contains(STORE.Snapshots)) {
+        db.createObjectStore(STORE.Snapshots, { keyPath: 'materialId' })
       }
-      if (!db.objectStoreNames.contains('testStates')) {
-        const s = db.createObjectStore('testStates', {
+      if (!db.objectStoreNames.contains(STORE.TestStates)) {
+        const s = db.createObjectStore(STORE.TestStates, {
           keyPath: ['materialId', 'compositeKey'],
         })
-        s.createIndex('byMaterialId', 'materialId', { unique: false })
+        s.createIndex(BY_MATERIAL_ID_INDEX, 'materialId', { unique: false })
       }
-      if (!db.objectStoreNames.contains('eventQueue')) {
-        const s = db.createObjectStore('eventQueue', { keyPath: 'clientEventId' })
-        s.createIndex('byMaterialId', 'materialId', { unique: false })
+      if (!db.objectStoreNames.contains(STORE.EventQueue)) {
+        const s = db.createObjectStore(STORE.EventQueue, { keyPath: 'clientEventId' })
+        s.createIndex(BY_MATERIAL_ID_INDEX, 'materialId', { unique: false })
       }
-      if (!db.objectStoreNames.contains('eventQueueOrphans')) {
-        const s = db.createObjectStore('eventQueueOrphans', {
+      if (!db.objectStoreNames.contains(STORE.EventQueueOrphans)) {
+        const s = db.createObjectStore(STORE.EventQueueOrphans, {
           keyPath: 'clientEventId',
         })
-        s.createIndex('byMaterialId', 'materialId', { unique: false })
+        s.createIndex(BY_MATERIAL_ID_INDEX, 'materialId', { unique: false })
       }
-      if (!db.objectStoreNames.contains('renders')) {
-        const s = db.createObjectStore('renders', {
+      if (!db.objectStoreNames.contains(STORE.Renders)) {
+        const s = db.createObjectStore(STORE.Renders, {
           keyPath: ['materialId', 'cardId'],
         })
-        s.createIndex('byMaterialId', 'materialId', { unique: false })
+        s.createIndex(BY_MATERIAL_ID_INDEX, 'materialId', { unique: false })
       }
     }
     req.onsuccess = () => resolve(req.result)
@@ -100,14 +114,14 @@ export interface SnapshotRow {
 export async function getSnapshot(materialId: string): Promise<SnapshotRow | undefined> {
   const db = await openDb()
   return promiseRequest<SnapshotRow | undefined>(
-    db.transaction('snapshots', 'readonly').objectStore('snapshots').get(materialId),
+    db.transaction(STORE.Snapshots, 'readonly').objectStore(STORE.Snapshots).get(materialId),
   )
 }
 
 export async function putSnapshot(row: SnapshotRow): Promise<void> {
   const db = await openDb()
   await promiseRequest(
-    db.transaction('snapshots', 'readwrite').objectStore('snapshots').put(row),
+    db.transaction(STORE.Snapshots, 'readwrite').objectStore(STORE.Snapshots).put(row),
   )
 }
 
@@ -127,9 +141,9 @@ interface TestStateRow {
 
 export async function getAllTestStates(materialId: string): Promise<TestStateEntry[]> {
   const db = await openDb()
-  const tx = db.transaction('testStates', 'readonly')
-  const store = tx.objectStore('testStates')
-  const idx = store.index('byMaterialId')
+  const tx = db.transaction(STORE.TestStates, 'readonly')
+  const store = tx.objectStore(STORE.TestStates)
+  const idx = store.index(BY_MATERIAL_ID_INDEX)
   return promiseRequest<TestStateRow[]>(idx.getAll(materialId)).then((rows) =>
     rows.map((r) => r.entry),
   )
@@ -143,9 +157,9 @@ export async function replaceAllTestStates(
   entries: TestStateEntry[],
 ): Promise<void> {
   const db = await openDb()
-  const tx = db.transaction('testStates', 'readwrite')
-  const store = tx.objectStore('testStates')
-  const idx = store.index('byMaterialId')
+  const tx = db.transaction(STORE.TestStates, 'readwrite')
+  const store = tx.objectStore(STORE.TestStates)
+  const idx = store.index(BY_MATERIAL_ID_INDEX)
   // Delete existing rows for this material first. getAllKeys is faster
   // than fetching the full rows when we only need to delete.
   const existingKeys = await promiseRequest<IDBValidKey[]>(idx.getAllKeys(materialId))
@@ -168,14 +182,14 @@ export type QueuedEvent = SyncEventUpload & { materialId: string }
 export async function appendQueuedEvent(event: QueuedEvent): Promise<void> {
   const db = await openDb()
   await promiseRequest(
-    db.transaction('eventQueue', 'readwrite').objectStore('eventQueue').put(event),
+    db.transaction(STORE.EventQueue, 'readwrite').objectStore(STORE.EventQueue).put(event),
   )
 }
 
 export async function getQueuedEvents(materialId: string): Promise<QueuedEvent[]> {
   const db = await openDb()
-  const tx = db.transaction('eventQueue', 'readonly')
-  const idx = tx.objectStore('eventQueue').index('byMaterialId')
+  const tx = db.transaction(STORE.EventQueue, 'readonly')
+  const idx = tx.objectStore(STORE.EventQueue).index(BY_MATERIAL_ID_INDEX)
   return promiseRequest<QueuedEvent[]>(idx.getAll(materialId))
 }
 
@@ -183,8 +197,8 @@ export async function getQueuedEvents(materialId: string): Promise<QueuedEvent[]
  *  against the index directly. Hot path: refreshCounts after every grade. */
 export async function countQueuedEvents(materialId: string): Promise<number> {
   const db = await openDb()
-  const tx = db.transaction('eventQueue', 'readonly')
-  const idx = tx.objectStore('eventQueue').index('byMaterialId')
+  const tx = db.transaction(STORE.EventQueue, 'readonly')
+  const idx = tx.objectStore(STORE.EventQueue).index(BY_MATERIAL_ID_INDEX)
   return promiseRequest<number>(idx.count(IDBKeyRange.only(materialId)))
 }
 
@@ -194,8 +208,8 @@ export async function countQueuedEvents(materialId: string): Promise<number> {
 export async function deleteQueuedEvents(clientEventIds: string[]): Promise<void> {
   if (clientEventIds.length === 0) return
   const db = await openDb()
-  const tx = db.transaction('eventQueue', 'readwrite')
-  const store = tx.objectStore('eventQueue')
+  const tx = db.transaction(STORE.EventQueue, 'readwrite')
+  const store = tx.objectStore(STORE.EventQueue)
   for (const id of clientEventIds) store.delete(id)
   await transactionComplete(tx)
 }
@@ -205,9 +219,9 @@ export async function deleteQueuedEvents(clientEventIds: string[]): Promise<void
 export async function moveToOrphans(events: QueuedEvent[]): Promise<void> {
   if (events.length === 0) return
   const db = await openDb()
-  const tx = db.transaction(['eventQueue', 'eventQueueOrphans'], 'readwrite')
-  const queue = tx.objectStore('eventQueue')
-  const orphans = tx.objectStore('eventQueueOrphans')
+  const tx = db.transaction([STORE.EventQueue, STORE.EventQueueOrphans], 'readwrite')
+  const queue = tx.objectStore(STORE.EventQueue)
+  const orphans = tx.objectStore(STORE.EventQueueOrphans)
   for (const e of events) {
     queue.delete(e.clientEventId)
     orphans.put(e)
@@ -217,8 +231,8 @@ export async function moveToOrphans(events: QueuedEvent[]): Promise<void> {
 
 export async function getOrphans(materialId: string): Promise<QueuedEvent[]> {
   const db = await openDb()
-  const tx = db.transaction('eventQueueOrphans', 'readonly')
-  const idx = tx.objectStore('eventQueueOrphans').index('byMaterialId')
+  const tx = db.transaction(STORE.EventQueueOrphans, 'readonly')
+  const idx = tx.objectStore(STORE.EventQueueOrphans).index(BY_MATERIAL_ID_INDEX)
   return promiseRequest<QueuedEvent[]>(idx.getAll(materialId))
 }
 
@@ -226,8 +240,8 @@ export async function getOrphans(materialId: string): Promise<QueuedEvent[]> {
  *  refreshCounts reactive surface. */
 export async function countOrphans(materialId: string): Promise<number> {
   const db = await openDb()
-  const tx = db.transaction('eventQueueOrphans', 'readonly')
-  const idx = tx.objectStore('eventQueueOrphans').index('byMaterialId')
+  const tx = db.transaction(STORE.EventQueueOrphans, 'readonly')
+  const idx = tx.objectStore(STORE.EventQueueOrphans).index(BY_MATERIAL_ID_INDEX)
   return promiseRequest<number>(idx.count(IDBKeyRange.only(materialId)))
 }
 
@@ -248,7 +262,7 @@ export async function getRender(
 ): Promise<RenderRow | undefined> {
   const db = await openDb()
   const row = await promiseRequest<RenderRow | undefined>(
-    db.transaction('renders', 'readonly').objectStore('renders').get([materialId, cardId]),
+    db.transaction(STORE.Renders, 'readonly').objectStore(STORE.Renders).get([materialId, cardId]),
   )
   if (!row) return undefined
   // TTL-on-read: treat anything past 30d as a miss so callers refresh.
@@ -259,7 +273,7 @@ export async function getRender(
 export async function putRender(row: RenderRow): Promise<void> {
   const db = await openDb()
   await promiseRequest(
-    db.transaction('renders', 'readwrite').objectStore('renders').put(row),
+    db.transaction(STORE.Renders, 'readwrite').objectStore(STORE.Renders).put(row),
   )
 }
 
@@ -268,9 +282,9 @@ export async function putRender(row: RenderRow): Promise<void> {
  *  changes underneath. */
 export async function clearRenders(materialId: string): Promise<void> {
   const db = await openDb()
-  const tx = db.transaction('renders', 'readwrite')
-  const store = tx.objectStore('renders')
-  const idx = store.index('byMaterialId')
+  const tx = db.transaction(STORE.Renders, 'readwrite')
+  const store = tx.objectStore(STORE.Renders)
+  const idx = store.index(BY_MATERIAL_ID_INDEX)
   const keys = await promiseRequest<IDBValidKey[]>(idx.getAllKeys(materialId))
   for (const k of keys) store.delete(k)
   await transactionComplete(tx)

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -144,15 +144,38 @@ function reviewBehindNew(s: YearSettings): boolean {
   return TIER_SCOPE_RANK[s.reviewScope] < TIER_SCOPE_RANK[s.newScope]
 }
 
+/** Settings that drive the WASM engine's MaterialConfig — change to
+ *  any of these means the engine + render cache must be rebuilt.
+ *  `lessonBatchSize` is intentionally excluded: it's a session-size
+ *  knob the engine doesn't consume, so flipping it shouldn't wipe a
+ *  full deck's render cache. */
+const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
+  'headings',
+  'ftv',
+  'newScope',
+  'reviewScope',
+  'clubCardScope',
+  'chapterListScope',
+]
+
+function affectsEngine(draft: YearSettings, current: YearSettings): boolean {
+  return ENGINE_AFFECTING_SETTINGS.some((k) => draft[k] !== current[k])
+}
+
 async function onSave(card: YearCard) {
   card.saving = true
   try {
+    const shouldInvalidate = affectsEngine(card.draft, card.view.settings)
     await api.updateYearSettings(card.view.materialId, card.draft)
-    // invalidateSession drops the cached engine AND the render cache,
-    // so the next ReviewView/MemorizeView visit rebuilds with the new
-    // MaterialConfig (and re-fetches renders that may reflect new card
-    // visibility under the changed scope toggles).
-    await invalidateSession(card.view.materialId)
+    if (shouldInvalidate) {
+      // invalidateSession drops the cached engine AND the render cache,
+      // so the next ReviewView/MemorizeView visit rebuilds with the new
+      // MaterialConfig (and re-fetches renders that may reflect new card
+      // visibility under the changed scope toggles). Skip when only
+      // session-size knobs (lessonBatchSize) changed — those don't move
+      // the engine state.
+      await invalidateSession(card.view.materialId)
+    }
     await refresh()
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref } from 'vue'
 
 import { type CardRender, type MemorizeSessionVerse, api } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
+import StaleMergeModal from '@/components/StaleMergeModal.vue'
 import { useEngine } from '@/composables/useEngine'
 import { buildMaterialConfig } from '@/lib/engine/types'
 
@@ -313,6 +314,15 @@ onMounted(async () => {
         </div>
       </div>
     </div>
+
+    <StaleMergeModal
+      v-if="engine.staleSummary.value"
+      :summary="engine.staleSummary.value"
+      :busy="engine.syncing.value"
+      @confirm="engine.confirmMerge"
+      @discard="engine.discardStale"
+      @cancel="engine.staleSummary.value = null"
+    />
   </div>
 </template>
 

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -321,7 +321,7 @@ onMounted(async () => {
       :busy="engine.syncing.value"
       @confirm="engine.confirmMerge"
       @discard="engine.discardStale"
-      @cancel="engine.staleSummary.value = null"
+      @cancel="engine.cancelStale"
     />
   </div>
 </template>

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -153,7 +153,7 @@ onMounted(async () => {
       :busy="engine.syncing.value"
       @confirm="engine.confirmMerge"
       @discard="engine.discardStale"
-      @cancel="engine.staleSummary.value = null"
+      @cancel="engine.cancelStale"
     />
   </div>
 </template>

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -7,6 +7,7 @@ import {
   api,
 } from '@/api'
 import CardPrompt from '@/components/CardPrompt.vue'
+import StaleMergeModal from '@/components/StaleMergeModal.vue'
 import { useEngine } from '@/composables/useEngine'
 import { buildMaterialConfig } from '@/lib/engine/types'
 
@@ -145,6 +146,15 @@ onMounted(async () => {
         </div>
       </div>
     </div>
+
+    <StaleMergeModal
+      v-if="engine.staleSummary.value"
+      :summary="engine.staleSummary.value"
+      :busy="engine.syncing.value"
+      @confirm="engine.confirmMerge"
+      @discard="engine.discardStale"
+      @cancel="engine.staleSummary.value = null"
+    />
   </div>
 </template>
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,7 +12,19 @@ export default {
     'scope-enum': [
       1,
       'always',
-      ['core', 'wasm', 'sim', 'api', 'web', 'desktop', 'cli', 'tools', 'docs'],
+      [
+        'core',
+        'wasm',
+        'sim',
+        'api',
+        'web',
+        'desktop',
+        'cli',
+        'tools',
+        'docs',
+        'ci',
+        'deploy',
+      ],
     ],
   },
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,8 +23,10 @@ verse-vault is structured as:
 * **Server (`packages/api/`)** — Hono + Better Auth + Drizzle + better-sqlite3. Hosts the engine,
   handles persistence, auth, and multi-user state. Five route groups under `/api/`: `cards`, `sync`,
   `materials`, `years`, `stats`.
-* **Web client (`apps/web/`)** — Vue 3 + Vite SPA. Currently a thin client (no local WASM); the Vue
-  app + the server engine round-trip every grade.
+* **Web client (`apps/web/`)** — Vue 3 + Vite SPA running the WASM engine in-browser. Each grade
+  replays locally; an IndexedDB-backed event queue ships batches to `/api/sync/*` on a 5 s
+  debounce + on tab hide. Ships as a fat client today; the thin `/api/cards/*` surface is kept for
+  tests + transitional callers.
 * **Desktop / CLI** — planned, not yet started.
 
 The core is the single source of truth for memory modeling. Every platform (server, browser,
@@ -33,25 +35,25 @@ desktop) runs the same compiled Rust.
 ## Data flow
 
 ```
-┌──────────────┐                    ┌──────────────────┐
-│  Vue web SPA │  HTTP (auth/api)   │  TypeScript API  │
-│  (thin)      │ ─────────────────► │  Hono + Better   │
-│              │                    │  Auth + Drizzle  │
-└──────────────┘                    └────────┬─────────┘
-   (future fat-client: same WASM             │
-    module loaded in browser)                ▼
-                                ┌──────────────────────────────────┐
-                                │    verse-vault-wasm (nodejs)     │
-                                │  WasmEngine: load → next_card    │
-                                │            → replay_event        │
-                                │            → export_test_states  │
-                                └──────────────┬───────────────────┘
-                                               │ (pure Rust)
-                                               ▼
-                                ┌──────────────────────────────────┐
-                                │     verse-vault-core (crates)    │
-                                │  TestState, ReviewEngine, …      │
-                                └──────────────────────────────────┘
+┌────────────────────────────┐  HTTP (auth/sync)   ┌──────────────────┐
+│  Vue web SPA               │ ──────────────────► │  TypeScript API  │
+│  + verse-vault-wasm-web    │                     │  Hono + Better   │
+│    (WasmEngine in-browser) │                     │  Auth + Drizzle  │
+│  + IndexedDB queue/cache   │                     └────────┬─────────┘
+└────────────────────────────┘                              │
+   (Tauri shell: same Vue + WASM bundle)                    ▼
+                                          ┌──────────────────────────────────┐
+                                          │    verse-vault-wasm (nodejs)     │
+                                          │  WasmEngine: load → next_card    │
+                                          │            → replay_event        │
+                                          │            → export_test_states  │
+                                          └──────────────┬───────────────────┘
+                                                         │ (pure Rust)
+                                                         ▼
+                                          ┌──────────────────────────────────┐
+                                          │     verse-vault-core (crates)    │
+                                          │  TestState, ReviewEngine, …      │
+                                          └──────────────────────────────────┘
 ```
 
 ## Client modes
@@ -59,17 +61,18 @@ desktop) runs the same compiled Rust.
 The server exposes two parallel route surfaces over the same engine + event log; both paths go
 through the same per-(user, material) lock and share the `review_events` audit trail.
 
-* **Thin client** (`/api/cards/*`): UI asks the server for the next card and submits one grade at a
-  time. Server runs the WASM engine, holds state in memory, persists to SQLite. _Implemented and
-  driving the Vue web app today._
 * **Fat client** (`/api/sync/*`): UI downloads the latest snapshot + test states from `/state`, runs
-  the WASM engine locally for offline reviews, uploads batched events to `/events` on reconnect
-  (with a `snapshotVersion` gate + `clientEventId` dedup). _Server-side endpoints are implemented;
-  no client uses them yet — needs the WASM crate built with `--target web`, an IndexedDB-backed
-  engine wrapper, and offline plumbing in the Vue app._
+  the WASM engine locally, queues grades + graduations in IndexedDB, and POSTs batches to `/events`
+  (with a `snapshotVersion` gate + `clientEventId` dedup). _Drives the Vue web app today._
+  Out-of-order arrivals trigger a full-log rebuild via `EngineStore.rebuildFromEvents`; batches
+  older than `STALE_MERGE_THRESHOLD` recent server events return a `needsConfirm` envelope so the
+  user can review before merging.
+* **Thin client** (`/api/cards/*`): legacy per-grade round-trip surface. UI asks the server for the
+  next card and submits one grade at a time. _Kept for tests + ad-hoc tooling; no view uses it now._
 
 Both modes use the same compiled core. The server's event log is the source of truth; a client that
-goes offline and submits events later has its events merged by timestamp and the state recomputed.
+goes offline and submits events later has its events merged by timestamp (or replayed from baseline
+when ordering drifts) and the state recomputed.
 
 ## Why a TypeScript server?
 

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -8,11 +8,10 @@ All `/api/*` routes except `/api/auth/*` require a valid Better Auth session coo
 
 Two parallel route surfaces sit on top of the same engine + event log:
 
-* **Thin client** (`/api/cards/*`) — server picks the next card, server replays the grade. The Vue
-  web app drives this path today.
 * **Fat client** (`/api/sync/*`) — server returns the snapshot + test states; the client runs the
-  engine locally and uploads batched events on reconnect. Server-side routes exist; no client
-  consumes them yet.
+  engine locally and uploads batched events on reconnect. _Drives the Vue web app today._
+* **Thin client** (`/api/cards/*`) — server picks the next card, server replays the grade. _Legacy;
+  kept for tests + ad-hoc tooling. No view consumes it now._
 
 Both paths go through the same `EngineStore.withLock(key, …)` serialisation per `(user, material)`
 and write to the same `review_events` table with `clientEventId` dedup. See
@@ -179,35 +178,92 @@ Request:
 {
   "events": [
     {
+      "kind": "review",
       "clientEventId": "...uuid...",
       "timestampSecs": 1747600000,
       "snapshotVersion": 3,
       "cardId": 42,
       "grade": 3
+    },
+    {
+      "kind": "graduate",
+      "clientEventId": "...uuid...",
+      "timestampSecs": 1747600005,
+      "snapshotVersion": 3,
+      "verseId": 17
     }
-  ]
+  ],
+  "confirmMerge": false
 }
 ```
 
-Response:
+Event kinds:
+
+* `review` — replays through `engine.replay_event(cardId, grade, …)`. Required fields: `cardId`,
+  `grade` (1=Again, 2=Hard, 3=Good, 4=Easy).
+* `graduate` — calls `engine.graduate_verse(verseId)` and upserts a `graduated_verses` row in the
+  same transaction. Required field: `verseId`.
+* Events without a `kind` field default to `review` for backward compatibility with the original
+  thin-client wire shape.
+
+`confirmMerge: true` bypasses the stale-merge preflight (see below). Defaults to `false`.
+
+Validation rejects (400) with these conditions:
+
+* `timestampSecs > server_now + 24h` (clock-skew guard — a broken device RTC could otherwise insert
+  events at arbitrary positions in the timeline).
+* `clientEventId` missing/empty, `snapshotVersion < 1`, `cardId < 0`, `grade ∉ {1,2,3,4}`,
+  `verseId < 0`, or an unknown `kind`.
+
+Response — normal merge:
 
 ```json
 {
   "accepted": 12,
   "duplicates": 0,
+  "rebuilt": false,
   "testStates": [ /* TestStateEntry[] — full set after replay */ ],
   "lastEventId": "01HXX..."
 }
 ```
 
+Response — stale-merge preflight (when the batch's oldest event predates more than
+`STALE_MERGE_THRESHOLD` already-applied server events and `confirmMerge !== true`):
+
+```json
+{
+  "needsConfirm": true,
+  "staleSummary": {
+    "queuedCount": 50,
+    "serverEventsSince": 3000,
+    "oldestQueuedTs": 1700000000,
+    "newestServerTs": 1747600000
+  }
+}
+```
+
+No events are applied in the preflight response. The client surfaces a confirmation prompt and
+re-POSTs the same batch with `confirmMerge: true` to proceed, or discards locally.
+
 Side effects (atomic, one transaction):
 
 * Appends accepted events to `review_events`.
-* Upserts touched rows in `test_states` (filtered to the keys the engine reported as changed).
+* For `graduate` events: upserts `graduated_verses` rows (`onConflictDoNothing`).
+* Upserts touched rows in `test_states`.
+* On out-of-order arrival (an incoming review's `timestampSecs` is earlier than any already applied
+  for the same `card_id`): drops the cached engine, replays the full `review_events` log in
+  `(timestamp_secs, client_event_id)` order through a fresh engine, writes the resulting
+  `test_states` back wholesale, and returns `rebuilt: true`. The client treats this as a wholesale
+  state replacement rather than a merge.
+* If the transaction itself throws, the cached engine is invalidated so the next request rebuilds
+  from disk state (the handler calls `engine.replay_event` / `engine.graduate_verse` before the
+  transaction, so the in-memory engine would otherwise diverge from `review_events` +
+  `graduated_verses` until process restart).
 
 Snapshot-version mismatch returns 409 — the client must re-fetch `/state` and rebuild its local
 engine before retrying. A duplicate `clientEventId` is silently dropped (counted under
-`duplicates`); the rest of the batch still applies.
+`duplicates`); the rest of the batch still applies. Graduate events whose `engine.graduate_verse()`
+returned 0 (the verse was already Active before this batch) are counted as duplicates too.
 
 ## Materials — `/api/materials/*`
 

--- a/docs/wasm-api.md
+++ b/docs/wasm-api.md
@@ -10,11 +10,23 @@ wire shapes a JS caller sees.
 
 ## Building
 
+Two targets ship from the same Rust source:
+
 ```
+# Server (Node 22). Consumed by `@verse-vault/api` as the
+# `verse-vault-wasm` workspace package.
 wasm-pack build crates/wasm --target nodejs --out-dir pkg
+
+# Browser bundle. Consumed by `apps/web` via `vite-plugin-wasm`
+# as the `verse-vault-wasm-web` workspace package; the wrapper
+# script renames the generated package.json so both outputs can
+# coexist in pnpm-workspace.yaml.
+bash tools/build-wasm-web.sh    # wasm-pack build --target bundler --out-dir pkg-web
 ```
 
-For the browser: `--target web`.
+`--target web` was the original plan for the browser side but `--target bundler` is what we actually
+ship — Vite handles the init / .wasm-asset wiring through `vite-plugin-wasm`, so the `bundler` shape
+integrates cleaner than the standalone `web` target's manual `init()` call would.
 
 The crate is also a plain `rlib`, so `cargo test -p verse-vault-wasm` runs the wire-format unit
 tests and the `roundtrip` integration smoke without needing `wasm-pack`.

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,15 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### Fixed
+
+* CI: `deploy-api.yml`'s "Tag release" step did `git rev-parse "$tag"` against the local clone to
+  decide whether to push. `actions/checkout@v4` doesn't fetch tags by default, so existing remote
+  tags (e.g. `core@0.1.0` from prior deploys) looked missing — the step tried to push them and the
+  remote rejected as duplicates, even though the deploy itself succeeded. Added
+  `git fetch --tags --quiet origin` at the top of the step. Cosmetic in 0.1.9 (the deploy was fine;
+  only the tag step went red); prevents the false-red on every future deploy.
+
 ## [0.1.9] — 2026-05-21
 
 ### Fixed


### PR DESCRIPTION
Eleven atomic commits covering everything that ended up in the post-#46/#47 wake — code, docs, and CI hygiene.

## Code

- **`5aecb86` feat(web): stale-merge modal + footer attribution**
  - New `StaleMergeModal.vue` reads `useEngine().staleSummary` and renders Sync/Discard/Cancel. Wired into ReviewView + MemorizeView. The composable methods (`confirmMerge`, `discardStale`) already existed; this gives the user a way to call them.
  - MAUA Starter-plan attribution footer in `App.vue` — canonical NKJV citation + api.bible link, visible on every route.

- **`576a3d6` perf(web): skip invalidate on batch-size change**
  MaterialView's `onSave` called `invalidateSession` unconditionally, wiping a deck's lazy-cached renders even when only `lessonBatchSize` (a session-size knob the engine doesn't consume) changed. Compare against an explicit list of engine-affecting keys; invalidate only when one moves.

- **`3d3d5f0` refactor(web): name IDB stores via constants**
  Five store names + the `byMaterialId` index were inlined 4-6 times each in `persistence.ts`. Centralised into `STORE` + `BY_MATERIAL_ID_INDEX` so TypeScript catches typos.

## CI

- **`6a0ca54` fix(ci): fetch tags before tag_if_missing check**
  api@0.1.9 deploy ([run 26254018559](https://github.com/TommyAmberson/verse-vault/actions/runs/26254018559)) succeeded on the VPS but the workflow showed red — `tag_if_missing` did `git rev-parse` against the local clone, which lacks remote tags after `actions/checkout@v4`. Added `git fetch --tags --quiet origin` once at the top of the step.

## Docs

- **`e71c519` docs(web): note in-flight follow-ups in CHANGELOG** — populates apps/web's `[Unreleased]` section (it was emptied when 0.1.7 cut).
- **`4b9f9ee` docs(api): note tag-step CI fix under [Unreleased]** — same for packages/api.
- **`75da5e2` docs(arch): reflect fat-client landed** — `docs/architecture.md`'s "Web client" / "Client modes" / data-flow diagram were all written when the fat client was still planned. Updated to describe what shipped.
- **`a5bdd2b` docs(readme): expand workspace structure** — README's tree listed only `crates/core`, `crates/sim`, `docs/`. Added `crates/wasm`, `packages/api/`, `apps/web/`, `deploy/`, `tools/`.
- **`74d6df4` docs(server-api): refresh /sync/events contract** — kinded events, `confirmMerge`, `rebuilt`, `needsConfirm`, clock-skew guard, txn-failure invalidate. Plus the "Thin vs. fat" overview was flipped (fat is what ships today, thin is legacy).
- **`ad3367f` docs(wasm-api): document bundler target** — said "for the browser: `--target web`" but we actually ship `--target bundler` via `tools/build-wasm-web.sh`.
- **`d0b644e` docs: note master branch protection** — CLAUDE.md merge section now mentions the required-checks + up-to-date-branch enforcement and the `--admin` bypass.

## Test plan

- [x] `pnpm --filter @verse-vault/web build` passes locally.
- [x] `pnpm --filter @verse-vault/api test` 95/95 passes.
- [ ] Next API deploy: confirm "Tag release" step completes cleanly.
- [ ] Manual: load any route, confirm NKJV footer + api.bible link are visible.
- [ ] Manual: change only `lessonBatchSize` in MaterialView; confirm IDB `renders` for that material is unchanged.
- [ ] Manual: seed a stale-merge scenario; confirm modal renders + Sync/Discard/Cancel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)