### PR TITLE
chore: release @verse-vault/web 0.1.14

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.14] — 2026-05-27
+
 ### Stale-row sign-in recovery
 
 * **Silent same-email recovery.** When `signInComplete` sees the new sign-in has a different
@@ -61,6 +63,11 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
   gets graded.
 * Internals: new `apps/web/src/lib/diff/wordDiff.ts` (LCS-based word diff), `CardPrompt.vue` owns
   the per-card `userInput` ref and resets it on card swap.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.2.0` — unchanged.
+* `verse-vault-wasm@0.2.0` — unchanged.
 
 ## [0.1.13] — 2026-05-26
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
Promote `[Unreleased]` to `[0.1.14]` and bump `apps/web/package.json` to trigger the Cloudflare Pages deploy. Bundles:

- Type-to-recite textarea + word diff on Recitation/Ftv
- Auth stale-row recovery + multiSession.setActive after signup
- Review/Memorize keyboard shortcuts (Enter, 1-4)
- "Already memorized" opt-out in Memorize
- Autofocus type-out box

Contract crates unchanged (core@0.2.0, wasm@0.2.0).

## Test plan
- [ ] CI green (rust, dprint, typos)
- [ ] deploy-web run succeeds post-merge