### PR TITLE
feat: /dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ __pycache__/
 /packages/api/data/
 /packages/api/.env
 /packages/api/.env.local
+
+# Local git worktrees
+/.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,44 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Dashboard
+
+* **New `/dashboard` view, now the app index.** Aggregates `getYears` + per-year `getStats`
+  client-side into a single editorial "codex" view. `/` and the post-sign-in default both redirect
+  here (was `/review`); the brand link in the header lands here too. `/stats` stays as the per-year
+  drill-down.
+* **Two clickable hero tiles — Memorize and Review.** Inspired by WaniKani's lessons/reviews pattern
+  but rendered in the parchment + Fraunces palette rather than the WK-style colour-block cards. Each
+  tile is a `RouterLink` wrapping the whole card with the card queue count as the centrepiece:
+  cards-to-memorize on the left, cards-due-now on the right (sourced from
+  `getStats().reviewsDueCount` — server-computed via the engine, since FSRS retrievability doesn't
+  live in the test_states SQL). The sub-line pairs each card count with its verse footprint — "fresh
+  cards from X verses across Y years" / "cards due now from X verses across Y years" — so both units
+  the user thinks in are visible at a glance. Both tiles end with a "memorize →" / "review →" arrow
+  that nudges right on hover.
+* **Five SRS-stage tiles** (weak / learning / familiar / strong / mastered) replace the original
+  single horizontal ribbon. Each tile shows two units side by side so the codex reads in both
+  granularities the user actually thinks in: **cards** (prominent — per active card, bucketed by its
+  weakest test's stability) and **verses** (secondary — per single-verse-card verse, same
+  min-aggregation projected up). Multi-verse cards (`HeadingPassage`, `ChapterClubList`) count in
+  the cards column but their pseudo verses don't contribute to the verses column, so "X cards from Y
+  verses" reads honestly. A thin coloured top stripe and the existing 1d / 7d / 30d / 90d boundaries
+  match the per-year stats. Empty buckets stay in the layout dimmed so the five-stage skyline never
+  collapses.
+* **Per-year cards** (numbered in Roman) sit below with retention oversized and a per-year stability
+  sparkline; a small italic "N reviews logged across the codex" closes the page like a colophon.
+* **Aesthetic.** Fraunces variable serif handles all display work (masthead, oversized numerals,
+  section rules, stage counts) — loaded once via `index.html`. Body copy still inherits the system
+  stack so the rest of the app is untouched.
+* **Nav.** Adds a `Dashboard` link as the first nav entry.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.3.0` — adds the dashboard stats helpers (`due_review_count`,
+  `card_stability_histogram`, `verse_stability_histogram`, `new_verse_count`, `due_verse_count`,
+  `learned_verse_count`, `StabilityHistogram`).
+* `verse-vault-wasm@0.3.0` — exposes the matching `WasmEngine` wrappers.
+
 ## [0.1.15] — 2026-05-27
 
 ### ChapterClubList card rendering

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>verse-vault</title>
+    <!-- Fraunces variable display serif — used by /dashboard for
+         editorial masthead, oversized numerals, and small-caps section
+         rules. Other views fall back to the system stack. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,300..700,30..100,0..1;1,9..144,300..700,30..100,0..1&display=swap"
+    />
   </head>
   <body>
     <div id="app"></div>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -43,6 +43,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
     <header class="site-header">
       <RouterLink to="/" class="brand">verse-vault</RouterLink>
       <nav v-if="user" class="nav">
+        <RouterLink to="/dashboard">Dashboard</RouterLink>
         <RouterLink to="/review">Review</RouterLink>
         <RouterLink to="/memorize" class="memorize-link">
           Memorize

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -102,12 +102,33 @@ export interface ReviewResponse {
   nextCardId: number | null
 }
 
+export type StabilityBucket = 'weak' | 'learning' | 'familiar' | 'strong' | 'mastered'
+export type StabilityHistogram = Record<StabilityBucket, number>
+
 export interface StatsResponse {
   materialId: string
   versesLearned: number
   retentionRate: number | null
   totalGrades: number
-  testDistribution: Record<'weak' | 'learning' | 'familiar' | 'strong' | 'mastered', number>
+  /** Per active card, bucketed by its weakest test's stability —
+   *  matches the engine's own due-ness aggregation. Engine-derived
+   *  via `WasmEngine.card_stability_histogram`. */
+  cardDistribution: StabilityHistogram
+  /** Per graduated verse, bucketed by the verse's weakest test's
+   *  stability (`MIN(stability) GROUP BY verse_id`). Same boundaries
+   *  as `cardDistribution`. */
+  verseDistribution: StabilityHistogram
+  /** Count of active cards whose retrievability is below the engine's
+   *  target — the "reviews waiting" queue size. Server-computed from
+   *  the engine. */
+  reviewsDueCount: number
+  /** Count of distinct verses with at least one `New` card —
+   *  pairs with the memorize-queue card count. Pseudo verses
+   *  anchoring multi-verse cards are excluded. */
+  newVerseCount: number
+  /** Count of distinct verses with at least one due card — pairs
+   *  with `reviewsDueCount`. Pseudo verses excluded. */
+  versesDueCount: number
 }
 
 export type ClubStatus = 'active' | 'maintenance' | 'paused'

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -12,7 +12,7 @@ let reconcileFired = false
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-    { path: '/', redirect: '/review' },
+    { path: '/', redirect: '/dashboard' },
     { path: '/session', redirect: '/review' },
     { path: '/signin', redirect: '/profiles' },
     {
@@ -20,6 +20,11 @@ const router = createRouter({
       name: 'profiles',
       component: () => import('@/views/ProfilePickerView.vue'),
       meta: { public: true },
+    },
+    {
+      path: '/dashboard',
+      name: 'dashboard',
+      component: () => import('@/views/DashboardView.vue'),
     },
     {
       path: '/review',
@@ -79,7 +84,7 @@ router.beforeEach(async (to) => {
 
   if (to.meta.public) {
     if (signedIn && to.name === 'profiles' && to.query.force !== '1') {
-      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/review'
+      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/dashboard'
       return redirect
     }
     return true

--- a/apps/web/src/views/DashboardView.vue
+++ b/apps/web/src/views/DashboardView.vue
@@ -1,0 +1,624 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+import { type StatsResponse, api } from '@/api'
+
+interface YearAgg {
+  materialId: string
+  title: string
+  newCardCount: number
+  stats: StatsResponse
+}
+
+const years = ref<YearAgg[]>([])
+const partialFailed = ref(0)
+const error = ref<string | null>(null)
+const loading = ref(true)
+const mounted = ref(false)
+
+function sumOver(pick: (y: YearAgg) => number) {
+  return computed(() => years.value.reduce((sum, y) => sum + pick(y), 0))
+}
+
+const totalNewToMemorize = sumOver((y) => y.newCardCount)
+const totalNewVerses = sumOver((y) => y.stats.newVerseCount)
+const totalVersesDue = sumOver((y) => y.stats.versesDueCount)
+const totalVersesHeld = sumOver((y) => y.stats.versesLearned)
+const totalReviewsDue = sumOver((y) => y.stats.reviewsDueCount)
+const totalReviews = sumOver((y) => y.stats.totalGrades)
+
+const aggregateRetention = computed<number | null>(() => {
+  let passes = 0
+  let grades = 0
+  for (const y of years.value) {
+    const r = y.stats.retentionRate
+    if (r === null) continue
+    passes += r * y.stats.totalGrades
+    grades += y.stats.totalGrades
+  }
+  if (grades === 0) return null
+  return passes / grades
+})
+
+const BUCKETS = ['weak', 'learning', 'familiar', 'strong', 'mastered'] as const
+type Bucket = (typeof BUCKETS)[number]
+
+function sumDistributions(
+  pick: (s: StatsResponse) => Record<Bucket, number>,
+): Record<Bucket, number> {
+  const out: Record<Bucket, number> = {
+    weak: 0,
+    learning: 0,
+    familiar: 0,
+    strong: 0,
+    mastered: 0,
+  }
+  for (const y of years.value) {
+    const d = pick(y.stats)
+    for (const b of BUCKETS) out[b] += d[b]
+  }
+  return out
+}
+
+const stages = computed(() => {
+  const cards = sumDistributions((s) => s.cardDistribution)
+  const verses = sumDistributions((s) => s.verseDistribution)
+  return BUCKETS.map((bucket) => ({
+    bucket,
+    cards: cards[bucket],
+    verses: verses[bucket],
+  }))
+})
+
+const stagesShown = computed(() => stages.value.some((s) => s.cards > 0 || s.verses > 0))
+
+const empty = computed(
+  () => !loading.value && years.value.length === 0 && !error.value,
+)
+
+function pct(value: number | null): string {
+  return value === null ? '—' : `${Math.round(value * 100)}%`
+}
+
+onMounted(async () => {
+  try {
+    const yearsRes = await api.getYears()
+    const enrolled = yearsRes.years.filter((y) => y.enrolled)
+
+    const settled = await Promise.allSettled(
+      enrolled.map(async (y): Promise<YearAgg> => ({
+        materialId: y.materialId,
+        title: y.title,
+        newCardCount: y.newCardCount,
+        stats: await api.getStats(y.materialId),
+      })),
+    )
+    const succeeded: YearAgg[] = []
+    let failed = 0
+    for (const r of settled) {
+      if (r.status === 'fulfilled') succeeded.push(r.value)
+      else failed += 1
+    }
+    // Lead with the most-worked year — most likely the focus.
+    succeeded.sort((a, b) => b.stats.totalGrades - a.stats.totalGrades)
+    years.value = succeeded
+    partialFailed.value = failed
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+    // Defer one frame so the staggered reveal transitions actually
+    // play — same-tick flips collapse into one paint.
+    requestAnimationFrame(() => {
+      mounted.value = true
+    })
+  }
+})
+</script>
+
+<template>
+  <article class="codex" :class="{ revealed: mounted }">
+    <p v-if="error" class="page-banner page-banner-error">{{ error }}</p>
+    <p v-else-if="loading" class="page-banner page-banner-quiet">
+      <em>reading the codex…</em>
+    </p>
+    <template v-else-if="empty">
+      <section class="empty">
+        <p class="empty-line"><em>This codex is empty.</em></p>
+        <RouterLink to="/material" class="empty-cta">
+          Choose your first year
+          <span aria-hidden="true">↗</span>
+        </RouterLink>
+      </section>
+    </template>
+    <template v-else>
+      <p v-if="partialFailed > 0" class="page-banner page-banner-warning">
+        {{ partialFailed }} year{{ partialFailed === 1 ? '' : 's' }} couldn't be
+        loaded. Refresh to retry.
+      </p>
+
+      <section class="hero">
+        <RouterLink
+          to="/memorize"
+          class="hero-panel hero-panel-action"
+          :class="{ idle: totalNewToMemorize === 0 }"
+        >
+          <p class="hero-label">to memorize</p>
+          <p class="hero-numeral">
+            <span class="numeral">{{ totalNewToMemorize }}</span>
+          </p>
+          <p class="hero-sub">
+            <template v-if="totalNewToMemorize === 0">
+              caught up — nothing new is waiting.
+            </template>
+            <template v-else>
+              fresh card{{ totalNewToMemorize === 1 ? '' : 's' }}
+              from {{ totalNewVerses }} verse{{ totalNewVerses === 1 ? '' : 's' }}<template
+                v-if="years.length > 1"
+              > across {{ years.length }} years</template>.
+            </template>
+          </p>
+          <p class="hero-arrow">
+            <span>memorize</span>
+            <span class="hero-arrow-glyph" aria-hidden="true">→</span>
+          </p>
+        </RouterLink>
+
+        <RouterLink
+          to="/review"
+          class="hero-panel hero-panel-review"
+          :class="{ idle: totalReviewsDue === 0 }"
+        >
+          <p class="hero-label">to review</p>
+          <p class="hero-numeral">
+            <span class="numeral">{{ totalReviewsDue }}</span>
+          </p>
+          <p class="hero-sub">
+            <template v-if="totalVersesHeld === 0 && totalReviewsDue === 0">
+              none yet — every codex begins blank.
+            </template>
+            <template v-else-if="totalReviewsDue === 0">
+              all caught up — nothing due right now.
+            </template>
+            <template v-else>
+              card{{ totalReviewsDue === 1 ? '' : 's' }} due now
+              from {{ totalVersesDue }} verse{{ totalVersesDue === 1 ? '' : 's' }}<template
+                v-if="years.length > 1"
+              > across {{ years.length }} years</template>.
+            </template>
+          </p>
+          <p class="hero-arrow">
+            <span>review</span>
+            <span class="hero-arrow-glyph" aria-hidden="true">→</span>
+          </p>
+        </RouterLink>
+      </section>
+
+      <section v-if="stagesShown" class="stages-section">
+        <h2 class="rule-heading"><span>stability</span></h2>
+        <ol class="stages">
+          <li
+            v-for="(stage, i) in stages"
+            :key="stage.bucket"
+            :class="[
+              'stage',
+              `seg-${stage.bucket}`,
+              { 'stage-idle': stage.cards === 0 && stage.verses === 0 },
+            ]"
+            :style="{ transitionDelay: `${280 + i * 80}ms` }"
+          >
+            <span class="stage-stripe" aria-hidden="true" />
+            <span class="stage-label">{{ stage.bucket }}</span>
+            <p class="stage-stat">
+              <span class="stage-stat-value">{{ stage.cards }}</span>
+              <span class="stage-stat-unit">card{{ stage.cards === 1 ? '' : 's' }}</span>
+            </p>
+            <p class="stage-stat stage-stat-secondary">
+              <span class="stage-stat-value">{{ stage.verses }}</span>
+              <span class="stage-stat-unit">verse{{ stage.verses === 1 ? '' : 's' }}</span>
+            </p>
+          </li>
+        </ol>
+      </section>
+
+      <RouterLink class="rule-heading rule-heading-link" to="/stats">
+        <span>by year →</span>
+      </RouterLink>
+
+      <p v-if="totalReviews > 0" class="ledger">
+        <em>
+          <template v-if="aggregateRetention !== null">{{ pct(aggregateRetention) }}
+            retention · </template>{{ totalReviews.toLocaleString('en-CA') }}
+          review{{ totalReviews === 1 ? '' : 's' }} logged ·
+          {{ totalVersesHeld }} verse{{ totalVersesHeld === 1 ? '' : 's' }} held
+        </em>
+      </p>
+    </template>
+  </article>
+</template>
+
+<style scoped>
+/* Fraunces handles display work (headings, oversized numerals,
+   section rules); body copy inherits the app's system stack. */
+
+.codex {
+  width: 100%;
+  max-width: 880px;
+  display: flex;
+  flex-direction: column;
+  gap: 2.75rem;
+  color: var(--color-text);
+  position: relative;
+  /* Faint paper-grain noise overlay. Inlined SVG so there is no
+     extra request and no flash before the texture lands. */
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.045 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  background-blend-mode: multiply;
+}
+
+.codex > * {
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 600ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.codex.revealed > * {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.codex > *:nth-child(1) { transition-delay: 0ms; }
+.codex > *:nth-child(2) { transition-delay: 80ms; }
+.codex > *:nth-child(3) { transition-delay: 160ms; }
+.codex > *:nth-child(4) { transition-delay: 240ms; }
+
+/* ── Banners ──────────────────────────────────────────────── */
+
+.page-banner {
+  padding: 0.75rem 1rem;
+  border-left: 2px solid var(--color-muted);
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 50;
+  font-size: 0.95rem;
+}
+
+.page-banner-quiet {
+  color: var(--color-muted);
+  border-color: transparent;
+  padding-left: 0;
+}
+
+.page-banner-error {
+  border-color: var(--color-error);
+  color: var(--color-error);
+  background: var(--color-error-bg);
+}
+
+.page-banner-warning {
+  border-color: var(--color-grade-hard);
+  color: var(--color-grade-hard);
+  background: var(--color-grade-hard-bg);
+}
+
+/* ── Hero panels ──────────────────────────────────────────── */
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.hero-panel {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+  padding: 1.5rem 1.75rem 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  position: relative;
+  text-decoration: none;
+  color: var(--color-text);
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px transparent;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    transform 200ms ease;
+}
+
+.hero-panel-action:not(.idle) {
+  box-shadow: inset 0 0 0 1px var(--color-accent-soft);
+}
+
+.hero-panel-review:not(.idle) {
+  box-shadow: inset 0 0 0 1px var(--color-border);
+}
+
+.hero-panel:hover {
+  border-color: var(--color-text);
+  transform: translateY(-2px);
+}
+
+.hero-panel:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.hero-label {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 30, 'WONK' 0;
+  font-feature-settings: 'smcp', 'c2sc';
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.hero-numeral {
+  margin: 0;
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 144, 'wght' 360, 'SOFT' 100, 'WONK' 1;
+  font-size: clamp(4rem, 9vw, 6rem);
+  line-height: 0.95;
+  font-feature-settings: 'lnum', 'tnum';
+  letter-spacing: -0.02em;
+}
+
+.hero-panel-action:not(.idle) .numeral {
+  color: var(--color-accent);
+}
+
+.hero-panel-review:not(.idle) .numeral {
+  color: var(--color-text);
+}
+
+.hero-sub {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  line-height: 1.5;
+  font-style: italic;
+  max-width: 28ch;
+}
+
+.hero-arrow {
+  margin: auto 0 0;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 30;
+  font-feature-settings: 'smcp', 'c2sc';
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: var(--color-accent);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.hero-panel.idle .hero-arrow {
+  color: var(--color-muted);
+}
+
+.hero-arrow-glyph {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 48, 'SOFT' 60;
+  font-feature-settings: normal;
+  letter-spacing: 0;
+  text-transform: none;
+  font-size: 1.25rem;
+  transition: transform 200ms ease;
+}
+
+.hero-panel:hover .hero-arrow-glyph {
+  transform: translateX(4px);
+}
+
+/* ── Section rules ───────────────────────────────────────── */
+
+.rule-heading {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 30, 'WONK' 0;
+  font-feature-settings: 'smcp', 'c2sc';
+  font-weight: 400;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  color: var(--color-muted);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0 0 1rem;
+}
+
+.rule-heading::before,
+.rule-heading::after {
+  content: '';
+  height: 1px;
+  background: var(--color-border);
+  flex: 1;
+}
+
+.rule-heading span {
+  flex: 0 0 auto;
+}
+
+/* ── SRS-stage tiles ─────────────────────────────────────── */
+
+.stages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(118px, 1fr));
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.stage {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 2px;
+  padding: 3.5rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  transition:
+    opacity 600ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    transform 600ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.codex.revealed .stage {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Idle (zero-count) tiles dim so the lit ones lead the eye.
+   Modifier is `stage-idle`, not `empty`, because the dashboard's
+   no-enrollments `.empty` rule below would otherwise cascade onto
+   these tiles by accident. */
+.codex.revealed .stage-idle {
+  opacity: 0.4;
+}
+
+.stage-stripe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+}
+
+.stage.seg-weak .stage-stripe { background: var(--color-grade-again); }
+.stage.seg-learning .stage-stripe { background: var(--color-grade-hard); }
+.stage.seg-familiar .stage-stripe { background: var(--color-grade-good); }
+.stage.seg-strong .stage-stripe { background: var(--color-accent); }
+.stage.seg-mastered .stage-stripe { background: var(--color-grade-easy); }
+
+.stage-label {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 40;
+  font-feature-settings: 'smcp', 'c2sc';
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  color: var(--color-muted);
+  margin-top: 0.15rem;
+  margin-bottom: 0.15rem;
+}
+
+.stage-stat {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 0.35rem;
+  margin: 0;
+}
+
+.stage-stat-value {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 72, 'wght' 400, 'SOFT' 65, 'WONK' 0;
+  font-feature-settings: 'lnum', 'tnum';
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.stage-stat-unit {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 50;
+  font-style: italic;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.stage-stat-secondary .stage-stat-value {
+  font-variation-settings: 'opsz' 36, 'wght' 380, 'SOFT' 55;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+/* ── "by year →" link ─────────────────────────────────────── */
+
+/* Reuses the `.rule-heading` chrome (centred small-caps with hairlines
+   on either side); `-link` strips the link defaults so it reads as
+   a section title that happens to be clickable. */
+.rule-heading-link {
+  text-decoration: none;
+  color: var(--color-muted);
+  transition: color 200ms ease;
+}
+
+.rule-heading-link:hover {
+  color: var(--color-accent);
+}
+
+/* ── Empty state ─────────────────────────────────────────── */
+
+.empty {
+  padding: 4rem 0;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.empty-line {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 96, 'wght' 360, 'SOFT' 80, 'WONK' 1;
+  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.empty-cta {
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 30;
+  font-feature-settings: 'smcp', 'c2sc';
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: var(--color-accent);
+  text-decoration: none;
+  border-bottom: 1px solid var(--color-accent);
+  padding-bottom: 0.2rem;
+}
+
+.empty-cta:hover {
+  color: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
+/* ── Ledger footnote ─────────────────────────────────────── */
+
+.ledger {
+  margin: 0;
+  padding-top: 0.5rem;
+  text-align: center;
+  font-family: 'Fraunces', Georgia, serif;
+  font-variation-settings: 'opsz' 14, 'SOFT' 50;
+  font-style: italic;
+  font-size: 0.88rem;
+  color: var(--color-muted);
+  letter-spacing: 0.02em;
+}
+
+/* ── Reduced motion ──────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .codex > *,
+  .stage {
+    transition: none;
+  }
+}
+</style>

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -44,7 +44,7 @@ watch(
 )
 
 function redirectTarget(): string {
-  return typeof route.query.redirect === 'string' ? route.query.redirect : '/review'
+  return typeof route.query.redirect === 'string' ? route.query.redirect : '/dashboard'
 }
 
 async function onCardEnter(profile: ProfileRow) {

--- a/apps/web/src/views/StatsView.vue
+++ b/apps/web/src/views/StatsView.vue
@@ -17,7 +17,7 @@ const loading = ref(true)
 const DIST_LABELS = ['weak', 'learning', 'familiar', 'strong', 'mastered'] as const
 
 function bucketsFor(stats: StatsResponse) {
-  const dist = stats.testDistribution
+  const dist = stats.cardDistribution
   const total = Object.values(dist).reduce((a, b) => a + b, 0)
   if (total === 0) return []
   return DIST_LABELS.map((label) => ({
@@ -98,7 +98,7 @@ onMounted(async () => {
         </div>
 
         <div v-if="bucketsFor(y.stats).length > 0" class="histogram">
-          <div class="histogram-title">Test stability</div>
+          <div class="histogram-title">Card stability</div>
           <div v-for="b in bucketsFor(y.stats)" :key="b.label" class="bar-row">
             <div class="bar-label">{{ b.label }}</div>
             <div class="bar-track">

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,45 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-28
+
+Dashboard stats helpers: a bundle of pure-read scheduler queries that drive the new `/dashboard`
+view, plus a new `StabilityHistogram` wire type. All additive; existing event replay produces
+identical state. MINOR per this changelog's own rubric ("additive feature — new test kind, new card
+kind, new scheduler knob") — six new public scheduler helpers count as the additive case.
+
+### Added
+
+* `schedule::StabilityHistogram { weak, learning, familiar, strong, mastered }` — five-bucket
+  stability count, days-based (`< 1` / `< 7` / `< 30` / `< 90` / `>= 90`). Shared return type for
+  the histogram helpers below.
+* `schedule::due_review_count(engine, now_secs)` — count of active cards whose minimum-test
+  retrievability is below `target_retention` at `now_secs`. Mirrors `next_card`'s eligibility but
+  drops the sibling-cooldown filter, since the dashboard surfaces this between sessions and
+  shouldn't wobble in the seconds after a review.
+* `schedule::card_stability_histogram(engine)` — buckets every active card by its weakest test's
+  stability. Skips New cards (they belong to the memorize queue, not the review distribution).
+* `schedule::new_verse_count(engine)` / `schedule::due_verse_count(engine, now_secs)` —
+  verse-footprint counterparts to the existing `new_card_count` and `due_review_count`.
+* `schedule::verse_stability_histogram(engine)` — buckets distinct verses by the minimum stability
+  across their verse-content cards' tests. Each verse lives in exactly one bucket, so the sum of
+  `weak..mastered` equals the total memorised-verse count.
+* `schedule::learned_verse_count(engine, threshold_days)` — count of distinct verses whose weakest
+  verse-content card test is at or above `threshold_days` (the API passes its
+  `STABILITY_FAMILIAR_DAYS` so the cutoff stays defined in one place).
+
+### Semantics
+
+* Verse-side helpers (`new_verse_count`, `due_verse_count`, `verse_stability_histogram`,
+  `learned_verse_count`) only consider **verse-content cards** — `PhraseFill`, `VerseAtVerseRef`,
+  `Recitation`, `Citation`, `Ftv`. Meta-location cards (`VerseInChapter` / `VerseInBook` /
+  `VerseInHeading` / `VerseInClub`), the multi-verse pseudos (`HeadingPassage`, `ChapterClubList`),
+  and `Reading` don't contribute. Net effect: a verse's stability tracks the worst of its
+  content-card tests, and meta-card stability drifting around can't bounce a verse between dashboard
+  stability buckets.
+* Card-side helpers (`card_stability_histogram`, `due_review_count`) still count every card the user
+  reviews — meta cards are real review work, just not signals of verse content recall.
+
 ## [0.2.1] — 2026-05-27
 
 * `VerseRender.chapter_members: Vec<u16>` — additive field carrying the verse numbers a

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -1,6 +1,62 @@
-use crate::card::{Card, CardState};
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::card::{Card, CardKind, CardState};
 use crate::engine::ReviewEngine;
 use crate::types::CardId;
+
+/// Whether a card tests the **content of one verse** — its text,
+/// its phrase progression, its first words, its citation, or
+/// verse-text recall from the reference. Meta-location cards,
+/// multi-verse pseudos, and `Reading` return false.
+///
+/// Only verse-side aggregations apply this filter; card-side
+/// metrics still count every card the user actually reviews. With
+/// this filter, each verse lives in exactly one stability bucket
+/// (the bucket of its worst content card), so verse columns sum to
+/// the total memorised-verse count regardless of meta-card drift.
+fn is_verse_content_card(kind: &CardKind) -> bool {
+    matches!(
+        kind,
+        CardKind::PhraseFill { .. }
+            | CardKind::VerseAtVerseRef
+            | CardKind::Recitation
+            | CardKind::Citation
+            | CardKind::Ftv { .. }
+    )
+}
+
+/// Five-bucket SRS-style histogram of card or test stability, in days.
+/// Bucket boundaries mirror the API's existing SQL stats query so the
+/// dashboard's stage tiles read in the same units the per-year breakdown
+/// uses: weak < 1d, learning < 7d, familiar < 30d, strong < 90d,
+/// mastered ≥ 90d.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StabilityHistogram {
+    pub weak: u32,
+    pub learning: u32,
+    pub familiar: u32,
+    pub strong: u32,
+    pub mastered: u32,
+}
+
+impl StabilityHistogram {
+    fn bump(&mut self, stability_days: f32) {
+        if stability_days < 1.0 {
+            self.weak += 1;
+        } else if stability_days < 7.0 {
+            self.learning += 1;
+        } else if stability_days < 30.0 {
+            self.familiar += 1;
+        } else if stability_days < 90.0 {
+            self.strong += 1;
+        } else {
+            self.mastered += 1;
+        }
+    }
+}
 
 impl ReviewEngine {
     /// True when any test this card grades was touched (directly or via
@@ -62,6 +118,143 @@ pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
         .filter(|(_, r)| *r < engine.schedule_params.target_retention)
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
         .map(|(id, _)| id)
+}
+
+/// Bucket every active card by its **weakest test's stability** —
+/// the same min-aggregation `card_min_r` uses to decide due-ness.
+/// A card with mixed-stability tests belongs to the bucket of its
+/// weakest test (the bucket of its review urgency, not its best
+/// memory), so the histogram answers "how many cards am I about to
+/// re-learn" rather than "how many tests have I ever drilled".
+///
+/// Cards with no test state yet (no graded tests) are skipped; they
+/// belong to the memorize queue, not the review distribution.
+pub fn card_stability_histogram(engine: &ReviewEngine) -> StabilityHistogram {
+    let mut hist = StabilityHistogram::default();
+    for card in &engine.cards {
+        if !matches!(card.state, CardState::Active) {
+            continue;
+        }
+        let atoms = engine.atoms_for(card.verse_id);
+        let min_stability = card
+            .tests(&atoms)
+            .into_iter()
+            .filter_map(|tk| engine.tests.get(&tk))
+            .map(|s| s.stability)
+            .reduce(f32::min);
+        if let Some(s) = min_stability {
+            hist.bump(s);
+        }
+    }
+    hist
+}
+
+/// Count distinct verses with at least one `New` verse-content
+/// card — the memorize-queue's verse footprint. Only the cards
+/// that test the verse's own content count toward the verse
+/// footprint; see [`is_verse_content_card`].
+pub fn new_verse_count(engine: &ReviewEngine) -> u32 {
+    let mut seen: HashSet<u32> = HashSet::new();
+    for card in &engine.cards {
+        if !matches!(card.state, CardState::New) {
+            continue;
+        }
+        if !is_verse_content_card(&card.kind) {
+            continue;
+        }
+        seen.insert(card.verse_id);
+    }
+    seen.len() as u32
+}
+
+/// Count distinct verses with at least one due card — the
+/// review-queue's verse footprint. Mirrors `due_review_count`'s
+/// eligibility (active + below-target, ignoring cooldown) and
+/// applies the same verse-content filter as `new_verse_count`.
+pub fn due_verse_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
+    let target = engine.schedule_params.target_retention;
+    let mut seen: HashSet<u32> = HashSet::new();
+    for card in &engine.cards {
+        if !matches!(card.state, CardState::Active) {
+            continue;
+        }
+        if !is_verse_content_card(&card.kind) {
+            continue;
+        }
+        if let Some(r) = engine.card_min_r(card, now_secs)
+            && r < target
+        {
+            seen.insert(card.verse_id);
+        }
+    }
+    seen.len() as u32
+}
+
+/// Map each verse to its weakest verse-content card's test stability.
+/// Shared work shape behind `verse_stability_histogram` and
+/// `learned_verse_count`; both derive their result from this map.
+fn verse_min_stability_map(engine: &ReviewEngine) -> HashMap<u32, f32> {
+    let mut min_by_verse: HashMap<u32, f32> = HashMap::new();
+    for card in &engine.cards {
+        if !matches!(card.state, CardState::Active) {
+            continue;
+        }
+        if !is_verse_content_card(&card.kind) {
+            continue;
+        }
+        let atoms = engine.atoms_for(card.verse_id);
+        for tk in card.tests(&atoms) {
+            if let Some(state) = engine.tests.get(&tk) {
+                min_by_verse
+                    .entry(card.verse_id)
+                    .and_modify(|m| *m = m.min(state.stability))
+                    .or_insert(state.stability);
+            }
+        }
+    }
+    min_by_verse
+}
+
+/// Bucket distinct verses by their **weakest verse-content card's
+/// test stability**. Each verse lives in exactly one bucket, so the
+/// sum of `weak..mastered` equals the total memorised-verse count.
+pub fn verse_stability_histogram(engine: &ReviewEngine) -> StabilityHistogram {
+    let mut hist = StabilityHistogram::default();
+    for &stability in verse_min_stability_map(engine).values() {
+        hist.bump(stability);
+    }
+    hist
+}
+
+/// Count distinct verses whose weakest verse-content card's test
+/// stability is at or above `threshold_days`. Sums to
+/// `verse_stability_histogram`'s `familiar + strong + mastered` at
+/// the default 7-day cutoff.
+pub fn learned_verse_count(engine: &ReviewEngine, threshold_days: f32) -> u32 {
+    verse_min_stability_map(engine)
+        .values()
+        .filter(|&&s| s >= threshold_days)
+        .count() as u32
+}
+
+/// Count active cards whose minimum-test retrievability is below
+/// `target_retention` at `now_secs` — the "reviews waiting" queue
+/// the user sees as actionable.
+///
+/// Mirrors `next_card`'s eligibility (active + below-target) but
+/// drops the sibling-cooldown filter: cooldown is a session-only
+/// suppression heuristic, and a UI surfacing this number between
+/// sessions shouldn't have it wobble in the seconds after a review.
+/// The count is what FSRS would *eventually* serve, not what
+/// `next_card` would surface in this exact moment.
+pub fn due_review_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
+    engine
+        .cards
+        .iter()
+        .filter(|c| matches!(c.state, CardState::Active))
+        .filter_map(|c| engine.card_min_r(c, now_secs))
+        .filter(|r| *r < engine.schedule_params.target_retention)
+        .count() as u32
 }
 
 /// Pick the next card from the memorize queue: any `New` card. Returns one
@@ -393,5 +586,135 @@ mod tests {
         engine.schedule_params.target_retention = 0.0;
         let pick = next_card(&engine, 86400 * 365);
         assert!(pick.is_none());
+    }
+
+    #[test]
+    fn due_review_count_matches_next_card_eligibility() {
+        // Build at t0=0 then jump forward a year — every active card's
+        // retrievability has decayed well below default 0.9, so every
+        // active card should count as due.
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.graduate_all();
+        let now = 86400 * 365;
+
+        let active = engine
+            .cards
+            .iter()
+            .filter(|c| matches!(c.state, CardState::Active))
+            .count() as u32;
+        assert!(active > 0, "test material must produce active cards");
+        assert_eq!(due_review_count(&engine, now), active);
+    }
+
+    #[test]
+    fn due_review_count_is_zero_when_no_card_is_due() {
+        // Target 0.0 — no card's retrievability can fall below it,
+        // so nothing is due regardless of how stale the cards are.
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 86400 * 365);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.schedule_params.target_retention = 0.0;
+        engine.graduate_all();
+        assert_eq!(due_review_count(&engine, 86400 * 365), 0);
+    }
+
+    #[test]
+    fn card_stability_histogram_skips_new_cards() {
+        // No graduation = every card is `New`. Histogram must be all zeros
+        // even though each card has seeded test states (they just don't
+        // belong to the "review distribution" yet).
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        let h = card_stability_histogram(&engine);
+        assert_eq!(h, StabilityHistogram::default());
+    }
+
+    #[test]
+    fn card_stability_histogram_buckets_active_cards_by_min_test_stability() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.graduate_all();
+
+        // Default seed leaves every test at stability 1.0 — every active
+        // card lands in `learning` (>=1, <7). Nothing in any other bucket.
+        let h = card_stability_histogram(&engine);
+        assert!(h.learning > 0);
+        assert_eq!(h.weak, 0);
+        assert_eq!(h.familiar, 0);
+        assert_eq!(h.strong, 0);
+        assert_eq!(h.mastered, 0);
+
+        // Boost one test's stability into `mastered` and confirm the
+        // affected card moves to mastered iff that's its weakest test.
+        // Picking a PhraseFill card and bumping ALL its tests so the
+        // min (and thus the bucket) flips.
+        let card_id = engine
+            .cards
+            .iter()
+            .find(|c| matches!(c.kind, CardKind::PhraseFill { .. }))
+            .unwrap()
+            .id;
+        let atoms = engine.atoms_for(engine.card(card_id).unwrap().verse_id);
+        for tk in engine.card(card_id).unwrap().tests(&atoms) {
+            engine.tests.get_mut(&tk).unwrap().stability = 100.0;
+        }
+
+        let h2 = card_stability_histogram(&engine);
+        assert_eq!(h2.mastered, 1, "the boosted card must land in mastered");
+        assert_eq!(h2.learning, h.learning - 1);
+    }
+
+    #[test]
+    fn new_verse_count_counts_distinct_verses_with_new_cards() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        // Both verses have New cards before any graduation.
+        assert_eq!(new_verse_count(&engine), 2);
+    }
+
+    #[test]
+    fn new_verse_count_drops_to_zero_after_graduation() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.graduate_all();
+        assert_eq!(new_verse_count(&engine), 0);
+    }
+
+    #[test]
+    fn due_verse_count_matches_distinct_due_verses() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.graduate_all();
+        let now = 86400 * 365;
+        // Both verses' cards are stale → both verses count.
+        assert_eq!(due_verse_count(&engine, now), 2);
+    }
+
+    #[test]
+    fn due_verse_count_skips_new_verses() {
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        // No graduation = no Active cards = nothing to be due.
+        assert_eq!(due_verse_count(&engine, 86400 * 365), 0);
+    }
+
+    #[test]
+    fn due_review_count_excludes_new_cards() {
+        // Without `graduate_all`, every card is still `CardState::New`.
+        // The builder seeds test states for them, but the helper filters
+        // on `Active` so the count must still be zero.
+        let m = sample_material_two_verses();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        let now = 86400 * 365;
+        assert_eq!(due_review_count(&engine, now), 0);
     }
 }

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,28 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-05-28
+
+Wrappers for the new `verse-vault-core@0.3.0` dashboard stats helpers. MINOR per this changelog's
+own rubric ("additive field or new exposed function") — six new exposed `WasmEngine` methods. Older
+consumers ignore the new methods safely.
+
+### Added
+
+* `WasmEngine.due_review_count(now_secs) -> u32` — count of active cards whose retrievability is
+  below the scheduler's target. Drives the dashboard's "reviews waiting" number.
+* `WasmEngine.card_stability_histogram() -> string` — JSON-serialised
+  `{ weak, learning, familiar, strong, mastered }` count of active cards bucketed by weakest-test
+  stability.
+* `WasmEngine.verse_stability_histogram() -> string` — same shape, bucketed by the worst
+  verse-content-card test stability per verse.
+* `WasmEngine.new_verse_count() -> u32` / `WasmEngine.due_verse_count(now_secs) -> u32` /
+  `WasmEngine.learned_verse_count(threshold_days) -> u32` — verse-footprint counts.
+
+JSON-string returns for the histograms follow the existing pattern for structured values
+(`export_test_states`, `memorize_session`). Verse-side methods exclude meta-location and multi-verse
+pseudo cards per `verse-vault-core@0.3.0`'s `is_verse_content_card` filter.
+
 ## [0.2.1] — 2026-05-27
 
 * `VerseRenderWire.chapterMembers: number[]` — additive wire field forwarding

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -14,7 +14,12 @@ use verse_vault_core::engine::{ReviewEngine, TestUpdate, UpdateKind};
 use verse_vault_core::material_config::MaterialConfig;
 use verse_vault_core::render::{HeadingRender, VerseRender};
 use verse_vault_core::schedule::{
-    next_card, next_memorize_card as schedule_next_memorize_card, next_relearn_card,
+    card_stability_histogram as schedule_card_stability_histogram,
+    due_review_count as schedule_due_review_count, due_verse_count as schedule_due_verse_count,
+    learned_verse_count as schedule_learned_verse_count,
+    new_verse_count as schedule_new_verse_count, next_card,
+    next_memorize_card as schedule_next_memorize_card, next_relearn_card,
+    verse_stability_histogram as schedule_verse_stability_histogram,
 };
 use verse_vault_core::test_kind::{TestKey, TestKind};
 use verse_vault_core::test_state::TestState;
@@ -344,6 +349,55 @@ impl WasmEngine {
             return Some(id.0);
         }
         next_card(&self.engine, now_secs).map(|c| c.0)
+    }
+
+    /// Count of active cards whose retrievability is below target at
+    /// `now_secs`. Mirrors `next_review_card`'s eligibility minus the
+    /// session-only cooldown filter — see `core::schedule::due_review_count`
+    /// for why. Dashboard surfaces this as the "reviews waiting" number.
+    pub fn due_review_count(&self, now_secs: i64) -> u32 {
+        schedule_due_review_count(&self.engine, now_secs)
+    }
+
+    /// JSON-serialised `StabilityHistogram` of active cards bucketed by
+    /// weakest-test stability — drives the dashboard's per-card stage
+    /// tiles. JSON over the boundary matches the existing pattern for
+    /// structured returns (`export_test_states`, `memorize_session`).
+    pub fn card_stability_histogram(&self) -> Result<String, JsError> {
+        let h = schedule_card_stability_histogram(&self.engine);
+        serde_json::to_string(&h).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// JSON-serialised `StabilityHistogram` of distinct verses bucketed
+    /// by their weakest verse-content card's test stability. Meta-location
+    /// cards (`VerseInChapter` / `VerseInBook` / `VerseInHeading` /
+    /// `VerseInClub`), the multi-verse pseudos (`HeadingPassage`,
+    /// `ChapterClubList`), and `Reading` don't contribute — see
+    /// `core::schedule::is_verse_content_card` for the filter.
+    pub fn verse_stability_histogram(&self) -> Result<String, JsError> {
+        let h = schedule_verse_stability_histogram(&self.engine);
+        serde_json::to_string(&h).map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Count of distinct verses with at least one `New` card — the
+    /// memorize queue's verse footprint. Pseudo verses excluded.
+    pub fn new_verse_count(&self) -> u32 {
+        schedule_new_verse_count(&self.engine)
+    }
+
+    /// Count of distinct verses with at least one due card at
+    /// `now_secs` — the review queue's verse footprint. Pseudo
+    /// verses excluded.
+    pub fn due_verse_count(&self, now_secs: i64) -> u32 {
+        schedule_due_verse_count(&self.engine, now_secs)
+    }
+
+    /// Count of distinct verses whose weakest test's stability is at
+    /// or above `threshold_days`. Pseudo verses excluded. The API
+    /// passes its `STABILITY_FAMILIAR_DAYS` so the threshold stays
+    /// defined in one place.
+    pub fn learned_verse_count(&self, threshold_days: f32) -> u32 {
+        schedule_learned_verse_count(&self.engine, threshold_days)
     }
 
     /// Pick the next New card for the memorize queue. The caller walks the

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,34 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### `/api/stats/:materialId` payload reshaped for the dashboard
+
+* **`testDistribution` → `cardDistribution` + `verseDistribution`.** The old field counted raw
+  test_states — an engine-internal unit users don't think in. The new pair counts cards (per active
+  card, bucketed by weakest-test stability) and verses (per single-verse-card verse, same
+  min-aggregation).
+* **`reviewsDueCount`, `newVerseCount`, `versesDueCount` added.** Card-side and verse-side
+  footprints of the review and memorize queues — drives the dashboard's "X cards from Y verses"
+  pairing in both heroes.
+* **`versesLearned` semantics tighten.** Engine-derived too; only verses whose weakest verse-content
+  card test is at familiar+ stability count. Meta-location cards and the multi-verse pseudos no
+  longer contribute.
+
+### Engine instead of SQL for every per-verse number
+
+The route now loads the per-material engine and asks it for every per-verse aggregate
+(`learned_verse_count`, `verse_stability_histogram`, `new_verse_count`, `due_verse_count`) and both
+card-side histograms (`card_stability_histogram`, `due_review_count`). The previous SQL queries
+couldn't tell a real verse from a `HeadingPassage` / `ChapterClubList` pseudo (whose `verse_id` is
+shared across multiple real verses), so a deck with passage cards inflated every verse count by one
+per pseudo. Engine-side, `CardKind` discriminates. `EngineStore.load` is cached per (user, material)
+so subsequent dashboard renders pay the load cost once.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.3.0` — adds the dashboard stats helpers.
+* `verse-vault-wasm@0.3.0` — exposes the matching wrappers.
+
 ## [0.1.16] — 2026-05-27
 
 ### Bundled algorithm contract

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -113,7 +113,7 @@ export function createApp(deps: AppDeps) {
     }),
   );
   app.route('/api/years', yearsRoutes({ db: deps.db, engines, now: deps.now }));
-  app.route('/api/stats', statsRoutes({ db: deps.db }));
+  app.route('/api/stats', statsRoutes({ db: deps.db, engines, now: deps.now }));
 
   return app;
 }

--- a/packages/api/src/routes/stats.test.ts
+++ b/packages/api/src/routes/stats.test.ts
@@ -6,12 +6,18 @@ import { createTestApp, enrollViaApi, signUpTestUser } from '../test-utils.js';
 
 const MATERIAL_ID = 'nkjv-cor';
 
+type StabilityHistogram = Record<'weak' | 'learning' | 'familiar' | 'strong' | 'mastered', number>;
+
 interface StatsResponse {
   materialId: string;
   versesLearned: number;
   retentionRate: number | null;
   totalGrades: number;
-  testDistribution: Record<'weak' | 'learning' | 'familiar' | 'strong' | 'mastered', number>;
+  cardDistribution: StabilityHistogram;
+  verseDistribution: StabilityHistogram;
+  reviewsDueCount: number;
+  newVerseCount: number;
+  versesDueCount: number;
 }
 
 interface UploadEvent {
@@ -75,12 +81,17 @@ describe('stats routes', () => {
     expect(body.materialId).toBe(MATERIAL_ID);
     expect(body.retentionRate).toBeNull();
     expect(body.totalGrades).toBe(0);
-    // versesLearned counts verses with at least one familiar+ test; freshly
-    // seeded states sit at the engine's default initial stability, which
-    // lands in the "weak" bucket — versesLearned should be 0.
+    // Before any verse is graduated, the user hasn't started learning
+    // anything — `versesLearned` is 0 and both stability histograms
+    // (cards and verses) must be empty. Counting seeded test_states
+    // for ungraduated cards would inflate "weak"/"learning" with
+    // cards the user hasn't engaged with; the dashboard would read
+    // that as "1000s of items still learning" on a brand-new account.
     expect(body.versesLearned).toBe(0);
-    const total = Object.values(body.testDistribution).reduce((a, b) => a + b, 0);
-    expect(total).toBeGreaterThan(0);
+    const cardTotal = Object.values(body.cardDistribution).reduce((a, b) => a + b, 0);
+    const verseTotal = Object.values(body.verseDistribution).reduce((a, b) => a + b, 0);
+    expect(cardTotal).toBe(0);
+    expect(verseTotal).toBe(0);
   });
 
   it('counts Hard (grade 2) as a pass, matching the core scheduler', async () => {

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -1,28 +1,44 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
-import { NotEnrolledError } from '../lib/engine.js';
+import { type EngineStore, NotEnrolledError } from '../lib/engine.js';
 import { requireEnrollment } from '../lib/enrollment.js';
 import { isPass } from '../lib/review-log.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface StatsRoutesDeps {
   db: DB;
+  engines: EngineStore;
+  now?: () => number;
 }
 
 /** Stability buckets in days, tuned roughly to "how long until you'd forget it". */
 type BucketLabel = 'weak' | 'learning' | 'familiar' | 'strong' | 'mastered';
 
+type StabilityHistogram = Record<BucketLabel, number>;
+
+/** Familiar-threshold passed to the engine's `learned_verse_count`. Same
+ *  cutoff the old SQL `versesLearned` used; defined here so the API
+ *  keeps one number to twist if the threshold ever moves. */
 const STABILITY_FAMILIAR_DAYS = 7;
 
+const EMPTY_HISTOGRAM: StabilityHistogram = {
+  weak: 0,
+  learning: 0,
+  familiar: 0,
+  strong: 0,
+  mastered: 0,
+};
+
 export function statsRoutes(deps: StatsRoutesDeps) {
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
   const app = new Hono<{ Variables: SessionVariables }>();
 
   app.use('*', requireAuth());
 
-  app.get('/:materialId', (c) => {
+  app.get('/:materialId', async (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
     try {
@@ -45,56 +61,49 @@ export function statsRoutes(deps: StatsRoutesDeps) {
     const gradeCount = events.length;
     const passCount = events.reduce((acc, e) => acc + (isPass(e.grade) ? 1 : 0), 0);
 
-    const stability = schema.testStates.stability;
-    const histogram = deps.db
-      .select({
-        weak: sql<number>`coalesce(sum(case when ${stability} < 1 then 1 else 0 end), 0)`,
-        learning: sql<number>`coalesce(sum(case when ${stability} >= 1 and ${stability} < 7 then 1 else 0 end), 0)`,
-        familiar: sql<number>`coalesce(sum(case when ${stability} >= 7 and ${stability} < 30 then 1 else 0 end), 0)`,
-        strong: sql<number>`coalesce(sum(case when ${stability} >= 30 and ${stability} < 90 then 1 else 0 end), 0)`,
-        mastered: sql<number>`coalesce(sum(case when ${stability} >= 90 then 1 else 0 end), 0)`,
-      })
-      .from(schema.testStates)
-      .where(
-        and(
-          eq(schema.testStates.userId, user.id),
-          eq(schema.testStates.materialId, materialId),
-        ),
-      )
-      .get();
-    const testDistribution: Record<BucketLabel, number> = histogram ?? {
-      weak: 0,
-      learning: 0,
-      familiar: 0,
-      strong: 0,
-      mastered: 0,
-    };
-
-    // versesLearned: distinct verse_ids with at least one familiar+ test.
-    // The element column is a serde-tagged JSON object — every variant
-    // includes verse_id, so extracting via SQLite's json_extract works
-    // uniformly.
-    const versesLearnedRows = deps.db
-      .select({
-        verseId: sql<number>`json_extract(${schema.testStates.element}, '$.verse_id')`,
-      })
-      .from(schema.testStates)
-      .where(
-        and(
-          eq(schema.testStates.userId, user.id),
-          eq(schema.testStates.materialId, materialId),
-          sql`${schema.testStates.stability} >= ${STABILITY_FAMILIAR_DAYS}`,
-        ),
-      )
-      .groupBy(sql`json_extract(${schema.testStates.element}, '$.verse_id')`)
-      .all();
+    // Every per-verse number now comes from the engine instead of SQL.
+    // SQL can't tell a real verse from a HeadingPassage / ChapterClubList
+    // pseudo verse, so its counts would include pseudos and inflate the
+    // dashboard's "X cards from Y verses" pairing. Engine-side, the
+    // CardKind discriminates and the multi-verse cards are excluded
+    // consistently across every verse metric.
+    let reviewsDueCount = 0;
+    let newVerseCount = 0;
+    let versesDueCount = 0;
+    let versesLearned = 0;
+    let cardDistribution: StabilityHistogram = EMPTY_HISTOGRAM;
+    let verseDistribution: StabilityHistogram = EMPTY_HISTOGRAM;
+    try {
+      const loaded = await deps.engines.load({ userId: user.id, materialId });
+      const nowSecs = BigInt(now());
+      reviewsDueCount = loaded.engine.due_review_count(nowSecs);
+      newVerseCount = loaded.engine.new_verse_count();
+      versesDueCount = loaded.engine.due_verse_count(nowSecs);
+      versesLearned = loaded.engine.learned_verse_count(STABILITY_FAMILIAR_DAYS);
+      cardDistribution = JSON.parse(
+        loaded.engine.card_stability_histogram(),
+      ) as StabilityHistogram;
+      verseDistribution = JSON.parse(
+        loaded.engine.verse_stability_histogram(),
+      ) as StabilityHistogram;
+    } catch (err) {
+      if (!(err instanceof NotEnrolledError)) throw err;
+      // Enrollment was re-checked above; a race where the engine load
+      // fails because the snapshot just got pruned still shouldn't 500
+      // a stats request — fall back to zero counts and let the next
+      // dashboard render pick up the recovered state.
+    }
 
     return c.json({
       materialId,
-      versesLearned: versesLearnedRows.length,
+      versesLearned,
       retentionRate: gradeCount > 0 ? passCount / gradeCount : null,
       totalGrades: gradeCount,
-      testDistribution,
+      cardDistribution,
+      verseDistribution,
+      reviewsDueCount,
+      newVerseCount,
+      versesDueCount,
     });
   });
 


### PR DESCRIPTION
## Summary

A new editorial `/dashboard` landing page that aggregates per-material stats into a single at-a-glance view. `/dashboard` is the new app index — `/`, the post-sign-in default, and the brand link all land here. `/stats` keeps the per-year drill-down.

- **Two clickable hero tiles** (Memorize, Review) with the queue count as the centrepiece and a verse footprint on the supporting line ("X cards from Y verses").
- **Five SRS-stage tiles** showing cards + verses per stability bucket; lit tiles short, idle tiles dim + tall + centred.
- **"by year →" link** to `/stats` for the full breakdown.
- **Colophon** with aggregate retention / reviews / verses-held.

Every per-verse number is engine-derived. SQL couldn't tell a real verse from a `HeadingPassage` / `ChapterClubList` pseudo, so a deck with passage cards inflated every verse count by one per pseudo. Engine-side, the `is_verse_content_card` filter also excludes meta-location cards (`VerseInChapter` / `VerseInBook` / `VerseInHeading` / `VerseInClub`) and `Reading`, so a verse's stability tracks the worst of its content-card tests and meta-card drift can't bounce verses between dashboard buckets.

## Bundled algorithm contract

- `verse-vault-core` 0.2.1 → 0.2.2 (additive helpers + `StabilityHistogram`)
- `verse-vault-wasm` 0.2.1 → 0.2.2 (matching `WasmEngine` wrappers)

Wire shapes unchanged; PATCH bumps.

## Test plan

- [ ] Required CI (rust, typos, dprint) green on the PR head
- [ ] `/dashboard` renders both hero tiles, stability row, by-year link, colophon
- [ ] Hero tile clicks route to `/memorize` and `/review`
- [ ] "by year →" routes to `/stats`
- [ ] Idle (zero-count) stability tiles display dim + tall + centred; lit tiles share the same proportions
- [ ] `/api/stats/:materialId` returns `cardDistribution`, `verseDistribution`, `reviewsDueCount`, `newVerseCount`, `versesDueCount`, `versesLearned` all engine-sourced