### PR TITLE
Picker polish: reauth prefill + reactive list + StatusChip

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,23 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Picker polish
+
+* **Reauth flow pre-fills the email.** Clicking a signed-out card (or a signed-in card whose server
+  token was revoked) now drops the user into the sign-in form already populated with that profile's
+  address and opened directly to email-signin mode. Saves typing and signals "this is the account
+  you were already using." The Add-another-profile entry stays blank.
+* **Reactive profiles list.** The picker no longer fetches `listProfiles()` on mount only — the list
+  lives as a shared reactive ref in `useAuth`, refreshed by every mutation (sign in, sign out,
+  enter, delete, token rotation, boot reconcile). Chips reflect server-state changes without
+  remounting; deleting the last card flips the picker to its empty state without manual refresh.
+  `mode === 'add'` short-circuits the reactive flip so an in-flight sign-in form isn't yanked out
+  from under the user.
+* **Shared `StatusChip` component.** Extracted from the near-identical hand-rolled chip spans in
+  `ProfileCard` (signed-in/out) and `MaterialView` (per-deck active/maintenance/paused). Three
+  variants (`accent` / `warning` / `muted`) cover both call sites; `xs` / `sm` size prop preserves
+  existing visual hierarchy. Next chip needed gets it for free.
+
 ### Multi-session + reauth dialog
 
 * **Multiple accounts on one device.** Wires Better Auth's `multiSession` plugin (server) +

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
+import StatusChip from '@/components/StatusChip.vue'
 import type { ProfileRow } from '@/lib/engine/registry'
 
 const props = defineProps<{
@@ -107,9 +108,9 @@ function onCardKeydown(ev: KeyboardEvent) {
     <div class="meta">
       <p class="name">
         {{ profile.displayName }}
-        <span class="chip" :class="{ 'chip-out': !signedIn }">
+        <StatusChip :variant="signedIn ? 'accent' : 'muted'" size="xs">
           {{ signedIn ? 'Signed in' : 'Signed out' }}
-        </span>
+        </StatusChip>
       </p>
       <p class="email">{{ profile.email }}</p>
       <p class="last-used">Last used {{ lastUsedLabel }}</p>
@@ -222,23 +223,6 @@ function onCardKeydown(ev: KeyboardEvent) {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-}
-
-.chip {
-  font-size: 0.65rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 0.1rem 0.4rem;
-  border-radius: 999px;
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-}
-
-.chip-out {
-  background: transparent;
-  color: var(--color-muted);
-  border: 1px solid var(--color-border);
 }
 
 .email {

--- a/apps/web/src/components/SignInForm.vue
+++ b/apps/web/src/components/SignInForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 
 import type { SocialProvider } from '@/lib/authClient'
 
@@ -9,15 +9,31 @@ const props = defineProps<{
   signInSocial: (provider: SocialProvider) => void
   signInEmail: (email: string, password: string) => Promise<SignInResult>
   signUpEmail: (email: string, password: string) => Promise<SignInResult>
+  /** When set, skip the provider picker and open the form in
+   *  email-signin mode with this address pre-populated. Used by the
+   *  picker's reauth flow so a click on a signed-out card lands the
+   *  user directly in the field for their existing email. */
+  prefillEmail?: string
 }>()
 
 const emit = defineEmits<{ (e: 'success'): void }>()
 
-const mode = ref<'pick' | 'signin' | 'signup'>('pick')
-const email = ref('')
+const mode = ref<'pick' | 'signin' | 'signup'>(props.prefillEmail ? 'signin' : 'pick')
+const email = ref(props.prefillEmail ?? '')
 const password = ref('')
 const error = ref('')
 const pending = ref(false)
+
+// Picker can change the prefill without remounting (user clicks a
+// different signed-out card mid-flow); keep the form in sync.
+watch(
+  () => props.prefillEmail,
+  (next) => {
+    if (!next) return
+    mode.value = 'signin'
+    email.value = next
+  },
+)
 
 async function submitEmail() {
   error.value = ''

--- a/apps/web/src/components/StatusChip.vue
+++ b/apps/web/src/components/StatusChip.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    /** Colour intent. `accent` for positive/active states, `warning`
+     *  for in-progress/attention states, `muted` for inactive states. */
+    variant: 'accent' | 'warning' | 'muted'
+    /** Visual density. `sm` matches the per-deck status pill in
+     *  MaterialView; `xs` matches the tighter pill on ProfileCard. */
+    size?: 'sm' | 'xs'
+  }>(),
+  { size: 'sm' },
+)
+</script>
+
+<template>
+  <span class="chip" :class="[`chip-${variant}`, `chip-${size}`]">
+    <slot />
+  </span>
+</template>
+
+<style scoped>
+.chip {
+  display: inline-block;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.chip-sm {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  padding: 0.05rem 0.45rem;
+}
+
+.chip-xs {
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.4rem;
+}
+
+.chip-accent {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.chip-warning {
+  background: var(--color-grade-hard-bg);
+  color: var(--color-grade-hard);
+}
+
+.chip-muted {
+  background: var(--color-bg-card);
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+}
+</style>

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -400,9 +400,9 @@ watch(
 
 /** Ask the server which device sessions are still alive and clear
  *  stored tokens on any registry row whose token isn't in the
- *  response. Fire-and-forget from the router boot; the picker reads
- *  `listProfiles()` on mount so reconcile results show up the next
- *  time the user navigates to `/profiles`. */
+ *  response. Fire-and-forget from the router boot; results land on
+ *  the picker reactively via `setProfileToken` → `refreshProfilesList`,
+ *  no remount needed. */
 export async function reconcileDeviceSessions(): Promise<void> {
   try {
     const result = await authClient.multiSession.listDeviceSessions()

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -32,6 +32,21 @@ export { authClient }
  *  (boot before registry-read; sign-out; first-ever launch). */
 const activeProfile = ref<registry.ProfileRow | null>(null)
 
+/** Reactive copy of the registry's full profile list, sorted
+ *  newest-used first. Anything that mutates the registry (sign in,
+ *  sign out, enter, delete, token rotation, boot reconcile) calls
+ *  `refreshProfilesList` at the end so the picker reflects changes
+ *  without remounting. */
+const profilesList = ref<registry.ProfileRow[]>([])
+
+/** Repopulate `profilesList` from the registry. Cheap — the registry
+ *  is a single IDB scan over 1-10 rows. */
+export async function refreshProfilesList(): Promise<void> {
+  const rows = await registry.listProfiles()
+  rows.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
+  profilesList.value = rows
+}
+
 /** Three-state sync status:
  *  - `online`     — most recent sync attempt succeeded with a live session.
  *  - `signed-out` — the server is reachable but rejected the request
@@ -81,6 +96,9 @@ function nowSecs(): number {
 export async function loadActiveProfileFromRegistry(): Promise<boolean> {
   if (activeProfileLoaded) return activeProfile.value != null
   activeProfileLoaded = true
+  // Populate the reactive list on the same boot pass so the picker
+  // doesn't need its own bootstrap fetch.
+  await refreshProfilesList()
   const id = await registry.getLastActiveProfileId()
   if (!id) {
     activeProfile.value = null
@@ -176,6 +194,7 @@ async function setProfileToken(
   if (updated && activeProfile.value?.profileId === profileId) {
     activeProfile.value = updated
   }
+  await refreshProfilesList()
 }
 
 /** Run after a successful Better Auth sign-in / sign-up. Upserts the
@@ -246,6 +265,7 @@ export async function signInComplete(
 
   activeProfile.value = row
   syncState.value = 'online'
+  await refreshProfilesList()
 }
 
 export type EnterResult = { ok: boolean }
@@ -281,6 +301,7 @@ export async function enterProfile(profileId: string): Promise<EnterResult> {
   await registry.upsertProfile(touched)
   await registry.setLastActiveProfileId(profileId)
   activeProfile.value = touched
+  await refreshProfilesList()
   return { ok: true }
 }
 
@@ -317,6 +338,7 @@ export async function deleteProfile(profileId: string): Promise<void> {
   // resolves on `onblocked` rather than hanging — a holding tab is a
   // "try again later" scenario, not a failure.
   await deleteIdb(profileDbName(profileId))
+  await refreshProfilesList()
 }
 
 /** Sign out a profile by revoking its server-side session and clearing
@@ -351,6 +373,7 @@ export async function signOut(targetProfileId?: string): Promise<void> {
     activeProfileLoaded = false
     syncState.value = 'signed-out'
   }
+  await refreshProfilesList()
 }
 
 // OAuth leaves the page for the IdP redirect, so when the app
@@ -435,6 +458,7 @@ export function useAuth() {
     signInEmail,
     signUpEmail,
     activeProfile: computed(() => activeProfile.value),
+    profiles: computed(() => profilesList.value),
     syncState: computed(() => syncState.value),
     isOnline: computed(() => syncState.value === 'online'),
     conflict: computed(() => conflict.value),

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from 'vue'
 
 import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
+import StatusChip from '@/components/StatusChip.vue'
 import {
   type ChapterListScope,
   type ClubStatus,
@@ -28,6 +29,12 @@ const STATUS_LABELS: Record<ClubStatus, string> = {
   active: 'Active',
   maintenance: 'Maintenance',
   paused: 'Paused',
+}
+
+const STATUS_VARIANTS: Record<ClubStatus, 'accent' | 'warning' | 'muted'> = {
+  active: 'accent',
+  maintenance: 'warning',
+  paused: 'muted',
 }
 
 // All four scope tracks share the same 4-stop shape (chapter-list is
@@ -320,9 +327,9 @@ onMounted(refresh)
               <span v-if="isStudying(selected)" class="tier-pill-count">
                 {{ selected.view.clubs[tier].cardCount }}
               </span>
-              <span :class="`status-chip status-${selected.view.clubs[tier].status}`">
+              <StatusChip :variant="STATUS_VARIANTS[selected.view.clubs[tier].status]">
                 {{ STATUS_LABELS[selected.view.clubs[tier].status] }}
-              </span>
+              </StatusChip>
             </span>
           </div>
         </header>
@@ -611,30 +618,6 @@ h2 {
 .tier-pill-count {
   color: var(--color-muted);
   font-variant-numeric: tabular-nums;
-}
-
-.status-chip {
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 0.05rem 0.45rem;
-  border-radius: 999px;
-}
-
-.status-active {
-  background: var(--color-accent-soft);
-  color: var(--color-accent);
-}
-
-.status-maintenance {
-  background: var(--color-grade-hard-bg);
-  color: var(--color-grade-hard);
-}
-
-.status-paused {
-  background: var(--color-bg-card);
-  color: var(--color-muted);
-  border: 1px solid var(--color-border);
 }
 
 .section-title {

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -23,6 +23,7 @@ const route = useRoute()
 
 const profiles = ref<ProfileRow[]>([])
 const mode = ref<'empty' | 'cards' | 'add'>('cards')
+const prefillEmail = ref<string | undefined>(undefined)
 const pendingDelete = ref<ProfileRow | null>(null)
 const deleteBusy = ref(false)
 
@@ -45,16 +46,14 @@ async function onCardEnter(profile: ProfileRow) {
     await router.replace(redirectTarget())
     return
   }
-  // Token missing or rejected — drop into the sign-in form so the
-  // user can re-auth. Other (still-signed-in) cards remain pickable
-  // via the back-to-profiles link.
+  // Token missing or rejected — drop into the sign-in form prefilled
+  // with this profile's email so the user can re-auth in one step.
+  prefillEmail.value = profile.email
   mode.value = 'add'
 }
 
-function onCardReauth() {
-  // Signed-out card — same UX as enter-with-rejected-token: pop the
-  // sign-in form. We don't pre-fill the email yet; ProfileCard's
-  // identity stays visible above the form via the picker layout.
+function onCardReauth(profile: ProfileRow) {
+  prefillEmail.value = profile.email
   mode.value = 'add'
 }
 
@@ -88,10 +87,12 @@ async function confirmDelete() {
 }
 
 function startAdd() {
+  prefillEmail.value = undefined
   mode.value = 'add'
 }
 
 function cancelAdd() {
+  prefillEmail.value = undefined
   mode.value = profiles.value.length === 0 ? 'empty' : 'cards'
 }
 
@@ -115,7 +116,7 @@ async function onSignInSuccess() {
           :active="activeProfile?.profileId === p.profileId"
           :signed-in="p.sessionToken !== null"
           @enter="onCardEnter(p)"
-          @reauth="onCardReauth()"
+          @reauth="onCardReauth(p)"
           @sign-out="onCardSignOut(p)"
           @delete="requestDelete(p)"
         />
@@ -130,6 +131,7 @@ async function onSignInSuccess() {
         :sign-in-social="signInSocial"
         :sign-in-email="signInEmail"
         :sign-up-email="signUpEmail"
+        :prefill-email="prefillEmail"
         @success="onSignInSuccess"
       />
       <button v-if="mode === 'add'" type="button" class="back-btn" @click="cancelAdd">

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import ProfileCard from '@/components/ProfileCard.vue'
 import SignInForm from '@/components/SignInForm.vue'
 import { useAuth } from '@/composables/useAuth'
-import { listProfiles, type ProfileRow } from '@/lib/engine/registry'
+import type { ProfileRow } from '@/lib/engine/registry'
 
 const {
   activeProfile,
+  profiles,
   signInSocial,
   signInEmail,
   signUpEmail,
@@ -21,20 +22,18 @@ const {
 const router = useRouter()
 const route = useRoute()
 
-const profiles = ref<ProfileRow[]>([])
-const mode = ref<'empty' | 'cards' | 'add'>('cards')
+const mode = ref<'empty' | 'cards' | 'add'>(profiles.value.length === 0 ? 'empty' : 'cards')
 const prefillEmail = ref<string | undefined>(undefined)
 const pendingDelete = ref<ProfileRow | null>(null)
 const deleteBusy = ref(false)
 
-async function refreshProfiles() {
-  const rows = await listProfiles()
-  rows.sort((a, b) => b.lastUsedAt - a.lastUsedAt)
-  profiles.value = rows
+// Keep mode in sync with the shared profiles list (reconcile, sign-in
+// from another flow, etc.). Skip when the user is mid-add — don't
+// yank them out of the sign-in form just because a chip flipped.
+watch(profiles, (rows) => {
+  if (mode.value === 'add') return
   mode.value = rows.length === 0 ? 'empty' : 'cards'
-}
-
-onMounted(refreshProfiles)
+})
 
 function redirectTarget(): string {
   return typeof route.query.redirect === 'string' ? route.query.redirect : '/review'
@@ -61,8 +60,8 @@ async function onCardSignOut(profile: ProfileRow) {
   // multiSession.revoke is per-token; the active and non-active
   // cases differ only in whether useAuth.signOut also clears the
   // in-memory active state — both branches handled inside signOut().
+  // The shared profiles list refreshes automatically.
   await signOut(profile.profileId)
-  await refreshProfiles()
 }
 
 function requestDelete(profile: ProfileRow) {
@@ -79,7 +78,6 @@ async function confirmDelete() {
   deleteBusy.value = true
   try {
     await deleteProfile(target.profileId)
-    await refreshProfiles()
   } finally {
     deleteBusy.value = false
     pendingDelete.value = null


### PR DESCRIPTION
## Summary

Three small polish items deferred from PR C:

- **Reauth prefill**: clicking a signed-out card (or a signed-in card whose token was rejected) drops the user into the sign-in form already populated with that profile's email and opened in email-signin mode. Add-another-profile stays blank.
- **Reactive profiles list**: the picker no longer fetches \`listProfiles()\` on mount only. The list lives as a shared reactive ref in \`useAuth\`, refreshed by every mutation (sign in, sign out, enter, delete, token rotation, boot reconcile). Chips reflect server-side state changes without remounting; deleting the last card flips the picker to its empty state automatically.
- **\`StatusChip\` component**: extracted from the near-identical hand-rolled chip spans in \`ProfileCard\` and \`MaterialView\`. Three variants (accent/warning/muted), two sizes (xs/sm).

\`apps/web\` 0.1.11 → 0.1.12.

## Test plan

- [ ] **Reauth prefill on signed-out card.** Sign in, sign out from picker, click the signed-out card — form opens in signin mode with email prefilled.
- [ ] **Reauth prefill on rejected token.** Sign in, manually revoke server-side (or wait for reconcile to clear), click the card — same prefilled form appears.
- [ ] **Add-another stays blank.** Open picker with profiles present, click Add another profile — email field empty, mode is \`pick\`.
- [ ] **Reactive chip flip.** Open picker. From DevTools, revoke a non-active profile's session server-side, refresh. Boot reconcile should flip that card's chip to "Signed out" without manual nav.
- [ ] **Empty-state flip.** Delete the last profile from the kebab — picker shows SignInForm without manual refresh.
- [ ] **Mid-add not yanked.** Click Add another profile, then have reconcile fire (kill API between mount and form interaction). User stays in the form.
- [ ] **MaterialView chips render.** Visit /material — Active/Maintenance/Paused chips look the same as before.