### PR TITLE
chore(api): align better-auth ^1.2.0 → ^1.6.5

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,21 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.14] — 2026-05-25
+
+### Changed
+
+* **Aligned `better-auth` with the web client** (`^1.2.0` → `^1.6.5`). The web has been on 1.6.5
+  since the offline-boot work; running mismatched majors on the wire surface was working only
+  because the multiSession plugin happens to be stable across 1.2 → 1.6. Bumping closes the drift
+  before the next plugin-affecting change hits a peer-dep surprise. No behaviour change expected;
+  full test suite green on the bumped version.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.1.0` — unchanged
+* `verse-vault-wasm@0.1.2` — unchanged
+
 ## [0.1.13] — 2026-05-25
 
 0.1.12's deploy failed because the multi-session entry stayed under `[Unreleased]` instead of being

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "scripts": {
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.13.0",
-    "better-auth": "^1.2.0",
+    "better-auth": "^1.6.5",
     "better-sqlite3": "^11.0.0",
     "drizzle-orm": "^0.44.0",
     "hono": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,7 +101,7 @@ importers:
         specifier: ^1.13.0
         version: 1.19.14(hono@4.12.14)
       better-auth:
-        specifier: ^1.2.0
+        specifier: ^1.6.5
         version: 1.6.5(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(better-sqlite3@11.10.0)(drizzle-kit@0.31.10)(drizzle-orm@0.44.7(@cloudflare/workers-types@4.20260519.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(kysely@0.28.16))(vitest@2.1.9(@types/node@22.19.17))(vue@3.5.34(typescript@5.9.3))
       better-sqlite3:
         specifier: ^11.0.0


### PR DESCRIPTION
## Summary

API better-auth was still on \`^1.2.0\` while the web has been on \`^1.6.5\` since the offline-boot work. The multiSession plugin (PR C) happens to be stable across that range so nothing actively broke, but the next plugin-affecting bump on either side would have hit a peer-dep surprise. This closes the drift.

\`packages/api\` 0.1.13 → 0.1.14.

## Test plan

- [x] \`pnpm --filter @verse-vault/api type-check\` — clean
- [x] \`pnpm --filter @verse-vault/api test\` — 101/101 green
- [ ] CI passes (rust + typos + dprint)
- [ ] Deploy lands cleanly (\`/api/auth/multi-session/list-device-sessions\` still serves)

## Notes

Two pnpm peer warnings surfaced (\`better-sqlite3@^12\`, \`drizzle-orm@^0.45.2\`) — pre-existing and unrelated to this change. Bumping either is a separate decision.