### PR TITLE
fix(api): promote 0.1.12 changelog as 0.1.13

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,14 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.13] — 2026-05-25
+
+0.1.12's deploy failed because the multi-session entry stayed under `[Unreleased]` instead of being
+promoted to a dated section (`tools/check-contract-versions.sh --ci` requires the dated section to
+exist for the current `package.json` version). Code has been on master since `1ea3265`; production
+goes straight from 0.1.11 → 0.1.13, bundling the changelog-promotion fix with the multi-session
+entry that was supposed to ship in 0.1.12.
+
 ### Added
 
 * **Better Auth `multiSession` plugin.** Lets one device hold cookies for several signed-in accounts

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

API deploy on 1ea3265 failed at the contract-version check — the multi-session entry stayed under \`[Unreleased]\` instead of being promoted to a dated section. Mirrors the 0.1.10 → 0.1.11 recovery from the prior incident: production goes straight from 0.1.11 → 0.1.13, with the entry under \`[0.1.13]\`.

## Test plan

- [ ] CI rust + typos + dprint pass
- [ ] Deploy fires on merge (paths trigger: \`packages/api/package.json\`)
- [ ] Deploy completes successfully
- [ ] \`curl https://www.versevault.ca/vv/api/auth/multi-session/list-device-sessions\` returns a non-404