### PR TITLE
fix: maintenance tier doesn't pollute memorize queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,35 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-05-28
+
+Tier status (`Active` / `Maintenance` / `Paused`) becomes a **runtime filter** instead of a
+build-time mutation: flipping a tier in settings only changes what surfaces in the memorize and
+review queues, never card state or FSRS state. Existing `Active` cards in a tier the user just moved
+to `Maintenance` keep their review schedule; only their never-graduated siblings stop appearing in
+`/memorize`. MINOR per the additive-feature rubric — adds new public surface on `ReviewEngine` and a
+new `schedule::new_card_count` helper.
+
+### Added
+
+* `ReviewEngine.material_config: MaterialConfig` — retained from the build so queue helpers can
+  consult per-tier scopes at request time without callers threading it through.
+* `ReviewEngine.verse_status(verse_id)` — effective `ClubStatus` (Active / Maintenance / Paused) for
+  a verse, derived from its most-specific tier and the current `material_config`.
+* `schedule::new_card_count(engine)` — count of `New` cards eligible for the memorize queue. Was
+  previously a wasm-only inline filter; the move to core keeps the tier-status filter colocated with
+  `next_memorize_card` and `new_verse_count`.
+
+### Changed
+
+* `next_memorize_card`, `new_card_count`, `new_verse_count` — now skip cards whose verse's tier is
+  in `Maintenance` status (the user opted that tier out of new-card introduction but kept it in the
+  review scope). Paused-tier verses were already excluded at build time and stay that way; their
+  `test_states` persist in the database and reconnect when the tier flips back.
+* Stats helpers (`card_stability_histogram`, `verse_stability_histogram`, `due_review_count`,
+  `due_verse_count`, `learned_verse_count`) deliberately stay unfiltered — they reflect what's in
+  the engine, not what's queued.
+
 ## [0.3.0] — 2026-05-28
 
 Dashboard stats helpers: a bundle of pure-read scheduler queries that drive the new `/dashboard`

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -32,6 +32,11 @@ pub struct BuildResult {
     /// frontends can render any card without re-parsing the source
     /// `MaterialData`.
     pub verse_render_data: HashMap<u32, VerseRender>,
+    /// The `MaterialConfig` the cards were built under. Retained on the
+    /// `ReviewEngine` so the scheduler queue helpers can consult
+    /// per-tier `new_scope` / `review_scope` at request time without
+    /// requiring callers to thread it through every call.
+    pub material_config: MaterialConfig,
 }
 
 /// Parse a raw tier list (as written in `VerseData.clubs`) into the
@@ -348,10 +353,9 @@ pub fn build_with_config(
 
         let clubs = parse_tiers(&verse.clubs);
 
-        // Per-user club statuses: verses in a `Paused` club are excluded
-        // entirely from the build. TestStates persisted from prior sessions
-        // still live in the DB and are restored verbatim when the club
-        // becomes Active/Maintenance again.
+        // Paused verses are skipped entirely; their test_states stay
+        // in the DB and reconnect when the tier becomes Active or
+        // Maintenance again.
         if config.verse_is_paused(&clubs) {
             continue;
         }
@@ -516,6 +520,7 @@ pub fn build_with_config(
         tests,
         verse_atoms_data: verse_atoms_by_id,
         verse_render_data: verse_render_by_id,
+        material_config: *config,
     }
 }
 

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::builder::BuildResult;
 use crate::card::{Card, CardState, VerseAtoms};
 use crate::fsrs_bridge::FsrsBridge;
+use crate::material_config::{ClubStatus, MaterialConfig};
 use crate::render::VerseRender;
 use crate::test_kind::TestKey;
 use crate::test_state::TestState;
@@ -68,6 +69,10 @@ pub struct ReviewEngine {
     /// FTV word count, heading ranges, club tiers. Verse text is composed
     /// server-side from api.bible chapter HTML at request time.
     pub verse_render_data: HashMap<u32, VerseRender>,
+    /// Retained so scheduler queue helpers can honour per-tier
+    /// `new_scope` / `review_scope` at request time without callers
+    /// re-threading the config.
+    pub material_config: MaterialConfig,
 }
 
 impl ReviewEngine {
@@ -83,7 +88,26 @@ impl ReviewEngine {
             },
             verse_atoms_data: b.verse_atoms_data,
             verse_render_data: b.verse_render_data,
+            material_config: b.material_config,
         }
+    }
+
+    /// Effective club status for a verse's most-specific tier under
+    /// the current `material_config`. `None` for pseudo-verses with
+    /// no tier list. Paused verses never get cards built in the
+    /// first place, so this returns `Active` or `Maintenance` in
+    /// practice.
+    pub fn verse_status(&self, verse_id: u32) -> Option<ClubStatus> {
+        let elements = self.verse_index.elements_of(verse_id)?;
+        let tier = *elements.clubs.first()?;
+        Some(self.material_config.effective_status(tier))
+    }
+
+    /// True when the verse may surface in the memorize queue —
+    /// every tier status except `Maintenance`. Pseudo-verses (no
+    /// tier) pass through.
+    pub fn verse_active_for_memorize(&self, verse_id: u32) -> bool {
+        !matches!(self.verse_status(verse_id), Some(ClubStatus::Maintenance))
     }
 
     /// Borrow the per-verse render data for a verse, or `None` if the verse

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -162,6 +162,12 @@ pub fn new_verse_count(engine: &ReviewEngine) -> u32 {
         if !is_verse_content_card(&card.kind) {
             continue;
         }
+        if seen.contains(&card.verse_id) {
+            continue;
+        }
+        if !engine.verse_active_for_memorize(card.verse_id) {
+            continue;
+        }
         seen.insert(card.verse_id);
     }
     seen.len() as u32
@@ -270,8 +276,20 @@ pub fn next_memorize_card(engine: &ReviewEngine, _now_secs: i64) -> Option<CardI
     engine
         .cards
         .iter()
-        .find(|c| matches!(c.state, CardState::New))
+        .find(|c| matches!(c.state, CardState::New) && engine.verse_active_for_memorize(c.verse_id))
         .map(|c| c.id)
+}
+
+/// Count of `New` cards eligible for the memorize queue — every
+/// `New` card whose verse's tier is currently `Active`. Drives the
+/// "N to memorize" nudge in the web UI nav and the dashboard.
+pub fn new_card_count(engine: &ReviewEngine) -> u32 {
+    engine
+        .cards
+        .iter()
+        .filter(|c| matches!(c.state, CardState::New))
+        .filter(|c| engine.verse_active_for_memorize(c.verse_id))
+        .count() as u32
 }
 
 /// Pick a card from the relearning priority lane: any `Active` card that has
@@ -364,6 +382,111 @@ mod tests {
             }"#,
         )
         .unwrap()
+    }
+
+    fn sample_material_mixed_tiers() -> MaterialData {
+        // Verse 16 → Club150; verse 17 → Club300. Lets a config with
+        // 150 Active + 300 Maintenance carve the memorize queue cleanly
+        // along verse_id.
+        serde_json::from_str(
+            r#"{
+                "year": 3,
+                "books": ["John"],
+                "chapters": [
+                    {"book": "John", "number": 3, "start_verse": 16, "end_verse": 17}
+                ],
+                "verses": [
+                    {
+                        "book": "John", "chapter": 3, "verse": 16,
+                        "phraseWordCounts": [2, 2], "annotations": [],
+                        "ftvWordCount": null, "clubs": [150]
+                    },
+                    {
+                        "book": "John", "chapter": 3, "verse": 17,
+                        "phraseWordCounts": [2, 3], "annotations": [],
+                        "ftvWordCount": null, "clubs": [300]
+                    }
+                ],
+                "headings": []
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn config_150_active_300_maintenance() -> crate::material_config::MaterialConfig {
+        crate::material_config::MaterialConfig {
+            new_scope: crate::material_config::TierScope::Up150,
+            review_scope: crate::material_config::TierScope::Up300,
+            ..crate::material_config::MaterialConfig::default()
+        }
+    }
+
+    #[test]
+    fn next_memorize_card_skips_maintenance_tier_verses() {
+        // Verse 17 (Club300) is Maintenance; the helper must hand
+        // back a card anchored to verse 16 (Club150 → Active).
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &config_150_active_300_maintenance(), 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        let card_id = next_memorize_card(&engine, 0).expect("a card should be due");
+        assert_eq!(engine.card(card_id).unwrap().verse_id, 0);
+    }
+
+    #[test]
+    fn new_card_count_excludes_maintenance_tier_verses() {
+        let m = sample_material_mixed_tiers();
+        let r_all_active = crate::builder::build_with_config(
+            &m,
+            &crate::material_config::MaterialConfig::default(),
+            0,
+        );
+        let engine_all = ReviewEngine::new(r_all_active, 0.9);
+        let total_when_all_active = new_card_count(&engine_all);
+
+        let r_mixed =
+            crate::builder::build_with_config(&m, &config_150_active_300_maintenance(), 0);
+        let engine_mixed = ReviewEngine::new(r_mixed, 0.9);
+        let count_with_300_maintenance = new_card_count(&engine_mixed);
+
+        assert!(
+            count_with_300_maintenance < total_when_all_active,
+            "expected fewer memorize cards when Club300 is in Maintenance: \
+             all-active={total_when_all_active}, mixed={count_with_300_maintenance}",
+        );
+        for c in &engine_mixed.cards {
+            if !matches!(c.state, CardState::New) {
+                continue;
+            }
+            if !engine_mixed.verse_active_for_memorize(c.verse_id) {
+                continue;
+            }
+            let elements = engine_mixed.verse_index.elements_of(c.verse_id);
+            let tier = elements.and_then(|e| e.clubs.first().copied());
+            assert!(
+                tier.is_none() || tier == Some(crate::element::ClubTier::Club150),
+                "card {c:?} should be Club150 or pseudo, got tier {tier:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn new_verse_count_excludes_maintenance_tier_verses() {
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &config_150_active_300_maintenance(), 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        // Two verses exist; only Club150 (verse_id 0) should count.
+        assert_eq!(new_verse_count(&engine), 1);
+    }
+
+    #[test]
+    fn card_stability_histogram_stays_unfiltered_across_tiers() {
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &config_150_active_300_maintenance(), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.graduate_all();
+        let h = card_stability_histogram(&engine);
+        let total = h.weak + h.learning + h.familiar + h.strong + h.mastered;
+        assert_eq!(total as usize, engine.cards.len());
     }
 
     #[test]

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,12 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-05-28
+
+Lockstep bump for `verse-vault-core@0.4.0`. `WasmEngine.new_card_count` now delegates to the core
+helper (same signature, tighter behaviour — filters out Maintenance-tier verses). No new exposed
+methods on `WasmEngine`; wire shapes unchanged.
+
 ## [0.3.0] — 2026-05-28
 
 Wrappers for the new `verse-vault-core@0.3.0` dashboard stats helpers. MINOR per this changelog's

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -16,7 +16,7 @@ use verse_vault_core::render::{HeadingRender, VerseRender};
 use verse_vault_core::schedule::{
     card_stability_histogram as schedule_card_stability_histogram,
     due_review_count as schedule_due_review_count, due_verse_count as schedule_due_verse_count,
-    learned_verse_count as schedule_learned_verse_count,
+    learned_verse_count as schedule_learned_verse_count, new_card_count as schedule_new_card_count,
     new_verse_count as schedule_new_verse_count, next_card,
     next_memorize_card as schedule_next_memorize_card, next_relearn_card,
     verse_stability_histogram as schedule_verse_stability_histogram,
@@ -640,14 +640,10 @@ impl WasmEngine {
         self.engine.graduate_verse(verse_id) as u32
     }
 
-    /// Count of `New` cards still awaiting memorize. Drives the
-    /// "N to memorize" nudge in the web UI nav.
+    /// Count of `New` cards eligible for the memorize queue. Drives
+    /// the "N to memorize" nudge in the web UI nav.
     pub fn new_card_count(&self) -> u32 {
-        self.engine
-            .cards
-            .iter()
-            .filter(|c| matches!(c.state, verse_vault_core::card::CardState::New))
-            .count() as u32
+        schedule_new_card_count(&self.engine)
     }
 
     /// Render data for a card: kind, verse_id, plus the verse's render data


### PR DESCRIPTION
## Summary

Pre-fix: a verse in a tier the user moved to **Maintenance** (e.g. "150 active, 300 maintenance") still had its never-graduated New cards surfaced through `next_memorize_card`, `new_card_count`, and `new_verse_count`. The user opted that tier out of new-card introduction but the engine kept adding new cards from it.

Fix: tier status (`Active` / `Maintenance` / `Paused`) becomes a **runtime filter**. Flipping a tier in settings only changes what surfaces in the memorize/review queues, never card state or FSRS state.

- Build emits cards unconditionally for Active and Maintenance tiers.
- Queue helpers skip Maintenance-tier verses on the memorize side.
- Review helpers are unchanged — already-graduated Maintenance-tier cards stay reviewable.
- Paused tiers stay build-time skipped (their `test_states` persist in the database and reconnect when the tier becomes Active/Maintenance again).

## Engine surface

- `ReviewEngine` retains `MaterialConfig` (was build-time only).
- `ReviewEngine.verse_status(verse_id)` — effective `ClubStatus` for a verse.
- `schedule::new_card_count(engine)` moved from inline wasm to core so the tier filter lives next to `next_memorize_card` and `new_verse_count`.

## Bundled algorithm contract

- `verse-vault-core` 0.3.0 → 0.4.0 (MINOR: new public surface on `ReviewEngine`, new `schedule::new_card_count` helper)
- `verse-vault-wasm` 0.3.0 → 0.4.0 (lockstep; `WasmEngine.new_card_count` behaviour tightens via core, no new exposed methods)

## Test plan

- [ ] Required CI green (rust, typos, dprint)
- [ ] Manually verify: with `newScope=up150` and `reviewScope=up300`, Club300 verses don't appear in `/memorize` but already-graduated Club300 verses still surface in `/review`
- [ ] Dashboard's "to memorize: X" count drops when 300 is toggled to Maintenance
- [ ] Dashboard's stability tiles still include Club300 active cards (stats stay unfiltered)