### PR TITLE
feat(web): profiles + offline-first boot (PR A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,23 @@ dprint check          # formatting for docs (also runs via lint-staged)
 * **`git rebase -i` is unavailable in Claude Code** (no interactive input). For targeted squashes,
   `git cherry-pick --no-commit <a> <b> <c>` followed by a single `git commit` collapses a contiguous
   group; for wider restructures, `git reset --soft <base>` then re-stage and re-commit in groups.
+* **Fixup + autosquash for review fixes.** When a later commit corrects something an earlier commit
+  on the same branch got wrong (typo, missed branch, /simplify finding, code-review reply), consider
+  `git commit --fixup=<orig-sha>` instead of a fresh `fix(...): ...` commit. That produces a commit
+  named `fixup! <orig-subject>` paired with the target. Before merging, collapse with
+  `git -c sequence.editor=: rebase -i --autosquash master` — `-i` is required (autosquash only
+  activates in interactive mode) and the no-op sequence editor accepts the auto-prepared todo list.
+  Fixup-marked commits discard their own message and keep the original's verbatim, so no editor
+  prompts fire. End state: `git blame` lands on the original commit (whose message explains the
+  change), not a follow-up "fix" commit that re-states the same scope. Works best when the target is
+  recent and no intermediate commits touch the same lines — long-lived branches with interleaved
+  refactors will produce conflicts on autosquash, in which case keep the fresh `fix(...)` commit.
+  Before squashing, check whether the fixup's content changes what the target commit's subject
+  claims: a typo or off-by-one fix slots in invisibly, but a fixup that meaningfully expands scope
+  or reverses a stated intent leaves the original subject misleading. In that case, use
+  `git commit --fixup=amend:<orig-sha>` instead — autosquash will prompt for a new subject when
+  collapsing — or just `git commit --amend` directly if the target is HEAD. Otherwise the squashed
+  commit will lie about what it does.
 
 ### Commit message format ([Conventional Commits](https://www.conventionalcommits.org/))
 

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,31 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Offline-first boot + profiles
+
+* **Profiles are now a first-class concept.** Each signed-in account on a device gets its own
+  IndexedDB database (`verse-vault-${userId}`). A shared `verse-vault-registry` DB tracks the list
+  of known profiles + a `lastActiveProfileId` pointer. The router boot reads the registry (a fast
+  local IDB read) instead of awaiting `authClient.getSession()` — workspace renders immediately on
+  launch, even when the API is unreachable. The previously-blank Tauri-shell boot path now works
+  offline.
+* **Online / offline state is profile-scoped.** A new offline banner ("Offline — sign in to sync N
+  grades") sits between the header and the router-view, visible only when the most recent sync
+  attempt failed. Clicking routes to /signin with the current path as `redirect`.
+* **Sign-out semantics now preserve the profile.** Sign-out clears the session cookie and the
+  `lastActiveProfileId` pointer, but the per-profile DB stays intact. Next sign-in as the same user
+  resumes their cached data; cross-account sign-in starts fresh.
+* **Migration:** the first sign-in after this lands copies the legacy un-namespaced `verse-vault` DB
+  into the newly-created profile DB, then deletes the legacy. One-shot; subsequent sign-ins find no
+  legacy DB and skip.
+* New: `apps/web/src/lib/engine/registry.ts`, `migrate-legacy.ts`, `components/OfflineBanner.vue`.
+* Modified: `useAuth.ts` exposes `activeProfile`, `isOnline`, `conflict`, `signInComplete`,
+  `markOnline`; `persistence.ts` is parameterised by the active profile; `router/index.ts` guard is
+  cache-first (no awaited network call); `App.vue` reads identity from `activeProfile`.
+
+The picker UI (multi-profile cards with sign-out and delete affordances) is deferred to a follow-up
+PR; this PR keeps the existing email/password form as the entry point for unauth'd users.
+
 ### Added
 
 * **Tauri v2 desktop shell.** New `apps/web/src-tauri/` Cargo project wraps the existing Vue + WASM

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -3,13 +3,23 @@ import { computed, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 
 import { api } from '@/api'
+import OfflineBanner from '@/components/OfflineBanner.vue'
 import { useAuth } from '@/composables/useAuth'
 
-const { session, signOut } = useAuth()
+const { activeProfile, signOut } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
-const user = computed(() => session.value?.data?.user ?? null)
+// Driven by the active profile (cached locally) rather than Better
+// Auth's reactive session. The profile is the durable identity;
+// session validity is a separate online/offline concern handled by
+// the offline banner. Reading from activeProfile lets the nav stay
+// rendered when the user is offline with a valid prior profile.
+const user = computed(() =>
+  activeProfile.value
+    ? { email: activeProfile.value.email, name: activeProfile.value.displayName }
+    : null,
+)
 const newToMemorize = ref<number>(0)
 
 async function refreshMemorizeCount() {
@@ -28,7 +38,7 @@ watch(user, refreshMemorizeCount, { immediate: true })
 watch(() => route.fullPath, refreshMemorizeCount)
 
 async function onSignOut() {
-  signOut()
+  await signOut()
   await router.push('/signin')
 }
 </script>
@@ -49,6 +59,7 @@ async function onSignOut() {
         <button type="button" class="sign-out" @click="onSignOut">Sign out</button>
       </nav>
     </header>
+    <OfflineBanner />
     <main class="site-main">
       <RouterView />
     </main>

--- a/apps/web/src/components/OfflineBanner.vue
+++ b/apps/web/src/components/OfflineBanner.vue
@@ -5,7 +5,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '@/composables/useAuth'
 import { countQueuedEvents } from '@/lib/engine/persistence'
 
-const { isOnline, activeProfile } = useAuth()
+const { syncState, activeProfile } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
@@ -17,11 +17,6 @@ async function refresh() {
     return
   }
   try {
-    // Sum the queue across every material the user is enrolled in.
-    // Without a materialId-list helper we can't count globally; for
-    // the banner copy "N grades" is good enough as a per-material
-    // proxy of the currently-routed material when applicable. For
-    // routes outside a material context we show 0.
     const materialId = typeof route.params.materialId === 'string'
       ? route.params.materialId
       : null
@@ -31,18 +26,23 @@ async function refresh() {
   }
 }
 
-watch([isOnline, () => route.fullPath, activeProfile], refresh, { immediate: true })
+watch([syncState, () => route.fullPath, activeProfile], refresh, { immediate: true })
 
-const visible = computed(() => activeProfile.value != null && !isOnline.value)
+const visible = computed(() => activeProfile.value != null && syncState.value !== 'online')
 
 const message = computed(() => {
   const n = pending.value
-  if (n === 0) return 'Offline — sign in to sync.'
-  if (n === 1) return 'Offline — sign in to sync 1 grade.'
-  return `Offline — sign in to sync ${n} grades.`
+  const pluralised = n === 1 ? '1 grade' : `${n} grades`
+  if (syncState.value === 'offline') {
+    return n === 0
+      ? 'Offline — changes will sync when you reconnect.'
+      : `Offline — ${pluralised} queued for next sync.`
+  }
+  // signed-out: server reachable, just no session.
+  return n === 0 ? 'Sign in to sync.' : `Sign in to sync ${pluralised}.`
 })
 
-function onSignIn() {
+function onClick() {
   void router.push({ name: 'signin', query: { redirect: route.fullPath } })
 }
 </script>
@@ -52,8 +52,9 @@ function onSignIn() {
     v-if="visible"
     type="button"
     class="offline-banner"
+    :class="{ 'is-offline': syncState === 'offline' }"
     aria-live="polite"
-    @click="onSignIn"
+    @click="onClick"
   >
     <span class="dot" aria-hidden="true" />
     <span class="msg">{{ message }}</span>

--- a/apps/web/src/components/OfflineBanner.vue
+++ b/apps/web/src/components/OfflineBanner.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { useAuth } from '@/composables/useAuth'
+import { countQueuedEvents } from '@/lib/engine/persistence'
+
+const { isOnline, activeProfile } = useAuth()
+const router = useRouter()
+const route = useRoute()
+
+const pending = ref<number>(0)
+
+async function refresh() {
+  if (!activeProfile.value) {
+    pending.value = 0
+    return
+  }
+  try {
+    // Sum the queue across every material the user is enrolled in.
+    // Without a materialId-list helper we can't count globally; for
+    // the banner copy "N grades" is good enough as a per-material
+    // proxy of the currently-routed material when applicable. For
+    // routes outside a material context we show 0.
+    const materialId = typeof route.params.materialId === 'string'
+      ? route.params.materialId
+      : null
+    pending.value = materialId ? await countQueuedEvents(materialId) : 0
+  } catch {
+    pending.value = 0
+  }
+}
+
+watch([isOnline, () => route.fullPath, activeProfile], refresh, { immediate: true })
+
+const visible = computed(() => activeProfile.value != null && !isOnline.value)
+
+const message = computed(() => {
+  const n = pending.value
+  if (n === 0) return 'Offline — sign in to sync.'
+  if (n === 1) return 'Offline — sign in to sync 1 grade.'
+  return `Offline — sign in to sync ${n} grades.`
+})
+
+function onSignIn() {
+  void router.push({ name: 'signin', query: { redirect: route.fullPath } })
+}
+</script>
+
+<template>
+  <button
+    v-if="visible"
+    type="button"
+    class="offline-banner"
+    aria-live="polite"
+    @click="onSignIn"
+  >
+    <span class="dot" aria-hidden="true" />
+    <span class="msg">{{ message }}</span>
+  </button>
+</template>
+
+<style scoped>
+.offline-banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background: var(--color-grade-hard-bg);
+  color: var(--color-grade-hard);
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.offline-banner:hover {
+  filter: brightness(1.05);
+}
+
+.dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.msg {
+  font-weight: 500;
+}
+</style>

--- a/apps/web/src/components/OfflineBanner.vue
+++ b/apps/web/src/components/OfflineBanner.vue
@@ -12,11 +12,17 @@ const route = useRoute()
 const pending = ref<number>(0)
 
 async function refresh() {
-  if (!activeProfile.value) {
+  // Skip the IDB read when the banner is invisible. The watcher re-fires
+  // on syncState flips, so the count populates the moment offline shows up.
+  if (!activeProfile.value || syncState.value === 'online') {
     pending.value = 0
     return
   }
   try {
+    // Scoped to the current material — countQueuedEvents requires a
+    // materialId. A global "total queued across all materials" would
+    // need a full eventQueue scan per nav, which isn't worth it for a
+    // banner copy. Routes without a materialId param show 0.
     const materialId = typeof route.params.materialId === 'string'
       ? route.params.materialId
       : null

--- a/apps/web/src/components/OfflineBanner.vue
+++ b/apps/web/src/components/OfflineBanner.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import { useAuth } from '@/composables/useAuth'
-import { countQueuedEvents } from '@/lib/engine/persistence'
+import { countAllQueuedEvents } from '@/lib/engine/persistence'
 
 const { syncState, activeProfile } = useAuth()
 const router = useRouter()
@@ -19,14 +19,7 @@ async function refresh() {
     return
   }
   try {
-    // Scoped to the current material — countQueuedEvents requires a
-    // materialId. A global "total queued across all materials" would
-    // need a full eventQueue scan per nav, which isn't worth it for a
-    // banner copy. Routes without a materialId param show 0.
-    const materialId = typeof route.params.materialId === 'string'
-      ? route.params.materialId
-      : null
-    pending.value = materialId ? await countQueuedEvents(materialId) : 0
+    pending.value = await countAllQueuedEvents()
   } catch {
     pending.value = 0
   }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -32,11 +32,19 @@ export { authClient }
  *  (boot before registry-read; sign-out; first-ever launch). */
 const activeProfile = ref<registry.ProfileRow | null>(null)
 
-/** True when the most recent sync attempt (or session check) succeeded.
- *  Drives the offline banner. Defaults true so the banner doesn't flash
- *  on cold boot before the first attempt resolves; flipped to false on
- *  any failure, back to true on the next success. */
-const isOnline = ref<boolean>(true)
+/** Three-state sync status:
+ *  - `online`     — most recent sync attempt succeeded with a live session.
+ *  - `signed-out` — the server is reachable but rejected the request
+ *                   (no cookie / cookie expired). Sign-in will work.
+ *  - `offline`    — the network call itself failed; can't sign in until
+ *                   connectivity is restored.
+ *
+ *  Defaults to `online` so the banner doesn't flash on cold boot before
+ *  the first attempt resolves. Distinguishing signed-out from offline
+ *  drives the banner copy (and lets us NOT misleadingly tell an offline
+ *  user to "sign in" as if that would help). */
+export type SyncState = 'online' | 'signed-out' | 'offline'
+const syncState = ref<SyncState>('online')
 
 /** Non-null when Better Auth returns a different user than the
  *  currently-active profile expected. The workspace surfaces this so
@@ -78,11 +86,12 @@ export async function loadActiveProfileFromRegistry(): Promise<void> {
   activeProfile.value = row
 }
 
-/** Mark the active profile as online (sync succeeded) or offline
- *  (sync failed for any reason). Called by the engine flush path and
- *  by anything else that wants to nudge the indicator. */
-export function markOnline(online: boolean): void {
-  isOnline.value = online
+/** Update the sync indicator state. Called from the router boot's
+ *  background `getSession()` and (eventually) from the engine flush
+ *  path so the banner reflects the actual result of the most recent
+ *  attempt. */
+export function markSyncState(state: SyncState): void {
+  syncState.value = state
 }
 
 /** Acknowledge + clear a pending conflict. UI calls this after the
@@ -140,7 +149,7 @@ export async function signInComplete(user: {
   }
 
   activeProfile.value = row
-  isOnline.value = true
+  syncState.value = 'online'
 }
 
 /** Sign out the current profile. Best-effort API call to invalidate
@@ -157,7 +166,7 @@ export async function signOut(): Promise<void> {
   await setActiveProfile(null)
   clearAllSessions()
   activeProfile.value = null
-  isOnline.value = false
+  syncState.value = 'signed-out'
 }
 
 // --- Composable surface -------------------------------------------------------
@@ -199,11 +208,12 @@ export function useAuth() {
     signUpEmail,
     // Profile-aware additions.
     activeProfile: computed(() => activeProfile.value),
-    isOnline: computed(() => isOnline.value),
+    syncState: computed(() => syncState.value),
+    isOnline: computed(() => syncState.value === 'online'),
     conflict: computed(() => conflict.value),
     signOut,
     signInComplete,
-    markOnline,
+    markSyncState,
     clearConflict,
   }
 }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -164,16 +164,39 @@ export async function signOut(): Promise<void> {
 
 /** The Vue composable retained from qzr-sheet's pattern. Exposes the
  *  reactive session, profile state, online flag, conflict ref, plus
- *  the sign-in / sign-up action verbs. */
+ *  the sign-in / sign-up action verbs.
+ *
+ *  Email/password sign-in returns the user inline in the Better Auth
+ *  response; we wrap the factory's verbs to call `signInComplete`
+ *  with that user before resolving — saves the caller a separate
+ *  `getSession()` roundtrip that races the cookie-set anyway.
+ *  Social sign-in goes through an OAuth redirect, so the
+ *  registry-upsert path for that case runs from a watcher on the
+ *  reactive session below. */
 export function useAuth() {
   const factoryShape = useAuthFactory()
+
+  async function signInEmail(email: string, password: string) {
+    const result = await factoryShape.signInEmail(email, password)
+    const user = extractUser(result)
+    if (user) await signInComplete(user)
+    return result
+  }
+
+  async function signUpEmail(email: string, password: string) {
+    const result = await factoryShape.signUpEmail(email, password)
+    const user = extractUser(result)
+    if (user) await signInComplete(user)
+    return result
+  }
+
   return {
     // Better Auth reactive session (pending / data / error).
     session: factoryShape.session,
-    // Sign-in / sign-up verbs (unchanged).
+    // Sign-in / sign-up verbs — wrapped to run signInComplete.
     signInSocial: factoryShape.signInSocial,
-    signInEmail: factoryShape.signInEmail,
-    signUpEmail: factoryShape.signUpEmail,
+    signInEmail,
+    signUpEmail,
     // Profile-aware additions.
     activeProfile: computed(() => activeProfile.value),
     isOnline: computed(() => isOnline.value),
@@ -183,4 +206,17 @@ export function useAuth() {
     markOnline,
     clearConflict,
   }
+}
+
+interface UserPayload {
+  id: string
+  email: string
+  name?: string
+  image?: string | null
+}
+
+function extractUser(
+  result: { data?: { user?: UserPayload } | null } | undefined,
+): UserPayload | null {
+  return result?.data?.user ?? null
 }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,4 +1,10 @@
+import { computed, ref } from 'vue'
+
 import { createAppAuthClient } from '@/lib/authClient'
+import { clearAllSessions } from '@/lib/engine/engineStore'
+import { migrateLegacyDb } from '@/lib/engine/migrate-legacy'
+import { setActiveProfile } from '@/lib/engine/persistence'
+import * as registry from '@/lib/engine/registry'
 
 // Better Auth's client auto-appends `/api/auth` to baseURL only when the
 // URL has no path component (see `withPath` / `checkHasPath` in
@@ -16,4 +22,165 @@ const authBaseURL = apiBase.startsWith('/')
   ? `${window.location.origin}${apiBase}/api/auth`
   : `${apiBase}/api/auth`
 
-export const { authClient, useAuth } = createAppAuthClient(authBaseURL)
+const { authClient, useAuth: useAuthFactory } = createAppAuthClient(authBaseURL)
+
+export { authClient }
+
+// --- Profile-aware module-level state -----------------------------------------
+
+/** The currently-active profile, or null when no profile is loaded
+ *  (boot before registry-read; sign-out; first-ever launch). */
+const activeProfile = ref<registry.ProfileRow | null>(null)
+
+/** True when the most recent sync attempt (or session check) succeeded.
+ *  Drives the offline banner. Defaults true so the banner doesn't flash
+ *  on cold boot before the first attempt resolves; flipped to false on
+ *  any failure, back to true on the next success. */
+const isOnline = ref<boolean>(true)
+
+/** Non-null when Better Auth returns a different user than the
+ *  currently-active profile expected. The workspace surfaces this so
+ *  the user can pick: sign out, or add the new user as a profile. */
+const conflict = ref<{ expectedEmail: string; actualEmail: string } | null>(null)
+
+let activeProfileLoaded = false
+
+function nowSecs(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+/** Read the registry on app boot. If a `lastActiveProfileId` is set and
+ *  its per-profile DB exists, populate `activeProfile` and tell the
+ *  persistence layer to open that DB. If the pointer is stale (DB was
+ *  deleted out from under us, etc.), clear it so the router falls back
+ *  to the sign-in form. */
+export async function loadActiveProfileFromRegistry(): Promise<void> {
+  if (activeProfileLoaded) return
+  activeProfileLoaded = true
+  const id = await registry.getLastActiveProfileId()
+  if (!id) {
+    activeProfile.value = null
+    return
+  }
+  const exists = await registry.profileDbExists(id)
+  if (!exists) {
+    await registry.setLastActiveProfileId(null)
+    activeProfile.value = null
+    return
+  }
+  const row = await registry.getProfile(id)
+  if (!row) {
+    await registry.setLastActiveProfileId(null)
+    activeProfile.value = null
+    return
+  }
+  await setActiveProfile(id)
+  activeProfile.value = row
+}
+
+/** Mark the active profile as online (sync succeeded) or offline
+ *  (sync failed for any reason). Called by the engine flush path and
+ *  by anything else that wants to nudge the indicator. */
+export function markOnline(online: boolean): void {
+  isOnline.value = online
+}
+
+/** Acknowledge + clear a pending conflict. UI calls this after the
+ *  user picks a resolution. */
+export function clearConflict(): void {
+  conflict.value = null
+}
+
+/** Called by `SignInView` after a successful Better Auth sign-in. We
+ *  upsert the profile in the registry, run the legacy-DB migration if
+ *  this is the first profile we've ever created, and open the
+ *  per-profile DB so the workspace can render. */
+export async function signInComplete(user: {
+  id: string
+  email: string
+  name?: string
+  image?: string | null
+}): Promise<void> {
+  const existing = await registry.getProfile(user.id)
+
+  // Conflict: user re-authed but came back as someone else. Leave the
+  // active profile alone; the UI reads `conflict` and prompts.
+  if (activeProfile.value && activeProfile.value.profileId !== user.id) {
+    conflict.value = {
+      expectedEmail: activeProfile.value.email,
+      actualEmail: user.email,
+    }
+    return
+  }
+
+  const now = nowSecs()
+  const isNew = existing == null
+  const row: registry.ProfileRow = {
+    profileId: user.id,
+    email: user.email,
+    displayName: user.name ?? user.email,
+    image: user.image ?? null,
+    createdAt: existing?.createdAt ?? now,
+    lastUsedAt: now,
+  }
+  await registry.upsertProfile(row)
+  await registry.setLastActiveProfileId(user.id)
+
+  // Switch the persistence layer to the new profile's DB before any
+  // migration so the eager open creates all stores.
+  clearAllSessions()
+  await setActiveProfile(user.id)
+
+  if (isNew) {
+    try {
+      await migrateLegacyDb(user.id)
+    } catch (err) {
+      console.warn('legacy DB migration failed; continuing:', err)
+    }
+  }
+
+  activeProfile.value = row
+  isOnline.value = true
+}
+
+/** Sign out the current profile. Best-effort API call to invalidate
+ *  the server session; local state is cleared regardless. The profile
+ *  + its IDB DB stay intact — sign-out is the "I'll be back" action.
+ *  Permanent removal is `removeActiveProfile()` (future PR B). */
+export async function signOut(): Promise<void> {
+  try {
+    await authClient.signOut()
+  } catch {
+    // Offline / 401 / anything — fine. We still clear local state.
+  }
+  await registry.setLastActiveProfileId(null)
+  await setActiveProfile(null)
+  clearAllSessions()
+  activeProfile.value = null
+  isOnline.value = false
+}
+
+// --- Composable surface -------------------------------------------------------
+
+/** The Vue composable retained from qzr-sheet's pattern. Exposes the
+ *  reactive session, profile state, online flag, conflict ref, plus
+ *  the sign-in / sign-up action verbs. */
+export function useAuth() {
+  const factoryShape = useAuthFactory()
+  return {
+    // Better Auth reactive session (pending / data / error).
+    session: factoryShape.session,
+    // Sign-in / sign-up verbs (unchanged).
+    signInSocial: factoryShape.signInSocial,
+    signInEmail: factoryShape.signInEmail,
+    signUpEmail: factoryShape.signUpEmail,
+    // Profile-aware additions.
+    activeProfile: computed(() => activeProfile.value),
+    isOnline: computed(() => isOnline.value),
+    conflict: computed(() => conflict.value),
+    signOut,
+    signInComplete,
+    markOnline,
+    clearConflict,
+  }
+}

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,4 +1,4 @@
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import { createAppAuthClient } from '@/lib/authClient'
 import { clearAllSessions } from '@/lib/engine/engineStore'
@@ -175,6 +175,26 @@ export async function signOut(): Promise<void> {
   activeProfileLoaded = false
   syncState.value = 'signed-out'
 }
+
+// Watcher: Better Auth's reactive session is the source of truth for
+// the OAuth (social) sign-in path. Email/password goes through the
+// wrapped `signInEmail` / `signUpEmail` verbs which call
+// `signInComplete` inline — but OAuth leaves the page for the IdP
+// redirect, so when the app re-mounts after the callback there's no
+// in-flight Promise to chain `signInComplete` onto. Instead we watch
+// the session ref: when a user appears that doesn't match the active
+// profile, run `signInComplete` to upsert the profile, swap the
+// per-profile DB, and migrate the legacy DB if needed. Idempotent —
+// no-ops if `activeProfile` already matches the session user.
+const sessionWatchRef = authClient.useSession()
+watch(
+  () => sessionWatchRef.value.data?.user,
+  (user) => {
+    if (!user) return
+    if (activeProfile.value?.profileId === user.id) return
+    void signInComplete(user)
+  },
+)
 
 // --- Composable surface -------------------------------------------------------
 

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -207,13 +207,10 @@ export function useAuth() {
   }
 
   return {
-    // Better Auth reactive session (pending / data / error).
     session: factoryShape.session,
-    // Sign-in / sign-up verbs — wrapped to run signInComplete.
     signInSocial: factoryShape.signInSocial,
     signInEmail,
     signUpEmail,
-    // Profile-aware additions.
     activeProfile: computed(() => activeProfile.value),
     syncState: computed(() => syncState.value),
     isOnline: computed(() => syncState.value === 'online'),

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -125,8 +125,16 @@ export async function signInComplete(user: {
     return
   }
 
+  // Read this BEFORE the upsert so the migration gate sees the
+  // pre-state (no profiles yet = this is the device's first-ever
+  // sign-in post-PR-A = legacy `verse-vault` data should be adopted
+  // into this user's profile DB). Gating on per-user `isNew` would
+  // be a footgun: if user A's first sign-in failed mid-migration and
+  // left the legacy DB on disk, user B signing in later would inherit
+  // A's data into B's profile.
+  const isFirstEverProfile = (await registry.listProfiles()).length === 0
+
   const now = nowSecs()
-  const isNew = existing == null
   const row: registry.ProfileRow = {
     profileId: user.id,
     email: user.email,
@@ -143,7 +151,7 @@ export async function signInComplete(user: {
   clearAllSessions()
   await setActiveProfile(user.id)
 
-  if (isNew) {
+  if (isFirstEverProfile) {
     try {
       await migrateLegacyDb(user.id)
     } catch (err) {

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -61,29 +61,32 @@ function nowSecs(): number {
  *  its per-profile DB exists, populate `activeProfile` and tell the
  *  persistence layer to open that DB. If the pointer is stale (DB was
  *  deleted out from under us, etc.), clear it so the router falls back
- *  to the sign-in form. */
-export async function loadActiveProfileFromRegistry(): Promise<void> {
-  if (activeProfileLoaded) return
+ *  to the sign-in form. Returns true when the active profile is set
+ *  and ready to use, false when the router should redirect to /signin.
+ *  Idempotent — repeat calls in the same session short-circuit. */
+export async function loadActiveProfileFromRegistry(): Promise<boolean> {
+  if (activeProfileLoaded) return activeProfile.value != null
   activeProfileLoaded = true
   const id = await registry.getLastActiveProfileId()
   if (!id) {
     activeProfile.value = null
-    return
+    return false
   }
   const exists = await registry.profileDbExists(id)
   if (!exists) {
     await registry.setLastActiveProfileId(null)
     activeProfile.value = null
-    return
+    return false
   }
   const row = await registry.getProfile(id)
   if (!row) {
     await registry.setLastActiveProfileId(null)
     activeProfile.value = null
-    return
+    return false
   }
   await setActiveProfile(id)
   activeProfile.value = row
+  return true
 }
 
 /** Update the sync indicator state. Called from the router boot's
@@ -166,6 +169,10 @@ export async function signOut(): Promise<void> {
   await setActiveProfile(null)
   clearAllSessions()
   activeProfile.value = null
+  // Reset the load-once flag so the next sign-in re-reads the
+  // registry — keeps the "flag true ⟺ registry consulted this
+  // session for the current profile" invariant honest.
+  activeProfileLoaded = false
   syncState.value = 'signed-out'
 }
 

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -472,9 +472,16 @@ export async function invalidateSession(materialId: string): Promise<void> {
   await idb.clearRenders(materialId)
 }
 
-/** Test/dev helper: clear all in-memory state. Does not touch IDB. */
+/** Reset all per-profile in-memory state. Frees every cached WASM
+ *  engine and drops the sessions / inflightFlushes / staleGate maps.
+ *  Called on profile switch + sign-out (`useAuth.signInComplete` and
+ *  `useAuth.signOut`) so the next profile starts fresh — without
+ *  clearing `staleGate`, a stale-merge gate from profile A would
+ *  silently no-op every flush in profile B (or the same user's next
+ *  session). Does not touch IDB. */
 export function clearAllSessions(): void {
   for (const session of sessions.values()) session.engine.free()
   sessions.clear()
   inflightFlushes.clear()
+  staleGate.clear()
 }

--- a/apps/web/src/lib/engine/migrate-legacy.ts
+++ b/apps/web/src/lib/engine/migrate-legacy.ts
@@ -1,0 +1,113 @@
+/**
+ * One-shot migration: copy the legacy un-namespaced `verse-vault`
+ * IndexedDB into a profile-namespaced `verse-vault-${profileId}` DB,
+ * then delete the legacy. Runs once, on the first sign-in after the
+ * profiles refactor lands.
+ *
+ * Pre-existing single-DB users (anyone who used verse-vault before
+ * this PR) would otherwise lose their cached snapshots, FSRS state,
+ * and queued events on first relaunch. This helper preserves that
+ * data by adopting it into whatever profile signs in first.
+ *
+ * If the legacy DB doesn't exist, the helper is a no-op. If the copy
+ * fails partway, the legacy DB is left intact (the caller logs the
+ * warning and the engine refetches from the server on next material
+ * load).
+ */
+
+import { promiseRequest, transactionComplete } from './persistence'
+
+const LEGACY_DB_NAME = 'verse-vault'
+const LEGACY_DB_VERSION = 1
+
+const STORES = [
+  'snapshots',
+  'testStates',
+  'eventQueue',
+  'eventQueueOrphans',
+  'renders',
+] as const
+
+export async function migrateLegacyDb(
+  targetProfileId: string,
+): Promise<{ migrated: boolean }> {
+  const legacyExists = await checkLegacyExists()
+  if (!legacyExists) return { migrated: false }
+
+  const legacyDb = await openLegacyReadOnly()
+  const targetDb = await openTargetReadWrite(targetProfileId)
+  try {
+    for (const storeName of STORES) {
+      await copyStore(legacyDb, targetDb, storeName)
+    }
+  } finally {
+    legacyDb.close()
+    targetDb.close()
+  }
+
+  await deleteLegacy()
+  return { migrated: true }
+}
+
+async function checkLegacyExists(): Promise<boolean> {
+  if (typeof indexedDB.databases !== 'function') {
+    // Older Safari can't enumerate; attempt the open and treat
+    // upgrade-from-nothing as "no legacy data."
+    return false
+  }
+  const list = await indexedDB.databases()
+  return list.some((d) => d.name === LEGACY_DB_NAME)
+}
+
+function openLegacyReadOnly(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(LEGACY_DB_NAME, LEGACY_DB_VERSION)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+    // No upgrade handler — if the legacy DB doesn't have a store we
+    // expect, copyStore() handles the missing-store case gracefully.
+  })
+}
+
+function openTargetReadWrite(profileId: string): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(`verse-vault-${profileId}`)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+    // Target DB's upgrade handler is in persistence.ts. We rely on
+    // setActiveProfile having already opened the target once before
+    // this runs — so it already has all stores created.
+  })
+}
+
+function deleteLegacy(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(LEGACY_DB_NAME)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+    req.onblocked = () => {
+      // Another tab holding a handle to the legacy DB — drop the
+      // wait and continue. Next launch will retry the delete (the
+      // helper sees the legacy DB and re-migrates; copyStore is
+      // idempotent against an empty target).
+      resolve()
+    }
+  })
+}
+
+async function copyStore(
+  source: IDBDatabase,
+  target: IDBDatabase,
+  storeName: (typeof STORES)[number],
+): Promise<void> {
+  if (!source.objectStoreNames.contains(storeName)) return
+  const sourceTx = source.transaction(storeName, 'readonly')
+  const rows = await promiseRequest<unknown[]>(
+    sourceTx.objectStore(storeName).getAll(),
+  )
+  if (rows.length === 0) return
+  const targetTx = target.transaction(storeName, 'readwrite')
+  const targetStore = targetTx.objectStore(storeName)
+  for (const row of rows) targetStore.put(row)
+  await transactionComplete(targetTx)
+}

--- a/apps/web/src/lib/engine/migrate-legacy.ts
+++ b/apps/web/src/lib/engine/migrate-legacy.ts
@@ -87,9 +87,14 @@ function deleteLegacy(): Promise<void> {
     req.onerror = () => reject(req.error)
     req.onblocked = () => {
       // Another tab holding a handle to the legacy DB — drop the
-      // wait and continue. Next launch will retry the delete (the
-      // helper sees the legacy DB and re-migrates; copyStore is
-      // idempotent against an empty target).
+      // wait and continue. The user's data has already been copied
+      // to the target by this point (delete is the final step), so
+      // they keep their cards. The legacy DB just sticks around
+      // taking up storage until the holding tab closes; the next
+      // first-ever sign-in (no profiles in registry) will see it
+      // and retry the cleanup. Subsequent sign-ins for the SAME
+      // user skip migration entirely (gate is per-device, not
+      // per-user) so we don't accidentally re-copy stale data.
       resolve()
     }
   })

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -252,6 +252,16 @@ export async function countQueuedEvents(materialId: string): Promise<number> {
   return promiseRequest<number>(idx.count(IDBKeyRange.only(materialId)))
 }
 
+/** Total queued events across all materials for the active profile.
+ *  Used by the offline banner where the workspace doesn't know (or
+ *  doesn't surface) the active materialId. */
+export async function countAllQueuedEvents(): Promise<number> {
+  const db = await openDb()
+  return promiseRequest<number>(
+    db.transaction(STORE.EventQueue, 'readonly').objectStore(STORE.EventQueue).count(),
+  )
+}
+
 /** Delete acked events by clientEventId. Mid-flush additions to the
  *  queue survive because we delete by explicit key, not by clearing
  *  the whole store. */

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -31,7 +31,6 @@
 
 import type { SyncEventUpload, TestStateEntry } from './types'
 
-const DB_NAME = 'verse-vault'
 const DB_VERSION = 1
 
 /** TTL the client cache honours, mirroring the server's
@@ -52,14 +51,34 @@ const STORE = {
 
 const BY_MATERIAL_ID_INDEX = 'byMaterialId'
 
+/** Profile-id of the currently active DB. Module-level — every helper
+ *  in this file opens `verse-vault-${activeProfileId}` indirectly
+ *  through `openDb()`. Set by `setActiveProfile` (called from the
+ *  profile-switch flow); null before any profile is active. */
+let activeProfileId: string | null = null
 let dbPromise: Promise<IDBDatabase> | null = null
 
-/** Open (or cache) the singleton DB. Subsequent calls return the same
- *  promise so multiple async callers share one open handle. */
+class NoActiveProfileError extends Error {
+  constructor() {
+    super('No active profile — call setActiveProfile() before opening the DB.')
+    this.name = 'NoActiveProfileError'
+  }
+}
+
+function dbNameFor(profileId: string): string {
+  return `verse-vault-${profileId}`
+}
+
+/** Open the active profile's DB (or return the cached handle). Throws
+ *  if no profile is active; the caller is responsible for ordering. */
 export function openDb(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
+  if (activeProfileId == null) {
+    return Promise.reject(new NoActiveProfileError())
+  }
+  const dbName = dbNameFor(activeProfileId)
   dbPromise = new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    const req = indexedDB.open(dbName, DB_VERSION)
     req.onupgradeneeded = () => {
       const db = req.result
       if (!db.objectStoreNames.contains(STORE.Snapshots)) {
@@ -94,8 +113,41 @@ export function openDb(): Promise<IDBDatabase> {
   return dbPromise
 }
 
-/** Drop the cached open-promise. Tests + sign-out paths use this to
- *  force a fresh handle on the next openDb call. */
+/** Set (or clear) the active profile. Closes any open handle for the
+ *  previous profile and resets the cache so the next `openDb()` opens
+ *  the new profile's DB. Pass `null` to detach; pass a profileId to
+ *  switch. Eagerly opens the new DB so the upgrade handler runs and
+ *  subsequent reads are cheap. */
+export async function setActiveProfile(profileId: string | null): Promise<void> {
+  if (profileId === activeProfileId) return
+  // Close the existing handle (if any) before swapping.
+  if (dbPromise) {
+    try {
+      const db = await dbPromise
+      db.close()
+    } catch {
+      // Resolution failure on the existing promise is fine — we're
+      // discarding it anyway.
+    }
+  }
+  dbPromise = null
+  activeProfileId = profileId
+  if (profileId != null) {
+    // Eagerly open so the upgrade handler runs now (rather than on
+    // the first helper call after a profile switch).
+    await openDb()
+  }
+}
+
+/** Returns the currently active profile id (null if none). Mostly
+ *  useful in tests + diagnostics. */
+export function getActiveProfileId(): string | null {
+  return activeProfileId
+}
+
+/** Drop the cached open-promise without changing the active profile.
+ *  Used by tests that want to force a fresh handle on the next openDb
+ *  call. Behaviour is identical to the historical `resetDbHandle`. */
 export function resetDbHandle(): void {
   dbPromise = null
 }

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -1,6 +1,13 @@
 /**
  * IndexedDB layer for the browser-side fat-client. Five object stores
- * under one DB (`verse-vault`):
+ * under one DB per profile, named `verse-vault-${profileId}`. The
+ * "current profile" is a module-level variable set by
+ * `setActiveProfile()` (called from `useAuth.signInComplete` /
+ * `useAuth.signOut` / profile-switch paths). The shared registry of
+ * known profiles + the last-active pointer lives in a separate
+ * `verse-vault-registry` DB; see `./registry.ts`.
+ *
+ * The five stores in a profile DB:
  *
  *   - `snapshots` — one row per material (`{ materialId, version,
  *     materialData, fetchedAt }`). Source of the MaterialData blob the

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -58,25 +58,16 @@ const BY_MATERIAL_ID_INDEX = 'byMaterialId'
 let activeProfileId: string | null = null
 let dbPromise: Promise<IDBDatabase> | null = null
 
-class NoActiveProfileError extends Error {
-  constructor() {
-    super('No active profile — call setActiveProfile() before opening the DB.')
-    this.name = 'NoActiveProfileError'
-  }
-}
-
-function dbNameFor(profileId: string): string {
-  return `verse-vault-${profileId}`
-}
-
 /** Open the active profile's DB (or return the cached handle). Throws
  *  if no profile is active; the caller is responsible for ordering. */
 export function openDb(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
   if (activeProfileId == null) {
-    return Promise.reject(new NoActiveProfileError())
+    return Promise.reject(
+      new Error('No active profile — call setActiveProfile() before opening the DB.'),
+    )
   }
-  const dbName = dbNameFor(activeProfileId)
+  const dbName = `verse-vault-${activeProfileId}`
   dbPromise = new Promise((resolve, reject) => {
     const req = indexedDB.open(dbName, DB_VERSION)
     req.onupgradeneeded = () => {
@@ -147,7 +138,7 @@ export function getActiveProfileId(): string | null {
 
 /** Drop the cached open-promise without changing the active profile.
  *  Used by tests that want to force a fresh handle on the next openDb
- *  call. Behaviour is identical to the historical `resetDbHandle`. */
+ *  call. */
 export function resetDbHandle(): void {
   dbPromise = null
 }

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -330,14 +330,14 @@ export async function clearRenders(materialId: string): Promise<void> {
 
 // --- IDB → Promise primitives ---
 
-function promiseRequest<T>(req: IDBRequest<T>): Promise<T> {
+export function promiseRequest<T>(req: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
     req.onsuccess = () => resolve(req.result)
     req.onerror = () => reject(req.error)
   })
 }
 
-function transactionComplete(tx: IDBTransaction): Promise<void> {
+export function transactionComplete(tx: IDBTransaction): Promise<void> {
   return new Promise((resolve, reject) => {
     tx.oncomplete = () => resolve()
     tx.onerror = () => reject(tx.error)

--- a/apps/web/src/lib/engine/registry.ts
+++ b/apps/web/src/lib/engine/registry.ts
@@ -1,0 +1,132 @@
+/**
+ * Profile registry: the shared `verse-vault-registry` IndexedDB that
+ * tracks which profiles exist on this device + which one was most
+ * recently active. The router reads this on every boot to decide
+ * whether to auto-enter a profile or fall through to the sign-in form.
+ *
+ * Profile *data* (snapshots, testStates, eventQueue, …) lives in a
+ * separate per-profile DB named `verse-vault-${profileId}` — see
+ * `persistence.ts`. The registry is the only thing readable before
+ * we know which profile-DB to open.
+ */
+
+import { promiseRequest, transactionComplete } from './persistence'
+
+const DB_NAME = 'verse-vault-registry'
+const DB_VERSION = 1
+
+const STORE = {
+  Profiles: 'profiles',
+  Meta: 'meta',
+} as const
+
+/** Singleton key the `meta` store uses — there is only ever one row. */
+const META_KEY = 'singleton'
+
+export interface ProfileRow {
+  /** Server-side `userId`; doubles as the per-profile DB suffix. */
+  profileId: string
+  email: string
+  /** Falls back to email when the server has no name. */
+  displayName: string
+  image: string | null
+  createdAt: number
+  lastUsedAt: number
+}
+
+interface MetaRow {
+  key: typeof META_KEY
+  lastActiveProfileId: string | null
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null
+
+export function openRegistry(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION)
+    req.onupgradeneeded = () => {
+      const db = req.result
+      if (!db.objectStoreNames.contains(STORE.Profiles)) {
+        db.createObjectStore(STORE.Profiles, { keyPath: 'profileId' })
+      }
+      if (!db.objectStoreNames.contains(STORE.Meta)) {
+        db.createObjectStore(STORE.Meta, { keyPath: 'key' })
+      }
+    }
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+  return dbPromise
+}
+
+export async function listProfiles(): Promise<ProfileRow[]> {
+  const db = await openRegistry()
+  return promiseRequest<ProfileRow[]>(
+    db.transaction(STORE.Profiles, 'readonly').objectStore(STORE.Profiles).getAll(),
+  )
+}
+
+export async function getProfile(profileId: string): Promise<ProfileRow | undefined> {
+  const db = await openRegistry()
+  return promiseRequest<ProfileRow | undefined>(
+    db.transaction(STORE.Profiles, 'readonly').objectStore(STORE.Profiles).get(profileId),
+  )
+}
+
+export async function upsertProfile(row: ProfileRow): Promise<void> {
+  const db = await openRegistry()
+  await promiseRequest(
+    db.transaction(STORE.Profiles, 'readwrite').objectStore(STORE.Profiles).put(row),
+  )
+}
+
+export async function removeProfile(profileId: string): Promise<void> {
+  const db = await openRegistry()
+  await promiseRequest(
+    db.transaction(STORE.Profiles, 'readwrite').objectStore(STORE.Profiles).delete(profileId),
+  )
+}
+
+export async function getLastActiveProfileId(): Promise<string | null> {
+  const db = await openRegistry()
+  const row = await promiseRequest<MetaRow | undefined>(
+    db.transaction(STORE.Meta, 'readonly').objectStore(STORE.Meta).get(META_KEY),
+  )
+  return row?.lastActiveProfileId ?? null
+}
+
+export async function setLastActiveProfileId(profileId: string | null): Promise<void> {
+  const db = await openRegistry()
+  const row: MetaRow = { key: META_KEY, lastActiveProfileId: profileId }
+  await promiseRequest(
+    db.transaction(STORE.Meta, 'readwrite').objectStore(STORE.Meta).put(row),
+  )
+}
+
+/** Cheap existence check for the per-profile DB. The launch path uses
+ *  this to detect the "registry points at a missing DB" edge case
+ *  (browser cleared site data, dev manually deleted the DB, etc.) and
+ *  fall back to the picker. */
+export async function profileDbExists(profileId: string): Promise<boolean> {
+  // `indexedDB.databases()` is missing on older Safari; treat its
+  // absence as "assume the DB exists" — opening it will recreate
+  // harmlessly if it doesn't.
+  if (typeof indexedDB.databases !== 'function') return true
+  const list = await indexedDB.databases()
+  return list.some((d) => d.name === `verse-vault-${profileId}`)
+}
+
+/** Test/dev helper: drop the cached open-promise so the next call to
+ *  openRegistry re-opens. The actual data on disk is untouched. */
+export function resetRegistryHandle(): void {
+  dbPromise = null
+}
+
+/** Updates the profile's `lastUsedAt` timestamp. Cheap shorthand for
+ *  the common pattern of "I just entered this profile." */
+export async function touchProfile(profileId: string, nowSecs: number): Promise<void> {
+  const existing = await getProfile(profileId)
+  if (!existing) return
+  await upsertProfile({ ...existing, lastUsedAt: nowSecs })
+}

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { authClient, loadActiveProfileFromRegistry, markOnline } from '@/composables/useAuth'
+import { authClient, loadActiveProfileFromRegistry, markSyncState } from '@/composables/useAuth'
 import { getLastActiveProfileId } from '@/lib/engine/registry'
 
 const router = createRouter({
@@ -53,11 +53,15 @@ router.beforeEach(async (to) => {
   const signedIn = lastActive != null
 
   // Kick off the live session check in the background. We don't await
-  // it; it just feeds the online/offline indicator via the watcher.
+  // it; it just feeds the sync-state indicator. The three-way outcome
+  // matters: a resolved-with-user response means online, a resolved-
+  // without-user response means the server is reachable but we're
+  // signed out (cookie expired or never set), and a rejection means
+  // we couldn't reach the server at all.
   void authClient
     .getSession()
-    .then((result) => markOnline(!!result?.data?.user))
-    .catch(() => markOnline(false))
+    .then((result) => markSyncState(result?.data?.user ? 'online' : 'signed-out'))
+    .catch(() => markSyncState('offline'))
 
   if (to.meta.public) {
     if (signedIn && to.name === 'signin') {

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { authClient } from '@/composables/useAuth'
+import { authClient, loadActiveProfileFromRegistry, markOnline } from '@/composables/useAuth'
+import { getLastActiveProfileId } from '@/lib/engine/registry'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -36,17 +37,28 @@ const router = createRouter({
   ],
 })
 
-// Read the signed-in state directly from `getSession()`'s return value
-// rather than from `useSession()`'s reactive ref. The reactive ref runs
-// its own async fetch and lags behind both (a) the initial cookie that
-// a hard refresh re-presents and (b) the just-set cookie that signIn
-// produces — so a synchronous read against it would bounce a real user
-// to /signin. `getSession()` always reflects the canonical state at the
-// moment of the await; Better Auth caches it internally so per-nav
-// fetches are cheap.
+// Cache-first guard. The signed-in/out decision is driven by the
+// profile registry on disk, NOT by an awaited `getSession()` call —
+// that's the offline-boot fix. The registry tells us "this device
+// last used profile X"; we honour that immediately and render the
+// workspace from the per-profile IDB cache. The live `getSession()`
+// fires unawaited and flips the `isOnline` reactive flag when it
+// resolves; the offline banner picks that up.
+//
+// If the registry has no last-active profile (or the referenced DB
+// has been wiped), fall through to the sign-in form.
 router.beforeEach(async (to) => {
-  const result = await authClient.getSession()
-  const signedIn = !!result?.data?.user
+  await loadActiveProfileFromRegistry()
+  const lastActive = await getLastActiveProfileId()
+  const signedIn = lastActive != null
+
+  // Kick off the live session check in the background. We don't await
+  // it; it just feeds the online/offline indicator via the watcher.
+  void authClient
+    .getSession()
+    .then((result) => markOnline(!!result?.data?.user))
+    .catch(() => markOnline(false))
+
   if (to.meta.public) {
     if (signedIn && to.name === 'signin') {
       const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/review'

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,7 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 import { authClient, loadActiveProfileFromRegistry, markSyncState } from '@/composables/useAuth'
-import { getLastActiveProfileId } from '@/lib/engine/registry'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -48,9 +47,7 @@ const router = createRouter({
 // If the registry has no last-active profile (or the referenced DB
 // has been wiped), fall through to the sign-in form.
 router.beforeEach(async (to) => {
-  await loadActiveProfileFromRegistry()
-  const lastActive = await getLastActiveProfileId()
-  const signedIn = lastActive != null
+  const signedIn = await loadActiveProfileFromRegistry()
 
   // Kick off the live session check in the background. We don't await
   // it; it just feeds the sync-state indicator. The three-way outcome

--- a/apps/web/src/views/SignInView.vue
+++ b/apps/web/src/views/SignInView.vue
@@ -2,25 +2,18 @@
 import { useRoute, useRouter } from 'vue-router'
 
 import SignInForm from '@/components/SignInForm.vue'
-import { authClient, signInComplete, useAuth } from '@/composables/useAuth'
+import { useAuth } from '@/composables/useAuth'
 
 const { signInSocial, signInEmail, signUpEmail } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
-async function onSuccess() {
-  // The SignInForm emits 'success' once Better Auth has set the
-  // cookie. Pull the session so we can give signInComplete a typed
-  // user object — Better Auth's reactive ref lags this point by
-  // up to a tick, but `getSession()` reads the freshly-cached value
-  // synchronously. signInComplete handles registry upsert + legacy
-  // DB migration + setting the active profile.
-  const result = await authClient.getSession()
-  if (result?.data?.user) {
-    await signInComplete(result.data.user)
-  }
+function onSuccess() {
+  // useAuth's wrapped signInEmail/signUpEmail have already called
+  // signInComplete by the time this fires — registry is populated +
+  // the active profile DB is open. Just navigate.
   const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/review'
-  router.replace(redirect)
+  void router.replace(redirect)
 }
 </script>
 

--- a/apps/web/src/views/SignInView.vue
+++ b/apps/web/src/views/SignInView.vue
@@ -2,14 +2,24 @@
 import { useRoute, useRouter } from 'vue-router'
 
 import SignInForm from '@/components/SignInForm.vue'
-import { useAuth } from '@/composables/useAuth'
+import { authClient, signInComplete, useAuth } from '@/composables/useAuth'
 
 const { signInSocial, signInEmail, signUpEmail } = useAuth()
 const router = useRouter()
 const route = useRoute()
 
-function onSuccess() {
-  const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/session'
+async function onSuccess() {
+  // The SignInForm emits 'success' once Better Auth has set the
+  // cookie. Pull the session so we can give signInComplete a typed
+  // user object — Better Auth's reactive ref lags this point by
+  // up to a tick, but `getSession()` reads the freshly-cached value
+  // synchronously. signInComplete handles registry upsert + legacy
+  // DB migration + setting the active profile.
+  const result = await authClient.getSession()
+  if (result?.data?.user) {
+    await signInComplete(result.data.user)
+  }
+  const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : '/review'
   router.replace(redirect)
 }
 </script>

--- a/docs/superpowers/specs/2026-05-22-profiles-design.md
+++ b/docs/superpowers/specs/2026-05-22-profiles-design.md
@@ -574,3 +574,6 @@ These are spelled out here so the implementation plan can pick them up explicitl
 * Account merging (two profiles representing the same server account, somehow drifted apart).
 * Sign-in with a deep-link from a different app/browser (OAuth bounce from a Tauri-external browser
   back into the Tauri window).
+* Anonymous (no account at all) card rendering. PR C grants device-token holders read-only refresh;
+  truly anonymous users still hit 401. If verse-vault ever wants a public-facing read-only Bible
+  reader, that's a separate product decision with its own MAUA review.

--- a/docs/superpowers/specs/2026-05-22-profiles-design.md
+++ b/docs/superpowers/specs/2026-05-22-profiles-design.md
@@ -1,0 +1,433 @@
+# Profiles + offline-first boot — design
+
+## Status
+
+Brainstormed 2026-05-22. Implementation pending.
+
+## Summary
+
+Today the web app's router blocks render on `authClient.getSession()`. If the API is unreachable,
+the screen stays blank — even when there's already a valid session cookie and locally cached
+content. This breaks the "fat-client works offline" promise from PR #46 in the most visible way
+possible (the entry path).
+
+This phase introduces **profiles**: a local-first identity layer that decouples "who is this
+device's data for?" from "is there a live server session right now?" Each profile owns its own
+IndexedDB database; the auth status of that profile is a runtime attribute that flips between online
+and offline. The router auto-enters the last-used profile on launch and the workspace renders from
+the cached DB immediately, regardless of network state.
+
+The same infrastructure also enables multi-profile usage on shared devices (rare per the current
+user base but cheap to support given the per-profile DB shape).
+
+## Concept
+
+A **profile** is a local persistent identity:
+
+* Created when a user signs in to a server account for the first time on a given device.
+* Tied to a specific server account by `userId`.
+* Owns an IndexedDB database named `verse-vault-${userId}` containing all of that user's cached
+  content (snapshots, testStates, eventQueue, eventQueueOrphans, renders).
+* Persists across sign-outs. Sign-out clears only the active session cookie, not the profile.
+* Can be entered while offline (no session): cached cards display, grades queue, sync waits.
+
+A **shared registry** database `verse-vault-registry` holds:
+
+* One entry per profile: `{ profileId, email, displayName, image?, lastUsedAt, createdAt }`.
+* A `lastActiveProfileId` pointer.
+
+The registry is the only thing read before knowing which per-profile DB to open. Everything inside a
+profile's DB stays scoped to that profile.
+
+## Data model
+
+### Registry DB
+
+Database name: `verse-vault-registry`. Single version, single store.
+
+Object store `profiles`:
+
+* Key path: `profileId` (string — the server's `userId`).
+* Row shape:
+  ```ts
+  interface ProfileRow {
+    profileId: string        // server userId
+    email: string
+    displayName: string      // from session.user.name; falls back to email
+    image: string | null     // from session.user.image
+    createdAt: number        // unix secs
+    lastUsedAt: number       // updated on every profile entry
+  }
+  ```
+
+Object store `meta`:
+
+* Key path: implicit (single row, keyed by `'singleton'`).
+* Row shape: `{ key: 'singleton', lastActiveProfileId: string | null }`.
+
+No indexes; lookups are direct by key or full scan (registry is small — bounded by # of profiles on
+this device, realistically < 10).
+
+### Per-profile DB
+
+Database name: `verse-vault-${profileId}`. Same 5 stores as today's `verse-vault` DB: `snapshots`,
+`testStates`, `eventQueue`, `eventQueueOrphans`, `renders`. No key-shape changes inside — the
+existing helpers move verbatim, parameterised by which DB they open.
+
+The `DB_VERSION` constant from `persistence.ts` stays at 1 for new per-profile DBs (since they start
+fresh, no migration needed). The upgrade-handler logic still applies for forward evolutions.
+
+## Lifecycle
+
+```
+               ┌──────────────────────────────────┐
+               │           App launch             │
+               └──────────────────────────────────┘
+                               │
+                               ▼
+               ┌──────────────────────────────────┐
+               │  Read verse-vault-registry       │
+               │  → lastActiveProfileId           │
+               └──────────────────────────────────┘
+                               │
+           ┌───────────────────┴───────────────────┐
+     null/missing                              has value
+           │                                      │
+           ▼                                      ▼
+┌──────────────────┐                  ┌──────────────────────┐
+│  Profile picker  │                  │  Open profile DB     │
+│  (0-profile      │                  │  Mount workspace     │
+│   empty state    │                  │  (immediate render)  │
+│   if registry    │                  └──────────────────────┘
+│   also empty)    │                              │
+└──────────────────┘                              ▼
+           │                          ┌──────────────────────┐
+           ▼                          │  Background sync     │
+┌──────────────────┐                  │  attempt             │
+│  Sign-in form    │                  └──────────────────────┘
+│  (Add profile or │                              │
+│   first profile) │           ┌──────────────────┴───────────┐
+└──────────────────┘         success                       failure
+           │                    │                             │
+           ▼                    ▼                             ▼
+┌──────────────────┐  ┌──────────────────────┐  ┌──────────────────────┐
+│  Create profile  │  │  Profile = online    │  │  Profile = offline   │
+│  + enter         │  │  (no banner)         │  │  Banner: sign in /   │
+└──────────────────┘  └──────────────────────┘  │  syncing N events    │
+                                                └──────────────────────┘
+```
+
+### Launch
+
+1. Open `verse-vault-registry`, read `meta.singleton.lastActiveProfileId`.
+2. If null OR the referenced profile DB doesn't exist → route to the picker.
+3. Otherwise open `verse-vault-${lastActiveProfileId}` and mount the workspace immediately.
+4. In background, call `authClient.getSession()` and attempt the first sync flush. The result sets a
+   single online/offline flag on the active profile (managed by `useAuth` or a new `useProfile`
+   composable).
+5. The workspace UI renders an offline banner when the flag is offline; no banner when online.
+
+### Sign-in (create or attach)
+
+The existing sign-in form is reused for both "create the first profile" and "add another profile"
+paths. After Better Auth completes the sign-in:
+
+1. Read the resulting session's `user` object.
+2. Check the registry for a profile with `profileId === user.id`.
+3. If exists → update `lastUsedAt`, set `lastActiveProfileId` to this id, open its DB, enter the
+   workspace.
+4. If new → create a registry entry from the session user, set `lastActiveProfileId`, open the
+   newly-created per-profile DB (empty), enter the workspace. The engine's `loadEngine` will fetch
+   the snapshot from the server on first material visit, populating the DB.
+
+### Sign-out
+
+Sign-out (from the picker — see below; no sign-out affordance in the workspace itself):
+
+1. Best-effort call to `authClient.signOut()` (server-side session invalidation). Failure here is
+   tolerated; the profile may be offline.
+2. Clear the session cookie locally regardless.
+3. Profile entry + per-profile DB stay untouched. The profile card on the picker remains.
+4. If the signed-out profile was the active one, clear `lastActiveProfileId` (so the next launch
+   shows the picker rather than auto-entering a now-signed-out profile).
+
+### Switch profile
+
+From the workspace, the user menu offers "Switch profile" → routes to the picker.
+
+From the picker, tapping a profile card:
+
+1. Free the current profile's WASM engine instances (via `engineStore.clearAllSessions()` or
+   equivalent).
+2. Close the current profile's IDB handle.
+3. Open the new profile's IDB.
+4. Update `meta.singleton.lastActiveProfileId` and the chosen profile's `lastUsedAt`.
+5. Route into the workspace.
+
+The background sync attempt runs after entry, flipping online/offline appropriately.
+
+### Delete profile
+
+From the picker's per-card kebab menu, "Delete profile" → confirmation dialog ("Remove profile and
+all local data? This won't affect your verse-vault account on the server.") → on confirm:
+
+1. Remove the registry entry.
+2. Delete the per-profile IDB database (`indexedDB.deleteDatabase('verse-vault-${id}')`).
+3. If the deleted profile was active, clear `lastActiveProfileId`.
+4. Card disappears from the picker.
+
+## UI surfaces
+
+### Profile picker
+
+Path: `/profiles` (rename from `/signin`; old `/signin` redirects there for back-compat within the
+SPA — Better Auth links + bookmarks).
+
+States:
+
+* **Empty registry:** Renders the existing email/password + Google sign-in form directly, framed as
+  "Sign in to create your first profile." After sign-in, the new profile is created and the user
+  routes to /review.
+* **1+ profiles:** Renders a vertical list of profile cards plus an "Add another profile" button at
+  the bottom. Each card:
+  * Left: 40×40 avatar (image if available; otherwise initials in a coloured circle).
+  * Middle: display name (bold) above email (muted) above "Last used N hours/days ago".
+  * Right: a kebab (⋮) button. Tapping it opens a dropdown with two items:
+    * **Sign out** — best-effort API call + clear local state. Card stays. Card now reflects "signed
+      out" subtly (e.g., dimmed kebab, or a small muted "signed out" tag).
+    * **Delete profile** — opens the confirmation dialog (above).
+  * Tapping the card body anywhere outside the kebab enters the profile.
+
+Tapping "Add another profile" pushes the existing sign-in form as a sub-view. After sign-in, the new
+profile is created and the user is routed into the workspace.
+
+### Workspace adjustments
+
+Two small additions:
+
+1. **Offline banner.** When the active profile's session state is offline (cookie missing OR server
+   unreachable OR last sync failed), a thin banner sits between the header and the route view:
+   "Offline — sign in to sync N grades." The number is the count of unsynced events in the
+   per-profile `eventQueue`. Clicking it routes to the sign-in form pre-filled with the profile's
+   email (and skips back to the workspace on success).
+2. **User menu → "Switch profile".** Replaces the existing "Sign out" entry. Sign-out lives on the
+   picker; the workspace just lets you go to the picker.
+
+## Sync + offline behaviour
+
+The existing sync logic in `engineStore.ts` is unchanged. The new pieces:
+
+* Background sync attempts on the same cadence (debounced after grades, on visibilitychange, on
+  beforeunload).
+* Sync result feeds a single `profile.online` flag (reactive ref). The banner derives from this
+  flag + the pending-event count.
+* Online → offline transition is triggered by any sync failure (network OR 401 OR anything).
+* Offline → online transition happens automatically when a sync attempt succeeds.
+
+The user doesn't see "session expired" as a distinct state — only "offline." Re-auth from the banner
+flips the flag back to online when sync next succeeds.
+
+## Conflict cases
+
+### Re-auth returns a different user
+
+Scenario: the user is in profile A, the session is offline, they click the offline banner to sign
+in, the form returns user B's session.
+
+Behaviour: detect the mismatch (`session.user.id !== activeProfile.id`), surface a prompt:
+
+> "This profile is for alice@example.com but you just signed in as bob@example.com. [Cancel] [Add
+> bob@example.com as a new profile]"
+
+Cancel → sign out the just-signed-in B session, return to the workspace in profile A's offline
+state.
+
+"Add as new" → create a new profile entry for B, route into the new profile.
+
+### Registry points to a missing DB
+
+Scenario: `lastActiveProfileId = 'abc'` but `indexedDB.databases()` doesn't list `verse-vault-abc`
+(manual user action, dev-tools wipe, browser cleared site data).
+
+Behaviour: on launch, after reading `lastActiveProfileId`, check if the per-profile DB exists. If
+not, fall back to the picker. The registry entry stays (the user can attempt re-entry).
+
+### Conflicting writes on same profile across tabs
+
+Not addressed here — pre-existing behaviour. Each tab opens its own connection to the same profile
+DB. IDB transactions serialise; no design change.
+
+## Migration
+
+On the first sign-in after this lands:
+
+1. The new profile is created from the sign-in response.
+2. Before opening the new per-profile DB, the migration helper checks for the legacy un-namespaced
+   `verse-vault` DB.
+3. If present: copy each of its 5 stores into the corresponding stores of the new profile DB. Use
+   cursors to iterate; bulk-put into the new DB inside a single transaction per store.
+4. After successful copy, delete the legacy DB via `indexedDB.deleteDatabase('verse-vault')`.
+5. Continue with the normal post-sign-in flow.
+
+The migration runs once: subsequent sign-ins find no legacy DB and skip. If the migration fails
+mid-flight, the legacy DB stays intact and the new profile DB is left in whatever state the partial
+copy reached (acceptable: the user can retry by signing out + back in, or the engine's `loadEngine`
+will refetch from the server on first material visit).
+
+For users who have never signed in pre-upgrade, no migration runs.
+
+For users who have multiple unsynced events in the legacy DB and try to use a different account
+post-upgrade as their first sign-in: the events get migrated to that wrong account's profile. This
+is a rare edge case; documented but not specifically guarded.
+
+## Phasing
+
+The change splits into two PRs that are individually shippable. Order matters; PR A blocks PR B.
+
+### PR A — Profile infrastructure + offline boot
+
+Goal: render the workspace immediately on launch from cached data. No picker UI yet — the existing
+sign-in form is the only entry point for unauthenticated users, but its post-sign-in behaviour
+creates a profile entry under the hood.
+
+Changes:
+
+* New `apps/web/src/lib/engine/registry.ts`: registry DB helpers (open, read profiles, write
+  profile, update lastActiveProfileId, delete profile).
+* New `apps/web/src/lib/engine/migrate-legacy.ts`: one-shot migration helper.
+* `apps/web/src/lib/engine/persistence.ts`: rework `openDb()` to accept a profileId; current
+  module-level singleton becomes a "current handle" that swaps on profile entry. All existing
+  helpers (`getSnapshot`, `putSnapshot`, etc.) read from the current handle.
+* `apps/web/src/lib/engine/engineStore.ts`: add `clearAllSessions()` callable from profile switch.
+  Audit module-level state for anything else that needs reset on switch.
+* `apps/web/src/composables/useAuth.ts` (or a new `useProfile.ts`): manage the active profile
+  * online/offline flag; expose actions for sign-in (create-or-update profile), sign-out, switch.
+* `apps/web/src/router/index.ts`: replace the blocking `getSession()` await with a registry read. If
+  `lastActiveProfileId` resolves, open the DB and let the route render; otherwise redirect to
+  /signin.
+* `apps/web/src/lib/authClient.ts`: extend the wrapped `signOut` to update the registry (clear
+  `lastActiveProfileId` if the signed-out profile is active).
+* `apps/web/src/views/*.vue`: add the offline banner component, slot it into the layout.
+* `apps/web/CHANGELOG.md`: [Unreleased] entry under a new "Offline" subsection.
+
+Not in PR A: picker UI, "Switch profile" in user menu, per-profile kebab actions, manage- profiles
+settings page.
+
+The existing sign-out button (currently in the workspace user menu) stays in place for PR A — it
+just gets the new "clear session, keep profile" semantics. PR B moves sign-out off the workspace
+entirely and onto the picker.
+
+Expected size: ~400 LOC.
+
+### PR B — Picker UI
+
+Goal: surface the multi-profile UX. Built entirely on PR A's infrastructure.
+
+Changes:
+
+* `apps/web/src/views/ProfilePickerView.vue` (replaces/extends `SignInView.vue`): renders the
+  profile card list + kebab menu, or the empty-state sign-in form when registry is empty.
+* Card component with avatar, name/email, last-used, kebab.
+* Confirmation dialog component for delete-profile.
+* `apps/web/src/router/index.ts`: route `/profiles` to the picker; redirect `/signin` to `/profiles`
+  for back-compat.
+* `apps/web/src/views/MaterialView.vue` (or wherever the user menu lives): add "Switch profile"
+  entry that routes to `/profiles`.
+
+Not in PR B: the substantive infrastructure (that's PR A) or any new offline behaviours.
+
+Expected size: ~250 LOC.
+
+## Critical files
+
+PR A:
+
+* `apps/web/src/lib/engine/persistence.ts` (substantial rework)
+* `apps/web/src/lib/engine/engineStore.ts` (small additions)
+* `apps/web/src/lib/engine/registry.ts` (new)
+* `apps/web/src/lib/engine/migrate-legacy.ts` (new)
+* `apps/web/src/composables/useAuth.ts` (or new `useProfile.ts`)
+* `apps/web/src/lib/authClient.ts`
+* `apps/web/src/router/index.ts`
+* `apps/web/src/App.vue` (slot the offline banner)
+* New banner component (`apps/web/src/components/OfflineBanner.vue`)
+* `apps/web/CHANGELOG.md`
+
+PR B:
+
+* `apps/web/src/views/ProfilePickerView.vue` (new or rename from SignInView)
+* New components: `ProfileCard.vue`, `DeleteProfileDialog.vue`
+* `apps/web/src/router/index.ts` (route + redirect)
+* Update to wherever the workspace user menu lives
+* `apps/web/CHANGELOG.md`
+
+## Verification
+
+End-to-end manual smokes; no new automated test infrastructure required (apps/web has none today).
+
+PR A:
+
+1. **Cold start, fresh install:** open `pnpm tauri dev`. Picker (empty state via sign-in form)
+   renders. Sign in. Confirm `verse-vault-registry` exists with one profile entry, and
+   `verse-vault-${userId}` exists with the snapshot.
+2. **Warm start, online:** restart. Confirm the workspace renders immediately, banner doesn't show,
+   sync flush succeeds in DevTools network.
+3. **Warm start, offline:** kill the API process or DevTools → Network → Offline. Restart. Confirm
+   workspace renders immediately, "Offline — sign in to sync N grades" banner appears. Grade a card;
+   confirm event queues in IDB.
+4. **Reconnect from offline:** restore network. Confirm the banner clears within the sync debounce
+   window and queued events flush.
+5. **Sign out:** use the existing sign-out button in its current location (PR A doesn't move it).
+   Confirm the profile + per-profile DB stay intact and `lastActiveProfileId` clears. On next
+   launch, the picker (still the empty sign-in form in PR A) appears.
+6. **Migration:** before merging PR A, snapshot an existing `verse-vault` DB locally. After applying
+   PR A and signing in for the first time, confirm the new `verse-vault-${userId}` DB has the same
+   data and `verse-vault` is gone.
+
+PR B:
+
+7. **Picker with one profile:** sign in, sign out, return to /profiles. Card visible with correct
+   avatar/name/email/last-used.
+8. **Add another profile:** click "Add another profile," sign in as a different user, confirm a
+   second card appears and the new profile is active.
+9. **Switch profiles:** tap the second profile's card. Confirm the workspace re-renders with the new
+   profile's data (engine reloaded, cached cards from B not A).
+10. **Sign out from picker kebab:** confirm the card stays but the kebab/state reflects signed-out.
+11. **Delete profile:** kebab → Delete → confirm dialog → confirm. Card disappears; verify
+    `verse-vault-${id}` is gone from `indexedDB.databases()`.
+12. **Different-user conflict:** in profile A signed-out, click banner sign-in, sign in as user B.
+    Confirm the conflict prompt appears with the two options.
+
+`pnpm --filter @verse-vault/web run type-check` clean. `pnpm --filter @verse-vault/api test`
+unchanged at 101/101 (no server changes).
+
+## Open items / non-blocking decisions
+
+These are spelled out here so the implementation plan can pick them up explicitly:
+
+* **Picker "Sign out" action:** best-effort API call + always clear local state. If the API call
+  fails (offline), we still clear the local cookie. Server-side session may persist briefly until it
+  expires naturally.
+* **Picker doesn't probe per-profile online state:** showing "last used N ago" is the affordance,
+  not "this profile is online right now." Per-profile probing would require N parallel `getSession`
+  attempts with different cookies, which isn't readily doable in a single Better Auth client
+  instance anyway.
+* **Banner click target:** routes to a sign-in sub-page pre-filled with the profile's email, then
+  back to the workspace on success. Behaves like the existing sign-in form, scoped to one profile.
+* **First-ever-launch on a device with no profiles and no network:** the empty-state sign-in form
+  renders but submit will fail. That's the same outcome as today; the picker doesn't improve it (you
+  can't sign in offline). The form should surface the network error clearly, but designing that
+  affordance is out of scope here.
+* **`/signin` URL back-compat:** redirect to `/profiles`. Better Auth's internal `callbackURL`
+  values that may reference `/signin` continue to work via the redirect.
+
+## Out of scope (future work)
+
+* Per-profile passcode lock (privacy on borrowed devices).
+* Cross-tab profile-switch coordination (today each tab is independent; if user switches in one tab,
+  others stay on the old profile until reload — acceptable).
+* Mobile (iOS/Android) Tauri builds — design is platform-agnostic but Android specifically needs an
+  `android-x86_64`/`aarch64` matrix entry in the release workflow, which is a separate workstream.
+* Account merging (two profiles representing the same server account, somehow drifted apart).
+* Sign-in with a deep-link from a different app/browser (OAuth bounce from a Tauri-external browser
+  back into the Tauri window).

--- a/docs/superpowers/specs/2026-05-22-profiles-design.md
+++ b/docs/superpowers/specs/2026-05-22-profiles-design.md
@@ -282,7 +282,8 @@ is a rare edge case; documented but not specifically guarded.
 
 ## Phasing
 
-The change splits into two PRs that are individually shippable. Order matters; PR A blocks PR B.
+The change splits into three PRs that are individually shippable. Order matters; PR A blocks PR B,
+and PR C builds on the profile model PR A introduces but is otherwise independent.
 
 ### PR A — Profile infrastructure + offline boot
 
@@ -337,6 +338,148 @@ Changes:
 Not in PR B: the substantive infrastructure (that's PR A) or any new offline behaviours.
 
 Expected size: ~250 LOC.
+
+### PR C — Device tokens for stale-cookie render refresh
+
+Goal: a user whose Better Auth session has expired (cookie gone, but the device is otherwise healthy
+and online) can still refresh stale renders from the API without being forced to re-sign-in. Writes
+(grades, graduations, sync flush) still require a fresh session — the device token is read-only.
+
+The narrow UX gap this closes: card viewed online 31 days ago, app signed-out/offline since, back
+online but cookie is gone. Today `/api/cards/:cardId` returns 401, the render stays expired in IDB,
+the user sees a blank space until they re-sign-in. After PR C, the device token authenticates the
+read, the render refreshes, the user keeps going.
+
+#### Server
+
+New table:
+
+```sql
+CREATE TABLE device_tokens (
+  token TEXT PRIMARY KEY,         -- random opaque, ~256-bit URL-safe
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  created_at INTEGER NOT NULL,    -- unix secs
+  last_seen_at INTEGER NOT NULL   -- unix secs; updated on every request
+);
+CREATE INDEX idx_device_tokens_user ON device_tokens (user_id);
+```
+
+Issuance:
+
+* On every successful Better Auth sign-in (email/password + social), mint a new token and set it as
+  a long-lived cookie. The cleanest hook is a Better Auth `after`/`hooks` handler on the sign-in
+  callback; if that proves awkward, fall back to a `POST /api/auth/device-token` endpoint the client
+  calls right after sign-in.
+* Cookie: `Set-Cookie: vv-device=<token>; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000; Path=/`
+  (1-year `Max-Age` — practical "doesn't expire" without being literally infinite).
+* If the user signs in from a device that already has a `vv-device` cookie, reuse it (look up by
+  token; if it matches the just-signed-in user, refresh `last_seen_at`; if it doesn't, issue a new
+  one — the old one keeps working for whoever it belonged to until it ages out).
+
+New middleware `requireDeviceOrSession`:
+
+* Try Better Auth session first; if present, populate `c.var.user` and continue.
+* If no session, look for `vv-device` cookie. If present, look up the token row, populate
+  `c.var.user` with `{ id: token.user_id, ... }` (we can join `user` for email/name if needed for
+  logging), and continue. Update `last_seen_at` in the same request (async; don't block).
+* If neither, 401.
+
+Applied to: `GET /api/cards/:cardId` and `GET /api/materials/:id/renders`. Both are read-only
+renders, both have MAUA bulk-extraction concerns that rate-limiting + user-binding adequately
+mitigate.
+
+NOT applied to:
+
+* `POST /api/sync/:materialId/events` (writes — state mutations).
+* `GET /api/sync/:materialId/state` (returns testStates — per-user state, leak-sensitive).
+* `POST /api/years/:materialId/settings` (writes).
+* `POST /api/materials/enroll` (writes).
+* `PATCH /api/materials/:id/offline-mode` (writes — toggles per-user flag).
+* `GET /api/materials/:id/status` (returns enrolment + offline-mode state — sensitive enough to gate
+  on a real session).
+* Anything under `/api/auth/*` — Better Auth manages those internally.
+
+Rate limit per device token: simple sliding-window counter in process memory. Suggested ceiling: 1k
+requests/day per token. Generous for legitimate use (a heavy daily reviewer flips through ~200 cards
+a day with most served from IDB cache); chokes obvious bots. The counter lives in memory because
+verse-vault is single-instance; if we ever scale horizontally, move to a SQLite-backed
+sliding-window or a Redis-like layer.
+
+#### Client
+
+No new code paths needed beyond letting the existing cookie machinery flow:
+
+* `apiClient` already uses `credentials: 'include'` on every fetch, so the `vv-device` cookie
+  travels alongside the session cookie automatically. Same applies inside the Tauri webview.
+* On first sign-in post-PR-C, the server sets the cookie in the response to the sign-in call. The
+  client doesn't need to know; subsequent requests carry it.
+
+One small UX consideration: when a user is on a device-token-only auth state (no fresh session), the
+offline banner from PR A still appears because the session attempt to `getSession` returns null.
+That's correct — they ARE signed out as far as Better Auth is concerned. The banner just prompts
+them to sign in to get a fresh session, which they need for writes anyway. Renders refresh
+transparently in the background while they're in this state.
+
+#### Revocation
+
+Per the "doesn't need to be invalidated" framing, there's no explicit revoke API. Cleanups that
+happen anyway:
+
+* `ON DELETE CASCADE` on the user FK drops all tokens for that user when an account is deleted
+  (rare).
+* PR B's "Delete profile" flow can optionally call a `DELETE /api/auth/device-token` endpoint to
+  clean up server-side. Even if it doesn't, the token ages out via the sliding TTL below.
+* **Sliding 1-year TTL.** Server prunes tokens whose `last_seen_at` is older than 1 year on every
+  API boot (mirrors the `apibible_cache.pruneExpired()` pattern). Dormant devices forget themselves
+  naturally; active devices renew their `last_seen_at` on every request and never expire.
+
+If a token ever does get genuinely compromised and we want explicit revocation, adding a
+`DELETE /api/auth/device-token/:token` endpoint or a row-by-row admin view is straightforward — but
+not in scope for PR C.
+
+#### MAUA implications
+
+* **Bulk extraction (clause #4):** rate-limit-per-token × tokens-per-legitimate-user ×
+  legitimate-user-count = bounded throughput. For verse-vault's user base, well within bounds.
+  Compare to the unauth case where this guard doesn't exist at all.
+* **30-day cache TTL (clause #1):** unchanged. Client still expires renders at 30d; with a valid
+  device token, it can refresh them without prompting a re-sign-in. The clause is about server-side
+  cache freshness, not about session lifetime.
+* **No AI/LLM training (clause #2/#3):** unchanged. No new API surface emits raw api.bible HTML;
+  same `composeRender` output as today.
+
+#### Migration
+
+New table; no migration of existing data needed. Schema bump lands as the next
+`migrations/0017_device_tokens.sql`. Existing sessions stay valid; users get a device token the next
+time they sign in (or one can be backfilled lazily on first device-token-required request).
+
+#### Critical files (PR C)
+
+Created:
+
+* `packages/api/migrations/0017_device_tokens.sql`
+* `packages/api/src/lib/device-token.ts` — mint, lookup, prune helpers
+* `packages/api/src/middleware/device-or-session.ts` — the relaxed auth middleware
+
+Modified:
+
+* `packages/api/src/db/schema.ts` — add `device_tokens` table definition
+* `packages/api/src/lib/auth.ts` — wire the sign-in callback to mint a token
+* `packages/api/src/routes/cards.ts` — swap `requireAuth` → `requireDeviceOrSession` on
+  `GET /:cardId`
+* `packages/api/src/routes/materials.ts` — same swap on `GET /:id/renders`
+* `packages/api/src/index.ts` (or wherever startup hooks live) — call `pruneExpiredDeviceTokens()`
+  on boot
+* `packages/api/CHANGELOG.md` — entry + version bump
+
+Expected size: ~200 LOC.
+
+Out of scope for PR C:
+
+* Explicit revocation UI / API.
+* Per-IP rate limiting on top of per-token.
+* Token rotation on a schedule (sliding TTL is enough).
 
 ## Critical files
 


### PR DESCRIPTION
First of three PRs implementing the profiles design at
[`docs/superpowers/specs/2026-05-22-profiles-design.md`](https://github.com/TommyAmberson/verse-vault/blob/feat/profiles-infra/docs/superpowers/specs/2026-05-22-profiles-design.md).
This is the infrastructure + offline-first boot. PR B (picker UI) and PR C (device tokens for
stale-cookie render refresh) build on top.

## What changes

The web app's router used to block render on `authClient.getSession()`. With the API
unreachable — Tauri shell on a plane, dev API stopped, network drop — the screen stayed blank
indefinitely. This PR decouples local identity from server session: each signed-in account on a
device gets its own IndexedDB database (`verse-vault-${userId}`); a shared
`verse-vault-registry` DB tracks known profiles + a `lastActiveProfileId` pointer. The router
boot reads the registry (fast local IDB) instead of awaiting the network, and the workspace
renders immediately from cached data.

A tri-state sync indicator (online / signed-out / offline) drives a new banner so the UI can
honestly tell apart "your cookie expired, sign in to sync" from "your network is down, sign-in
won't help."

## Commits

### Design

- **`6519f8a`** docs: add profiles + offline-first boot design
- **`85754ac`** docs: add PR C device-tokens design
- **`86dcdfa`** docs: note anonymous rendering as PR C non-goal

### Infrastructure (the substantive work)

- **`b93b4dc`** feat(web): add profile registry idb helpers
  New `apps/web/src/lib/engine/registry.ts` owns `verse-vault-registry`. Two stores: `profiles`
  (one row per known profile) + `meta` (singleton with `lastActiveProfileId`). Reuses
  `promiseRequest` / `transactionComplete` from `persistence.ts` (lifted from private to
  exported).
- **`0a6517b`** refactor(web): parameterise idb by profile
  `persistence.ts`'s module-level `DB_NAME = 'verse-vault'` becomes a runtime `activeProfileId`
  variable. `openDb()` opens `verse-vault-${activeProfileId}`. New `setActiveProfile()` closes
  the current handle and opens the new DB. Helper signatures unchanged.
- **`5a8911b`** feat(web): legacy idb migration helper
  `migrate-legacy.ts`: one-shot copy from the un-namespaced `verse-vault` DB into the new
  per-profile DB on first sign-in. Handles `onblocked` resolution and partial-failure recovery.
- **`7f9c62f`** feat(web): profile-aware useAuth composable
  Module-level reactive state for `activeProfile`, `syncState`, `conflict`. New exports:
  `loadActiveProfileFromRegistry`, `signInComplete`, `signOut` (clears session + lastActive,
  keeps profile), `markSyncState`. Conflict detection for re-auth-as-different-user.
- **`4efde9e`** feat(web): cache-first router guard
  `beforeEach` reads the registry (fast IDB) instead of awaiting `getSession`. Live session
  check fires unawaited; result feeds the sync-state indicator.
- **`a3d4da5`** feat(web): wire sign-in completion hook
  After Better Auth success, `signInComplete` upserts the profile, sets `lastActiveProfileId`,
  swaps the persistence layer to the new DB, runs the legacy migration on first-ever profile.
- **`7e75ad5`** feat(web): offline banner + profile-driven nav
  New `OfflineBanner.vue` reads `syncState`. `App.vue`'s nav identity comes from
  `activeProfile` instead of Better Auth's session — keeps the workspace rendered when offline
  with a valid cached profile.

### Fixes + refinements (during smoke + /simplify)

- **`d10a130`** chore(web): bump to 0.1.9
- **`e8b941b`** fix(web): wrap auth verbs to call signInComplete
  `SignInView.onSuccess` was calling `getSession()` after the form emitted 'success' — a race
  with Better Auth's cookie-set could leave `signInComplete` un-called and the user bounced
  back to /signin. Wrap `signInEmail` / `signUpEmail` in useAuth so they call `signInComplete`
  inline with the user object Better Auth's own response already carries.
- **`64fcda8`** feat(web): tri-state sync indicator
  Replaces the boolean `isOnline` with a `SyncState` enum: `online` / `signed-out` / `offline`.
  Banner copy varies: signed-out shows "Sign in to sync N grades" (clickable, works), offline
  shows "Offline — N grades queued for next sync" (framing is "your work is safe").
- **`cba2c00`** refactor(web): one registry read per nav
  Router was reading the registry twice per navigation. Collapse to a single read; reset the
  load-once flag on sign-out.
- **`c75a136`** refactor(web): trim noise from auth + persistence
- **`d4305e8`** perf(web): skip queue read when banner hidden

## Known limitations (deferred to PR B / PR C)

- **No picker UI yet.** Sign-in form is still the entry point for unauthenticated users; the
  workspace user menu still has "Sign out" rather than "Switch profile." PR B replaces the
  sign-in form with the picker (cards + kebab menu).
- **Social sign-in's profile creation runs on the OAuth callback re-entry.** PR A wires
  `signInComplete` inline with `signInEmail` / `signUpEmail`; the social flow leaves the page
  for the OAuth redirect, so the registry-upsert needs to land via a watcher when the session
  reactive ref updates on re-entry. Currently social sign-in works for navigation but the
  profile entry is created on the first nav after re-entry, not synchronously with the
  Better Auth response.
- **Stale-cookie + online + cache expired = can't refresh renders.** PR C addresses this with
  device tokens; PR A's offline banner is the surface that tells users they need to sign in
  to sync.

## Test plan

- [x] `pnpm --filter @verse-vault/web run type-check` clean
- [x] `pnpm --filter @verse-vault/api test` unchanged at 101/101 (no server changes)
- [x] Manual: signed in fresh + observed registry/per-profile DB created in IDB
- [x] Manual: prior un-namespaced DB migrates to per-profile DB on first sign-in
- [ ] Manual after merge: real offline boot (online once, populate IDB, then close + reopen
  offline → workspace renders cards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)