### PR TITLE
card audit: heading passage card, FTV simplification, changelog CI

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -64,7 +64,7 @@ jobs:
       # contract crate versions. Catches "bumped core but forgot to update
       # the API changelog's Bundled algorithm contract subsection."
       - name: Verify contract crate references in CHANGELOG
-        run: tools/check-contract-versions.sh --ci
+        run: tools/check-contract-versions.sh --ci api
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/deploy-vv-router.yml
+++ b/.github/workflows/deploy-vv-router.yml
@@ -45,6 +45,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fail fast if the router CHANGELOG hasn't been promoted for the
+      # version being deployed. The router doesn't bundle the contract
+      # crates, so this is a section-existence check only — same shape
+      # as the api/web variants of the script.
+      - name: Verify CHANGELOG entry for this release
+        run: tools/check-contract-versions.sh --ci vv-router
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -46,6 +46,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Fail fast if the web CHANGELOG entry for the version being deployed
+      # doesn't exist as a dated section that references the current
+      # verse-vault-core / verse-vault-wasm contract crate versions. Mirrors
+      # the API deploy's same check — catches "bumped apps/web/package.json
+      # but left the entry under [Unreleased]" or "bumped the WASM contract
+      # crate but forgot to update web's Bundled algorithm contract list."
+      - name: Verify CHANGELOG entry for this release
+        run: tools/check-contract-versions.sh --ci web
+
       # WASM toolchain — the web bundle now embeds the verse-vault engine
       # via crates/wasm/pkg-web (bundler target). Built before pnpm install
       # so the `verse-vault-wasm-web` workspace package exists when pnpm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ you're touching before making non-trivial changes.
 Hooks are wired via `simple-git-hooks` + `lint-staged` and installed by `pnpm install` (see the
 `postinstall` script in `package.json`). The `pre-commit` hook runs `lint-staged`,
 `cargo fmt --check`, `typos`, and `tools/check-contract-versions.sh` (blocks commits that touch
-`crates/{core,wasm}/src/` without a matching `Cargo.toml` version bump — bypass with `--no-verify`
-for refactors that don't change observable behaviour). `commit-msg` runs `commitlint` against the
-conventional-commits config.
+`crates/{core,wasm}/src/` without a matching `Cargo.toml` version bump, and commits that bump any
+package's version without a matching `## [X.Y.Z]` section in its `CHANGELOG.md` — bypass with
+`--no-verify` for refactors that don't change observable behaviour). `commit-msg` runs `commitlint`
+against the conventional-commits config.
 
 Manually run the slower checks before pushing:
 
@@ -167,12 +168,19 @@ Discipline when changing them:
 
 Enforcement:
 
-* **Pre-commit** (`tools/check-contract-versions.sh`): blocks commits where
-  `crates/<core|wasm>/src/` changed but the version didn't. Bypass with `git commit --no-verify` for
-  refactors with no observable effect.
-* **CI** (`.github/workflows/deploy-api.yml`, run on API deploys): blocks deploys when
-  `packages/api/CHANGELOG.md`'s entry for the version being deployed doesn't reference the current
-  contract crate versions. Catches "bumped core but forgot to update the API changelog."
+* **Pre-commit** (`tools/check-contract-versions.sh`): two checks.
+  * Blocks commits where `crates/<core|wasm>/src/` changed but the matching `Cargo.toml` `version`
+    didn't. Bypass with `git commit --no-verify` for refactors with no observable effect.
+  * Blocks commits that bump any package's version (`crates/<core|wasm>/Cargo.toml`,
+    `packages/api/package.json`, `apps/web/package.json`, `deploy/vv-router/package.json`) without a
+    matching `## [X.Y.Z]` (non-Unreleased) section in the same package's `CHANGELOG.md`. Promote
+    `[Unreleased]` to `[X.Y.Z] — YYYY-MM-DD` in the same commit.
+* **CI** (`tools/check-contract-versions.sh --ci <target>`, run by each consumer's deploy workflow).
+  Targets are `api` (`deploy-api.yml`), `web` (`deploy-web.yml`), and `vv-router`
+  (`deploy-vv-router.yml`). Each blocks the deploy when the consumer's CHANGELOG doesn't have a
+  dated section for the version being deployed; `api` and `web` additionally require that section to
+  reference the current `verse-vault-core` and `verse-vault-wasm` versions (catches "bumped the
+  contract crate but forgot to update the consumer's `Bundled algorithm contract` subsection").
 
 See top-level `CHANGELOG.md` for the contract model and per-package changelog index.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,10 @@ corresponds to a top-level workspace member or root-level directory (`crates/<sc
 `docs:` (no sub-scope) for doc-only edits — sub-scoping by doc-area (`docs(arch)`,
 `docs(server-api)`, etc.) sprawls fast and isn't enforced.
 
-Subject in lowercase, no trailing period, imperative mood ("add X", not "added X"), and **≤ 50
-characters** including the type/scope prefix. Body wrapped at ~72 cols, focuses on the why.
+Subject in lowercase, no trailing period, imperative mood, and **≤ 50 characters** including the
+type/scope prefix. Apply the "if applied, this commit will <subject>" test — `simplify cleanup pass`
+and `heading split + passage card render` fail it because they describe the commit or the change as
+a noun rather than the action. Body wrapped at ~72 cols, focuses on the why.
 
 ## Contract crate versioning
 
@@ -187,20 +189,26 @@ See top-level `CHANGELOG.md` for the contract model and per-package changelog in
 ## Other conventions
 
 * Slight preference for writing tests before features.
-* Redundant inline comments are not helpful. Comments that simply say "what" is happening when the
-  code is obvious should be brief or perhaps even omitted. Prefer comments that explain "why" or
-  clarify complex logic. Docstrings should be brief and focused on info that is not obvious from the
-  signature and would be useful to consumers. (but don't be too picky about removing comments)
+* Comments are part of the code: update them when surrounding code changes — stale comments are
+  bugs. Use correct grammar and spelling.
+* Comments explain **why**, sometimes **how at a high level**, never **how at a low level** (don't
+  restate what well-named code already says). Prefer line comments on the previous line over block
+  or trailing comments. Docstrings on functions — especially public APIs — stay brief and focus on
+  what isn't obvious from the signature.
 
 ## Gotchas
 
 Footguns and non-obvious wiring. Add to this list when you trip over something that wasn't obvious
 from the code or design docs.
 
-* **`crates/wasm/pkg/` is gitignored.** Regenerate with
-  `wasm-pack build crates/wasm --target nodejs --out-dir pkg` before running anything that imports
-  it (the API tests, `apps/web` in WASM mode). The deploy workflow rebuilds it from scratch on every
-  API deploy.
+* **`crates/wasm/pkg/` (nodejs target) and `crates/wasm/pkg-web/` (bundler target) are both
+  gitignored.** `pkg/` is consumed by `packages/api`; `pkg-web/` by `apps/web`. Regenerate the
+  nodejs build with `wasm-pack build crates/wasm --target nodejs --out-dir pkg`; the bundler build
+  runs automatically via `apps/web`'s `predev` hook (`tools/build-wasm-web.sh`, gated by a
+  stamp-file check against the watched src — set `WASM_REBUILD=1` to force). Deploy workflows
+  rebuild both from scratch. A stale `pkg-web/` surfaces as misleading downstream symptoms
+  (engine-init failures cascading into "no session for <materialId>"), so when Rust changes don't
+  appear in the web dev server, suspect this first.
 * **Better Auth `baseURL` rejects relative paths.** `createAuthClient({ baseURL: '/vv' })` throws
   `Invalid base URL: /vv` because Better Auth runs it through `new URL(...)`. Resolve against
   `window.location.origin` first. See the `apps/web/CHANGELOG.md` [0.1.5] entry for the original
@@ -217,5 +225,10 @@ from the code or design docs.
   files under the API workspace, so the deploy workflow has to copy `/data/*.json` into the bundle
   separately. `materials.ts` searches bundle-local first with a repo-root fallback so dev keeps
   working.
+* **Drizzle migrations need `--> statement-breakpoint` between statements.** better-sqlite3 only
+  accepts one statement per `prepare()`, so multi-statement `.sql` migrations fail at apply-time
+  with `The supplied SQL string contains more than one statement` unless each `;` is followed by
+  `--> statement-breakpoint` on its own line. See `migrations/0013_relearn_and_wipe.sql` for the
+  shape.
 * **Abandoned branches.** `django-vue*`, `laravel*`, `express-vue`, and similar are spike
   experiments that were superseded. Don't merge from them; treat as read-only history.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,29 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Added
+
+* **Heading config split + `HeadingPassage` card render.** Settings now exposes two heading toggles:
+  "Heading passage prompts" (the new per-heading `HeadingPassage` card, defaulting on) and
+  "Per-verse heading prompts" (the old `VerseInHeading` card, defaulting off). Both grade the same
+  `VerseHeadingBinding` test set, so the two cards share FSRS state per member; the passage card is
+  the higher-signal default and the per-verse card is now opt-in for users who specifically want it.
+  The API consumes the renamed `headingCard` / `headingPassageCard` fields and the web client
+  forwards them through `buildMaterialConfig` to the WASM engine.
+* `CardPrompt` renders the new card minimally: passage range as the ref, placeholder prompt on the
+  front, heading title on the back. Verse-colour stripe stays suppressed because the card is
+  anchored to a pseudo verse (`verse === 0` sentinel) — the colour mnemonic is per-verse-number and
+  doesn't apply here.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.2.0` — adds `CardKind::HeadingPassage`, splits the heading toggle on
+  `MaterialConfig`.
+* `verse-vault-wasm@0.2.0` — adds `CardKindWire::HeadingPassage`; reworks pseudo-card session
+  placement so `HeadingPassage` introduces when any heading member is started and `ChapterClubList`
+  when every chapter+tier member is started, with one-per-kind-per-verse capping and catch-up
+  attachment for backlog cards.
+
 ## [0.1.12] — 2026-05-24
 
 ### Picker polish

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.13] — 2026-05-26
+
 ### Added
 
 * **Heading config split + `HeadingPassage` card render.** Settings now exposes two heading toggles:

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "predev": "pnpm run build:wasm",
+    "predev": "pnpm run build:wasm:dev",
     "dev": "vite",
     "build:wasm": "bash ../../tools/build-wasm-web.sh",
+    "build:wasm:dev": "bash ../../tools/build-wasm-web.sh --dev",
     "build": "pnpm run build:wasm && run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "build-only": "vite build",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "pnpm run build:wasm",
     "dev": "vite",
     "build:wasm": "bash ../../tools/build-wasm-web.sh",
     "build": "pnpm run build:wasm && run-p type-check \"build-only {@}\" --",

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -45,6 +45,7 @@ export type CardKind =
   | 'Citation'
   | 'Ftv'
   | 'ChapterClubList'
+  | 'HeadingPassage'
   | 'Reading'
 
 export interface VerseRender {
@@ -99,7 +100,8 @@ export type TierScope = 'off' | 'up150' | 'up300' | 'all'
 export type ChapterListScope = 'off' | 'up150' | 'up300'
 
 export interface YearSettings {
-  headings: boolean
+  headingCard: boolean
+  headingPassageCard: boolean
   ftv: boolean
   newScope: TierScope
   reviewScope: TierScope

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -97,6 +97,8 @@ const promptLabel = computed(() => {
       return 'What book?'
     case 'VerseInHeading':
       return 'What heading?'
+    case 'HeadingPassage':
+      return 'What heading is this passage under?'
     case 'VerseInClub':
       return 'What club?'
     case 'Recitation':
@@ -118,6 +120,25 @@ const ftvHtml = computed(() => props.card.composed?.ftvHtml ?? null)
 const headingTitle = computed(() => props.card.composed?.headings[0]?.title ?? null)
 const clubLabel = computed(() => props.card.tier ?? props.card.verse.clubs[0] ?? '')
 const composedMissing = computed(() => props.card.composed === null)
+
+/** Sentinel `verse === 0` marks a pseudo-verse card (ChapterClubList,
+ *  HeadingPassage) anchored to a heading or chapter rather than a
+ *  single verse. The verse-colour mnemonic doesn't apply — there's no
+ *  single verse number to encode — so the stripe is suppressed by
+ *  forcing `no-verse-accent` on `.card-box`. */
+const isPseudoVerse = computed(() => props.card.verse.verse === 0)
+
+/** "John 3:16-17" or "Romans 6:1-7:14" for a heading card. Drives the
+ *  HeadingPassage front-side ref. */
+const passageRange = computed(() => {
+  const h = props.card.verse.headings[0]
+  if (!h) return `${props.card.verse.book} ${props.card.verse.chapter}`
+  const same = h.startChapter === h.endChapter
+  const range = same
+    ? `${h.startChapter}:${h.startVerse}-${h.endVerse}`
+    : `${h.startChapter}:${h.startVerse}-${h.endChapter}:${h.endVerse}`
+  return `${props.card.verse.book} ${range}`
+})
 </script>
 
 <template>
@@ -130,7 +151,7 @@ const composedMissing = computed(() => props.card.composed === null)
        `--active-verse-colour` from this scope, so they always agree. -->
   <div
     class="card-box"
-    :class="{ 'no-verse-accent': !refParts.showVerse }"
+    :class="{ 'no-verse-accent': !refParts.showVerse || isPseudoVerse }"
     :style="{ '--active-verse-colour': verseColour }"
   >
     <div class="deck">{{ promptLabel }}</div>
@@ -222,6 +243,23 @@ const composedMissing = computed(() => props.card.composed === null)
           <div class="verse-text" v-html="verseHtml" />
         </template>
         <div v-else class="placeholder">…continue the verse…</div>
+      </div>
+
+      <div v-else-if="card.kind === 'HeadingPassage'" class="centered">
+        <!-- Pseudo-verse card anchored to a heading; verse number is 0
+             (sentinel) so the verse-colour stripe is suppressed via the
+             `pseudo-verse` class. Front shows the passage range as the
+             prompt; back reveals the heading title. Verse text rendering
+             for the passage is server-side composition (TODO: bulk-compose
+             on the API). -->
+        <div class="ref">{{ passageRange }}</div>
+        <hr />
+        <template v-if="revealed">
+          <div class="verse-text" v-html="verseHtml" />
+          <hr class="type" />
+          <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
+        </template>
+        <div v-else class="placeholder">…what heading is this passage under?…</div>
       </div>
 
       <div v-else-if="card.kind === 'Reading'" class="centered">

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -14,10 +14,14 @@ const VERSE_COLOUR_VARS = [
   '--verse-c1', '--verse-c2', '--verse-c3', '--verse-c4', '--verse-c5',
   '--verse-c6', '--verse-c7', '--verse-c8', '--verse-c9', '--verse-c10',
 ]
-const verseColour = computed(() => {
-  const idx = (props.card.verse.verse - 1) % VERSE_COLOUR_VARS.length
-  return `var(${VERSE_COLOUR_VARS[idx]})`
-})
+function verseColourVar(verse: number): string {
+  // Modulo math is always in-range for real verses (verse >= 1); the
+  // non-null assertion is needed because TS sees indexed access as
+  // possibly undefined. Pseudo cards (verse === 0) compute an undefined
+  // index but their result is never visually consumed.
+  return VERSE_COLOUR_VARS[(verse - 1) % VERSE_COLOUR_VARS.length]!
+}
+const verseColour = computed(() => `var(${verseColourVar(props.card.verse.verse)})`)
 
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
@@ -125,16 +129,21 @@ const composedMissing = computed(() => props.card.composed === null)
  *  forcing `no-verse-accent` on `.card-box`. */
 const isPseudoVerse = computed(() => props.card.verse.verse === 0)
 
-/** "John 3:16-17" or "Romans 6:1-7:14" for a heading card. Drives the
- *  HeadingPassage front-side ref. */
-const passageRange = computed(() => {
+/** "John 3:16-17" or "Romans 6:1-7:14" for a heading card. Each verse
+ *  number gets its own verse-colour via a per-span `--active-verse-colour`
+ *  override — the card-level stripe stays off (no single verse to anchor
+ *  it), but the individual verse-number mnemonics still apply. */
+const passageRangeHtml = computed(() => {
   const h = props.card.verse.headings[0]
-  if (!h) return `${props.card.verse.book} ${props.card.verse.chapter}`
+  const book = escapeHtml(props.card.verse.book)
+  if (!h) return `${book} ${props.card.verse.chapter}`
+  const vNum = (n: number) =>
+    `<span class="verse-number" style="--active-verse-colour: var(${verseColourVar(n)})">${n}</span>`
   const same = h.startChapter === h.endChapter
   const range = same
-    ? `${h.startChapter}:${h.startVerse}-${h.endVerse}`
-    : `${h.startChapter}:${h.startVerse}-${h.endChapter}:${h.endVerse}`
-  return `${props.card.verse.book} ${range}`
+    ? `${h.startChapter}:${vNum(h.startVerse)}-${vNum(h.endVerse)}`
+    : `${h.startChapter}:${vNum(h.startVerse)}-${h.endChapter}:${vNum(h.endVerse)}`
+  return `${book} ${range}`
 })
 </script>
 
@@ -244,12 +253,14 @@ const passageRange = computed(() => {
         <div v-else class="placeholder">…continue the verse…</div>
       </div>
 
-      <!-- Pseudo-verse card anchored to a heading: no single verse number
-           to mnemonic, so the verse-colour stripe stays off. Front shows
-           the passage range; back reveals the heading title.
+      <!-- Pseudo-verse card anchored to a heading: card-level verse-colour
+           stripe stays off (no single verse to anchor), but each verse
+           number in the range gets its own colour via a per-span
+           `--active-verse-colour` override. Front shows the range; back
+           reveals the heading title.
            TODO: passage text needs server-side bulk composition. -->
       <div v-else-if="card.kind === 'HeadingPassage'" class="centered">
-        <div class="ref">{{ passageRange }}</div>
+        <div class="ref" v-html="passageRangeHtml" />
         <hr />
         <template v-if="revealed">
           <div class="verse-text" v-html="verseHtml" />

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -34,6 +34,14 @@ const refParts = computed(() => {
       return { showBook: true, showChapter: true, showVerse: reveal }
     case 'Citation':
       return { showBook: reveal, showChapter: reveal, showVerse: reveal }
+    case 'Ftv':
+      // FTV's front is the first-words prompt with no ref. Hiding the
+      // verse-colour stripe pre-reveal keeps the verse-colour from
+      // mnemonic-leaking the verse number; on reveal the citation
+      // appears and the stripe lights up alongside it. `showVerse:
+      // reveal` is what `no-verse-accent` keys off, so mirroring the
+      // Citation pattern gets that for free.
+      return { showBook: reveal, showChapter: reveal, showVerse: reveal }
     default:
       return { showBook: true, showChapter: true, showVerse: true }
   }
@@ -207,7 +215,7 @@ const composedMissing = computed(() => props.card.composed === null)
       </div>
 
       <div v-else-if="card.kind === 'Ftv'" class="centered">
-        <div v-if="revealed && card.withCitation" class="ref" v-html="refHtml" />
+        <div v-if="revealed" class="ref" v-html="refHtml" />
         <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
         <template v-if="revealed">
           <hr class="type" />

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -35,12 +35,9 @@ const refParts = computed(() => {
     case 'Citation':
       return { showBook: reveal, showChapter: reveal, showVerse: reveal }
     case 'Ftv':
-      // FTV's front is the first-words prompt with no ref. Hiding the
-      // verse-colour stripe pre-reveal keeps the verse-colour from
-      // mnemonic-leaking the verse number; on reveal the citation
-      // appears and the stripe lights up alongside it. `showVerse:
-      // reveal` is what `no-verse-accent` keys off, so mirroring the
-      // Citation pattern gets that for free.
+      // FTV's front has no ref. Hide the verse-colour pre-reveal so it
+      // can't mnemonic-leak the verse number; on reveal the citation
+      // and the stripe come back together.
       return { showBook: reveal, showChapter: reveal, showVerse: reveal }
     default:
       return { showBook: true, showChapter: true, showVerse: true }
@@ -235,6 +232,8 @@ const passageRange = computed(() => {
         <div class="verse-text" v-html="verseHtml" />
       </div>
 
+      <!-- FTV: front shows the verse's first few words as a "continue…"
+           prompt; back reveals the citation and the full verse text. -->
       <div v-else-if="card.kind === 'Ftv'" class="centered">
         <div v-if="revealed" class="ref" v-html="refHtml" />
         <div class="verse-text ftv" v-html="`${ftvHtml ?? ''}…`" />
@@ -245,13 +244,11 @@ const passageRange = computed(() => {
         <div v-else class="placeholder">…continue the verse…</div>
       </div>
 
+      <!-- Pseudo-verse card anchored to a heading: no single verse number
+           to mnemonic, so the verse-colour stripe stays off. Front shows
+           the passage range; back reveals the heading title.
+           TODO: passage text needs server-side bulk composition. -->
       <div v-else-if="card.kind === 'HeadingPassage'" class="centered">
-        <!-- Pseudo-verse card anchored to a heading; verse number is 0
-             (sentinel) so the verse-colour stripe is suppressed via the
-             `pseudo-verse` class. Front shows the passage range as the
-             prompt; back reveals the heading title. Verse text rendering
-             for the passage is server-side composition (TODO: bulk-compose
-             on the API). -->
         <div class="ref">{{ passageRange }}</div>
         <hr />
         <template v-if="revealed">

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -160,13 +160,10 @@ export function useEngine() {
       // material. Backgrounded — don't block the UI on it.
       void flushOne(id).catch(() => {})
     } catch (e) {
-      // Log alongside storing on `error.value` so the real exception is
-      // visible in the dev console even when no UI surface renders the
-      // ref. The historical failure mode was a stale wasm pkg-web whose
-      // MaterialConfig schema disagreed with the API's wire shape: init
-      // threw at the WASM constructor and the swallowed error cascaded
-      // into "no session for <materialId>" / spurious fetch failures
-      // downstream, which was the misleading symptom.
+      // Log alongside storing on `error.value`: not every caller renders
+      // the ref, and a swallowed init failure cascades into misleading
+      // downstream symptoms ("no session for <materialId>", spurious
+      // fetch errors). Keep the real exception visible in the dev console.
       console.error(`useEngine.init: failed for ${id}`, e)
       error.value = e
     }

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -160,6 +160,14 @@ export function useEngine() {
       // material. Backgrounded — don't block the UI on it.
       void flushOne(id).catch(() => {})
     } catch (e) {
+      // Log alongside storing on `error.value` so the real exception is
+      // visible in the dev console even when no UI surface renders the
+      // ref. The historical failure mode was a stale wasm pkg-web whose
+      // MaterialConfig schema disagreed with the API's wire shape: init
+      // threw at the WASM constructor and the swallowed error cascaded
+      // into "no session for <materialId>" / spurious fetch failures
+      // downstream, which was the misleading symptom.
+      console.error(`useEngine.init: failed for ${id}`, e)
       error.value = e
     }
   }

--- a/apps/web/src/lib/engine/types.ts
+++ b/apps/web/src/lib/engine/types.ts
@@ -18,7 +18,8 @@ export type Grade = 1 | 2 | 3 | 4
  *  `#[serde(rename_all = "camelCase")]` enum values combined with
  *  snake_case struct field names. */
 export interface WireMaterialConfig {
-  headings: boolean
+  heading_card: boolean
+  heading_passage_card: boolean
   ftv: boolean
   new_scope: 'off' | 'up150' | 'up300' | 'all'
   review_scope: 'off' | 'up150' | 'up300' | 'all'
@@ -31,7 +32,8 @@ export interface WireMaterialConfig {
  *  translate — `off`, `up150`, `up300`, `all` are camelCase already
  *  per the Rust serde rename — only the field names change. */
 export function buildMaterialConfig(s: {
-  headings: boolean
+  headingCard: boolean
+  headingPassageCard: boolean
   ftv: boolean
   newScope: 'off' | 'up150' | 'up300' | 'all'
   reviewScope: 'off' | 'up150' | 'up300' | 'all'
@@ -39,7 +41,8 @@ export function buildMaterialConfig(s: {
   chapterListScope: 'off' | 'up150' | 'up300'
 }): WireMaterialConfig {
   return {
-    headings: s.headings,
+    heading_card: s.headingCard,
+    heading_passage_card: s.headingPassageCard,
     ftv: s.ftv,
     new_scope: s.newScope,
     review_scope: s.reviewScope,

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -172,7 +172,8 @@ function reviewBehindNew(s: YearSettings): boolean {
  *  knob the engine doesn't consume, so flipping it shouldn't wipe a
  *  full deck's render cache. */
 const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
-  'headings',
+  'headingCard',
+  'headingPassageCard',
   'ftv',
   'newScope',
   'reviewScope',
@@ -366,11 +367,19 @@ onMounted(refresh)
           <div class="scope-stack">
             <label class="toggle">
               <input
-                v-model="selected.draft.headings"
+                v-model="selected.draft.headingPassageCard"
                 type="checkbox"
                 :disabled="selected.saving"
               />
-              <span>Headings</span>
+              <span>Heading passage prompts <span class="toggle-hint">— "what heading is this passage under?"</span></span>
+            </label>
+            <label class="toggle">
+              <input
+                v-model="selected.draft.headingCard"
+                type="checkbox"
+                :disabled="selected.saving"
+              />
+              <span>Per-verse heading prompts <span class="toggle-hint">— "which heading is this verse in?" (one card per verse)</span></span>
             </label>
             <label class="toggle">
               <input
@@ -647,6 +656,11 @@ h2 {
 
 .toggle input[type='checkbox'] {
   accent-color: var(--color-accent);
+}
+
+.toggle-hint {
+  color: var(--color-muted);
+  font-size: 0.85em;
 }
 
 .scope-row {

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,8 +22,26 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+### Added
+
+* `CardKind::HeadingPassage { heading_idx }` — composite card anchored to a pseudo verse_id whose
+  `VerseAtoms.heading_members` lists every real verse in the heading's range. Grades each member's
+  `VerseHeadingBinding` for the card's `heading_idx`, so the passage prompt shares FSRS state with
+  the per-verse `VerseInHeading` cards rather than spawning parallel bindings.
+* `VerseAtoms.heading_members: Vec<u32>` — the per-heading member list consumed by
+  `HeadingPassage::tests`. Empty for real verses.
+
 ### Changed
 
+* `MaterialConfig.headings: bool` is split into two independent toggles:
+  * `heading_card: bool` (default **false**) — gates the per-verse `VerseInHeading` card. Defaults
+    off because the passage-cued version is the primary heading test and the per-verse version is
+    high-volume / low-signal for most learners. Old JSON with the legacy `headings` key deserializes
+    into this field via a serde alias, so existing rows keep their preference.
+  * `heading_passage_card: bool` (default **true**) — gates the new `HeadingPassage` card.
+* Builder emits one `HeadingPassage` card per heading that covers at least one included real verse,
+  ordered after the main verse loop and before `emit_chapter_club_list_cards` (pseudo-id allocator
+  is shared and monotonic).
 * Builder emits one `Ftv` card per FTV-eligible verse (always `with_citation: true`) instead of two.
   The no-citation variant was near-identical to its sibling on the prompt side — only the reveal
   differed — and `Recitation` already covers the recall-without-ref shape from the verse-text side.

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,12 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-05-26
+
+Card-audit pass: drops the redundant no-citation FTV variant and introduces a passage-cued heading
+prompt as the new primary heading test. The intermediate `0.1.1` bump (FTV-only) never shipped on
+its own; both changes land together as `0.2.0`.
+
 ### Added
 
 * `CardKind::HeadingPassage { heading_idx }` — composite card anchored to a pseudo verse_id whose

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,15 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+### Changed
+
+* Builder emits one `Ftv` card per FTV-eligible verse (always `with_citation: true`) instead of two.
+  The no-citation variant was near-identical to its sibling on the prompt side — only the reveal
+  differed — and `Recitation` already covers the recall-without-ref shape from the verse-text side.
+  The `CardKind::Ftv { with_citation }` enum variant keeps its field for wire-format compatibility;
+  existing `with_citation: false` cards in persisted state are unaffected but won't be re-emitted on
+  rebuild.
+
 ## [0.1.0] — 2026-05-20 (baseline)
 
 ### Added

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -300,23 +300,19 @@ pub fn build_with_config(
         push_card(CardKind::Recitation, &mut cards, &mut next_card_id);
         push_card(CardKind::Citation, &mut cards, &mut next_card_id);
 
-        // Composite: Ftv (with and without citation). Eligibility:
-        // verse has phrases, FTV is short enough, FTV doesn't exceed
-        // phrase 0 length. derive_structure verified the prefix invariant
-        // when emitting ftv_word_count, so we trust it here.
+        // Composite: Ftv. Eligibility: verse has phrases, FTV is short
+        // enough, FTV doesn't exceed phrase 0 length. derive_structure
+        // verified the prefix invariant when emitting ftv_word_count,
+        // so we trust it here. The single FTV card always tests the
+        // citation triple on reveal — the no-citation variant was
+        // dropped because Recitation already covers the
+        // recall-without-ref case from the verse-text side.
         if config.ftv
             && let Some(ftv_words) = verse.ftv_word_count
             && phrase_count > 0
             && (ftv_words as usize) <= FTV_MAX_WORDS
             && ftv_words <= phrase_zero_word_count
         {
-            push_card(
-                CardKind::Ftv {
-                    with_citation: false,
-                },
-                &mut cards,
-                &mut next_card_id,
-            );
             push_card(
                 CardKind::Ftv {
                     with_citation: true,
@@ -554,13 +550,19 @@ mod tests {
         );
         assert!(r.cards.iter().any(|c| matches!(c.kind, CardKind::Citation)));
         // FTV "For God" is a strict prefix of phrase zero "For God" (equal),
-        // so both Ftv variants are emitted.
-        let ftv_cards = r
+        // so one Ftv card emits — always with citation on the answer side.
+        let ftv_cards: Vec<&Card> = r
             .cards
             .iter()
             .filter(|c| matches!(c.kind, CardKind::Ftv { .. }))
-            .count();
-        assert_eq!(ftv_cards, 2);
+            .collect();
+        assert_eq!(ftv_cards.len(), 1);
+        assert!(matches!(
+            ftv_cards[0].kind,
+            CardKind::Ftv {
+                with_citation: true
+            }
+        ));
     }
 
     #[test]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -134,6 +134,7 @@ fn emit_chapter_club_list_cards(
                     ftv_word_count: None,
                     phrase_zero_word_count: 0,
                     chapter_members: members,
+                    heading_members: Vec::new(),
                 },
             );
             verse_render_by_id.insert(
@@ -157,6 +158,103 @@ fn emit_chapter_club_list_cards(
             });
             *next_card_id += 1;
         }
+    }
+}
+
+/// Allocate pseudo verse_ids and emit one `HeadingPassage` card per
+/// heading whose range covers at least one included real verse. The
+/// pseudo's `VerseAtoms.heading_members` carries the member verse_ids
+/// in ascending order so `Card::tests` can grade each member's
+/// `VerseHeadingBinding`. Same pseudo-id contract as
+/// `emit_chapter_club_list_cards`: ids start one past the current
+/// max so real-verse TestStates aren't disturbed.
+fn emit_heading_passage_cards(
+    cards: &mut Vec<Card>,
+    next_card_id: &mut u32,
+    verse_atoms_by_id: &mut HashMap<u32, VerseAtoms>,
+    verse_render_by_id: &mut HashMap<u32, VerseRender>,
+    headings_data: &[HeadingData],
+) {
+    let mut next_pseudo_verse_id: u32 =
+        verse_atoms_by_id.keys().copied().max().map_or(0, |m| m + 1);
+
+    for (h_idx, heading) in headings_data.iter().enumerate() {
+        let heading_idx = h_idx as u16;
+        let mut members: Vec<u32> = verse_render_by_id
+            .iter()
+            .filter_map(|(vid, render)| {
+                if render.book != heading.book {
+                    return None;
+                }
+                // Sentinel verse=0 marks a pseudo verse (heading-passage
+                // pseudos added by prior iterations of this loop, or
+                // chapter-list pseudos if call order ever changes). They
+                // aren't real verses; skip.
+                if render.verse == 0 {
+                    return None;
+                }
+                let in_range = if heading.start_chapter == heading.end_chapter {
+                    render.chapter == heading.start_chapter
+                        && render.verse >= heading.start_verse
+                        && render.verse <= heading.end_verse
+                } else if render.chapter == heading.start_chapter {
+                    render.verse >= heading.start_verse
+                } else if render.chapter == heading.end_chapter {
+                    render.verse <= heading.end_verse
+                } else {
+                    render.chapter > heading.start_chapter && render.chapter < heading.end_chapter
+                };
+                in_range.then_some(*vid)
+            })
+            .collect();
+        members.sort();
+        if members.is_empty() {
+            continue;
+        }
+
+        let pseudo_id = next_pseudo_verse_id;
+        next_pseudo_verse_id += 1;
+
+        verse_atoms_by_id.insert(
+            pseudo_id,
+            VerseAtoms {
+                verse_id: pseudo_id,
+                phrase_count: 0,
+                phrase_ranges: Vec::new(),
+                headings: vec![heading_idx],
+                clubs: Vec::new(),
+                ftv_word_count: None,
+                phrase_zero_word_count: 0,
+                chapter_members: Vec::new(),
+                heading_members: members,
+            },
+        );
+        verse_render_by_id.insert(
+            pseudo_id,
+            VerseRender {
+                book: heading.book.clone(),
+                chapter: heading.start_chapter,
+                verse: 0, // sentinel: heading-scoped, no specific verse
+                phrase_word_counts: Vec::new(),
+                annotations: Vec::new(),
+                ftv_word_count: None,
+                headings: vec![HeadingRender {
+                    heading_idx,
+                    start_chapter: heading.start_chapter,
+                    start_verse: heading.start_verse,
+                    end_chapter: heading.end_chapter,
+                    end_verse: heading.end_verse,
+                }],
+                clubs: Vec::new(),
+            },
+        );
+        cards.push(Card {
+            id: CardId(*next_card_id),
+            kind: CardKind::HeadingPassage { heading_idx },
+            verse_id: pseudo_id,
+            state: CardState::New,
+        });
+        *next_card_id += 1;
     }
 }
 
@@ -278,7 +376,7 @@ pub fn build_with_config(
         push_card(CardKind::VerseAtVerseRef, &mut cards, &mut next_card_id);
         push_card(CardKind::VerseInChapter, &mut cards, &mut next_card_id);
         push_card(CardKind::VerseInBook, &mut cards, &mut next_card_id);
-        if config.headings {
+        if config.heading_card {
             for &h_idx in &headings {
                 push_card(
                     CardKind::VerseInHeading { heading_idx: h_idx },
@@ -360,7 +458,18 @@ pub fn build_with_config(
                 ftv_word_count: verse.ftv_word_count,
                 phrase_zero_word_count,
                 chapter_members: Vec::new(),
+                heading_members: Vec::new(),
             },
+        );
+    }
+
+    if config.heading_passage_card {
+        emit_heading_passage_cards(
+            &mut cards,
+            &mut next_card_id,
+            &mut verse_atoms_by_id,
+            &mut verse_render_by_id,
+            &data.headings,
         );
     }
 
@@ -484,8 +593,11 @@ mod tests {
         let m = material_one_verse_with_heading_and_club();
         // club_card_scope defaults to Off, so VerseInClub cards need an
         // explicit opt-in for this test to exercise their emission.
+        // heading_card likewise defaults off; flip it on so the
+        // VerseInHeading assertion below exercises a real emission.
         let cfg = MaterialConfig {
             club_card_scope: crate::material_config::TierScope::All,
+            heading_card: true,
             ..MaterialConfig::default()
         };
         let r = build_with_config(&m, &cfg, 0);
@@ -711,15 +823,86 @@ mod tests {
     }
 
     #[test]
-    fn builder_headings_off_emits_no_heading_cards() {
+    fn builder_heading_card_off_emits_no_verse_in_heading_cards() {
+        // Default already has heading_card=false, so this verifies the
+        // default explicitly. The HeadingPassage card is the primary
+        // heading-binding test; VerseInHeading is opt-in.
+        let m = material_one_verse_with_heading_and_club();
+        let r = build_with_config(&m, &MaterialConfig::default(), 0);
+        assert!(
+            !r.cards
+                .iter()
+                .any(|c| matches!(c.kind, CardKind::VerseInHeading { .. }))
+        );
+    }
+
+    #[test]
+    fn builder_emits_one_heading_passage_card_per_heading() {
+        // Heading covers John 3:16–17. Both verses are included, so the
+        // pseudo HeadingPassage card lists both as members. Default
+        // config has heading_passage_card=true so this exercises the
+        // out-of-the-box path.
+        let json = r#"{
+            "year": 4,
+            "books": ["John"],
+            "chapters": [{"book": "John", "number": 3, "start_verse": 16, "end_verse": 17}],
+            "verses": [
+                {"book": "John", "chapter": 3, "verse": 16, "phraseWordCounts": [2, 2], "annotations": [], "clubs": []},
+                {"book": "John", "chapter": 3, "verse": 17, "phraseWordCounts": [2, 2], "annotations": [], "clubs": []}
+            ],
+            "headings": [{
+                "book": "John",
+                "startChapter": 3, "startVerse": 16,
+                "endChapter": 3, "endVerse": 17
+            }]
+        }"#;
+        let m: MaterialData = serde_json::from_str(json).unwrap();
+        let r = build(&m, 0);
+
+        let passage_cards: Vec<&Card> = r
+            .cards
+            .iter()
+            .filter(|c| matches!(c.kind, CardKind::HeadingPassage { .. }))
+            .collect();
+        assert_eq!(passage_cards.len(), 1);
+        let atoms = r.verse_atoms_data.get(&passage_cards[0].verse_id).unwrap();
+        assert_eq!(atoms.heading_members, vec![0, 1]);
+
+        // Member tests are seeded — verifies the propagation surface for
+        // grading the card.
+        for tk in passage_cards[0].tests(atoms) {
+            assert!(
+                r.tests.contains_key(&tk),
+                "missing seeded TestState for {tk:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn builder_heading_passage_off_emits_no_heading_passage_cards() {
         let m = material_one_verse_with_heading_and_club();
         let config = MaterialConfig {
-            headings: false,
+            heading_passage_card: false,
             ..MaterialConfig::default()
         };
         let r = build_with_config(&m, &config, 0);
         assert!(
             !r.cards
+                .iter()
+                .any(|c| matches!(c.kind, CardKind::HeadingPassage { .. }))
+        );
+    }
+
+    #[test]
+    fn builder_heading_card_on_emits_verse_in_heading_cards() {
+        let m = material_one_verse_with_heading_and_club();
+        let config = MaterialConfig {
+            heading_card: true,
+            ..MaterialConfig::default()
+        };
+        let r = build_with_config(&m, &config, 0);
+        assert!(
+            r.cards
                 .iter()
                 .any(|c| matches!(c.kind, CardKind::VerseInHeading { .. }))
         );
@@ -783,7 +966,7 @@ mod tests {
         // VerseInBook, Recitation, Citation.
         let m = material_one_verse_with_heading_and_club();
         let config = MaterialConfig {
-            headings: false,
+            heading_passage_card: false,
             ftv: false,
             ..config_with_club_cards_off()
         };

--- a/crates/core/src/card.rs
+++ b/crates/core/src/card.rs
@@ -57,6 +57,18 @@ pub enum CardKind {
     ChapterClubList {
         tier: ClubTier,
     },
+    /// "What heading is this passage under?" Composite card that shows
+    /// every real verse in the heading's range and grades the
+    /// `VerseHeadingBinding` for each. Anchored to a pseudo verse_id
+    /// whose `VerseAtoms.heading_members` carries the member verse_ids.
+    /// Pairs with the atomic `VerseInHeading` ("which heading is *this*
+    /// verse in?") and serves as the passage-cued reverse: same binding
+    /// is graded, but the cue is the whole passage rather than one
+    /// verse — so the two cards share `TestState` on each member's
+    /// binding.
+    HeadingPassage {
+        heading_idx: u16,
+    },
     /// UX-only: progressive-reveal entry that shows the verse text to the
     /// learner. Carries no FSRS state and is never emitted by `builder::build`;
     /// it only appears in `Session::new_verse_progression`.
@@ -111,6 +123,13 @@ pub struct VerseAtoms {
     /// shares state with the per-verse `VerseInClub` cards rather
     /// than spawning parallel bindings. Empty for real verses.
     pub chapter_members: Vec<(u32, ClubTier)>,
+    /// For pseudo verses anchoring `HeadingPassage` cards: the
+    /// verse_ids of every real verse whose (book, chapter, verse)
+    /// falls inside the heading's range. Tests for the card grade
+    /// each member's `VerseHeadingBinding` for the card's heading,
+    /// so the passage card shares state with the per-verse
+    /// `VerseInHeading` cards. Empty for real verses.
+    pub heading_members: Vec<u32>,
 }
 
 impl VerseAtoms {
@@ -273,6 +292,17 @@ impl Card {
                     },
                 })
                 .collect(),
+            CardKind::HeadingPassage { heading_idx } => atoms
+                .heading_members
+                .iter()
+                .map(|&v| TestKey {
+                    kind: TestKind::VerseHeading,
+                    element: ElementId::VerseHeadingBinding {
+                        verse_id: v,
+                        heading_idx,
+                    },
+                })
+                .collect(),
             CardKind::Reading => Vec::new(),
         }
     }
@@ -295,6 +325,7 @@ mod tests {
             ftv_word_count: None,
             phrase_zero_word_count: 0,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         }
     }
 
@@ -339,6 +370,7 @@ mod tests {
             ftv_word_count: Some(2),
             phrase_zero_word_count: 4,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         };
         assert_eq!(atoms.phrase_positions(), vec![0u16, 1, 2]);
     }
@@ -444,6 +476,7 @@ mod tests {
             ftv_word_count: Some(2),
             phrase_zero_word_count: 6,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         };
         let c = atomic_card(
             0,
@@ -468,6 +501,7 @@ mod tests {
             ftv_word_count: Some(6),
             phrase_zero_word_count: 6,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         };
         let c = atomic_card(
             0,
@@ -491,6 +525,7 @@ mod tests {
             ftv_word_count: Some(2),
             phrase_zero_word_count: 6,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         };
         let c = atomic_card(
             0,
@@ -541,6 +576,48 @@ mod tests {
         let c = atomic_card(0, CardKind::Reading, 7);
         let tests = c.tests(&sample_atoms(7, 4));
         assert!(tests.is_empty());
+    }
+
+    #[test]
+    fn heading_passage_grades_member_bindings() {
+        // HeadingPassage anchored to a pseudo verse_id whose
+        // heading_members list spans three real verses. Card grades a
+        // VerseHeadingBinding per member, all tagged with the card's
+        // heading_idx — that's what couples its FSRS state to each
+        // member's per-verse VerseInHeading.
+        let atoms = VerseAtoms {
+            verse_id: 99,
+            phrase_count: 0,
+            phrase_ranges: vec![],
+            headings: vec![2],
+            clubs: vec![],
+            ftv_word_count: None,
+            phrase_zero_word_count: 0,
+            chapter_members: Vec::new(),
+            heading_members: vec![7, 8, 9],
+        };
+        let c = atomic_card(0, CardKind::HeadingPassage { heading_idx: 2 }, 99);
+        let tests = c.tests(&atoms);
+        assert_eq!(tests.len(), 3);
+        for (i, expected_verse) in [7, 8, 9].into_iter().enumerate() {
+            assert_eq!(
+                tests[i],
+                TestKey {
+                    kind: TestKind::VerseHeading,
+                    element: ElementId::VerseHeadingBinding {
+                        verse_id: expected_verse,
+                        heading_idx: 2,
+                    }
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn heading_passage_with_no_members_grades_no_tests() {
+        let atoms = sample_atoms(99, 0);
+        let c = atomic_card(0, CardKind::HeadingPassage { heading_idx: 0 }, 99);
+        assert!(c.tests(&atoms).is_empty());
     }
 
     #[test]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -127,6 +127,7 @@ impl ReviewEngine {
             ftv_word_count: None,
             phrase_zero_word_count: 0,
             chapter_members: Vec::new(),
+            heading_members: Vec::new(),
         }
     }
 

--- a/crates/core/src/material_config.rs
+++ b/crates/core/src/material_config.rs
@@ -80,10 +80,24 @@ impl ChapterListScope {
 /// is introducing verses without re-surfacing them; still valid, just
 /// unusual.)
 ///
-/// `headings` and `ftv` are independent bool toggles.
+/// `heading_card`, `heading_passage_card`, and `ftv` are independent
+/// bool toggles. `heading_card` controls the per-verse
+/// `VerseInHeading` ("which heading is *this* verse in?") card;
+/// `heading_passage_card` controls the per-heading `HeadingPassage`
+/// ("what heading is this whole passage under?") card. Both grade the
+/// same `VerseHeadingBinding` test set, so the two cards share FSRS
+/// state on each member's binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MaterialConfig {
-    pub headings: bool,
+    /// Per-verse "which heading?" card. Defaults off: the passage-cued
+    /// version (`heading_passage_card`) is the primary heading test;
+    /// asking the same question per-verse is high-volume and low-signal
+    /// for most learners. Old JSON with the legacy `headings` key is
+    /// accepted via the serde alias.
+    #[serde(default, alias = "headings")]
+    pub heading_card: bool,
+    #[serde(default = "default_true")]
+    pub heading_passage_card: bool,
     pub ftv: bool,
     #[serde(default)]
     pub new_scope: TierScope,
@@ -102,10 +116,15 @@ fn default_club_card_scope() -> TierScope {
     TierScope::Off
 }
 
+fn default_true() -> bool {
+    true
+}
+
 impl Default for MaterialConfig {
     fn default() -> Self {
         Self {
-            headings: true,
+            heading_card: false,
+            heading_passage_card: true,
             ftv: true,
             new_scope: TierScope::All,
             review_scope: TierScope::All,
@@ -157,7 +176,11 @@ mod tests {
     #[test]
     fn default_is_everything_active() {
         let c = MaterialConfig::default();
-        assert!(c.headings);
+        // VerseInHeading defaults off; HeadingPassage defaults on. The
+        // passage-cued card is the primary heading test; the per-verse
+        // version is opt-in.
+        assert!(!c.heading_card);
+        assert!(c.heading_passage_card);
         assert!(c.ftv);
         assert_eq!(c.new_scope, TierScope::All);
         assert_eq!(c.review_scope, TierScope::All);
@@ -167,6 +190,17 @@ mod tests {
         for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
             assert_eq!(c.effective_status(tier), ClubStatus::Active);
         }
+    }
+
+    #[test]
+    fn legacy_headings_key_aliases_to_heading_card() {
+        // Pre-split JSON had `headings: bool`. The serde alias keeps
+        // those rows readable so existing users don't lose their
+        // VerseInHeading preference on the bump.
+        let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
+        assert!(c.heading_card);
+        // Missing field falls back to the new default (on).
+        assert!(c.heading_passage_card);
     }
 
     #[test]

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,11 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-05-26
+
+Bundles the previously-unreleased `all_card_renders` additions with the new `HeadingPassage` wire
+variant. Ships alongside `verse-vault-core@0.2.0`.
+
 ### Added
 
 * `CardKindWire::HeadingPassage { headingIdx }` — wire-format mirror of the new core

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -24,6 +24,20 @@ The contract is documented in `docs/wasm-api.md`.
 
 ### Added
 
+* `CardKindWire::HeadingPassage { headingIdx }` — wire-format mirror of the new core
+  `CardKind::HeadingPassage` variant. Composite passage card anchored to a pseudo verse whose atoms
+  list every real verse in the heading; grades each member's `VerseHeadingBinding`. Additive; old
+  consumers that match on `kind` will fall through their default branch on this variant (the API
+  forwards the wire shape unchanged so the web client can route it).
+* `next_memorize_card`'s pseudo-card placement is overhauled. `HeadingPassage` cards introduce when
+  at least one heading member is "started" (Active or being graduated this session) and attach to
+  the earliest such member; `ChapterClubList` cards introduce when every chapter+tier member is
+  started and attach to the latest. When the trigger conditions are met purely from prior Actives —
+  e.g. the user just enabled the per-passage card in settings after memorising the relevant verses —
+  the card is attached as a catch-up to a session-verse with capacity. Each session-verse caps at
+  one `HeadingPassage` and one `ChapterClubList` so a backlog spreads across `verse_order` instead
+  of piling on the first verse. Replaces the previous "last member is the current verse" trigger
+  which misfired when verses graduated out of order.
 * `all_card_renders()` — returns `CardRenderWire[]` for every card in the deck in card-id order.
   Used by the API's bulk `GET /materials/:id/renders` endpoint to compose every card's HTML in one
   engine call. Additive; existing consumers ignore it.

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -110,6 +110,10 @@ pub enum CardKindWire {
     ChapterClubList {
         tier: ClubTier,
     },
+    HeadingPassage {
+        #[serde(rename = "headingIdx")]
+        heading_idx: u16,
+    },
     Reading,
 }
 
@@ -128,6 +132,9 @@ impl From<CardKind> for CardKindWire {
             CardKind::Citation => CardKindWire::Citation,
             CardKind::Ftv { with_citation } => CardKindWire::Ftv { with_citation },
             CardKind::ChapterClubList { tier } => CardKindWire::ChapterClubList { tier },
+            CardKind::HeadingPassage { heading_idx } => {
+                CardKindWire::HeadingPassage { heading_idx }
+            }
             CardKind::Reading => CardKindWire::Reading,
         }
     }
@@ -347,13 +354,16 @@ impl WasmEngine {
     /// front, drill across them in any order, and walk back through them
     /// for graduation.
     ///
-    /// Same per-card filtering rules as `memorize_progression`, plus an
-    /// extra session-scoped dedupe: a `VerseInHeading` heading is only
-    /// drilled on the first verse that introduces it within this batch,
-    /// and a `ChapterClubList` card only attaches to the single verse
-    /// (per session) whose last-member rule fires.
+    /// Same per-card filtering rules as `memorize_progression`, plus
+    /// session-scoped pseudo-card placement: a `VerseInHeading` heading
+    /// is drilled on the first verse that introduces it within this
+    /// batch; `HeadingPassage` and `ChapterClubList` cards are attached
+    /// to a session-verse when their trigger conditions are met (any
+    /// heading member started for HP, all chapter+tier members started
+    /// for CCL), capped at one of each kind per verse so backlog cards
+    /// spread instead of piling on a single attach point.
     pub fn memorize_session(&self, limit: u32) -> Result<String, JsError> {
-        use std::collections::HashSet;
+        use std::collections::{HashMap, HashSet};
         use verse_vault_core::card::{CardKind, CardState};
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
@@ -383,15 +393,149 @@ impl WasmEngine {
             }
         }
 
+        // Pre-compute pseudo-card attachments before walking the verses.
+        // Two rules govern when a HeadingPassage / ChapterClubList card
+        // moves from `New` into the session:
+        //
+        //   * HeadingPassage: introduce when at least one heading member
+        //     is "started" (Active before this session or being graduated
+        //     in it). Attach to the earliest member in this session's
+        //     `verse_order` — or, when conditions are met purely from
+        //     prior Actives (orphan / catch-up after a settings flip),
+        //     attach to whichever session verse still has capacity.
+        //   * ChapterClubList: introduce when every chapter+tier member
+        //     is started by end-of-session. Attach to the latest member
+        //     in `verse_order`, or to remaining capacity as a catch-up.
+        //
+        // Cap at 1 of each kind per session-verse so a backlog of orphan
+        // cards doesn't pile onto the first verse — they spread across
+        // `verse_order` and the overflow defers to the next session.
+        let session_verses: HashSet<u32> = verse_order.iter().copied().collect();
+        let active_verses: HashSet<u32> = cards
+            .iter()
+            .filter(|c| matches!(c.state, CardState::Active))
+            .filter(|c| {
+                !matches!(
+                    c.kind,
+                    CardKind::ChapterClubList { .. } | CardKind::HeadingPassage { .. }
+                )
+            })
+            .map(|c| c.verse_id)
+            .collect();
+
+        enum AttachIntent {
+            Normal(u32),
+            Orphan,
+            None,
+        }
+
+        let mut hp_assigned: HashMap<u32, u32> = HashMap::new();
+        let mut ccl_assigned: HashMap<u32, u32> = HashMap::new();
+        let mut hp_pending: Vec<u32> = Vec::new();
+        let mut ccl_pending: Vec<u32> = Vec::new();
+
+        for card in cards.iter() {
+            if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            let (is_hp, intent) = match card.kind {
+                CardKind::HeadingPassage { .. } => {
+                    let atoms = self.engine.atoms_for(card.verse_id);
+                    let in_session_min = atoms
+                        .heading_members
+                        .iter()
+                        .copied()
+                        .filter(|v| session_verses.contains(v))
+                        .min();
+                    let any_active = atoms
+                        .heading_members
+                        .iter()
+                        .any(|v| active_verses.contains(v));
+                    let intent = if let Some(v) = in_session_min {
+                        AttachIntent::Normal(v)
+                    } else if any_active {
+                        AttachIntent::Orphan
+                    } else {
+                        AttachIntent::None
+                    };
+                    (true, intent)
+                }
+                CardKind::ChapterClubList { .. } => {
+                    let atoms = self.engine.atoms_for(card.verse_id);
+                    let all_settled = atoms
+                        .chapter_members
+                        .iter()
+                        .all(|(v, _)| active_verses.contains(v) || session_verses.contains(v));
+                    let in_session_max = atoms
+                        .chapter_members
+                        .iter()
+                        .map(|(v, _)| *v)
+                        .filter(|v| session_verses.contains(v))
+                        .max();
+                    let intent = if !all_settled {
+                        AttachIntent::None
+                    } else if let Some(v) = in_session_max {
+                        AttachIntent::Normal(v)
+                    } else {
+                        AttachIntent::Orphan
+                    };
+                    (false, intent)
+                }
+                _ => continue,
+            };
+            let (assigned, pending) = if is_hp {
+                (&mut hp_assigned, &mut hp_pending)
+            } else {
+                (&mut ccl_assigned, &mut ccl_pending)
+            };
+            match intent {
+                AttachIntent::Normal(v) => match assigned.entry(v) {
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert(card.id.0);
+                    }
+                    // Clash: another card of the same kind already claimed
+                    // this verse. Defer to the pending pool; the second
+                    // pass places it on the next session-verse with
+                    // capacity.
+                    std::collections::hash_map::Entry::Occupied(_) => {
+                        pending.push(card.id.0);
+                    }
+                },
+                AttachIntent::Orphan => pending.push(card.id.0),
+                AttachIntent::None => {}
+            }
+        }
+
+        // Second pass: drain the pending pool into remaining capacity in
+        // `verse_order` order so catch-ups land at the start of the
+        // session.
+        let mut hp_idx = 0usize;
+        let mut ccl_idx = 0usize;
+        for &verse_id in &verse_order {
+            if hp_idx < hp_pending.len()
+                && let std::collections::hash_map::Entry::Vacant(e) = hp_assigned.entry(verse_id)
+            {
+                e.insert(hp_pending[hp_idx]);
+                hp_idx += 1;
+            }
+            if ccl_idx < ccl_pending.len()
+                && let std::collections::hash_map::Entry::Vacant(e) = ccl_assigned.entry(verse_id)
+            {
+                e.insert(ccl_pending[ccl_idx]);
+                ccl_idx += 1;
+            }
+        }
+
         let mut session_headings: HashSet<u16> = HashSet::new();
-        let mut session_chapter_lists: HashSet<u32> = HashSet::new();
         let mut entries: Vec<Entry> = Vec::with_capacity(verse_order.len());
 
         for verse_id in verse_order {
             let mut card_ids: Vec<u32> = Vec::new();
             for card in cards.iter().filter(|c| c.verse_id == verse_id) {
                 match card.kind {
-                    CardKind::ChapterClubList { .. } | CardKind::Reading => continue,
+                    CardKind::ChapterClubList { .. }
+                    | CardKind::HeadingPassage { .. }
+                    | CardKind::Reading => continue,
                     CardKind::VerseInHeading { heading_idx } => {
                         let already_introduced = cards.iter().any(|other| {
                             other.verse_id != verse_id
@@ -408,23 +552,11 @@ impl WasmEngine {
                     _ => card_ids.push(card.id.0),
                 }
             }
-            for card in cards.iter() {
-                let CardKind::ChapterClubList { .. } = card.kind else {
-                    continue;
-                };
-                if !matches!(card.state, CardState::New) {
-                    continue;
-                }
-                if !session_chapter_lists.insert(card.id.0) {
-                    continue;
-                }
-                let atoms = self.engine.atoms_for(card.verse_id);
-                if atoms.chapter_members.last().map(|(v, _)| *v) == Some(verse_id) {
-                    card_ids.push(card.id.0);
-                } else {
-                    // Not this verse — un-mark so a later verse can claim it.
-                    session_chapter_lists.remove(&card.id.0);
-                }
+            if let Some(&c) = hp_assigned.get(&verse_id) {
+                card_ids.push(c);
+            }
+            if let Some(&c) = ccl_assigned.get(&verse_id) {
+                card_ids.push(c);
             }
             let recitation_card_id = cards
                 .iter()

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,8 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.15] — 2026-05-26
+
 ### Added
 
 * **Heading config split + new `HeadingPassage` card kind.** The `user_year_settings.headings`

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,32 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### Added
+
+* **Heading config split + new `HeadingPassage` card kind.** The `user_year_settings.headings`
+  column is renamed to `heading_card` (controls the per-verse `VerseInHeading` "which heading is
+  this verse in?" prompt), and a new `heading_passage_card` column gates the new per-heading
+  `HeadingPassage` "what heading is this whole passage under?" card. Migration
+  `0017_heading_card_split` UPDATE-resets every existing row's `heading_card` to 0 — the per-verse
+  card is now opt-in, and the design intent is "everyone starts on the new defaults; re-enable
+  per-verse from settings if you specifically want it." `heading_passage_card` defaults to 1 (on) as
+  the primary heading test in the new design.
+* `POST /api/years/:materialId/settings` accepts the two new keys (`headingCard`,
+  `headingPassageCard`) on the request body; both default unchanged when omitted. The legacy
+  `headings` key is no longer accepted — clients must send the renamed field.
+* `engine.ts`'s `readMaterialConfigJson` serializes the two fields to the Rust core, which has
+  consumed the new shape since `verse-vault-core@0.2.0`.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.2.0` — new `CardKind::HeadingPassage` variant, split `headings` →
+  `heading_card` + `heading_passage_card` on `MaterialConfig`.
+* `verse-vault-wasm@0.2.0` — adds `CardKindWire::HeadingPassage`; reworks pseudo-card session
+  placement so `HeadingPassage` introduces when any heading member is started (earliest such member
+  as attach point) and `ChapterClubList` introduces when every chapter+tier member is started
+  (latest as attach point), with one-per-kind-per-verse capping and catch-up attachment for trigger
+  conditions met purely from prior Actives.
+
 ## [0.1.14] — 2026-05-25
 
 ### Changed

--- a/packages/api/migrations/0017_heading_card_split.sql
+++ b/packages/api/migrations/0017_heading_card_split.sql
@@ -1,0 +1,23 @@
+-- Split the legacy `headings` toggle into two independent fields and
+-- reset everyone to the new defaults:
+--
+--   * `heading_card`         — per-verse "which heading is this verse in?"
+--                              prompt (the old VerseInHeading card).
+--                              Renamed from `headings`, then UPDATE-reset
+--                              to 0 so every existing user gets the new
+--                              "off by default" behaviour. Users who want
+--                              the per-verse card can re-enable it from
+--                              the settings UI; the new design treats it
+--                              as opt-in.
+--   * `heading_passage_card` — per-heading "what heading is this whole
+--                              passage under?" prompt (the new HeadingPassage
+--                              card). Defaults to 1 (on) — the passage-cued
+--                              card is the primary heading test in the new
+--                              design.
+--
+-- See core 0.2.0 CHANGELOG for the algorithm side of the split.
+ALTER TABLE `user_year_settings` RENAME COLUMN `headings` TO `heading_card`;
+--> statement-breakpoint
+ALTER TABLE `user_year_settings` ADD COLUMN `heading_passage_card` integer DEFAULT 1 NOT NULL;
+--> statement-breakpoint
+UPDATE `user_year_settings` SET `heading_card` = 0;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779000000000,
       "tag": "0016_user_materials_offline_mode",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1779100000000,
+      "tag": "0017_heading_card_split",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -122,7 +122,8 @@ export const userYearSettings = sqliteTable(
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
     materialId: text('material_id').notNull(),
-    headings: integer('headings', { mode: 'boolean' }).notNull(),
+    headingCard: integer('heading_card', { mode: 'boolean' }).notNull(),
+    headingPassageCard: integer('heading_passage_card', { mode: 'boolean' }).notNull(),
     ftv: integer('ftv', { mode: 'boolean' }).notNull(),
     newScope: text('new_scope').notNull(),
     reviewScope: text('review_scope').notNull(),

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -111,7 +111,8 @@ function readMaterialConfigJson(db: DB, key: EngineKey): string {
   if (!settings) return '';
 
   return JSON.stringify({
-    headings: settings.headings,
+    heading_card: settings.headingCard,
+    heading_passage_card: settings.headingPassageCard,
     ftv: settings.ftv,
     new_scope: settings.newScope,
     review_scope: settings.reviewScope,

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -17,7 +17,8 @@ interface YearsResponse {
     description: string;
     enrolled: boolean;
     settings: {
-      headings: boolean;
+      headingCard: boolean;
+      headingPassageCard: boolean;
       ftv: boolean;
       newScope: TierScope;
       reviewScope: TierScope;
@@ -83,7 +84,8 @@ describe('years routes', () => {
     const body = (await res.json()) as YearsResponse;
     const year = body.years.find((y) => y.materialId === MATERIAL_ID)!;
     expect(year.settings).toEqual({
-      headings: true,
+      headingCard: false,
+      headingPassageCard: true,
       ftv: true,
       newScope: 'all',
       reviewScope: 'all',
@@ -147,7 +149,7 @@ describe('years routes', () => {
     const res = await test.app.request(`/api/years/${MATERIAL_ID}/settings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({ headings: false, lessonBatchSize: 5 }),
+      body: JSON.stringify({ headingCard: true, lessonBatchSize: 5 }),
     });
     expect(res.status).toBe(200);
 
@@ -161,7 +163,8 @@ describe('years routes', () => {
         ),
       )
       .get();
-    expect(row?.headings).toBe(false);
+    expect(row?.headingCard).toBe(true);
+    expect(row?.headingPassageCard).toBe(true);
     expect(row?.lessonBatchSize).toBe(5);
     // Other scopes preserved at their defaults.
     expect(row?.newScope).toBe('all');
@@ -199,7 +202,7 @@ describe('years routes', () => {
     const res = await test.app.request(`/api/years/not-a-material/settings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', cookie },
-      body: JSON.stringify({ headings: false }),
+      body: JSON.stringify({ headingCard: false }),
     });
     expect(res.status).toBe(404);
   });

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -28,7 +28,8 @@ const MIN_LESSON_BATCH_SIZE = 1;
 const MAX_LESSON_BATCH_SIZE = 10;
 
 interface YearSettings {
-  headings: boolean;
+  headingCard: boolean;
+  headingPassageCard: boolean;
   ftv: boolean;
   newScope: TierScope;
   reviewScope: TierScope;
@@ -67,7 +68,8 @@ interface YearView {
 }
 
 interface SettingsBody {
-  headings?: boolean;
+  headingCard?: boolean;
+  headingPassageCard?: boolean;
   ftv?: boolean;
   newScope?: string;
   reviewScope?: string;
@@ -138,8 +140,13 @@ function effectiveStatus(settings: YearSettings, tier: ClubTier): ClubStatus {
 // per-tier chip doesn't lie ("Active" on a year the user hasn't
 // touched would be misleading). Either way, the user can opt in or
 // out from the picker.
+// VerseInHeading defaults off; HeadingPassage defaults on. Mirrors
+// `MaterialConfig::default()` after the heading config split (core
+// 0.2.0): the passage-cued card is the primary heading test and the
+// per-verse "which heading?" card is now opt-in.
 const ENROLLED_DEFAULTS: YearSettings = {
-  headings: true,
+  headingCard: false,
+  headingPassageCard: true,
   ftv: true,
   newScope: 'all',
   reviewScope: 'all',
@@ -172,7 +179,8 @@ function readYearSettings(
     .get();
   if (!row) return fallback;
   return {
-    headings: row.headings,
+    headingCard: row.headingCard,
+    headingPassageCard: row.headingPassageCard,
     ftv: row.ftv,
     newScope: row.newScope as TierScope,
     reviewScope: row.reviewScope as TierScope,
@@ -294,7 +302,10 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
         body[field] === undefined ? existing[field] : validate(body[field]);
 
       next = {
-        headings: pick('headings', (v) => ensureBoolean(v, 'headings')),
+        headingCard: pick('headingCard', (v) => ensureBoolean(v, 'headingCard')),
+        headingPassageCard: pick('headingPassageCard', (v) =>
+          ensureBoolean(v, 'headingPassageCard'),
+        ),
         ftv: pick('ftv', (v) => ensureBoolean(v, 'ftv')),
         newScope: pick('newScope', (v) => ensureEnum(v, 'newScope', TIER_SCOPES)),
         reviewScope: pick('reviewScope', (v) => ensureEnum(v, 'reviewScope', TIER_SCOPES)),

--- a/tools/build-wasm-web.sh
+++ b/tools/build-wasm-web.sh
@@ -17,6 +17,23 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
+# Skip the rebuild when pkg-web is newer than every watched input. Means
+# `pnpm dev`'s predev hook is ~instant on restart when no Rust changed,
+# without sacrificing the freshness guarantee on real edits. Set
+# `WASM_REBUILD=1` to force a rebuild anyway.
+STAMP="$ROOT/crates/wasm/pkg-web/verse_vault_wasm_bg.wasm"
+if [ "${WASM_REBUILD:-}" != "1" ] && [ -f "$STAMP" ]; then
+	if [ -z "$(find \
+		crates/core/src \
+		crates/wasm/src \
+		crates/core/Cargo.toml \
+		crates/wasm/Cargo.toml \
+		-newer "$STAMP" -print -quit 2>/dev/null)" ]; then
+		echo "pkg-web is fresh — skipping wasm-pack (set WASM_REBUILD=1 to force)."
+		exit 0
+	fi
+fi
+
 wasm-pack build crates/wasm --target bundler --out-dir pkg-web "$@"
 
 PKG_JSON="crates/wasm/pkg-web/package.json"

--- a/tools/check-contract-versions.sh
+++ b/tools/check-contract-versions.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Two-mode guard for the "contract crate" versioning convention.
+# Guard for the contract-crate versioning convention and the wider
+# "package version bump requires a dated CHANGELOG section" rule.
 #
 # `crates/core` (algorithm + state semantics) and `crates/wasm` (JS↔Rust
 # wire format) are contracts across consumers (API today, future fat
@@ -8,13 +9,19 @@
 # changelogs must reference which contract versions they ship.
 #
 # Modes:
-#   pre-commit (default): blocks commits that touch crates/<core|wasm>/src/
-#     without a matching Cargo.toml version bump. Run as part of the
-#     simple-git-hooks pre-commit chain.
-#   --ci: blocks consumer deploy workflows when the consumer's CHANGELOG
-#     doesn't reference the current contract crate versions for the
-#     current consumer version. Catches "bumped core but forgot to
-#     update the API changelog's Bundled algorithm contract subsection."
+#   pre-commit (default): blocks
+#     a) crates/<core|wasm>/src/ changes without a matching Cargo.toml
+#        version bump (contract version is a compatibility signal).
+#     b) any package version bump (core, wasm, api, web, vv-router)
+#        without a matching dated CHANGELOG section. Catches the
+#        "bumped package.json but left the entry under [Unreleased]"
+#        mistake that would later fail the deploy CI check.
+#   --ci <target>: blocks consumer deploy workflows. <target> is one of
+#     {api, web, vv-router}; defaults to `api` for back-compat with the
+#     pre-existing deploy-api.yml step. Requires the dated section to
+#     exist; for api+web (which ship the contract crates), also requires
+#     it to reference the current verse-vault-core / verse-vault-wasm
+#     versions.
 #
 # Refactor that's truly a no-op? Bypass pre-commit with `--no-verify`,
 # or the CI check by ensuring the changelog explicitly notes that the
@@ -25,12 +32,59 @@
 set -euo pipefail
 
 MODE="${1:-pre-commit}"
+TARGET="${2:-}"
 
 ###############################################################################
-# Mode 1: pre-commit
+# Helpers
 ###############################################################################
 
-check_staged() {
+cargo_version() {
+	grep -E '^version = ' "$1" | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# Return the new (staged) version line for a manifest, or empty if no
+# version change was staged. Supports `Cargo.toml` (`^version = "X"`)
+# and `package.json` (`^  "version": "X"`) — the only two forms we use.
+staged_version() {
+	local manifest=$1
+	local pattern
+	case "$manifest" in
+		*.toml) pattern='^\+version = ' ;;
+		*.json) pattern='^\+  "version":' ;;
+		*) return 0 ;;
+	esac
+	git diff --cached --unified=0 -- "$manifest" 2>/dev/null \
+		| grep -E "$pattern" | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# Extract the section of a Keep-a-Changelog file for a specific version.
+changelog_section() {
+	local file=$1
+	local version=$2
+	awk -v ver="$version" '
+		$0 ~ "^## \\[" ver "\\]" { flag=1; next }
+		$0 ~ "^## \\[" && flag { exit }
+		flag { print }
+	' "$file"
+}
+
+# True iff the changelog has a `## [X.Y.Z]` header (i.e. promoted, not
+# the bare `## [Unreleased]`) for the given version.
+changelog_has_section() {
+	local file=$1
+	local version=$2
+	local escaped
+	escaped=$(printf '%s' "$version" | sed 's/\./\\./g')
+	grep -qE "^## \\[$escaped\\]" "$file"
+}
+
+###############################################################################
+# Pre-commit checks
+###############################################################################
+
+# Contract-crate-only: src/ touched but Cargo.toml version not bumped.
+# Refactor escape valve is `git commit --no-verify`.
+check_src_requires_bump() {
 	local crate=$1
 	local src="crates/$crate/src"
 	local manifest="crates/$crate/Cargo.toml"
@@ -38,11 +92,7 @@ check_staged() {
 	if ! git diff --cached --name-only | grep -q "^$src/"; then
 		return 0
 	fi
-
-	# Anchored to `^\+version = ` so dep version edits (which sit indented
-	# under [dependencies]) don't satisfy the check.
-	if git diff --cached --unified=0 -- "$manifest" 2>/dev/null \
-		| grep -qE '^\+version = '; then
+	if [ -n "$(staged_version "$manifest")" ]; then
 		return 0
 	fi
 
@@ -60,31 +110,46 @@ EOF
 	return 1
 }
 
-###############################################################################
-# Mode 2: --ci
-###############################################################################
+# Any package: version was bumped → CHANGELOG must have a dated section
+# for the new version. Catches the "bumped but left under [Unreleased]"
+# mistake at commit time, before the deploy CI check has to.
+check_version_promotion() {
+	local manifest=$1
+	local changelog=$2
+	local new_version
+	new_version=$(staged_version "$manifest")
+	if [ -z "$new_version" ]; then
+		return 0
+	fi
+	if [ ! -f "$changelog" ]; then
+		echo "::error::$changelog missing" >&2
+		return 1
+	fi
+	if changelog_has_section "$changelog" "$new_version"; then
+		return 0
+	fi
 
-cargo_version() {
-	grep -E '^version = ' "$1" | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
+	cat >&2 <<EOF
+
+  $manifest version bumped to $new_version but $changelog has no
+  dated [$new_version] section.
+
+  Promote [Unreleased] to '[$new_version] — YYYY-MM-DD' in the same
+  commit. See CLAUDE.md "Contract crate versioning".
+
+EOF
+	return 1
 }
 
-# Extract the section of a Keep-a-Changelog file for a specific version.
-changelog_section() {
-	local file=$1
-	local version=$2
-	awk -v ver="$version" '
-		$0 ~ "^## \\[" ver "\\]" { flag=1; next }
-		$0 ~ "^## \\[" && flag { exit }
-		flag { print }
-	' "$file"
-}
+###############################################################################
+# CI checks
+###############################################################################
 
 check_changelog() {
-	local consumer_name=$1
-	local consumer_version=$2
-	local changelog=$3
-	local core_v=$4
-	local wasm_v=$5
+	local consumer_version=$1
+	local changelog=$2
+	local core_v="${3:-}"
+	local wasm_v="${4:-}"
 
 	if [ ! -f "$changelog" ]; then
 		echo "::error::$changelog missing" >&2
@@ -99,13 +164,17 @@ check_changelog() {
 	fi
 
 	local failed=0
-	if ! echo "$section" | grep -qE "verse-vault-core@$core_v"; then
-		echo "::error::$changelog [$consumer_version] doesn't reference verse-vault-core@$core_v" >&2
-		failed=1
+	if [ -n "$core_v" ]; then
+		if ! echo "$section" | grep -qE "verse-vault-core@$core_v"; then
+			echo "::error::$changelog [$consumer_version] doesn't reference verse-vault-core@$core_v" >&2
+			failed=1
+		fi
 	fi
-	if ! echo "$section" | grep -qE "verse-vault-wasm@$wasm_v"; then
-		echo "::error::$changelog [$consumer_version] doesn't reference verse-vault-wasm@$wasm_v" >&2
-		failed=1
+	if [ -n "$wasm_v" ]; then
+		if ! echo "$section" | grep -qE "verse-vault-wasm@$wasm_v"; then
+			echo "::error::$changelog [$consumer_version] doesn't reference verse-vault-wasm@$wasm_v" >&2
+			failed=1
+		fi
 	fi
 	return $failed
 }
@@ -118,28 +187,56 @@ failed=0
 case "$MODE" in
 	pre-commit)
 		for crate in core wasm; do
-			check_staged "$crate" || failed=1
+			check_src_requires_bump "$crate" || failed=1
 		done
+		check_version_promotion crates/core/Cargo.toml crates/core/CHANGELOG.md \
+			|| failed=1
+		check_version_promotion crates/wasm/Cargo.toml crates/wasm/CHANGELOG.md \
+			|| failed=1
+		check_version_promotion packages/api/package.json packages/api/CHANGELOG.md \
+			|| failed=1
+		check_version_promotion apps/web/package.json apps/web/CHANGELOG.md \
+			|| failed=1
+		check_version_promotion \
+			deploy/vv-router/package.json deploy/vv-router/CHANGELOG.md \
+			|| failed=1
 		;;
 	--ci)
+		target="${TARGET:-api}"
 		core_v=$(cargo_version crates/core/Cargo.toml)
 		wasm_v=$(cargo_version crates/wasm/Cargo.toml)
-		api_v=$(node -p "require('./packages/api/package.json').version")
-
-		echo "  Current contract versions: core@$core_v, wasm@$wasm_v"
-		echo "  Verifying packages/api/CHANGELOG.md [$api_v] references both…"
-		check_changelog "api" "$api_v" packages/api/CHANGELOG.md "$core_v" "$wasm_v" \
-			|| failed=1
-
-		# When fat clients land (apps/web ships verse-vault-wasm directly,
-		# Tauri ships both), add the same check for their CHANGELOGs.
-
+		case "$target" in
+			api)
+				v=$(node -p "require('./packages/api/package.json').version")
+				echo "  Verifying packages/api/CHANGELOG.md [$v] references core@$core_v, wasm@$wasm_v…"
+				check_changelog "$v" packages/api/CHANGELOG.md "$core_v" "$wasm_v" \
+					|| failed=1
+				;;
+			web)
+				v=$(node -p "require('./apps/web/package.json').version")
+				echo "  Verifying apps/web/CHANGELOG.md [$v] references core@$core_v, wasm@$wasm_v…"
+				check_changelog "$v" apps/web/CHANGELOG.md "$core_v" "$wasm_v" \
+					|| failed=1
+				;;
+			vv-router)
+				v=$(node -p "require('./deploy/vv-router/package.json').version")
+				echo "  Verifying deploy/vv-router/CHANGELOG.md has dated [$v]…"
+				# Router doesn't bundle the contract crates — section-existence
+				# check only.
+				check_changelog "$v" deploy/vv-router/CHANGELOG.md \
+					|| failed=1
+				;;
+			*)
+				echo "Unknown --ci target: $target. Expected one of: api, web, vv-router" >&2
+				exit 2
+				;;
+		esac
 		if [ "$failed" -eq 0 ]; then
 			echo "  OK."
 		fi
 		;;
 	*)
-		echo "Usage: $0 [pre-commit | --ci]" >&2
+		echo "Usage: $0 [pre-commit | --ci <api|web|vv-router>]" >&2
 		exit 2
 		;;
 esac


### PR DESCRIPTION
## Summary

Card-audit pass driven by review of the existing card kinds:

- **One FTV card per verse.** Drop the no-citation Ftv variant — the two FTV cards differed only on reveal, and Recitation already covers the recall-without-ref shape. The remaining card always shows the citation on the back.
- **Verse-colour suppressed on FTV front.** No ref on the front; suppress the verse-colour stripe pre-reveal so it doesn't mnemonic-leak the verse number.
- **New `HeadingPassage` card.** Composite passage prompt anchored to a pseudo verse_id whose `heading_members` enumerates the heading's members. Grades each member's `VerseHeadingBinding` — shares FSRS state with the per-verse `VerseInHeading` cards rather than spawning parallel bindings. Verse numbers in the passage range render in their own per-verse colours (card-level stripe stays off since there's no single verse to anchor it).
- **Heading config split.** `MaterialConfig.headings` → `heading_card` (per-verse, defaults off) + `heading_passage_card` (per-passage, defaults on). The per-verse card is now opt-in; the passage card is the primary heading test. Migration `0017_heading_card_split` UPDATE-resets every existing row's `heading_card` to 0 so everyone starts on the new defaults.
- **Pseudo-card introduction rules reworked.** `HeadingPassage` cards introduce when at least one heading member is "started" (Active or being graduated this session) and attach to the earliest such member. `ChapterClubList` cards introduce when every chapter+tier member is started and attach to the latest. Catch-up attachment for trigger conditions met purely from prior Actives. Capped at one of each kind per session-verse so backlog cards spread instead of piling up. Replaces the previous "last member is the current verse" trigger which misfired when verses graduated out of order.

**Version bumps:** core 0.1.0 → 0.2.0, wasm 0.1.2 → 0.2.0, api 0.1.14 → 0.1.15, web 0.1.12 → 0.1.13.

## CI

Mirror the API deploy's CHANGELOG-promotion check onto the web (`deploy-web.yml`) and router (`deploy-vv-router.yml`) workflows, and add a pre-commit gate that blocks any package version bump landing without a matching `## [X.Y.Z]` section in its `CHANGELOG.md`.

## Dev experience

- `apps/web` gains a `predev` hook that rebuilds `pkg-web` before vite starts, gated by a stamp-file check against the watched src (sub-10ms when no Rust changed). `WASM_REBUILD=1` forces.
- `useEngine.init` failures now log to the dev console alongside `error.value` — otherwise a stale pkg-web schema mismatch cascades into misleading downstream symptoms.

## Test plan

- [ ] `/material`: two heading toggles render (passage on, per-verse off by default)
- [ ] `/memorize`: passage cards surface alongside the first member graduating in a heading; chapter-list cards surface when the last needed member graduates
- [ ] `/review`: FTV cards have no verse-colour stripe pre-reveal, show citation on back
- [ ] `/review`: HeadingPassage card range shows each verse number in its own colour
- [ ] `cargo test` green
- [ ] `pnpm --filter @verse-vault/api test` green