### PR TITLE
Multi-session sign-in + per-card reauth

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,34 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Multi-session + reauth dialog
+
+* **Multiple accounts on one device.** Wires Better Auth's `multiSession` plugin (server) +
+  `multiSessionClient` (client). Each sign-in stacks a new session cookie alongside any existing
+  ones rather than replacing them; `enterProfile` calls `multiSession.setActive` before swapping
+  per-profile IDB so the API sees the right user for that profile's session. Tokens are stored on
+  the registry row (`ProfileRow.sessionToken`); the picker uses them to render a "Signed in" /
+  "Signed out" chip per card.
+* **Per-card sign-out.** Any signed-in card's kebab now exposes Sign out. Active-card sign-out
+  clears the in-memory active state and drops back to the picker; non-active sign-out just flips
+  that card's chip to "Signed out" — the workspace continues uninterrupted on the active profile.
+  Built on `multiSession.revoke` so other profiles' cookies stay intact.
+* **Click-to-reauth on signed-out cards.** Cards without a valid token emit `reauth` instead of
+  `enter`; the picker drops into the sign-in form so the user can refresh their session.
+* **Reauth dialog for conflicting sessions.** When the OAuth callback or a fresh email sign-in
+  returns a different user than the currently-active profile, the workspace surfaces a modal: Switch
+  to the new account (becomes active; old profile remains on the device as a signed-out card) or
+  Stay signed in (revoke the new token, keep the prior active profile — typically stale until the
+  user re-auths). Replaces the previously-orphaned `useAuth().conflict` ref that had no consumer.
+* **Boot reconciliation.** The router boot kicks off `multiSession.listDeviceSessions` and clears
+  stored tokens for any registry profile whose session no longer exists server-side, so the chip
+  reflects reality after expirations or remote revocations.
+* New: `ConfirmDialog` reused as the reauth modal in `App.vue`.
+* Modified: `lib/engine/registry.ts` (DB v1 → v2, backfills `sessionToken: null`); `useAuth.ts`
+  (token capture + reconcile + accept/cancel resolvers; `signOut(profileId?)`); `lib/authClient.ts`
+  (attaches `multiSessionClient`); `components/ProfileCard.vue` (chip + always-on Sign out + reauth
+  event); `views/ProfilePickerView.vue` (wires the new events).
+
 ### Profile picker UI
 
 * **`/profiles` is the new entry point.** Replaces the single-form `SignInView`; lists every profile

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -3,10 +3,11 @@ import { computed, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
 
 import { api } from '@/api'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import OfflineBanner from '@/components/OfflineBanner.vue'
 import { useAuth } from '@/composables/useAuth'
 
-const { activeProfile } = useAuth()
+const { activeProfile, conflict, acceptPendingSignIn, cancelPendingSignIn } = useAuth()
 const route = useRoute()
 
 // Driven by the active profile (cached locally) rather than Better
@@ -54,6 +55,23 @@ watch(() => route.fullPath, refreshMemorizeCount)
       </nav>
     </header>
     <OfflineBanner />
+    <ConfirmDialog
+      v-if="conflict"
+      title="Switch to a different account?"
+      :confirm-label="`Switch to ${conflict.pendingUser.email}`"
+      cancel-label="Stay signed in"
+      @confirm="acceptPendingSignIn"
+      @cancel="cancelPendingSignIn"
+    >
+      <p>
+        You were signed in as <strong>{{ conflict.expectedEmail }}</strong>,
+        but the sign-in just completed as
+        <strong>{{ conflict.pendingUser.email }}</strong>. Switching will make
+        the new account the active workspace and leave
+        {{ conflict.expectedEmail }} on this device as a signed-out
+        profile you can return to.
+      </p>
+    </ConfirmDialog>
     <main class="site-main">
       <RouterView />
     </main>

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -5,16 +5,18 @@ import type { ProfileRow } from '@/lib/engine/registry'
 
 const props = defineProps<{
   profile: ProfileRow
-  /** True when this card represents the currently-active profile.
-   *  Drives whether the kebab surfaces "Sign out" — non-active
-   *  profiles share the active profile's cookie in PR B, so signing
-   *  them out independently isn't meaningful until per-profile device
-   *  tokens land. */
+  /** True when this card represents the currently-active profile. */
   active: boolean
+  /** Whether the profile has a live session on this device. Drives
+   *  the chip + whether card click means enter or re-auth. */
+  signedIn: boolean
 }>()
 
 const emit = defineEmits<{
+  /** Clicked a signed-in card — swap workspace to this profile. */
   (e: 'enter'): void
+  /** Clicked a signed-out card — re-auth required to use it. */
+  (e: 'reauth'): void
   (e: 'sign-out'): void
   (e: 'delete'): void
 }>()
@@ -76,10 +78,15 @@ function onDeleteClick(ev: Event) {
 // <button>, so the kebab + menu items inside it remain valid
 // interactive descendants. Native button-in-button is invalid HTML
 // and confuses screen readers.
+function onCardActivate() {
+  if (props.signedIn) emit('enter')
+  else emit('reauth')
+}
+
 function onCardKeydown(ev: KeyboardEvent) {
   if (ev.key === 'Enter' || ev.key === ' ') {
     ev.preventDefault()
-    emit('enter')
+    onCardActivate()
   }
 }
 </script>
@@ -87,9 +94,10 @@ function onCardKeydown(ev: KeyboardEvent) {
 <template>
   <div
     class="card"
+    :class="{ 'is-active': active, 'is-signed-out': !signedIn }"
     role="button"
     tabindex="0"
-    @click="emit('enter')"
+    @click="onCardActivate"
     @keydown="onCardKeydown"
   >
     <div class="avatar">
@@ -97,7 +105,12 @@ function onCardKeydown(ev: KeyboardEvent) {
       <span v-else class="initials">{{ initials }}</span>
     </div>
     <div class="meta">
-      <p class="name">{{ profile.displayName }}</p>
+      <p class="name">
+        {{ profile.displayName }}
+        <span class="chip" :class="{ 'chip-out': !signedIn }">
+          {{ signedIn ? 'Signed in' : 'Signed out' }}
+        </span>
+      </p>
       <p class="email">{{ profile.email }}</p>
       <p class="last-used">Last used {{ lastUsedLabel }}</p>
     </div>
@@ -113,7 +126,7 @@ function onCardKeydown(ev: KeyboardEvent) {
       </button>
       <div v-if="menuOpen" class="menu" role="menu">
         <button
-          v-if="active"
+          v-if="signedIn"
           type="button"
           class="menu-item"
           role="menuitem"
@@ -155,6 +168,18 @@ function onCardKeydown(ev: KeyboardEvent) {
   background: var(--color-bg);
 }
 
+.card.is-active {
+  border-color: var(--color-accent);
+}
+
+.card.is-signed-out {
+  opacity: 0.75;
+}
+
+.card.is-signed-out:hover {
+  opacity: 1;
+}
+
 .avatar {
   flex: 0 0 auto;
   width: 2.5rem;
@@ -194,6 +219,26 @@ function onCardKeydown(ev: KeyboardEvent) {
 .name {
   font-weight: 600;
   font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.chip {
+  font-size: 0.65rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.chip-out {
+  background: transparent;
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
 }
 
 .email {

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -109,12 +109,15 @@ export function clearConflict(): void {
  *  the workspace can render. Idempotent on re-entry with the same
  *  user; surfaces `conflict` and returns early when the session user
  *  doesn't match the currently-active profile. */
-export async function signInComplete(user: {
-  id: string
-  email: string
-  name?: string
-  image?: string | null
-}): Promise<void> {
+export async function signInComplete(
+  user: {
+    id: string
+    email: string
+    name?: string
+    image?: string | null
+  },
+  sessionToken: string | null = null,
+): Promise<void> {
   const existing = await registry.getProfile(user.id)
 
   // Conflict: user re-authed but came back as someone else. Leave the
@@ -144,9 +147,10 @@ export async function signInComplete(user: {
     image: user.image ?? null,
     createdAt: existing?.createdAt ?? now,
     lastUsedAt: now,
-    // Placeholder; populated by the session-token capture path that
-    // runs after the sign-in response or session-watcher resolves.
-    sessionToken: existing?.sessionToken ?? null,
+    // Prefer the freshly-issued token; fall back to whatever was on
+    // the existing row so a re-entry without a new token (e.g. an
+    // idempotent watcher fire) doesn't blow away a valid stored one.
+    sessionToken: sessionToken ?? existing?.sessionToken ?? null,
   }
   await registry.upsertProfile(row)
   await registry.setLastActiveProfileId(user.id)
@@ -242,16 +246,61 @@ export async function signOut(): Promise<void> {
 // the session ref: when a user appears that doesn't match the active
 // profile, run `signInComplete` to upsert the profile, swap the
 // per-profile DB, and migrate the legacy DB if needed. Idempotent —
-// no-ops if `activeProfile` already matches the session user.
+// no-ops if `activeProfile` already matches the session user. Also
+// keeps the stored sessionToken fresh for the active profile when the
+// server rotates it (cookie refresh, etc.).
 const sessionWatchRef = authClient.useSession()
 watch(
-  () => sessionWatchRef.value.data?.user,
-  (user) => {
+  () => sessionWatchRef.value.data,
+  (data) => {
+    const user = data?.user
     if (!user) return
-    if (activeProfile.value?.profileId === user.id) return
-    void signInComplete(user)
+    const sessionToken = data?.session?.token ?? null
+    if (activeProfile.value?.profileId === user.id) {
+      // Same user as the active profile; just refresh the stored
+      // token if it changed (no DB swap, no migration).
+      if (sessionToken && activeProfile.value.sessionToken !== sessionToken) {
+        void registry
+          .updateProfileSessionToken(user.id, sessionToken)
+          .then((row) => {
+            if (row) activeProfile.value = row
+          })
+      }
+      return
+    }
+    void signInComplete(user, sessionToken)
   },
 )
+
+/** Background reconcile: ask the server which device sessions are
+ *  still alive, then clear stored sessionTokens on any registry row
+ *  whose token isn't in the response. Called from the router boot —
+ *  fire-and-forget, never throws. The picker reads `listProfiles()`
+ *  on mount so reconcile results show up the next time the user
+ *  navigates to `/profiles`. */
+export async function reconcileDeviceSessions(): Promise<void> {
+  try {
+    const result = await authClient.multiSession.listDeviceSessions()
+    const sessions = result?.data ?? []
+    const liveTokens = new Set(
+      sessions
+        .map((entry: { session?: { token?: string } }) => entry.session?.token)
+        .filter((t): t is string => typeof t === 'string'),
+    )
+    const profiles = await registry.listProfiles()
+    for (const p of profiles) {
+      if (p.sessionToken && !liveTokens.has(p.sessionToken)) {
+        const updated = await registry.updateProfileSessionToken(p.profileId, null)
+        if (updated && activeProfile.value?.profileId === p.profileId) {
+          activeProfile.value = updated
+        }
+      }
+    }
+  } catch {
+    // Offline / 401 / anything — leave stored tokens alone. They'll
+    // be reconciled on the next successful boot.
+  }
+}
 
 // --- Composable surface -------------------------------------------------------
 
@@ -272,14 +321,14 @@ export function useAuth() {
   async function signInEmail(email: string, password: string) {
     const result = await factoryShape.signInEmail(email, password)
     const user = extractUser(result)
-    if (user) await signInComplete(user)
+    if (user) await signInComplete(user, extractSessionToken(result))
     return result
   }
 
   async function signUpEmail(email: string, password: string) {
     const result = await factoryShape.signUpEmail(email, password)
     const user = extractUser(result)
-    if (user) await signInComplete(user)
+    if (user) await signInComplete(user, extractSessionToken(result))
     return result
   }
 
@@ -308,8 +357,26 @@ interface UserPayload {
   image?: string | null
 }
 
-function extractUser(
-  result: { data?: { user?: UserPayload } | null } | undefined,
-): UserPayload | null {
-  return result?.data?.user ?? null
+interface SignInData {
+  user?: UserPayload
+  token?: string | null
+  session?: { token?: string | null } | null
+}
+
+function extractUser(result: unknown): UserPayload | null {
+  return readData(result)?.user ?? null
+}
+
+function extractSessionToken(result: unknown): string | null {
+  // Better Auth's email/password response surfaces the session token
+  // at `data.token`; some plugin paths put it under `data.session.token`.
+  // Take whichever is present.
+  const data = readData(result)
+  return data?.token ?? data?.session?.token ?? null
+}
+
+function readData(result: unknown): SignInData | null {
+  if (!result || typeof result !== 'object') return null
+  const data = (result as { data?: unknown }).data
+  return data && typeof data === 'object' ? (data as SignInData) : null
 }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -140,13 +140,28 @@ export async function acceptPendingSignIn(): Promise<void> {
  *  profile (typically stale — that's what triggered the re-auth). */
 export async function cancelPendingSignIn(): Promise<void> {
   const pending = takePendingConflict()
-  if (!pending?.pendingSessionToken) return
-  try {
-    await authClient.multiSession.revoke({
-      sessionToken: pending.pendingSessionToken,
-    })
-  } catch {
-    // Best-effort; the token expires server-side eventually.
+  if (!pending) return
+  if (pending.pendingSessionToken) {
+    try {
+      await authClient.multiSession.revoke({
+        sessionToken: pending.pendingSessionToken,
+      })
+    } catch {
+      // Best-effort; the token expires server-side eventually.
+    }
+  }
+  // Re-pin the prior active profile as Better Auth's current session
+  // cookie. multiSession.revoke clears the server-side token but
+  // doesn't repoint the cookie, so without this getSession() would
+  // return null and the workspace would think the user is signed out.
+  if (activeProfile.value?.sessionToken) {
+    try {
+      await authClient.multiSession.setActive({
+        sessionToken: activeProfile.value.sessionToken,
+      })
+    } catch {
+      // If repinning fails the next getSession will mark us signed-out.
+    }
   }
 }
 

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -172,12 +172,38 @@ export async function signInComplete(
   syncState.value = 'online'
 }
 
+/** Outcome of an attempt to enter a profile. Callers branch on
+ *  `ok: false` to route the user to re-auth instead of the workspace. */
+export type EnterResult =
+  | { ok: true }
+  | { ok: false; reason: 'no-token' | 'token-rejected' }
+
 /** Switch the in-memory + persistence-layer active profile to
- *  `profileId`. Assumes the profile already exists in the registry
- *  (the picker only renders cards backed by `listProfiles()`). Updates
- *  `lastUsedAt` + `lastActiveProfileId`. Does NOT navigate — the
- *  caller (ProfilePickerView) handles routing. */
-export async function enterProfile(profileId: string): Promise<void> {
+ *  `profileId`. Calls `multiSession.setActive` first so Better Auth
+ *  treats the stored token as the current session; if the row has no
+ *  token (signed-out profile) or the server rejects it (revoked),
+ *  returns `ok: false` and the caller routes to the sign-in form
+ *  instead of the workspace. Does NOT navigate — the caller
+ *  (ProfilePickerView) handles routing. */
+export async function enterProfile(profileId: string): Promise<EnterResult> {
+  const row = await registry.getProfile(profileId)
+  if (!row) throw new Error(`enterProfile: no registry row for ${profileId}`)
+  if (!row.sessionToken) return { ok: false, reason: 'no-token' }
+
+  try {
+    const result = await authClient.multiSession.setActive({
+      sessionToken: row.sessionToken,
+    })
+    if (result?.error) {
+      await registry.updateProfileSessionToken(profileId, null)
+      return { ok: false, reason: 'token-rejected' }
+    }
+  } catch {
+    // Network error / offline — fall through and enter the cached
+    // profile anyway. The IDB cache still works; sync resumes when
+    // the network returns.
+  }
+
   clearAllSessions()
   await setActiveProfile(profileId)
 
@@ -189,6 +215,7 @@ export async function enterProfile(profileId: string): Promise<void> {
   // Don't touch syncState here — entering a profile doesn't tell us
   // anything about session validity. The router boot's background
   // getSession() will flip it within the next tick.
+  return { ok: true }
 }
 
 /** Permanently remove a profile from this device: drop its registry

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -284,13 +284,23 @@ export async function enterProfile(profileId: string): Promise<EnterResult> {
   return { ok: true }
 }
 
-/** Permanently remove a profile from this device: drop its registry
- *  row AND its per-profile IDB DB. If the deleted profile is the
- *  currently-active one, also clear in-memory engine state and the
- *  `lastActiveProfileId` pointer (so the next render sees no active
- *  profile — the picker stays put rather than auto-redirecting). */
+/** Permanently remove a profile from this device: revoke its server
+ *  session, drop its registry row, drop its per-profile IDB DB. If
+ *  the deleted profile is the currently-active one, also clear
+ *  in-memory engine state and the `lastActiveProfileId` pointer (so
+ *  the next render sees no active profile — the picker stays put
+ *  rather than auto-redirecting). */
 export async function deleteProfile(profileId: string): Promise<void> {
   const wasActive = activeProfile.value?.profileId === profileId
+  const row = await registry.getProfile(profileId)
+
+  if (row?.sessionToken) {
+    try {
+      await authClient.multiSession.revoke({ sessionToken: row.sessionToken })
+    } catch {
+      // Best-effort; the token expires server-side eventually.
+    }
+  }
 
   if (wasActive) {
     clearAllSessions()

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -144,6 +144,9 @@ export async function signInComplete(user: {
     image: user.image ?? null,
     createdAt: existing?.createdAt ?? now,
     lastUsedAt: now,
+    // Placeholder; populated by the session-token capture path that
+    // runs after the sign-in response or session-watcher resolves.
+    sessionToken: existing?.sessionToken ?? null,
   }
   await registry.upsertProfile(row)
   await registry.setLastActiveProfileId(user.id)

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -243,25 +243,42 @@ export async function deleteProfile(profileId: string): Promise<void> {
   await deleteIdb(profileDbName(profileId))
 }
 
-/** Sign out the current profile. Best-effort API call to invalidate
- *  the server session; local state is cleared regardless. The profile
- *  + its IDB DB stay intact — sign-out is the "I'll be back" action.
- *  Permanent removal is `deleteProfile()`. */
-export async function signOut(): Promise<void> {
-  try {
-    await authClient.signOut()
-  } catch {
-    // Offline / 401 / anything — fine. We still clear local state.
+/** Sign out a profile by revoking its server-side session and clearing
+ *  its stored token. Defaults to the active profile when no id is
+ *  given. Profile + IDB stay intact — sign-out is the "I'll be back"
+ *  action; permanent removal is `deleteProfile()`.
+ *
+ *  When the target is the active profile, also clears the in-memory
+ *  active state + lastActiveProfileId so the next render falls back
+ *  to the picker. When the target is a non-active profile, just
+ *  revokes its token and flips the chip — the active workspace is
+ *  untouched. */
+export async function signOut(targetProfileId?: string): Promise<void> {
+  const targetId = targetProfileId ?? activeProfile.value?.profileId ?? null
+  if (!targetId) return
+
+  const row = await registry.getProfile(targetId)
+  if (row?.sessionToken) {
+    try {
+      await authClient.multiSession.revoke({ sessionToken: row.sessionToken })
+    } catch {
+      // Offline / 401 / anything — fine. We still clear local state
+      // so the chip flips and the cookie won't be reused next boot.
+    }
   }
-  await registry.setLastActiveProfileId(null)
-  await setActiveProfile(null)
-  clearAllSessions()
-  activeProfile.value = null
-  // Reset the load-once flag so the next sign-in re-reads the
-  // registry — keeps the "flag true ⟺ registry consulted this
-  // session for the current profile" invariant honest.
-  activeProfileLoaded = false
-  syncState.value = 'signed-out'
+  await registry.updateProfileSessionToken(targetId, null)
+
+  if (activeProfile.value?.profileId === targetId) {
+    await registry.setLastActiveProfileId(null)
+    await setActiveProfile(null)
+    clearAllSessions()
+    activeProfile.value = null
+    // Reset the load-once flag so the next sign-in re-reads the
+    // registry — keeps the "flag true ⟺ registry consulted this
+    // session for the current profile" invariant honest.
+    activeProfileLoaded = false
+    syncState.value = 'signed-out'
+  }
 }
 
 // Watcher: Better Auth's reactive session is the source of truth for

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -46,21 +46,21 @@ const activeProfile = ref<registry.ProfileRow | null>(null)
 export type SyncState = 'online' | 'signed-out' | 'offline'
 const syncState = ref<SyncState>('online')
 
+interface UserPayload {
+  id: string
+  email: string
+  name?: string
+  image?: string | null
+}
+
 /** Non-null when Better Auth returns a different user than the
- *  currently-active profile expected. The dialog surfaces this so
- *  the user can pick: switch to the new account (becomes the active
- *  profile; old one stays on the device as a signed-out card) or
- *  cancel (the new server-issued token is revoked, leaving the old
- *  profile active but stale until a real re-auth). */
+ *  currently-active profile expected. The user picks either Switch
+ *  (new account becomes active; old one stays on the device as a
+ *  signed-out card) or Stay (revoke the new server-issued token,
+ *  leaving the old profile active but stale until a real re-auth). */
 interface ConflictState {
   expectedEmail: string
-  actualEmail: string
-  pendingUser: {
-    id: string
-    email: string
-    name?: string
-    image?: string | null
-  }
+  pendingUser: UserPayload
   pendingSessionToken: string | null
 }
 const conflict = ref<ConflictState | null>(null)
@@ -117,40 +117,49 @@ export function clearConflict(): void {
   conflict.value = null
 }
 
-/** Conflict resolution: accept the new user the server returned.
- *  Replaces the active profile (the old one stays on the device as a
- *  signed-out card). Re-runs signInComplete with a snapshot of the
- *  active profile cleared so the conflict guard doesn't re-trigger. */
-export async function acceptPendingSignIn(): Promise<void> {
+function takePendingConflict(): ConflictState | null {
   const pending = conflict.value
-  if (!pending) return
   conflict.value = null
-  // Mark the old active profile as signed-out (its cookie was rotated
-  // by the new sign-in anyway; the stored token would be invalid).
+  return pending
+}
+
+/** Accept the new user: replace the active profile (old stays as a
+ *  signed-out card) and re-run signInComplete past the conflict guard. */
+export async function acceptPendingSignIn(): Promise<void> {
+  const pending = takePendingConflict()
+  if (!pending) return
   if (activeProfile.value) {
-    await registry.updateProfileSessionToken(activeProfile.value.profileId, null)
+    await setProfileToken(activeProfile.value.profileId, null)
   }
   activeProfile.value = null
   activeProfileLoaded = false
   await signInComplete(pending.pendingUser, pending.pendingSessionToken)
 }
 
-/** Conflict resolution: revoke the new session and keep the previous
- *  active profile. The previous profile's cookie may still be expired
- *  (that's what triggered the re-auth), so the workspace continues in
- *  offline/stale mode until the user explicitly re-authenticates. */
+/** Decline the new session: revoke its token, keep the previous active
+ *  profile (typically stale — that's what triggered the re-auth). */
 export async function cancelPendingSignIn(): Promise<void> {
-  const pending = conflict.value
-  if (!pending) return
-  conflict.value = null
-  if (pending.pendingSessionToken) {
-    try {
-      await authClient.multiSession.revoke({
-        sessionToken: pending.pendingSessionToken,
-      })
-    } catch {
-      // Best-effort; the token expires server-side eventually.
-    }
+  const pending = takePendingConflict()
+  if (!pending?.pendingSessionToken) return
+  try {
+    await authClient.multiSession.revoke({
+      sessionToken: pending.pendingSessionToken,
+    })
+  } catch {
+    // Best-effort; the token expires server-side eventually.
+  }
+}
+
+/** Wraps `registry.updateProfileSessionToken` and mirrors the change
+ *  into `activeProfile.value` when the target is the active profile,
+ *  so callers don't repeat the if-active-then-refresh dance. */
+async function setProfileToken(
+  profileId: string,
+  sessionToken: string | null,
+): Promise<void> {
+  const updated = await registry.updateProfileSessionToken(profileId, sessionToken)
+  if (updated && activeProfile.value?.profileId === profileId) {
+    activeProfile.value = updated
   }
 }
 
@@ -171,14 +180,11 @@ export async function signInComplete(
 ): Promise<void> {
   const existing = await registry.getProfile(user.id)
 
-  // Conflict: user re-authed but came back as someone else. Leave the
-  // active profile alone; the dialog reads `conflict` and prompts.
-  // Capture the pending payload so the resolver can re-run this with
-  // `force: true` without re-fetching from the server.
+  // Capture the pending payload so the resolver can re-enter without
+  // a second server round-trip.
   if (activeProfile.value && activeProfile.value.profileId !== user.id) {
     conflict.value = {
       expectedEmail: activeProfile.value.email,
-      actualEmail: user.email,
       pendingUser: user,
       pendingSessionToken: sessionToken,
     }
@@ -227,49 +233,39 @@ export async function signInComplete(
   syncState.value = 'online'
 }
 
-/** Outcome of an attempt to enter a profile. Callers branch on
- *  `ok: false` to route the user to re-auth instead of the workspace. */
-export type EnterResult =
-  | { ok: true }
-  | { ok: false; reason: 'no-token' | 'token-rejected' }
+export type EnterResult = { ok: boolean }
 
 /** Switch the in-memory + persistence-layer active profile to
  *  `profileId`. Calls `multiSession.setActive` first so Better Auth
- *  treats the stored token as the current session; if the row has no
- *  token (signed-out profile) or the server rejects it (revoked),
- *  returns `ok: false` and the caller routes to the sign-in form
- *  instead of the workspace. Does NOT navigate — the caller
- *  (ProfilePickerView) handles routing. */
+ *  treats the stored token as the current session. Returns `ok: false`
+ *  when the row has no token or the server rejects it, so the caller
+ *  can route to the sign-in form. Network errors during setActive
+ *  fall through — the IDB cache is offline-usable; sync resumes when
+ *  connectivity returns. Does NOT navigate. */
 export async function enterProfile(profileId: string): Promise<EnterResult> {
   const row = await registry.getProfile(profileId)
   if (!row) throw new Error(`enterProfile: no registry row for ${profileId}`)
-  if (!row.sessionToken) return { ok: false, reason: 'no-token' }
+  if (!row.sessionToken) return { ok: false }
 
   try {
     const result = await authClient.multiSession.setActive({
       sessionToken: row.sessionToken,
     })
     if (result?.error) {
-      await registry.updateProfileSessionToken(profileId, null)
-      return { ok: false, reason: 'token-rejected' }
+      await setProfileToken(profileId, null)
+      return { ok: false }
     }
   } catch {
-    // Network error / offline — fall through and enter the cached
-    // profile anyway. The IDB cache still works; sync resumes when
-    // the network returns.
+    // Offline — enter the cached profile anyway.
   }
 
   clearAllSessions()
   await setActiveProfile(profileId)
 
-  const updated = await registry.touchProfile(profileId, nowSecs())
-  if (!updated) throw new Error(`enterProfile: no registry row for ${profileId}`)
+  const touched: registry.ProfileRow = { ...row, lastUsedAt: nowSecs() }
+  await registry.upsertProfile(touched)
   await registry.setLastActiveProfileId(profileId)
-
-  activeProfile.value = updated
-  // Don't touch syncState here — entering a profile doesn't tell us
-  // anything about session validity. The router boot's background
-  // getSession() will flip it within the next tick.
+  activeProfile.value = touched
   return { ok: true }
 }
 
@@ -301,27 +297,23 @@ export async function deleteProfile(profileId: string): Promise<void> {
 /** Sign out a profile by revoking its server-side session and clearing
  *  its stored token. Defaults to the active profile when no id is
  *  given. Profile + IDB stay intact — sign-out is the "I'll be back"
- *  action; permanent removal is `deleteProfile()`.
- *
- *  When the target is the active profile, also clears the in-memory
- *  active state + lastActiveProfileId so the next render falls back
- *  to the picker. When the target is a non-active profile, just
- *  revokes its token and flips the chip — the active workspace is
- *  untouched. */
+ *  action; permanent removal is `deleteProfile()`. Active-target also
+ *  clears in-memory state so the picker takes over; non-active just
+ *  flips the chip. */
 export async function signOut(targetProfileId?: string): Promise<void> {
   const targetId = targetProfileId ?? activeProfile.value?.profileId ?? null
   if (!targetId) return
 
   const row = await registry.getProfile(targetId)
-  if (row?.sessionToken) {
+  if (!row) return
+  if (row.sessionToken) {
     try {
       await authClient.multiSession.revoke({ sessionToken: row.sessionToken })
     } catch {
-      // Offline / 401 / anything — fine. We still clear local state
-      // so the chip flips and the cookie won't be reused next boot.
+      // Cookie still flips locally; server token will expire on its own.
     }
   }
-  await registry.updateProfileSessionToken(targetId, null)
+  await registry.upsertProfile({ ...row, sessionToken: null })
 
   if (activeProfile.value?.profileId === targetId) {
     await registry.setLastActiveProfileId(null)
@@ -336,18 +328,11 @@ export async function signOut(targetProfileId?: string): Promise<void> {
   }
 }
 
-// Watcher: Better Auth's reactive session is the source of truth for
-// the OAuth (social) sign-in path. Email/password goes through the
-// wrapped `signInEmail` / `signUpEmail` verbs which call
-// `signInComplete` inline — but OAuth leaves the page for the IdP
-// redirect, so when the app re-mounts after the callback there's no
-// in-flight Promise to chain `signInComplete` onto. Instead we watch
-// the session ref: when a user appears that doesn't match the active
-// profile, run `signInComplete` to upsert the profile, swap the
-// per-profile DB, and migrate the legacy DB if needed. Idempotent —
-// no-ops if `activeProfile` already matches the session user. Also
-// keeps the stored sessionToken fresh for the active profile when the
-// server rotates it (cookie refresh, etc.).
+// OAuth leaves the page for the IdP redirect, so when the app
+// re-mounts after the callback there's no in-flight Promise to chain
+// `signInComplete` onto. Watch the reactive session instead and run
+// it on user-change; also keep the stored token fresh when the server
+// rotates a cookie under the existing user.
 const sessionWatchRef = authClient.useSession()
 watch(
   () => sessionWatchRef.value.data,
@@ -356,14 +341,8 @@ watch(
     if (!user) return
     const sessionToken = data?.session?.token ?? null
     if (activeProfile.value?.profileId === user.id) {
-      // Same user as the active profile; just refresh the stored
-      // token if it changed (no DB swap, no migration).
       if (sessionToken && activeProfile.value.sessionToken !== sessionToken) {
-        void registry
-          .updateProfileSessionToken(user.id, sessionToken)
-          .then((row) => {
-            if (row) activeProfile.value = row
-          })
+        void setProfileToken(user.id, sessionToken)
       }
       return
     }
@@ -371,12 +350,11 @@ watch(
   },
 )
 
-/** Background reconcile: ask the server which device sessions are
- *  still alive, then clear stored sessionTokens on any registry row
- *  whose token isn't in the response. Called from the router boot —
- *  fire-and-forget, never throws. The picker reads `listProfiles()`
- *  on mount so reconcile results show up the next time the user
- *  navigates to `/profiles`. */
+/** Ask the server which device sessions are still alive and clear
+ *  stored tokens on any registry row whose token isn't in the
+ *  response. Fire-and-forget from the router boot; the picker reads
+ *  `listProfiles()` on mount so reconcile results show up the next
+ *  time the user navigates to `/profiles`. */
 export async function reconcileDeviceSessions(): Promise<void> {
   try {
     const result = await authClient.multiSession.listDeviceSessions()
@@ -387,17 +365,12 @@ export async function reconcileDeviceSessions(): Promise<void> {
         .filter((t): t is string => typeof t === 'string'),
     )
     const profiles = await registry.listProfiles()
-    for (const p of profiles) {
-      if (p.sessionToken && !liveTokens.has(p.sessionToken)) {
-        const updated = await registry.updateProfileSessionToken(p.profileId, null)
-        if (updated && activeProfile.value?.profileId === p.profileId) {
-          activeProfile.value = updated
-        }
-      }
-    }
+    const stale = profiles.filter(
+      (p) => p.sessionToken && !liveTokens.has(p.sessionToken),
+    )
+    await Promise.all(stale.map((p) => setProfileToken(p.profileId, null)))
   } catch {
-    // Offline / 401 / anything — leave stored tokens alone. They'll
-    // be reconciled on the next successful boot.
+    // Offline — leave stored tokens alone; next boot will retry.
   }
 }
 
@@ -451,13 +424,6 @@ export function useAuth() {
   }
 }
 
-interface UserPayload {
-  id: string
-  email: string
-  name?: string
-  image?: string | null
-}
-
 interface SignInData {
   user?: UserPayload
   token?: string | null
@@ -468,10 +434,9 @@ function extractUser(result: unknown): UserPayload | null {
   return readData(result)?.user ?? null
 }
 
+// Better Auth surfaces the session token at `data.token` for email/
+// password; some plugin paths put it under `data.session.token`.
 function extractSessionToken(result: unknown): string | null {
-  // Better Auth's email/password response surfaces the session token
-  // at `data.token`; some plugin paths put it under `data.session.token`.
-  // Take whichever is present.
   const data = readData(result)
   return data?.token ?? data?.session?.token ?? null
 }

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -47,9 +47,23 @@ export type SyncState = 'online' | 'signed-out' | 'offline'
 const syncState = ref<SyncState>('online')
 
 /** Non-null when Better Auth returns a different user than the
- *  currently-active profile expected. The workspace surfaces this so
- *  the user can pick: sign out, or add the new user as a profile. */
-const conflict = ref<{ expectedEmail: string; actualEmail: string } | null>(null)
+ *  currently-active profile expected. The dialog surfaces this so
+ *  the user can pick: switch to the new account (becomes the active
+ *  profile; old one stays on the device as a signed-out card) or
+ *  cancel (the new server-issued token is revoked, leaving the old
+ *  profile active but stale until a real re-auth). */
+interface ConflictState {
+  expectedEmail: string
+  actualEmail: string
+  pendingUser: {
+    id: string
+    email: string
+    name?: string
+    image?: string | null
+  }
+  pendingSessionToken: string | null
+}
+const conflict = ref<ConflictState | null>(null)
 
 let activeProfileLoaded = false
 
@@ -103,6 +117,43 @@ export function clearConflict(): void {
   conflict.value = null
 }
 
+/** Conflict resolution: accept the new user the server returned.
+ *  Replaces the active profile (the old one stays on the device as a
+ *  signed-out card). Re-runs signInComplete with a snapshot of the
+ *  active profile cleared so the conflict guard doesn't re-trigger. */
+export async function acceptPendingSignIn(): Promise<void> {
+  const pending = conflict.value
+  if (!pending) return
+  conflict.value = null
+  // Mark the old active profile as signed-out (its cookie was rotated
+  // by the new sign-in anyway; the stored token would be invalid).
+  if (activeProfile.value) {
+    await registry.updateProfileSessionToken(activeProfile.value.profileId, null)
+  }
+  activeProfile.value = null
+  activeProfileLoaded = false
+  await signInComplete(pending.pendingUser, pending.pendingSessionToken)
+}
+
+/** Conflict resolution: revoke the new session and keep the previous
+ *  active profile. The previous profile's cookie may still be expired
+ *  (that's what triggered the re-auth), so the workspace continues in
+ *  offline/stale mode until the user explicitly re-authenticates. */
+export async function cancelPendingSignIn(): Promise<void> {
+  const pending = conflict.value
+  if (!pending) return
+  conflict.value = null
+  if (pending.pendingSessionToken) {
+    try {
+      await authClient.multiSession.revoke({
+        sessionToken: pending.pendingSessionToken,
+      })
+    } catch {
+      // Best-effort; the token expires server-side eventually.
+    }
+  }
+}
+
 /** Run after a successful Better Auth sign-in / sign-up. Upserts the
  *  profile in the registry, runs the legacy-DB migration when this is
  *  the device's first-ever profile, and opens the per-profile DB so
@@ -121,11 +172,15 @@ export async function signInComplete(
   const existing = await registry.getProfile(user.id)
 
   // Conflict: user re-authed but came back as someone else. Leave the
-  // active profile alone; the UI reads `conflict` and prompts.
+  // active profile alone; the dialog reads `conflict` and prompts.
+  // Capture the pending payload so the resolver can re-run this with
+  // `force: true` without re-fetching from the server.
   if (activeProfile.value && activeProfile.value.profileId !== user.id) {
     conflict.value = {
       expectedEmail: activeProfile.value.email,
       actualEmail: user.email,
+      pendingUser: user,
+      pendingSessionToken: sessionToken,
     }
     return
   }
@@ -391,6 +446,8 @@ export function useAuth() {
     deleteProfile,
     markSyncState,
     clearConflict,
+    acceptPendingSignIn,
+    cancelPendingSignIn,
   }
 }
 

--- a/apps/web/src/lib/authClient.ts
+++ b/apps/web/src/lib/authClient.ts
@@ -1,14 +1,22 @@
+import { multiSessionClient } from 'better-auth/client/plugins'
 import { createAuthClient } from 'better-auth/vue'
 
 /** Mirrors qzr-sheet's `createAppAuthClient` factory: a `createAuthClient`
  *  bound to a base URL plus a `useAuth` composable that exposes the
  *  reactive session and the action verbs the UI needs. Skipping GitHub
- *  for now — Google + email/password only. */
+ *  for now — Google + email/password only.
+ *
+ *  `multiSessionClient` mirrors the server-side `multiSession()` plugin
+ *  and surfaces `authClient.multiSession.{listDeviceSessions, setActive,
+ *  revoke}` for the picker. */
 
 export type SocialProvider = 'google'
 
 export function createAppAuthClient(baseURL: string) {
-  const authClient = createAuthClient({ baseURL })
+  const authClient = createAuthClient({
+    baseURL,
+    plugins: [multiSessionClient()],
+  })
 
   function useAuth() {
     const session = authClient.useSession()

--- a/apps/web/src/lib/engine/registry.ts
+++ b/apps/web/src/lib/engine/registry.ts
@@ -13,7 +13,7 @@
 import { profileDbName, promiseRequest, transactionComplete } from './persistence'
 
 const DB_NAME = 'verse-vault-registry'
-const DB_VERSION = 1
+const DB_VERSION = 2
 
 const STORE = {
   Profiles: 'profiles',
@@ -32,6 +32,11 @@ export interface ProfileRow {
   image: string | null
   createdAt: number
   lastUsedAt: number
+  /** Better Auth session token for this profile's multi-session cookie,
+   *  or null when the profile is signed-out on this device. The picker
+   *  uses this to drive the signed-in/out chip and to call
+   *  `multiSession.setActive` / `multiSession.revoke` by token. */
+  sessionToken: string | null
 }
 
 interface MetaRow {
@@ -45,13 +50,32 @@ export function openRegistry(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
   dbPromise = new Promise((resolve, reject) => {
     const req = indexedDB.open(DB_NAME, DB_VERSION)
-    req.onupgradeneeded = () => {
+    req.onupgradeneeded = (ev) => {
       const db = req.result
       if (!db.objectStoreNames.contains(STORE.Profiles)) {
         db.createObjectStore(STORE.Profiles, { keyPath: 'profileId' })
       }
       if (!db.objectStoreNames.contains(STORE.Meta)) {
         db.createObjectStore(STORE.Meta, { keyPath: 'key' })
+      }
+      // v1 → v2: backfill `sessionToken: null` on every existing row so
+      // reads don't need to coerce `undefined`. New devices skip this
+      // (oldVersion === 0); v1-era users get one cursor-pass on first
+      // launch post-PR-C. Runs inside the upgrade transaction.
+      if (ev.oldVersion < 2) {
+        const tx = req.transaction
+        if (tx) {
+          const store = tx.objectStore(STORE.Profiles)
+          store.openCursor().onsuccess = (cursorEv) => {
+            const cursor = (cursorEv.target as IDBRequest<IDBCursorWithValue>).result
+            if (!cursor) return
+            const row = cursor.value as Partial<ProfileRow>
+            if (row.sessionToken === undefined) {
+              cursor.update({ ...row, sessionToken: null })
+            }
+            cursor.continue()
+          }
+        }
       }
     }
     req.onsuccess = () => resolve(req.result)
@@ -134,6 +158,21 @@ export async function touchProfile(
   const existing = await getProfile(profileId)
   if (!existing) return null
   const updated: ProfileRow = { ...existing, lastUsedAt: nowSecs }
+  await upsertProfile(updated)
+  return updated
+}
+
+/** Set or clear the Better Auth session token for a profile. Returns
+ *  the updated row, or null when the profile doesn't exist. Callers in
+ *  useAuth use this after sign-in (set), sign-out (null), and the boot
+ *  reconciliation pass (null on tokens the server no longer knows). */
+export async function updateProfileSessionToken(
+  profileId: string,
+  sessionToken: string | null,
+): Promise<ProfileRow | null> {
+  const existing = await getProfile(profileId)
+  if (!existing) return null
+  const updated: ProfileRow = { ...existing, sessionToken }
   await upsertProfile(updated)
   return updated
 }

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -1,6 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
-import { authClient, loadActiveProfileFromRegistry, markSyncState } from '@/composables/useAuth'
+import {
+  authClient,
+  loadActiveProfileFromRegistry,
+  markSyncState,
+  reconcileDeviceSessions,
+} from '@/composables/useAuth'
+
+let reconcileFired = false
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -60,6 +67,15 @@ router.beforeEach(async (to) => {
     .getSession()
     .then((result) => markSyncState(result?.data?.user ? 'online' : 'signed-out'))
     .catch(() => markSyncState('offline'))
+
+  // Reconcile stored multi-session tokens against the server once per
+  // app launch, not on every navigation — it's a network roundtrip
+  // plus per-stale-row IDB writes. First boot wins; subsequent
+  // navigations rely on the watcher to keep the active profile fresh.
+  if (!reconcileFired) {
+    reconcileFired = true
+    void reconcileDeviceSessions()
+  }
 
   if (to.meta.public) {
     if (signedIn && to.name === 'profiles' && to.query.force !== '1') {

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -45,19 +45,24 @@ async function onCardEnter(profile: ProfileRow) {
     await router.replace(redirectTarget())
     return
   }
-  // Token missing or rejected — drop the user into the sign-in form
-  // so they can re-auth. The card stays so they can also pick a
-  // different (still-signed-in) profile.
+  // Token missing or rejected — drop into the sign-in form so the
+  // user can re-auth. Other (still-signed-in) cards remain pickable
+  // via the back-to-profiles link.
+  mode.value = 'add'
+}
+
+function onCardReauth() {
+  // Signed-out card — same UX as enter-with-rejected-token: pop the
+  // sign-in form. We don't pre-fill the email yet; ProfileCard's
+  // identity stays visible above the form via the picker layout.
   mode.value = 'add'
 }
 
 async function onCardSignOut(profile: ProfileRow) {
-  // Only the active card surfaces Sign out (see ProfileCard doc
-  // comment) so this implicitly targets the active profile. signOut()
-  // clears the cookie + lastActiveProfileId; the profile + its DB
-  // stay intact.
-  if (activeProfile.value?.profileId !== profile.profileId) return
-  await signOut()
+  // multiSession.revoke is per-token; the active and non-active
+  // cases differ only in whether useAuth.signOut also clears the
+  // in-memory active state — both branches handled inside signOut().
+  await signOut(profile.profileId)
   await refreshProfiles()
 }
 
@@ -108,7 +113,9 @@ async function onSignInSuccess() {
           :key="p.profileId"
           :profile="p"
           :active="activeProfile?.profileId === p.profileId"
+          :signed-in="p.sessionToken !== null"
           @enter="onCardEnter(p)"
+          @reauth="onCardReauth()"
           @sign-out="onCardSignOut(p)"
           @delete="requestDelete(p)"
         />

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -40,8 +40,15 @@ function redirectTarget(): string {
 }
 
 async function onCardEnter(profile: ProfileRow) {
-  await enterProfile(profile.profileId)
-  await router.replace(redirectTarget())
+  const result = await enterProfile(profile.profileId)
+  if (result.ok) {
+    await router.replace(redirectTarget())
+    return
+  }
+  // Token missing or rejected — drop the user into the sign-in form
+  // so they can re-auth. The card stays so they can also pick a
+  // different (still-signed-in) profile.
+  mode.value = 'add'
 }
 
 async function onCardSignOut(profile: ProfileRow) {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,21 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### Added
+
+* **Better Auth `multiSession` plugin.** Lets one device hold cookies for several signed-in accounts
+  at once. Stacks a new session cookie on each sign-in rather than replacing the previous one;
+  exposes `/api/auth/multi-session/list-device-sessions`, `/api/auth/multi-session/set-active`, and
+  `/api/auth/multi-session/revoke` for the picker to enumerate, swap, and individually revoke
+  per-account sessions. No schema changes (existing `session` table already keyed by `token`). Older
+  clients that don't know about multi-session keep working — they just see whichever single session
+  the plugin reports as active.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged
+* `verse-vault-wasm@0.1.2` — unchanged
+
 ## [0.1.11] — 2026-05-22
 
 0.1.10's deploy failed because the offline-mode entries stayed under `[Unreleased]` instead of being

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {
@@ -22,7 +22,8 @@
     "hono": "^4.7.0",
     "node-html-parser": "^7.1.0",
     "varcon": "^1.0.1",
-    "verse-vault-wasm": "workspace:*"
+    "verse-vault-wasm": "workspace:*",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.0.0",

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from 'better-auth';
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { multiSession } from 'better-auth/plugins';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
@@ -80,6 +81,13 @@ export function createAuth(db: DB, env: AuthEnv) {
         trustedProviders: ['google'],
       },
     },
+    // Multi-session lets the device hold cookies for several signed-in
+    // accounts at once. Each new sign-in is stacked alongside any
+    // existing session cookies rather than replacing them; the picker
+    // uses `multiSession.{listDeviceSessions,setActive,revoke}` to
+    // swap between accounts and to sign out a single profile without
+    // disturbing the others. Schema-compatible — no new tables.
+    plugins: [multiSession()],
   });
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       verse-vault-wasm:
         specifier: workspace:*
         version: link:../../crates/wasm/pkg
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.0.0
@@ -3081,8 +3084,8 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3105,53 +3108,53 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)':
+  '@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@4.4.3)
       jose: 6.2.2
       kysely: 0.28.16
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260519.1
 
-  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))':
+  '@better-auth/drizzle-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       drizzle-orm: 0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16)
 
-  '@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
+  '@better-auth/kysely-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
     optionalDependencies:
       kysely: 0.28.16
 
-  '@better-auth/memory-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/memory-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/mongo-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/mongo-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/prisma-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
+  '@better-auth/prisma-adapter@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
 
-  '@better-auth/telemetry@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+  '@better-auth/telemetry@1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
@@ -4238,23 +4241,23 @@ snapshots:
 
   better-auth@1.6.5(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
-      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
-      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
+      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.2
       kysely: 0.28.16
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       better-sqlite3: 11.10.0
       drizzle-kit: 0.31.10
@@ -4267,23 +4270,23 @@ snapshots:
 
   better-auth@1.6.5(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(vitest@2.1.9(@types/node@24.12.3))(vue@3.5.34(typescript@5.9.3)):
     dependencies:
-      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
-      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
-      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
-      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
-      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/core': 1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0)
+      '@better-auth/drizzle-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))
+      '@better-auth/kysely-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(kysely@0.28.16)
+      '@better-auth/memory-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.5(@better-auth/core@1.6.5(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.5(zod@4.3.6)
+      better-call: 1.3.5(zod@4.4.3)
       defu: 6.1.7
       jose: 6.2.2
       kysely: 0.28.16
       nanostores: 1.3.0
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       drizzle-kit: 0.31.10
       vitest: 2.1.9(@types/node@24.12.3)
@@ -4292,14 +4295,14 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.5(zod@4.3.6):
+  better-call@1.3.5(zod@4.4.3):
     dependencies:
       '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
       set-cookie-parser: 3.1.0
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   better-sqlite3@11.10.0:
     dependencies:
@@ -5550,4 +5553,4 @@ snapshots:
       cookie: 1.1.1
       youch-core: 0.3.3
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary

- Wires Better Auth's `multiSession` plugin (server + client) so a single browser can hold
  signed-in cookies for multiple profiles concurrently. Each profile's session token is stored on
  its `ProfileRow` and used to drive `setActive` / `revoke` per card.
- Picker upgrades: every card now shows a "Signed in" / "Signed out" chip; Sign out works on any
  signed-in profile (not just the active one); clicking a signed-out card pops the sign-in form
  instead of trying to enter the workspace.
- App-level reauth modal consumes the previously-orphaned `useAuth().conflict` ref: when a fresh
  sign-in returns a different user than the active profile, the user picks Switch (new becomes
  active, old stays as a signed-out card) or Stay (revoke the new token, keep the prior active
  profile — typically stale).
- Boot reconciles registry tokens against `multiSession.listDeviceSessions` so chips reflect
  server-side expirations / remote revocations. Gated to once per app launch.

## API changes

- `packages/api`: added `multiSession()` plugin (no schema changes). New endpoints under
  `/api/auth/multi-session/{list-device-sessions,set-active,revoke}`. Added `zod` as a direct dep
  so `tsc` can emit a portable `.d.ts` for the plugin-augmented Auth type.
- `packages/api` bumped 0.1.11 -> 0.1.12.
- `apps/web` bumped 0.1.10 -> 0.1.11.

## Storage migration

`verse-vault-registry` DB version 1 -> 2. Upgrade cursors through existing profiles and backfills
`sessionToken: null`. v1-era users start out with every card showing "Signed out" until they sign
in again (the device's cookie is still alive but the registry doesn't know its token); first
sign-in repopulates.

## Test plan

- [ ] **Single profile, fresh.** Wipe IDB, sign in. Card chip shows "Signed in". Reload -> workspace
      auto-enters.
- [ ] **Add second account.** Picker -> "Add another profile" -> sign in as User B. Both cards
      "Signed in"; active highlights B. Click A -> workspace swaps to A (no reload). API calls fire
      under A's identity (check a /api/years response).
- [ ] **Sign out non-active.** Picker -> kebab on B -> Sign out. B's chip flips to "Signed out".
      Workspace stays on A. Server: \`select count(*) from session where userId=...\` shows B's row
      gone.
- [ ] **Sign out active.** Picker -> kebab on A -> Sign out. Card stays as "Signed out". Picker takes
      over. No \`lastActiveProfileId\`.
- [ ] **Click signed-out card.** Card click -> sign-in form (mode=add). Re-auth -> chip flips back
      to "Signed in"; workspace renders.
- [ ] **Reauth dialog.** With User A active, force a session as User B (incognito sign-in or
      manual cookie swap). Dialog appears. Switch -> A demoted to signed-out, B active. Repeat,
      Cancel -> B's token revoked, A remains.
- [ ] **Offline reconcile no-op.** Kill API, reload. Picker chips reflect last-known state
      (reconcile silently no-ops on network failure).
- [ ] **v1 -> v2 upgrade.** Pre-0.1.11 device with a profile: launch new build, picker shows the
      card as "Signed out" until re-sign-in (acceptable; documented in changelog).

## Out of scope

- "Add another profile" still doesn't pre-fill the email when triggered by a reauth click. Easy
  follow-up if the back-and-forth feels clunky.
- Picker doesn't reactively re-fetch after the boot reconcile completes; users who happen to be
  staring at /profiles when reconciliation lands need a manual refresh. Mounts re-fetch, so any
  real navigation fixes it.