### PR TITLE
Render ChapterClubList card (core/wasm 0.2.1, web 0.1.15, api 0.1.16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,16 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### ChapterClubList card rendering
+
+* **Render the card properly.** `ChapterClubList` (the engine's pseudo-card asking "which verses in
+  this chapter are in tier X?") was producing a blank `CardPrompt` shell with the deck label
+  defaulting to "Card" — no template branch handled the kind. Surfaced as a user-visible bug after
+  `chapter_list_scope` defaulted to `up150`. Adds a template branch, `promptLabel` case, and a
+  per-verse-colour answer list driven by the new `VerseRender.chapterMembers` wire field.
+* Internals: `clubTierLabel('Club150') = 'Club 150'`; the back reads the verse numbers off
+  `card.verse.chapterMembers` (sourced from `verse-vault-wasm@0.2.1` / `verse-vault-core@0.2.1`).
+
 ## [0.1.14] — 2026-05-27
 
 ### Stale-row sign-in recovery

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.15] — 2026-05-27
+
 ### ChapterClubList card rendering
 
 * **Render the card properly.** `ChapterClubList` (the engine's pseudo-card asking "which verses in
@@ -18,6 +20,12 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
   per-verse-colour answer list driven by the new `VerseRender.chapterMembers` wire field.
 * Internals: `clubTierLabel('Club150') = 'Club 150'`; the back reads the verse numbers off
   `card.verse.chapterMembers` (sourced from `verse-vault-wasm@0.2.1` / `verse-vault-core@0.2.1`).
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.2.1` — adds `VerseRender.chapter_members` carrying the verse numbers a
+  `ChapterClubList` pseudo asks about.
+* `verse-vault-wasm@0.2.1` — forwards the new field on `VerseRenderWire`.
 
 ## [0.1.14] — 2026-05-27
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -13,13 +13,26 @@ import type {
 
 export type Grade = 1 | 2 | 3 | 4
 
+/** Wire-format tier string on a `CardRender` (`Club150` / `Club300`).
+ *  Distinct from `ClubTier` in settings, which uses the bare numeric
+ *  form (`'150'` / `'300'`). */
+export type CardTier = 'Club150' | 'Club300'
+
+/** User-facing label for a card's tier — used by every render site
+ *  that shows a tier to avoid drift across components. */
+export function formatCardTier(tier: CardTier | undefined): string {
+  if (tier === 'Club150') return 'Club 150'
+  if (tier === 'Club300') return 'Club 300'
+  return ''
+}
+
 export interface CardRender {
   cardId: number
   verseId: number
   kind: CardKind
   position?: number
   headingIdx?: number
-  tier?: 'Club150' | 'Club300'
+  tier?: CardTier
   withCitation?: boolean
   verse: VerseRender
   /** Server-composed HTML from the api.bible cache layered with user
@@ -62,7 +75,7 @@ export interface VerseRender {
     endChapter: number
     endVerse: number
   }[]
-  clubs: ('Club150' | 'Club300')[]
+  clubs: CardTier[]
   /** Verse numbers on a `ChapterClubList` pseudo-verse — the chapter's
    *  tier members the card asks about. Empty elsewhere. */
   chapterMembers: number[]

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -63,6 +63,9 @@ export interface VerseRender {
     endVerse: number
   }[]
   clubs: ('Club150' | 'Club300')[]
+  /** Verse numbers on a `ChapterClubList` pseudo-verse — the chapter's
+   *  tier members the card asks about. Empty elsewhere. */
+  chapterMembers: number[]
 }
 
 export interface TestUpdate {

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from 'vue'
 
-import type { CardRender } from '@/api'
+import { type CardRender, formatCardTier } from '@/api'
 import { type DiffItem, normalize, wordDiff } from '@/lib/diff/wordDiff'
 
 const props = defineProps<{
@@ -56,6 +56,14 @@ function verseColourVar(verse: number): string {
   return VERSE_COLOUR_VARS[(verse - 1) % VERSE_COLOUR_VARS.length]!
 }
 const verseColour = computed(() => `var(${verseColourVar(props.card.verse.verse)})`)
+
+/** Verse-number chip rendered inside refs and answer lists. The CSS
+ *  custom property is set inline so each span gets its own colour,
+ *  letting a chapter or passage range render multiple verse-coloured
+ *  numbers within one parent that doesn't pick a single colour. */
+function verseNumberSpan(n: number): string {
+  return `<span class="verse-number" style="--active-verse-colour: var(${verseColourVar(n)})">${n}</span>`
+}
 
 /** Per-card visibility of each ref component. For "what chapter?" /
  *  "what book?" / "what verse?" / Citation, the asked-about parts stay
@@ -155,7 +163,9 @@ const phraseHtml = computed(() => props.card.composed?.phraseHtml ?? [])
 const verseHtml = computed(() => phraseHtml.value.join(' '))
 const ftvHtml = computed(() => props.card.composed?.ftvHtml ?? null)
 const headingTitle = computed(() => props.card.composed?.headings[0]?.title ?? null)
-const clubLabel = computed(() => props.card.tier ?? props.card.verse.clubs[0] ?? '')
+const clubLabel = computed(() =>
+  formatCardTier(props.card.tier ?? props.card.verse.clubs[0]),
+)
 const composedMissing = computed(() => props.card.composed === null)
 
 /** Sentinel `verse === 0` marks a pseudo-verse card (ChapterClubList,
@@ -173,42 +183,22 @@ const passageRangeHtml = computed(() => {
   const h = props.card.verse.headings[0]
   const book = escapeHtml(props.card.verse.book)
   if (!h) return `${book} ${props.card.verse.chapter}`
-  const vNum = (n: number) =>
-    `<span class="verse-number" style="--active-verse-colour: var(${verseColourVar(n)})">${n}</span>`
   const same = h.startChapter === h.endChapter
   const range = same
-    ? `${h.startChapter}:${vNum(h.startVerse)}-${vNum(h.endVerse)}`
-    : `${h.startChapter}:${vNum(h.startVerse)}-${h.endChapter}:${vNum(h.endVerse)}`
+    ? `${h.startChapter}:${verseNumberSpan(h.startVerse)}-${verseNumberSpan(h.endVerse)}`
+    : `${h.startChapter}:${verseNumberSpan(h.startVerse)}-${h.endChapter}:${verseNumberSpan(h.endVerse)}`
   return `${book} ${range}`
 })
 
-function clubTierLabel(tier: string | undefined): string {
-  if (tier === 'Club150') return 'Club 150'
-  if (tier === 'Club300') return 'Club 300'
-  return ''
-}
-
-/** "John 3 · Club 150" — the ref shown on a ChapterClubList card. No
- *  verse-colour on the chapter number since the card asks about a list
- *  of verses, not one. */
 const chapterClubRefHtml = computed(() => {
   const book = escapeHtml(props.card.verse.book)
-  const tier = clubTierLabel(props.card.tier)
-  return `${book} ${props.card.verse.chapter} · ${tier}`
+  return `${book} ${props.card.verse.chapter} · ${formatCardTier(props.card.tier)}`
 })
 
-/** Comma-separated verse-number list for the ChapterClubList back.
- *  Each number gets its own verse-colour via the same per-span override
- *  used in passageRangeHtml. */
 const chapterMembersHtml = computed(() => {
   const members = props.card.verse.chapterMembers ?? []
   if (members.length === 0) return '—'
-  return members
-    .map(
-      (n) =>
-        `<span class="verse-number" style="--active-verse-colour: var(${verseColourVar(n)})">${n}</span>`,
-    )
-    .join(', ')
+  return members.map(verseNumberSpan).join(', ')
 })
 
 /** Plain-text canonical answer for the type-to-recite diff. Strips
@@ -439,12 +429,9 @@ const diffHtml = computed(() => {
         <div v-else class="placeholder">…what heading is this passage under?…</div>
       </div>
 
-      <!-- Pseudo-verse card anchored to a chapter+tier. Front asks
-           which verses are in this chapter's tier (e.g. John 3 · Club
-           150); back reveals the verse-number list. The pseudo's
-           verse=0 sentinel keeps the card-level stripe off; each
-           verse number in the answer gets its own colour via a
-           per-span override. -->
+      <!-- Pseudo-verse card anchored to a chapter+tier; the verse=0
+           sentinel keeps the card-level stripe off while each verse
+           number in the answer list still gets its own colour. -->
       <div v-else-if="card.kind === 'ChapterClubList'" class="centered">
         <div class="ref" v-html="chapterClubRefHtml" />
         <hr v-if="revealed" class="type" />
@@ -455,7 +442,7 @@ const diffHtml = computed(() => {
           v-html="chapterMembersHtml"
         />
         <div v-else class="placeholder">
-          …recite the {{ clubTierLabel(card.tier) }} verses in this chapter…
+          …recite the {{ formatCardTier(card.tier) }} verses in this chapter…
         </div>
       </div>
 

--- a/apps/web/src/components/CardPrompt.vue
+++ b/apps/web/src/components/CardPrompt.vue
@@ -134,6 +134,8 @@ const promptLabel = computed(() => {
       return 'What heading?'
     case 'HeadingPassage':
       return 'What heading is this passage under?'
+    case 'ChapterClubList':
+      return 'Which verses are in this club?'
     case 'VerseInClub':
       return 'What club?'
     case 'Recitation':
@@ -178,6 +180,35 @@ const passageRangeHtml = computed(() => {
     ? `${h.startChapter}:${vNum(h.startVerse)}-${vNum(h.endVerse)}`
     : `${h.startChapter}:${vNum(h.startVerse)}-${h.endChapter}:${vNum(h.endVerse)}`
   return `${book} ${range}`
+})
+
+function clubTierLabel(tier: string | undefined): string {
+  if (tier === 'Club150') return 'Club 150'
+  if (tier === 'Club300') return 'Club 300'
+  return ''
+}
+
+/** "John 3 · Club 150" — the ref shown on a ChapterClubList card. No
+ *  verse-colour on the chapter number since the card asks about a list
+ *  of verses, not one. */
+const chapterClubRefHtml = computed(() => {
+  const book = escapeHtml(props.card.verse.book)
+  const tier = clubTierLabel(props.card.tier)
+  return `${book} ${props.card.verse.chapter} · ${tier}`
+})
+
+/** Comma-separated verse-number list for the ChapterClubList back.
+ *  Each number gets its own verse-colour via the same per-span override
+ *  used in passageRangeHtml. */
+const chapterMembersHtml = computed(() => {
+  const members = props.card.verse.chapterMembers ?? []
+  if (members.length === 0) return '—'
+  return members
+    .map(
+      (n) =>
+        `<span class="verse-number" style="--active-verse-colour: var(${verseColourVar(n)})">${n}</span>`,
+    )
+    .join(', ')
 })
 
 /** Plain-text canonical answer for the type-to-recite diff. Strips
@@ -406,6 +437,26 @@ const diffHtml = computed(() => {
           <div class="answer">Heading: {{ headingTitle ?? '(none)' }}</div>
         </template>
         <div v-else class="placeholder">…what heading is this passage under?…</div>
+      </div>
+
+      <!-- Pseudo-verse card anchored to a chapter+tier. Front asks
+           which verses are in this chapter's tier (e.g. John 3 · Club
+           150); back reveals the verse-number list. The pseudo's
+           verse=0 sentinel keeps the card-level stripe off; each
+           verse number in the answer gets its own colour via a
+           per-span override. -->
+      <div v-else-if="card.kind === 'ChapterClubList'" class="centered">
+        <div class="ref" v-html="chapterClubRefHtml" />
+        <hr v-if="revealed" class="type" />
+        <hr v-else />
+        <div
+          v-if="revealed"
+          class="verse-text"
+          v-html="chapterMembersHtml"
+        />
+        <div v-else class="placeholder">
+          …recite the {{ clubTierLabel(card.tier) }} verses in this chapter…
+        </div>
       </div>
 
       <div v-else-if="card.kind === 'Reading'" class="centered">

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,14 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-05-27
+
+* `VerseRender.chapter_members: Vec<u16>` — additive field carrying the verse numbers a
+  `ChapterClubList` pseudo-card asks about. Empty for real verses and other pseudos; the
+  `emit_chapter_club_list_cards` builder populates it from the matching-tier members so consumers
+  can render the back-of-card answer without a separate lookup. `#[serde(default)]` so older
+  snapshot data still loads.
+
 ## [0.2.0] — 2026-05-26
 
 Card-audit pass: drops the redundant no-citation FTV variant and introduces a passage-cued heading

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -125,14 +125,14 @@ fn emit_chapter_club_list_cards(
 
             // Resolve each member's verse_id to a human verse number so
             // the client can render the back-of-card list without
-            // exposing internal ids. `members` only contains real
-            // verse_ids (it's built from `chapter_verses`, which iterates
-            // real verses), so every lookup hits a real VerseRender.
-            let mut member_numbers: Vec<u16> = members
+            // exposing internal ids. `members` is already sorted by
+            // verse_id (above) and verse numbers within a chapter
+            // increase monotonically with verse_id, so the mapped
+            // vec stays in ascending verse-number order.
+            let member_numbers: Vec<u16> = members
                 .iter()
                 .filter_map(|(vid, _)| verse_render_by_id.get(vid).map(|r| r.verse))
                 .collect();
-            member_numbers.sort();
 
             verse_atoms_by_id.insert(
                 pseudo_id,

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -123,6 +123,17 @@ fn emit_chapter_club_list_cards(
             let pseudo_id = next_pseudo_verse_id;
             next_pseudo_verse_id += 1;
 
+            // Resolve each member's verse_id to a human verse number so
+            // the client can render the back-of-card list without
+            // exposing internal ids. `members` only contains real
+            // verse_ids (it's built from `chapter_verses`, which iterates
+            // real verses), so every lookup hits a real VerseRender.
+            let mut member_numbers: Vec<u16> = members
+                .iter()
+                .filter_map(|(vid, _)| verse_render_by_id.get(vid).map(|r| r.verse))
+                .collect();
+            member_numbers.sort();
+
             verse_atoms_by_id.insert(
                 pseudo_id,
                 VerseAtoms {
@@ -148,6 +159,7 @@ fn emit_chapter_club_list_cards(
                     ftv_word_count: None,
                     headings: Vec::new(),
                     clubs: vec![card_tier],
+                    chapter_members: member_numbers,
                 },
             );
             cards.push(Card {
@@ -246,6 +258,7 @@ fn emit_heading_passage_cards(
                     end_verse: heading.end_verse,
                 }],
                 clubs: Vec::new(),
+                chapter_members: Vec::new(),
             },
         );
         cards.push(Card {
@@ -444,6 +457,7 @@ pub fn build_with_config(
                 ftv_word_count: verse.ftv_word_count,
                 headings: heading_renders,
                 clubs: clubs.clone(),
+                chapter_members: Vec::new(),
             },
         );
 

--- a/crates/core/src/render.rs
+++ b/crates/core/src/render.rs
@@ -33,4 +33,11 @@ pub struct VerseRender {
     pub ftv_word_count: Option<u16>,
     pub headings: Vec<HeadingRender>,
     pub clubs: Vec<ClubTier>,
+    /// Verse numbers in this chapter that belong to the pseudo's tier,
+    /// populated only for `ChapterClubList` pseudo-verses so the client
+    /// can render the back-of-card answer without a follow-up lookup.
+    /// Empty for real verses and other pseudos. Defaults to empty on
+    /// deserialise so older snapshot data still loads.
+    #[serde(default)]
+    pub chapter_members: Vec<u16>,
 }

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,13 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-05-27
+
+* `VerseRenderWire.chapterMembers: number[]` — additive wire field forwarding
+  `VerseRender.chapter_members` from `verse-vault-core@0.2.1`. Populated on `ChapterClubList`
+  pseudo-verses so JS clients can render the back-of-card list without a follow-up lookup; empty
+  everywhere else.
+
 ## [0.2.0] — 2026-05-26
 
 Bundles the previously-unreleased `all_card_renders` additions with the new `HeadingPassage` wire

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -195,6 +195,10 @@ pub struct VerseRenderWire {
     pub ftv_word_count: Option<u16>,
     pub headings: Vec<HeadingRenderWire>,
     pub clubs: Vec<ClubTier>,
+    /// Populated on `ChapterClubList` pseudo-verses with the verse
+    /// numbers in the chapter that match the card's tier; empty
+    /// everywhere else.
+    pub chapter_members: Vec<u16>,
 }
 
 impl From<&VerseRender> for VerseRenderWire {
@@ -213,6 +217,7 @@ impl From<&VerseRender> for VerseRenderWire {
             ftv_word_count: v.ftv_word_count,
             headings: v.headings.iter().map(HeadingRenderWire::from).collect(),
             clubs: v.clubs.clone(),
+            chapter_members: v.chapter_members.clone(),
         }
     }
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,16 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.16] — 2026-05-27
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.2.1` — adds `VerseRender.chapter_members` carrying the verse numbers a
+  `ChapterClubList` pseudo-card asks about. Required server-side so the API actually sends the field
+  on the wire; without redeploying the API, the web 0.1.15 ChapterClubList back-of-card list would
+  render as an em-dash.
+* `verse-vault-wasm@0.2.1` — forwards the new field on `VerseRenderWire`.
+
 ## [0.1.15] — 2026-05-26
 
 ### Added

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- `verse-vault-core@0.2.1`: additive `VerseRender.chapter_members` populated for `ChapterClubList` pseudos.
- `verse-vault-wasm@0.2.1`: forwards the new field on `VerseRenderWire`.
- `apps/web@0.1.15`: adds `CardPrompt` template branch + `promptLabel` case; back lists verse numbers with per-span verse-colour.
- `packages/api@0.1.16`: redeploys so the server actually emits the new field (without this the web back-of-card would render an em-dash).

Bug existed since the card kind was added; surfaced when `chapter_list_scope` defaulted to `up150`.

## Test plan
- [ ] CI green (rust, dprint, typos)
- [ ] After merge: api 0.1.16 + web 0.1.15 deploy workflows succeed
- [ ] Live: a chapter with finished verses shows the ChapterClubList prompt with verse-number list on back