### PR TITLE
fix(web): align tauri devUrl with vite port

### DIFF
--- a/apps/web/src-tauri/tauri.conf.json
+++ b/apps/web/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "ca.versevault.app",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:5173",
+    "devUrl": "http://localhost:5180",
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build"
   },

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
     // WebAssembly streaming compilation already meets this anyway.
     target: 'es2022',
   },
+  // 5180 keeps verse-vault clear of qzr-sheet (which runs Vite on
+  // 5173 / 5174 without strictPort). Must match src-tauri/tauri.conf.json
+  // `devUrl`. strictPort: true so Vite errors loudly if the port is
+  // taken rather than drifting onto one Tauri can't find.
   server: { port: 5180, strictPort: true },
   resolve: {
     alias: {


### PR DESCRIPTION
Single-commit fix surfaced when smoke-testing PR #52's Tauri shell locally.

`apps/web/vite.config.ts` was set to port 5180 (verse-vault's established dev port, clear of
qzr-sheet which runs on 5173 / 5174 without `strictPort`). But `apps/web/src-tauri/tauri.conf.json`
was created with `devUrl: http://localhost:5173` — copied from qzr-sheet's scaffold without
adjusting for verse-vault's port choice.

Result: even when Vite started cleanly on 5180, Tauri couldn't connect to its expected 5173 dev
URL and the desktop window stayed blank. The 5180-busy error surfaced this because Vite errored
loudly on `strictPort` instead of drifting.

Fix: point `devUrl` at 5180 to match `vite.config.ts`. Add a comment block to the Vite port
config explaining the choice (clear of qzr-sheet's cascade range) so future readers don't move
it casually.

## Test plan
- [x] `pnpm --filter @verse-vault/web type-check` clean
- [ ] Local: `pnpm --filter @verse-vault/web tauri dev` opens the desktop window and connects
  to the Vite server without manual port juggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)