### PR TITLE
chore(web): picker-cluster cleanup

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.12] — 2026-05-24
+
 ### Picker polish
 
 * **Reauth flow pre-fills the email.** Clicking a signed-out card (or a signed-in card whose server
@@ -25,6 +27,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
   `ProfileCard` (signed-in/out) and `MaterialView` (per-deck active/maintenance/paused). Three
   variants (`accent` / `warning` / `muted`) cover both call sites; `xs` / `sm` size prop preserves
   existing visual hierarchy. Next chip needed gets it for free.
+
+## [0.1.11] — 2026-05-23
 
 ### Multi-session + reauth dialog
 
@@ -54,6 +58,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
   (attaches `multiSessionClient`); `components/ProfileCard.vue` (chip + always-on Sign out + reauth
   event); `views/ProfilePickerView.vue` (wires the new events).
 
+## [0.1.10] — 2026-05-23
+
 ### Profile picker UI
 
 * **`/profiles` is the new entry point.** Replaces the single-form `SignInView`; lists every profile
@@ -77,6 +83,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 * Modified: `useAuth.ts` exposes `enterProfile` + `deleteProfile`; `router/index.ts` registers
   `/profiles` (and redirects `/signin` → `/profiles`); `App.vue` swaps Sign out for Switch profile.
 * Deleted: `apps/web/src/views/SignInView.vue` (functionality absorbed into `ProfilePickerView`).
+
+## [0.1.9] — 2026-05-22
 
 ### Offline-first boot + profiles
 
@@ -102,6 +110,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 The picker UI (multi-profile cards with sign-out and delete affordances) is deferred to a follow-up
 PR; this PR keeps the existing email/password form as the entry point for unauth'd users.
+
+## [0.1.8] — 2026-05-22
 
 ### Added
 

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -317,12 +317,7 @@ onMounted(refresh)
           </div>
           <p class="year-description">{{ selected.view.description }}</p>
           <div class="tier-summary">
-            <span
-              v-for="tier in CLUB_TIERS"
-              :key="tier"
-              class="tier-pill"
-              :class="`tier-status-${selected.view.clubs[tier].status}`"
-            >
+            <span v-for="tier in CLUB_TIERS" :key="tier" class="tier-pill">
               <span class="tier-pill-name">{{ TIER_LABELS[tier] }}</span>
               <span v-if="isStudying(selected)" class="tier-pill-count">
                 {{ selected.view.clubs[tier].cardCount }}

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -30,10 +30,18 @@ const deleteBusy = ref(false)
 // Keep mode in sync with the shared profiles list (reconcile, sign-in
 // from another flow, etc.). Skip when the user is mid-add — don't
 // yank them out of the sign-in form just because a chip flipped.
-watch(profiles, (rows) => {
-  if (mode.value === 'add') return
-  mode.value = rows.length === 0 ? 'empty' : 'cards'
-})
+// `immediate: true` defends against any future router refactor where
+// `loadActiveProfileFromRegistry` isn't awaited before navigation:
+// the synchronous `mode` init at setup would otherwise read the
+// pre-populate value and never get a chance to flip.
+watch(
+  profiles,
+  (rows) => {
+    if (mode.value === 'add') return
+    mode.value = rows.length === 0 ? 'empty' : 'cards'
+  },
+  { immediate: true },
+)
 
 function redirectTarget(): string {
   return typeof route.query.redirect === 'string' ? route.query.redirect : '/review'


### PR DESCRIPTION
## Summary

Three mechanical cleanup items from the post-merge follow-up sweep on the picker work (PRs A/B/C/D):

- **CHANGELOG promotion**: \`apps/web/CHANGELOG.md\` had five releases (0.1.8 → 0.1.12) stacked under \`[Unreleased]\` instead of being promoted as they shipped. Inserted dated headers; section content unchanged.
- **Dead \`tier-status-\${status}\` class** on \`.tier-pill\` (MaterialView): rule was removed with the StatusChip extraction in PR D but the class application was left behind. Two-line cleanup.
- **\`immediate: true\` on the picker \`watch(profiles, ...)\`**: defensive change so the \`empty\`/\`cards\` mode derivation doesn't rely on the router guard awaiting \`loadActiveProfileFromRegistry()\`. The race window is closed today, but a future guard refactor would otherwise re-open it.

No version bump — these don't justify a deploy. Next real feature PR will pick up the changes.

## Test plan

- [x] type-check passes
- [ ] CI green (rust + typos + dprint)
- [ ] CHANGELOG render on GitHub looks right (headers continue past 0.1.7)