### PR TITLE
feat: NIV side-decks for all 8 years

### DIFF
--- a/data/1-gepc-niv.json
+++ b/data/1-gepc-niv.json
@@ -1,0 +1,10793 @@
+{
+  "year": 1,
+  "books": [
+    "Galatians",
+    "Ephesians",
+    "Philippians",
+    "Colossians"
+  ],
+  "chapters": [
+    {
+      "book": "Colossians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "Colossians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Colossians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Colossians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "Ephesians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Ephesians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Ephesians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Ephesians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 32
+    },
+    {
+      "book": "Ephesians",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "Ephesians",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "Galatians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "Galatians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Galatians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "Galatians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Galatians",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 26
+    },
+    {
+      "book": "Galatians",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "Philippians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 30
+    },
+    {
+      "book": "Philippians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 30
+    },
+    {
+      "book": "Philippians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Philippians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 23
+    }
+  ],
+  "verses": [
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 12,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Colossians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 12,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 25,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 26,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 27,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 28,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 29,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 4,
+      "verse": 32,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 23,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 24,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 27,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 30,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 31,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 32,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 5,
+      "verse": 33,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 21,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 22,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 23,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Ephesians",
+      "chapter": 6,
+      "verse": 24,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        52
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 46,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 50,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 51,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        58
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 26,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 27,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 28,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 3,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 26,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 27,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 28,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 29,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 30,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 4,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 23,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 24,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 25,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 5,
+      "verse": 26,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Galatians",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 27,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 2,
+      "verse": 30,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Philippians",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    }
+  ],
+  "headings": [
+    {
+      "book": "Colossians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 2
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 1,
+      "startVerse": 3,
+      "endChapter": 1,
+      "endVerse": 8
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 1,
+      "startVerse": 9,
+      "endChapter": 1,
+      "endVerse": 18
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 1,
+      "startVerse": 19,
+      "endChapter": 1,
+      "endVerse": 23
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 1,
+      "startVerse": 24,
+      "endChapter": 1,
+      "endVerse": 29
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 23
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 11
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 3,
+      "startVerse": 12,
+      "endChapter": 3,
+      "endVerse": 17
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 3,
+      "startVerse": 18,
+      "endChapter": 4,
+      "endVerse": 1
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 4,
+      "startVerse": 2,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 15
+    },
+    {
+      "book": "Colossians",
+      "startChapter": 4,
+      "startVerse": 16,
+      "endChapter": 4,
+      "endVerse": 18
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 2
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 1,
+      "startVerse": 3,
+      "endChapter": 1,
+      "endVerse": 14
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 1,
+      "startVerse": 15,
+      "endChapter": 1,
+      "endVerse": 23
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 13
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 2,
+      "startVerse": 14,
+      "endChapter": 2,
+      "endVerse": 18
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 2,
+      "startVerse": 19,
+      "endChapter": 2,
+      "endVerse": 22
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 7
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 3,
+      "startVerse": 8,
+      "endChapter": 3,
+      "endVerse": 13
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 3,
+      "startVerse": 14,
+      "endChapter": 3,
+      "endVerse": 21
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 16
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 4,
+      "startVerse": 17,
+      "endChapter": 4,
+      "endVerse": 24
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 4,
+      "startVerse": 25,
+      "endChapter": 4,
+      "endVerse": 32
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 7
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 5,
+      "startVerse": 8,
+      "endChapter": 5,
+      "endVerse": 14
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 5,
+      "startVerse": 15,
+      "endChapter": 5,
+      "endVerse": 21
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 5,
+      "startVerse": 22,
+      "endChapter": 5,
+      "endVerse": 33
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 4
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 6,
+      "startVerse": 5,
+      "endChapter": 6,
+      "endVerse": 9
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 6,
+      "startVerse": 10,
+      "endChapter": 6,
+      "endVerse": 20
+    },
+    {
+      "book": "Ephesians",
+      "startChapter": 6,
+      "startVerse": 21,
+      "endChapter": 6,
+      "endVerse": 24
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 5
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 1,
+      "startVerse": 6,
+      "endChapter": 1,
+      "endVerse": 10
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 1,
+      "startVerse": 11,
+      "endChapter": 1,
+      "endVerse": 17
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 1,
+      "startVerse": 18,
+      "endChapter": 1,
+      "endVerse": 24
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 21
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 9
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 3,
+      "startVerse": 10,
+      "endChapter": 3,
+      "endVerse": 14
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 3,
+      "startVerse": 15,
+      "endChapter": 3,
+      "endVerse": 18
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 3,
+      "startVerse": 19,
+      "endChapter": 3,
+      "endVerse": 25
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 3,
+      "startVerse": 26,
+      "endChapter": 4,
+      "endVerse": 7
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 4,
+      "startVerse": 8,
+      "endChapter": 4,
+      "endVerse": 20
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 4,
+      "startVerse": 21,
+      "endChapter": 4,
+      "endVerse": 31
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 6
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 5,
+      "startVerse": 7,
+      "endChapter": 5,
+      "endVerse": 15
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 5,
+      "startVerse": 16,
+      "endChapter": 5,
+      "endVerse": 26
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 5
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 6,
+      "startVerse": 6,
+      "endChapter": 6,
+      "endVerse": 10
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 6,
+      "startVerse": 11,
+      "endChapter": 6,
+      "endVerse": 15
+    },
+    {
+      "book": "Galatians",
+      "startChapter": 6,
+      "startVerse": 16,
+      "endChapter": 6,
+      "endVerse": 18
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 2
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 1,
+      "startVerse": 3,
+      "endChapter": 1,
+      "endVerse": 11
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 1,
+      "startVerse": 12,
+      "endChapter": 1,
+      "endVerse": 18
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 1,
+      "startVerse": 19,
+      "endChapter": 1,
+      "endVerse": 26
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 1,
+      "startVerse": 27,
+      "endChapter": 1,
+      "endVerse": 30
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 4
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 2,
+      "startVerse": 5,
+      "endChapter": 2,
+      "endVerse": 11
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 2,
+      "startVerse": 12,
+      "endChapter": 2,
+      "endVerse": 18
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 2,
+      "startVerse": 19,
+      "endChapter": 2,
+      "endVerse": 24
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 2,
+      "startVerse": 25,
+      "endChapter": 2,
+      "endVerse": 30
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 11
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 3,
+      "startVerse": 12,
+      "endChapter": 3,
+      "endVerse": 16
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 3,
+      "startVerse": 17,
+      "endChapter": 4,
+      "endVerse": 1
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 4,
+      "startVerse": 2,
+      "endChapter": 4,
+      "endVerse": 7
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 4,
+      "startVerse": 8,
+      "endChapter": 4,
+      "endVerse": 9
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 4,
+      "startVerse": 10,
+      "endChapter": 4,
+      "endVerse": 20
+    },
+    {
+      "book": "Philippians",
+      "startChapter": 4,
+      "startVerse": 21,
+      "endChapter": 4,
+      "endVerse": 23
+    }
+  ]
+}

--- a/data/2-nt-survey-niv.json
+++ b/data/2-nt-survey-niv.json
@@ -1,0 +1,16247 @@
+{
+  "year": 2,
+  "books": [
+    "Matthew",
+    "Acts",
+    "1 Thessalonians",
+    "1 Timothy",
+    "2 Timothy",
+    "Titus",
+    "1 John",
+    "Revelation"
+  ],
+  "chapters": [
+    {
+      "book": "1 John",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 10
+    },
+    {
+      "book": "1 John",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "1 John",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "1 Thessalonians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 10
+    },
+    {
+      "book": "1 Thessalonians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "1 Thessalonians",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 28
+    },
+    {
+      "book": "1 Timothy",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "2 Timothy",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "Acts",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 26
+    },
+    {
+      "book": "Acts",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 47
+    },
+    {
+      "book": "Acts",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Acts",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Acts",
+      "number": 15,
+      "start_verse": 1,
+      "end_verse": 41
+    },
+    {
+      "book": "Acts",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 40
+    },
+    {
+      "book": "Matthew",
+      "number": 1,
+      "start_verse": 18,
+      "end_verse": 25
+    },
+    {
+      "book": "Matthew",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Matthew",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Matthew",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 48
+    },
+    {
+      "book": "Matthew",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 34
+    },
+    {
+      "book": "Matthew",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "Matthew",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Matthew",
+      "number": 16,
+      "start_verse": 13,
+      "end_verse": 28
+    },
+    {
+      "book": "Matthew",
+      "number": 27,
+      "start_verse": 1,
+      "end_verse": 66
+    },
+    {
+      "book": "Matthew",
+      "number": 28,
+      "start_verse": 1,
+      "end_verse": 20
+    },
+    {
+      "book": "Revelation",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 20
+    },
+    {
+      "book": "Revelation",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 11
+    },
+    {
+      "book": "Revelation",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "Revelation",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "Revelation",
+      "number": 19,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Revelation",
+      "number": 20,
+      "start_verse": 1,
+      "end_verse": 15
+    },
+    {
+      "book": "Revelation",
+      "number": 21,
+      "start_verse": 1,
+      "end_verse": 27
+    },
+    {
+      "book": "Revelation",
+      "number": 22,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Titus",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 15
+    }
+  ],
+  "verses": [
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        50
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 27,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 John",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        2
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        2
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 22,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 23,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 24,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 25,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 26,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 27,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Thessalonians",
+      "chapter": 5,
+      "verse": 28,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Timothy",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Timothy",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 27,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 30,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 31,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 32,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 33,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 34,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 35,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 36,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 37,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 38,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 39,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 40,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 41,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 42,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 43,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 44,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 45,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 46,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 2,
+      "verse": 47,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 29,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 9,
+      "verse": 31,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 48,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 23,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 24,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 12,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 3,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 6,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 7,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 13,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 15,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 18,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 20,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 22,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 23,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 27,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 28,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 29,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 30,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 31,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 32,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 33,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 34,
+      "phraseWordCounts": [],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 35,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 36,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 37,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 38,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 39,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 40,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 15,
+      "verse": 41,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 26,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 27,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 28,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 29,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 30,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 31,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 32,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 33,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 34,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 35,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 36,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 37,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 38,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 39,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Acts",
+      "chapter": 16,
+      "verse": 40,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 11,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 11,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 4,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 22,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 25,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 27,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 29,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 30,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 31,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 32,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 33,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 35,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 36,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 37,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 38,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 39,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 40,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 41,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 42,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 43,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 44,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 45,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 46,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 47,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 5,
+      "verse": 48,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 24,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 25,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 26,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 27,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 29,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 30,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 32,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 6,
+      "verse": 34,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 20,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 21,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 22,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 23,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 25,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 17,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 26,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 27,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 17,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 28,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 7,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 15,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 17,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 18,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 19,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 22,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 13,
+      "verse": 23,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        51
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 26,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 27,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 16,
+      "verse": 28,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 3,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 6,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 16,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 19,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 24,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 25,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 26,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 27,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 28,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 29,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 30,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 31,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 32,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 33,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 35,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 36,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 37,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 38,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 39,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 40,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 41,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 42,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 43,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 44,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 45,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 46,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 47,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 48,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 49,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 50,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 51,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 52,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 53,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 54,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 55,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 56,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 57,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 58,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 59,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 60,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 61,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 62,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 63,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 64,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 65,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 27,
+      "verse": 66,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 3,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 4,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 8,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 9,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 17,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Matthew",
+      "chapter": 28,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        48
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 2,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 10,
+      "phraseWordCounts": [
+        52
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 12,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 15,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 18,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 20,
+      "phraseWordCounts": [
+        52
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 19,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 3,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 4,
+      "phraseWordCounts": [
+        71
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 47,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 65,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 6,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 8,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 10,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 12,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 13,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 20,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 3,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 4,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 6,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 8,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 9,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 16,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 20,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 23,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 24,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 26,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 21,
+      "verse": 27,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 2,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 3,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 5,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 6,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 8,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 9,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 11,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 17,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 18,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 19,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Revelation",
+      "chapter": 22,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Titus",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    }
+  ],
+  "headings": [
+    {
+      "book": "1 John",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 4
+    },
+    {
+      "book": "1 John",
+      "startChapter": 1,
+      "startVerse": 5,
+      "endChapter": 2,
+      "endVerse": 2
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 3,
+      "endChapter": 2,
+      "endVerse": 11
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 12,
+      "endChapter": 2,
+      "endVerse": 14
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 15,
+      "endChapter": 2,
+      "endVerse": 17
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 18,
+      "endChapter": 2,
+      "endVerse": 23
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 24,
+      "endChapter": 2,
+      "endVerse": 27
+    },
+    {
+      "book": "1 John",
+      "startChapter": 2,
+      "startVerse": 28,
+      "endChapter": 3,
+      "endVerse": 3
+    },
+    {
+      "book": "1 John",
+      "startChapter": 3,
+      "startVerse": 24,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "1 John",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 11
+    },
+    {
+      "book": "1 John",
+      "startChapter": 4,
+      "startVerse": 12,
+      "endChapter": 4,
+      "endVerse": 16
+    },
+    {
+      "book": "1 John",
+      "startChapter": 4,
+      "startVerse": 17,
+      "endChapter": 4,
+      "endVerse": 19
+    },
+    {
+      "book": "1 John",
+      "startChapter": 4,
+      "startVerse": 20,
+      "endChapter": 5,
+      "endVerse": 5
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 1
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 1,
+      "startVerse": 2,
+      "endChapter": 1,
+      "endVerse": 10
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 8
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 4,
+      "startVerse": 9,
+      "endChapter": 4,
+      "endVerse": 12
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 4,
+      "startVerse": 13,
+      "endChapter": 4,
+      "endVerse": 18
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 5,
+      "startVerse": 12,
+      "endChapter": 5,
+      "endVerse": 22
+    },
+    {
+      "book": "1 Thessalonians",
+      "startChapter": 5,
+      "startVerse": 23,
+      "endChapter": 5,
+      "endVerse": 28
+    },
+    {
+      "book": "1 Timothy",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 5
+    },
+    {
+      "book": "1 Timothy",
+      "startChapter": 4,
+      "startVerse": 6,
+      "endChapter": 4,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Timothy",
+      "startChapter": 4,
+      "startVerse": 12,
+      "endChapter": 4,
+      "endVerse": 16
+    },
+    {
+      "book": "2 Timothy",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 9
+    },
+    {
+      "book": "2 Timothy",
+      "startChapter": 3,
+      "startVerse": 10,
+      "endChapter": 3,
+      "endVerse": 17
+    },
+    {
+      "book": "Acts",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 3
+    },
+    {
+      "book": "Acts",
+      "startChapter": 1,
+      "startVerse": 4,
+      "endChapter": 1,
+      "endVerse": 8
+    },
+    {
+      "book": "Acts",
+      "startChapter": 1,
+      "startVerse": 9,
+      "endChapter": 1,
+      "endVerse": 11
+    },
+    {
+      "book": "Acts",
+      "startChapter": 1,
+      "startVerse": 12,
+      "endChapter": 1,
+      "endVerse": 14
+    },
+    {
+      "book": "Acts",
+      "startChapter": 1,
+      "startVerse": 15,
+      "endChapter": 1,
+      "endVerse": 26
+    },
+    {
+      "book": "Acts",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 4
+    },
+    {
+      "book": "Acts",
+      "startChapter": 2,
+      "startVerse": 5,
+      "endChapter": 2,
+      "endVerse": 13
+    },
+    {
+      "book": "Acts",
+      "startChapter": 2,
+      "startVerse": 14,
+      "endChapter": 2,
+      "endVerse": 39
+    },
+    {
+      "book": "Acts",
+      "startChapter": 2,
+      "startVerse": 40,
+      "endChapter": 2,
+      "endVerse": 47
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 9
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 10,
+      "endChapter": 9,
+      "endVerse": 19
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 20,
+      "endChapter": 9,
+      "endVerse": 22
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 23,
+      "endChapter": 9,
+      "endVerse": 25
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 26,
+      "endChapter": 9,
+      "endVerse": 30
+    },
+    {
+      "book": "Acts",
+      "startChapter": 9,
+      "startVerse": 31,
+      "endChapter": 9,
+      "endVerse": 31
+    },
+    {
+      "book": "Acts",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 4
+    },
+    {
+      "book": "Acts",
+      "startChapter": 12,
+      "startVerse": 5,
+      "endChapter": 12,
+      "endVerse": 19
+    },
+    {
+      "book": "Acts",
+      "startChapter": 12,
+      "startVerse": 20,
+      "endChapter": 12,
+      "endVerse": 24
+    },
+    {
+      "book": "Acts",
+      "startChapter": 12,
+      "startVerse": 25,
+      "endChapter": 13,
+      "endVerse": 3
+    },
+    {
+      "book": "Acts",
+      "startChapter": 15,
+      "startVerse": 1,
+      "endChapter": 15,
+      "endVerse": 5
+    },
+    {
+      "book": "Acts",
+      "startChapter": 15,
+      "startVerse": 6,
+      "endChapter": 15,
+      "endVerse": 21
+    },
+    {
+      "book": "Acts",
+      "startChapter": 15,
+      "startVerse": 22,
+      "endChapter": 15,
+      "endVerse": 29
+    },
+    {
+      "book": "Acts",
+      "startChapter": 15,
+      "startVerse": 30,
+      "endChapter": 15,
+      "endVerse": 35
+    },
+    {
+      "book": "Acts",
+      "startChapter": 15,
+      "startVerse": 36,
+      "endChapter": 15,
+      "endVerse": 41
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 1,
+      "endChapter": 16,
+      "endVerse": 5
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 6,
+      "endChapter": 16,
+      "endVerse": 10
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 11,
+      "endChapter": 16,
+      "endVerse": 15
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 16,
+      "endChapter": 16,
+      "endVerse": 24
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 25,
+      "endChapter": 16,
+      "endVerse": 34
+    },
+    {
+      "book": "Acts",
+      "startChapter": 16,
+      "startVerse": 35,
+      "endChapter": 16,
+      "endVerse": 40
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 1,
+      "startVerse": 18,
+      "endChapter": 1,
+      "endVerse": 25
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 12
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 2,
+      "startVerse": 13,
+      "endChapter": 2,
+      "endVerse": 15
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 2,
+      "startVerse": 16,
+      "endChapter": 2,
+      "endVerse": 18
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 2,
+      "startVerse": 19,
+      "endChapter": 2,
+      "endVerse": 23
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 11
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 4,
+      "startVerse": 12,
+      "endChapter": 4,
+      "endVerse": 17
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 4,
+      "startVerse": 18,
+      "endChapter": 4,
+      "endVerse": 22
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 4,
+      "startVerse": 23,
+      "endChapter": 4,
+      "endVerse": 25
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 12
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 13,
+      "endChapter": 5,
+      "endVerse": 16
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 17,
+      "endChapter": 5,
+      "endVerse": 20
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 21,
+      "endChapter": 5,
+      "endVerse": 26
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 27,
+      "endChapter": 5,
+      "endVerse": 30
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 31,
+      "endChapter": 5,
+      "endVerse": 32
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 33,
+      "endChapter": 5,
+      "endVerse": 37
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 38,
+      "endChapter": 5,
+      "endVerse": 42
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 5,
+      "startVerse": 43,
+      "endChapter": 5,
+      "endVerse": 48
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 4
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 5,
+      "endChapter": 6,
+      "endVerse": 15
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 16,
+      "endChapter": 6,
+      "endVerse": 18
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 19,
+      "endChapter": 6,
+      "endVerse": 21
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 22,
+      "endChapter": 6,
+      "endVerse": 23
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 24,
+      "endChapter": 6,
+      "endVerse": 24
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 6,
+      "startVerse": 25,
+      "endChapter": 6,
+      "endVerse": 34
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 6
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 7,
+      "endChapter": 7,
+      "endVerse": 12
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 13,
+      "endChapter": 7,
+      "endVerse": 14
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 15,
+      "endChapter": 7,
+      "endVerse": 20
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 21,
+      "endChapter": 7,
+      "endVerse": 23
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 7,
+      "startVerse": 24,
+      "endChapter": 7,
+      "endVerse": 29
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 9
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 13,
+      "startVerse": 10,
+      "endChapter": 13,
+      "endVerse": 17
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 13,
+      "startVerse": 18,
+      "endChapter": 13,
+      "endVerse": 23
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 16,
+      "startVerse": 13,
+      "endChapter": 16,
+      "endVerse": 20
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 16,
+      "startVerse": 21,
+      "endChapter": 16,
+      "endVerse": 23
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 16,
+      "startVerse": 24,
+      "endChapter": 16,
+      "endVerse": 28
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 1,
+      "endChapter": 27,
+      "endVerse": 2
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 3,
+      "endChapter": 27,
+      "endVerse": 10
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 11,
+      "endChapter": 27,
+      "endVerse": 14
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 15,
+      "endChapter": 27,
+      "endVerse": 26
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 27,
+      "endChapter": 27,
+      "endVerse": 31
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 32,
+      "endChapter": 27,
+      "endVerse": 44
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 45,
+      "endChapter": 27,
+      "endVerse": 56
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 57,
+      "endChapter": 27,
+      "endVerse": 61
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 27,
+      "startVerse": 62,
+      "endChapter": 27,
+      "endVerse": 66
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 28,
+      "startVerse": 1,
+      "endChapter": 28,
+      "endVerse": 8
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 28,
+      "startVerse": 9,
+      "endChapter": 28,
+      "endVerse": 10
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 28,
+      "startVerse": 11,
+      "endChapter": 28,
+      "endVerse": 15
+    },
+    {
+      "book": "Matthew",
+      "startChapter": 28,
+      "startVerse": 16,
+      "endChapter": 28,
+      "endVerse": 20
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 3
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 1,
+      "startVerse": 4,
+      "endChapter": 1,
+      "endVerse": 8
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 1,
+      "startVerse": 9,
+      "endChapter": 1,
+      "endVerse": 20
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 11
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 7
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 5,
+      "startVerse": 8,
+      "endChapter": 5,
+      "endVerse": 14
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 2
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 3,
+      "endChapter": 6,
+      "endVerse": 4
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 5,
+      "endChapter": 6,
+      "endVerse": 6
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 7,
+      "endChapter": 6,
+      "endVerse": 8
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 9,
+      "endChapter": 6,
+      "endVerse": 11
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 6,
+      "startVerse": 12,
+      "endChapter": 6,
+      "endVerse": 17
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 19,
+      "startVerse": 1,
+      "endChapter": 19,
+      "endVerse": 10
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 19,
+      "startVerse": 11,
+      "endChapter": 19,
+      "endVerse": 16
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 19,
+      "startVerse": 17,
+      "endChapter": 19,
+      "endVerse": 21
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 20,
+      "startVerse": 1,
+      "endChapter": 20,
+      "endVerse": 3
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 20,
+      "startVerse": 4,
+      "endChapter": 20,
+      "endVerse": 6
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 20,
+      "startVerse": 7,
+      "endChapter": 20,
+      "endVerse": 10
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 20,
+      "startVerse": 11,
+      "endChapter": 20,
+      "endVerse": 15
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 21,
+      "startVerse": 1,
+      "endChapter": 21,
+      "endVerse": 8
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 21,
+      "startVerse": 9,
+      "endChapter": 21,
+      "endVerse": 21
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 21,
+      "startVerse": 22,
+      "endChapter": 21,
+      "endVerse": 27
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 22,
+      "startVerse": 1,
+      "endChapter": 22,
+      "endVerse": 5
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 22,
+      "startVerse": 6,
+      "endChapter": 22,
+      "endVerse": 11
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 22,
+      "startVerse": 12,
+      "endChapter": 22,
+      "endVerse": 17
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 22,
+      "startVerse": 18,
+      "endChapter": 22,
+      "endVerse": 19
+    },
+    {
+      "book": "Revelation",
+      "startChapter": 22,
+      "startVerse": 20,
+      "endChapter": 22,
+      "endVerse": 21
+    },
+    {
+      "book": "Titus",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Titus",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 15
+    }
+  ]
+}

--- a/data/3-corinthians-niv.json
+++ b/data/3-corinthians-niv.json
@@ -1,0 +1,14534 @@
+{
+  "year": 3,
+  "books": [
+    "1 Corinthians",
+    "2 Corinthians"
+  ],
+  "chapters": [
+    {
+      "book": "1 Corinthians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 20
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 40
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 8,
+      "start_verse": 1,
+      "end_verse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 27
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 34
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 14,
+      "start_verse": 1,
+      "end_verse": 40
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 15,
+      "start_verse": 1,
+      "end_verse": 58
+    },
+    {
+      "book": "1 Corinthians",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 8,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 15
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "2 Corinthians",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 14
+    }
+  ],
+  "verses": [
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        54
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 45,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 23,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 22,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 23,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 24,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 27,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 28,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 29,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 30,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 31,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 32,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 33,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 34,
+      "phraseWordCounts": [
+        48
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 35,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 36,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 37,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 38,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 39,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 7,
+      "verse": 40,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 3,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 6,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 7,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 10,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 8,
+      "verse": 13,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 21,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 23,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 24,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 25,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 26,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 28,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 30,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 31,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 32,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 10,
+      "verse": 33,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 11,
+      "verse": 34,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 22,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 23,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 25,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 27,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 28,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 29,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 30,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 12,
+      "verse": 31,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 2,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 5,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 6,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 7,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 9,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 13,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 14,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 15,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 16,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 17,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 21,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 23,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 25,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 26,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 27,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 28,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 29,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 30,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 31,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 32,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 33,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 34,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 35,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 36,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 37,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 38,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 39,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 14,
+      "verse": 40,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 2,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 7,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 10,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 12,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 15,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 18,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 20,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 25,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 26,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 27,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 28,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 29,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 30,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 32,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 33,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 34,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 35,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 36,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 37,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 38,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 39,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 40,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 41,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 42,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 43,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 44,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 45,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 46,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 47,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 48,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 49,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 50,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 51,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 52,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 53,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 54,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 55,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 56,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 57,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 15,
+      "verse": 58,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        4
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Corinthians",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 7,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 10,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 14,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 15,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 18,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 19,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 22,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 8,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        48
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 45,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 46,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Corinthians",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    }
+  ],
+  "headings": [
+    {
+      "book": "1 Corinthians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 4
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 1,
+      "startVerse": 10,
+      "endChapter": 1,
+      "endVerse": 17
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 1,
+      "startVerse": 18,
+      "endChapter": 1,
+      "endVerse": 25
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 1,
+      "startVerse": 26,
+      "endChapter": 1,
+      "endVerse": 31
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 5
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 2,
+      "startVerse": 6,
+      "endChapter": 2,
+      "endVerse": 16
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 4
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 3,
+      "startVerse": 5,
+      "endChapter": 3,
+      "endVerse": 17
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 3,
+      "startVerse": 18,
+      "endChapter": 3,
+      "endVerse": 23
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 5
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 4,
+      "startVerse": 6,
+      "endChapter": 4,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 4,
+      "startVerse": 14,
+      "endChapter": 4,
+      "endVerse": 21
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 8
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 5,
+      "startVerse": 9,
+      "endChapter": 5,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 6,
+      "startVerse": 12,
+      "endChapter": 6,
+      "endVerse": 20
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 9
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 7,
+      "startVerse": 10,
+      "endChapter": 7,
+      "endVerse": 16
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 7,
+      "startVerse": 17,
+      "endChapter": 7,
+      "endVerse": 24
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 7,
+      "startVerse": 25,
+      "endChapter": 7,
+      "endVerse": 40
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 8,
+      "startVerse": 1,
+      "endChapter": 8,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 18
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 9,
+      "startVerse": 19,
+      "endChapter": 9,
+      "endVerse": 23
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 9,
+      "startVerse": 24,
+      "endChapter": 9,
+      "endVerse": 27
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 10,
+      "startVerse": 14,
+      "endChapter": 10,
+      "endVerse": 22
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 11,
+      "startVerse": 2,
+      "endChapter": 11,
+      "endVerse": 16
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 11,
+      "startVerse": 17,
+      "endChapter": 11,
+      "endVerse": 22
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 11,
+      "startVerse": 23,
+      "endChapter": 11,
+      "endVerse": 26
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 11,
+      "startVerse": 27,
+      "endChapter": 11,
+      "endVerse": 34
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 12,
+      "startVerse": 12,
+      "endChapter": 12,
+      "endVerse": 31
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 14,
+      "startVerse": 1,
+      "endChapter": 14,
+      "endVerse": 5
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 14,
+      "startVerse": 6,
+      "endChapter": 14,
+      "endVerse": 19
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 14,
+      "startVerse": 20,
+      "endChapter": 14,
+      "endVerse": 25
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 14,
+      "startVerse": 26,
+      "endChapter": 14,
+      "endVerse": 40
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 1,
+      "endChapter": 15,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 12,
+      "endChapter": 15,
+      "endVerse": 19
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 20,
+      "endChapter": 15,
+      "endVerse": 28
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 29,
+      "endChapter": 15,
+      "endVerse": 34
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 35,
+      "endChapter": 15,
+      "endVerse": 49
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 15,
+      "startVerse": 50,
+      "endChapter": 15,
+      "endVerse": 58
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 16,
+      "startVerse": 1,
+      "endChapter": 16,
+      "endVerse": 4
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 16,
+      "startVerse": 5,
+      "endChapter": 16,
+      "endVerse": 12
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 16,
+      "startVerse": 13,
+      "endChapter": 16,
+      "endVerse": 18
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 16,
+      "startVerse": 19,
+      "endChapter": 16,
+      "endVerse": 24
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 2
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 1,
+      "startVerse": 3,
+      "endChapter": 1,
+      "endVerse": 7
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 1,
+      "startVerse": 8,
+      "endChapter": 1,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 1,
+      "startVerse": 12,
+      "endChapter": 1,
+      "endVerse": 14
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 2,
+      "startVerse": 3,
+      "endChapter": 2,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 2,
+      "startVerse": 12,
+      "endChapter": 2,
+      "endVerse": 17
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 3
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 3,
+      "startVerse": 4,
+      "endChapter": 3,
+      "endVerse": 6
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 3,
+      "startVerse": 7,
+      "endChapter": 3,
+      "endVerse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 15
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 4,
+      "startVerse": 16,
+      "endChapter": 4,
+      "endVerse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 8
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 5,
+      "startVerse": 9,
+      "endChapter": 5,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 5,
+      "startVerse": 12,
+      "endChapter": 5,
+      "endVerse": 21
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 10
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 7,
+      "startVerse": 2,
+      "endChapter": 7,
+      "endVerse": 12
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 7,
+      "startVerse": 13,
+      "endChapter": 7,
+      "endVerse": 16
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 8,
+      "startVerse": 1,
+      "endChapter": 8,
+      "endVerse": 7
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 8,
+      "startVerse": 8,
+      "endChapter": 8,
+      "endVerse": 15
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 8,
+      "startVerse": 16,
+      "endChapter": 8,
+      "endVerse": 24
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 5
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 9,
+      "startVerse": 6,
+      "endChapter": 9,
+      "endVerse": 15
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 6
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 10,
+      "startVerse": 7,
+      "endChapter": 10,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 10,
+      "startVerse": 12,
+      "endChapter": 10,
+      "endVerse": 18
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 4
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 11,
+      "startVerse": 5,
+      "endChapter": 11,
+      "endVerse": 15
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 11,
+      "startVerse": 16,
+      "endChapter": 11,
+      "endVerse": 21
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 11,
+      "startVerse": 22,
+      "endChapter": 11,
+      "endVerse": 33
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 6
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 12,
+      "startVerse": 7,
+      "endChapter": 12,
+      "endVerse": 10
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 12,
+      "startVerse": 11,
+      "endChapter": 12,
+      "endVerse": 13
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 12,
+      "startVerse": 14,
+      "endChapter": 12,
+      "endVerse": 21
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 6
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 13,
+      "startVerse": 7,
+      "endChapter": 13,
+      "endVerse": 10
+    },
+    {
+      "book": "2 Corinthians",
+      "startChapter": 13,
+      "startVerse": 11,
+      "endChapter": 13,
+      "endVerse": 14
+    },
+    {
+      "book": "1 Corinthians",
+      "startChapter": 1,
+      "startVerse": 4,
+      "endChapter": 1,
+      "endVerse": 9
+    }
+  ]
+}

--- a/data/4-john-niv.json
+++ b/data/4-john-niv.json
@@ -1,0 +1,15235 @@
+{
+  "year": 4,
+  "books": [
+    "John"
+  ],
+  "chapters": [
+    {
+      "book": "John",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 51
+    },
+    {
+      "book": "John",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "John",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 36
+    },
+    {
+      "book": "John",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 54
+    },
+    {
+      "book": "John",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 47
+    },
+    {
+      "book": "John",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 71
+    },
+    {
+      "book": "John",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 53
+    },
+    {
+      "book": "John",
+      "number": 8,
+      "start_verse": 1,
+      "end_verse": 59
+    },
+    {
+      "book": "John",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 41
+    },
+    {
+      "book": "John",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 42
+    },
+    {
+      "book": "John",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 57
+    },
+    {
+      "book": "John",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 50
+    },
+    {
+      "book": "John",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 38
+    },
+    {
+      "book": "John",
+      "number": 14,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "John",
+      "number": 15,
+      "start_verse": 1,
+      "end_verse": 27
+    },
+    {
+      "book": "John",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "John",
+      "number": 17,
+      "start_verse": 1,
+      "end_verse": 26
+    },
+    {
+      "book": "John",
+      "number": 18,
+      "start_verse": 1,
+      "end_verse": 40
+    },
+    {
+      "book": "John",
+      "number": 19,
+      "start_verse": 1,
+      "end_verse": 42
+    },
+    {
+      "book": "John",
+      "number": 20,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "John",
+      "number": 21,
+      "start_verse": 1,
+      "end_verse": 25
+    }
+  ],
+  "verses": [
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 32,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 33,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 34,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 35,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 36,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 37,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 38,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 39,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 40,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 41,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 42,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 43,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 44,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 45,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 46,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 47,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 48,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 49,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 50,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 1,
+      "verse": 51,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 10,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 26,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 27,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 28,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 29,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 30,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 31,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 32,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 33,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 35,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 3,
+      "verse": 36,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 26,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 27,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 28,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 30,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 31,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 32,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 33,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 35,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 36,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 37,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 38,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 39,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 40,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 41,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 42,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 43,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 44,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 45,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 46,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 47,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 48,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 49,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 50,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 51,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 52,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 53,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 4,
+      "verse": 54,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 22,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 24,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 25,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 26,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 27,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 28,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 29,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 30,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 31,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 32,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 33,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 34,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 35,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 36,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 37,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 38,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 39,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 40,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 41,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 42,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 43,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 44,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 45,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 46,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 5,
+      "verse": 47,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 21,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 22,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 26,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 27,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 28,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 31,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 32,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 34,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 35,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 36,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 37,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 38,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 39,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 40,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 41,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 42,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 43,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 44,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 45,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 46,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 47,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 48,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 49,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 50,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 51,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 52,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 53,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 54,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 55,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 56,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 9,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 57,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 58,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 59,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 60,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 61,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 62,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 63,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 64,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 65,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 66,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 67,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 68,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 69,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 70,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 6,
+      "verse": 71,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 21,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 23,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 24,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 25,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 26,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 27,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 28,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 29,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 31,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 32,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 33,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 34,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 35,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 36,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 37,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 38,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 39,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 40,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 41,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 42,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 43,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 44,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 45,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 46,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 47,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 48,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 49,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 50,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 51,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 52,
+      "phraseWordCounts": [
+        56
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 48,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 50,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 51,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 52,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 54,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 55,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 7,
+      "verse": 53,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 1,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 2,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 6,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 8,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 14,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 15,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 16,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 17,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 20,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 21,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 24,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 25,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 26,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 27,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 28,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 29,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 30,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 31,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 32,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 33,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 34,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 35,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 36,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 37,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 38,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 39,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 40,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 41,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 42,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 43,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 44,
+      "phraseWordCounts": [
+        53
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 52,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 45,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 46,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 47,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 48,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 49,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 50,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 51,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 52,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 53,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 54,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 55,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 56,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 57,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 58,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 8,
+      "verse": 59,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 28,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 32,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 33,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 34,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 35,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 36,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 37,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 38,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 39,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 40,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 9,
+      "verse": 41,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 19,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 22,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 23,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 25,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 26,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 27,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 30,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 31,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 32,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 33,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 34,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 35,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 36,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 37,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 38,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 39,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 40,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 41,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 10,
+      "verse": 42,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 34,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 35,
+      "phraseWordCounts": [
+        2
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 36,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 37,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 38,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 39,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 40,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 41,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 42,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 43,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 44,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 45,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 46,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 47,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 48,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 49,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 50,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 51,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 52,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 53,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 54,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 55,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 56,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 11,
+      "verse": 57,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 24,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 25,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 26,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 27,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 30,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 32,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 33,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 34,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 35,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 36,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 37,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 38,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 39,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 40,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 41,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 42,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 43,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 44,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 45,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 46,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 47,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 48,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 49,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 12,
+      "verse": 50,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 16,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 18,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 21,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 22,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 23,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 25,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 26,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 27,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 28,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 29,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 30,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 32,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 33,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 34,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 35,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 36,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 37,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 13,
+      "verse": 38,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 9,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 10,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 12,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 15,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 21,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 24,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 25,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 26,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 27,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 28,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 29,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 14,
+      "verse": 31,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 4,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 14,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 15,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 16,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 17,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 19,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 20,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 21,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 23,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 24,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 26,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 15,
+      "verse": 27,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 45,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 25,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 26,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 29,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 30,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 31,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 32,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 16,
+      "verse": 33,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 7,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 11,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 13,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 16,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 17,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 21,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 23,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 24,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 17,
+      "verse": 26,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 1,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 16,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 19,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 21,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 24,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 25,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 26,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 27,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 28,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 30,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 31,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 32,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 34,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 35,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 36,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 37,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 38,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 39,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 18,
+      "verse": 40,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 1,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 6,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 8,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 11,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 12,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 15,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 21,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 22,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 23,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 24,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 26,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 28,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 29,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 31,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 32,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 35,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 36,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 37,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 38,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 39,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 40,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 41,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 19,
+      "verse": 42,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 2,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 3,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 10,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 15,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 17,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 19,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 23,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 24,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 25,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 26,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 27,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 28,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 20,
+      "verse": 31,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 3,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 6,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 7,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 10,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 15,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 17,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 18,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 20,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 21,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 23,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 24,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "John",
+      "chapter": 21,
+      "verse": 25,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    }
+  ],
+  "headings": [
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 5
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 6,
+      "endChapter": 1,
+      "endVerse": 13
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 14,
+      "endChapter": 1,
+      "endVerse": 18
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 19,
+      "endChapter": 1,
+      "endVerse": 28
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 29,
+      "endChapter": 1,
+      "endVerse": 34
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 35,
+      "endChapter": 1,
+      "endVerse": 42
+    },
+    {
+      "book": "John",
+      "startChapter": 1,
+      "startVerse": 43,
+      "endChapter": 1,
+      "endVerse": 51
+    },
+    {
+      "book": "John",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 12
+    },
+    {
+      "book": "John",
+      "startChapter": 2,
+      "startVerse": 13,
+      "endChapter": 2,
+      "endVerse": 22
+    },
+    {
+      "book": "John",
+      "startChapter": 2,
+      "startVerse": 23,
+      "endChapter": 2,
+      "endVerse": 25
+    },
+    {
+      "book": "John",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 21
+    },
+    {
+      "book": "John",
+      "startChapter": 3,
+      "startVerse": 22,
+      "endChapter": 3,
+      "endVerse": 36
+    },
+    {
+      "book": "John",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 26
+    },
+    {
+      "book": "John",
+      "startChapter": 4,
+      "startVerse": 27,
+      "endChapter": 4,
+      "endVerse": 38
+    },
+    {
+      "book": "John",
+      "startChapter": 4,
+      "startVerse": 39,
+      "endChapter": 4,
+      "endVerse": 42
+    },
+    {
+      "book": "John",
+      "startChapter": 4,
+      "startVerse": 43,
+      "endChapter": 4,
+      "endVerse": 45
+    },
+    {
+      "book": "John",
+      "startChapter": 4,
+      "startVerse": 46,
+      "endChapter": 4,
+      "endVerse": 54
+    },
+    {
+      "book": "John",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 15
+    },
+    {
+      "book": "John",
+      "startChapter": 5,
+      "startVerse": 16,
+      "endChapter": 5,
+      "endVerse": 23
+    },
+    {
+      "book": "John",
+      "startChapter": 5,
+      "startVerse": 24,
+      "endChapter": 5,
+      "endVerse": 30
+    },
+    {
+      "book": "John",
+      "startChapter": 5,
+      "startVerse": 31,
+      "endChapter": 5,
+      "endVerse": 47
+    },
+    {
+      "book": "John",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 14
+    },
+    {
+      "book": "John",
+      "startChapter": 6,
+      "startVerse": 15,
+      "endChapter": 6,
+      "endVerse": 21
+    },
+    {
+      "book": "John",
+      "startChapter": 6,
+      "startVerse": 22,
+      "endChapter": 6,
+      "endVerse": 40
+    },
+    {
+      "book": "John",
+      "startChapter": 6,
+      "startVerse": 41,
+      "endChapter": 6,
+      "endVerse": 59
+    },
+    {
+      "book": "John",
+      "startChapter": 6,
+      "startVerse": 60,
+      "endChapter": 6,
+      "endVerse": 71
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 9
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 10,
+      "endChapter": 7,
+      "endVerse": 24
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 25,
+      "endChapter": 7,
+      "endVerse": 31
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 32,
+      "endChapter": 7,
+      "endVerse": 36
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 37,
+      "endChapter": 7,
+      "endVerse": 39
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 40,
+      "endChapter": 7,
+      "endVerse": 44
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 45,
+      "endChapter": 7,
+      "endVerse": 52
+    },
+    {
+      "book": "John",
+      "startChapter": 7,
+      "startVerse": 53,
+      "endChapter": 8,
+      "endVerse": 12
+    },
+    {
+      "book": "John",
+      "startChapter": 8,
+      "startVerse": 13,
+      "endChapter": 8,
+      "endVerse": 20
+    },
+    {
+      "book": "John",
+      "startChapter": 8,
+      "startVerse": 21,
+      "endChapter": 8,
+      "endVerse": 30
+    },
+    {
+      "book": "John",
+      "startChapter": 8,
+      "startVerse": 31,
+      "endChapter": 8,
+      "endVerse": 36
+    },
+    {
+      "book": "John",
+      "startChapter": 8,
+      "startVerse": 37,
+      "endChapter": 8,
+      "endVerse": 47
+    },
+    {
+      "book": "John",
+      "startChapter": 8,
+      "startVerse": 48,
+      "endChapter": 8,
+      "endVerse": 59
+    },
+    {
+      "book": "John",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 12
+    },
+    {
+      "book": "John",
+      "startChapter": 9,
+      "startVerse": 13,
+      "endChapter": 9,
+      "endVerse": 34
+    },
+    {
+      "book": "John",
+      "startChapter": 9,
+      "startVerse": 35,
+      "endChapter": 9,
+      "endVerse": 41
+    },
+    {
+      "book": "John",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 6
+    },
+    {
+      "book": "John",
+      "startChapter": 10,
+      "startVerse": 7,
+      "endChapter": 10,
+      "endVerse": 21
+    },
+    {
+      "book": "John",
+      "startChapter": 10,
+      "startVerse": 22,
+      "endChapter": 10,
+      "endVerse": 30
+    },
+    {
+      "book": "John",
+      "startChapter": 10,
+      "startVerse": 31,
+      "endChapter": 10,
+      "endVerse": 39
+    },
+    {
+      "book": "John",
+      "startChapter": 10,
+      "startVerse": 40,
+      "endChapter": 10,
+      "endVerse": 42
+    },
+    {
+      "book": "John",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 16
+    },
+    {
+      "book": "John",
+      "startChapter": 11,
+      "startVerse": 17,
+      "endChapter": 11,
+      "endVerse": 27
+    },
+    {
+      "book": "John",
+      "startChapter": 11,
+      "startVerse": 28,
+      "endChapter": 11,
+      "endVerse": 37
+    },
+    {
+      "book": "John",
+      "startChapter": 11,
+      "startVerse": 38,
+      "endChapter": 11,
+      "endVerse": 44
+    },
+    {
+      "book": "John",
+      "startChapter": 11,
+      "startVerse": 45,
+      "endChapter": 11,
+      "endVerse": 57
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 8
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 9,
+      "endChapter": 12,
+      "endVerse": 11
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 12,
+      "endChapter": 12,
+      "endVerse": 19
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 20,
+      "endChapter": 12,
+      "endVerse": 26
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 27,
+      "endChapter": 12,
+      "endVerse": 36
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 37,
+      "endChapter": 12,
+      "endVerse": 41
+    },
+    {
+      "book": "John",
+      "startChapter": 12,
+      "startVerse": 42,
+      "endChapter": 12,
+      "endVerse": 50
+    },
+    {
+      "book": "John",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 17
+    },
+    {
+      "book": "John",
+      "startChapter": 13,
+      "startVerse": 18,
+      "endChapter": 13,
+      "endVerse": 30
+    },
+    {
+      "book": "John",
+      "startChapter": 13,
+      "startVerse": 31,
+      "endChapter": 13,
+      "endVerse": 35
+    },
+    {
+      "book": "John",
+      "startChapter": 13,
+      "startVerse": 36,
+      "endChapter": 13,
+      "endVerse": 38
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 1,
+      "endChapter": 14,
+      "endVerse": 6
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 7,
+      "endChapter": 14,
+      "endVerse": 11
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 12,
+      "endChapter": 14,
+      "endVerse": 14
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 15,
+      "endChapter": 14,
+      "endVerse": 18
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 19,
+      "endChapter": 14,
+      "endVerse": 24
+    },
+    {
+      "book": "John",
+      "startChapter": 14,
+      "startVerse": 25,
+      "endChapter": 14,
+      "endVerse": 31
+    },
+    {
+      "book": "John",
+      "startChapter": 15,
+      "startVerse": 1,
+      "endChapter": 15,
+      "endVerse": 8
+    },
+    {
+      "book": "John",
+      "startChapter": 15,
+      "startVerse": 9,
+      "endChapter": 15,
+      "endVerse": 17
+    },
+    {
+      "book": "John",
+      "startChapter": 15,
+      "startVerse": 18,
+      "endChapter": 15,
+      "endVerse": 25
+    },
+    {
+      "book": "John",
+      "startChapter": 15,
+      "startVerse": 26,
+      "endChapter": 16,
+      "endVerse": 4
+    },
+    {
+      "book": "John",
+      "startChapter": 16,
+      "startVerse": 5,
+      "endChapter": 16,
+      "endVerse": 15
+    },
+    {
+      "book": "John",
+      "startChapter": 16,
+      "startVerse": 16,
+      "endChapter": 16,
+      "endVerse": 24
+    },
+    {
+      "book": "John",
+      "startChapter": 16,
+      "startVerse": 25,
+      "endChapter": 16,
+      "endVerse": 33
+    },
+    {
+      "book": "John",
+      "startChapter": 17,
+      "startVerse": 1,
+      "endChapter": 17,
+      "endVerse": 5
+    },
+    {
+      "book": "John",
+      "startChapter": 17,
+      "startVerse": 6,
+      "endChapter": 17,
+      "endVerse": 19
+    },
+    {
+      "book": "John",
+      "startChapter": 17,
+      "startVerse": 20,
+      "endChapter": 17,
+      "endVerse": 26
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 1,
+      "endChapter": 18,
+      "endVerse": 11
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 12,
+      "endChapter": 18,
+      "endVerse": 14
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 15,
+      "endChapter": 18,
+      "endVerse": 18
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 19,
+      "endChapter": 18,
+      "endVerse": 24
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 25,
+      "endChapter": 18,
+      "endVerse": 27
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 28,
+      "endChapter": 18,
+      "endVerse": 38
+    },
+    {
+      "book": "John",
+      "startChapter": 18,
+      "startVerse": 39,
+      "endChapter": 18,
+      "endVerse": 40
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 1,
+      "endChapter": 19,
+      "endVerse": 4
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 5,
+      "endChapter": 19,
+      "endVerse": 16
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 17,
+      "endChapter": 19,
+      "endVerse": 24
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 25,
+      "endChapter": 19,
+      "endVerse": 27
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 28,
+      "endChapter": 19,
+      "endVerse": 30
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 31,
+      "endChapter": 19,
+      "endVerse": 37
+    },
+    {
+      "book": "John",
+      "startChapter": 19,
+      "startVerse": 38,
+      "endChapter": 19,
+      "endVerse": 42
+    },
+    {
+      "book": "John",
+      "startChapter": 20,
+      "startVerse": 1,
+      "endChapter": 20,
+      "endVerse": 10
+    },
+    {
+      "book": "John",
+      "startChapter": 20,
+      "startVerse": 11,
+      "endChapter": 20,
+      "endVerse": 18
+    },
+    {
+      "book": "John",
+      "startChapter": 20,
+      "startVerse": 19,
+      "endChapter": 20,
+      "endVerse": 23
+    },
+    {
+      "book": "John",
+      "startChapter": 20,
+      "startVerse": 24,
+      "endChapter": 20,
+      "endVerse": 29
+    },
+    {
+      "book": "John",
+      "startChapter": 20,
+      "startVerse": 30,
+      "endChapter": 20,
+      "endVerse": 31
+    },
+    {
+      "book": "John",
+      "startChapter": 21,
+      "startVerse": 1,
+      "endChapter": 21,
+      "endVerse": 14
+    },
+    {
+      "book": "John",
+      "startChapter": 21,
+      "startVerse": 15,
+      "endChapter": 21,
+      "endVerse": 19
+    },
+    {
+      "book": "John",
+      "startChapter": 21,
+      "startVerse": 20,
+      "endChapter": 21,
+      "endVerse": 25
+    }
+  ]
+}

--- a/data/4-john-niv.json
+++ b/data/4-john-niv.json
@@ -137,7 +137,9 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        17
+        6,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -161,7 +163,8 @@
       "chapter": 1,
       "verse": 3,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -174,7 +177,8 @@
       "chapter": 1,
       "verse": 4,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -187,7 +191,8 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -216,7 +221,8 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -229,7 +235,8 @@
       "chapter": 1,
       "verse": 8,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -251,7 +258,8 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        19
+        5,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -264,7 +272,8 @@
       "chapter": 1,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -277,7 +286,9 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        23
+        7,
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -290,7 +301,9 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        18
+        6,
+        8,
+        4
       ],
       "annotations": [
         {
@@ -314,7 +327,10 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        33
+        10,
+        5,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -336,7 +352,11 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        32
+        4,
+        4,
+        10,
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -347,7 +367,8 @@
       "chapter": 1,
       "verse": 16,
       "phraseWordCounts": [
-        15
+        4,
+        11
       ],
       "annotations": [
         {
@@ -371,7 +392,8 @@
       "chapter": 1,
       "verse": 17,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -389,7 +411,9 @@
       "chapter": 1,
       "verse": 18,
       "phraseWordCounts": [
-        28
+        6,
+        18,
+        4
       ],
       "annotations": [
         {
@@ -411,7 +435,8 @@
       "chapter": 1,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        5,
+        16
       ],
       "annotations": [
         {
@@ -427,7 +452,8 @@
       "chapter": 1,
       "verse": 20,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -455,7 +481,9 @@
       "chapter": 1,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        10,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -471,7 +499,9 @@
       "chapter": 1,
       "verse": 22,
       "phraseWordCounts": [
-        24
+        6,
+        12,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -484,7 +514,9 @@
       "chapter": 1,
       "verse": 23,
       "phraseWordCounts": [
-        27
+        9,
+        10,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -508,7 +540,8 @@
       "chapter": 1,
       "verse": 25,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -524,7 +557,8 @@
       "chapter": 1,
       "verse": 26,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -537,7 +571,8 @@
       "chapter": 1,
       "verse": 27,
       "phraseWordCounts": [
-        19
+        8,
+        11
       ],
       "annotations": [
         {
@@ -567,7 +602,8 @@
       "chapter": 1,
       "verse": 28,
       "phraseWordCounts": [
-        16
+        12,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -578,7 +614,9 @@
       "chapter": 1,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        11,
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -591,7 +629,8 @@
       "chapter": 1,
       "verse": 30,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -604,7 +643,8 @@
       "chapter": 1,
       "verse": 31,
       "phraseWordCounts": [
-        22
+        6,
+        16
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -615,7 +655,8 @@
       "chapter": 1,
       "verse": 32,
       "phraseWordCounts": [
-        20
+        5,
+        15
       ],
       "annotations": [
         {
@@ -633,7 +674,10 @@
       "chapter": 1,
       "verse": 33,
       "phraseWordCounts": [
-        41
+        7,
+        12,
+        12,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -644,7 +688,8 @@
       "chapter": 1,
       "verse": 34,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -668,7 +713,8 @@
       "chapter": 1,
       "verse": 36,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -686,7 +732,8 @@
       "chapter": 1,
       "verse": 37,
       "phraseWordCounts": [
-        11
+        8,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -699,7 +746,9 @@
       "chapter": 1,
       "verse": 38,
       "phraseWordCounts": [
-        22
+        8,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -710,7 +759,9 @@
       "chapter": 1,
       "verse": 39,
       "phraseWordCounts": [
-        30
+        7,
+        16,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -721,7 +772,8 @@
       "chapter": 1,
       "verse": 40,
       "phraseWordCounts": [
-        20
+        4,
+        16
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -734,7 +786,8 @@
       "chapter": 1,
       "verse": 41,
       "phraseWordCounts": [
-        23
+        14,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -747,7 +800,9 @@
       "chapter": 1,
       "verse": 42,
       "phraseWordCounts": [
-        28
+        6,
+        12,
+        10
       ],
       "annotations": [
         {
@@ -769,7 +824,8 @@
       "chapter": 1,
       "verse": 43,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [
         {
@@ -796,7 +852,9 @@
       "chapter": 1,
       "verse": 45,
       "phraseWordCounts": [
-        31
+        6,
+        11,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -807,7 +865,8 @@
       "chapter": 1,
       "verse": 46,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -818,7 +877,8 @@
       "chapter": 1,
       "verse": 47,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [
         {
@@ -838,7 +898,9 @@
       "chapter": 1,
       "verse": 48,
       "phraseWordCounts": [
-        24
+        7,
+        13,
+        4
       ],
       "annotations": [
         {
@@ -858,7 +920,8 @@
       "chapter": 1,
       "verse": 49,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -869,7 +932,8 @@
       "chapter": 1,
       "verse": 50,
       "phraseWordCounts": [
-        22
+        15,
+        7
       ],
       "annotations": [
         {
@@ -889,7 +953,9 @@
       "chapter": 1,
       "verse": 51,
       "phraseWordCounts": [
-        26
+        8,
+        5,
+        13
       ],
       "annotations": [
         {
@@ -915,7 +981,8 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        16
+        12,
+        4
       ],
       "annotations": [
         {
@@ -951,7 +1018,8 @@
       "chapter": 2,
       "verse": 3,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -962,7 +1030,8 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -978,7 +1047,8 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -989,7 +1059,9 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        22
+        6,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -1017,7 +1089,8 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [
         {
@@ -1037,7 +1110,8 @@
       "chapter": 2,
       "verse": 8,
       "phraseWordCounts": [
-        20
+        17,
+        3
       ],
       "annotations": [
         {
@@ -1053,7 +1127,10 @@
       "chapter": 2,
       "verse": 9,
       "phraseWordCounts": [
-        39
+        15,
+        9,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -1077,7 +1154,9 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        31
+        9,
+        14,
+        8
       ],
       "annotations": [
         {
@@ -1113,7 +1192,8 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        26
+        20,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1126,7 +1206,8 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        22
+        15,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1137,7 +1218,8 @@
       "chapter": 2,
       "verse": 13,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 10,
@@ -1150,7 +1232,8 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        12,
+        7
       ],
       "annotations": [
         {
@@ -1188,7 +1271,9 @@
       "chapter": 2,
       "verse": 15,
       "phraseWordCounts": [
-        31
+        8,
+        11,
+        12
       ],
       "annotations": [
         {
@@ -1234,7 +1319,9 @@
       "chapter": 2,
       "verse": 16,
       "phraseWordCounts": [
-        20
+        7,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -1256,7 +1343,8 @@
       "chapter": 2,
       "verse": 17,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -1280,7 +1368,8 @@
       "chapter": 2,
       "verse": 18,
       "phraseWordCounts": [
-        20
+        6,
+        14
       ],
       "annotations": [
         {
@@ -1296,7 +1385,8 @@
       "chapter": 2,
       "verse": 19,
       "phraseWordCounts": [
-        15
+        3,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1309,7 +1399,9 @@
       "chapter": 2,
       "verse": 20,
       "phraseWordCounts": [
-        21
+        2,
+        9,
+        10
       ],
       "annotations": [
         {
@@ -1342,7 +1434,8 @@
       "chapter": 2,
       "verse": 22,
       "phraseWordCounts": [
-        26
+        14,
+        12
       ],
       "annotations": [
         {
@@ -1360,7 +1453,8 @@
       "chapter": 2,
       "verse": 23,
       "phraseWordCounts": [
-        23
+        10,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1373,7 +1467,8 @@
       "chapter": 2,
       "verse": 24,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [
         {
@@ -1391,7 +1486,8 @@
       "chapter": 2,
       "verse": 25,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1404,7 +1500,9 @@
       "chapter": 3,
       "verse": 1,
       "phraseWordCounts": [
-        18
+        5,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -1434,7 +1532,10 @@
       "chapter": 3,
       "verse": 2,
       "phraseWordCounts": [
-        37
+        8,
+        13,
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1447,7 +1548,9 @@
       "chapter": 3,
       "verse": 3,
       "phraseWordCounts": [
-        20
+        2,
+        5,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 8,
@@ -1460,7 +1563,9 @@
       "chapter": 3,
       "verse": 4,
       "phraseWordCounts": [
-        25
+        9,
+        2,
+        14
       ],
       "annotations": [
         {
@@ -1476,7 +1581,9 @@
       "chapter": 3,
       "verse": 5,
       "phraseWordCounts": [
-        24
+        2,
+        5,
+        17
       ],
       "annotations": [],
       "ftvWordCount": 8,
@@ -1487,7 +1594,8 @@
       "chapter": 3,
       "verse": 6,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -1498,7 +1606,8 @@
       "chapter": 3,
       "verse": 7,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1509,7 +1618,10 @@
       "chapter": 3,
       "verse": 8,
       "phraseWordCounts": [
-        32
+        6,
+        4,
+        13,
+        9
       ],
       "annotations": [
         {
@@ -1544,7 +1656,9 @@
       "chapter": 3,
       "verse": 10,
       "phraseWordCounts": [
-        13
+        4,
+        2,
+        7
       ],
       "annotations": [
         {
@@ -1560,7 +1674,10 @@
       "chapter": 3,
       "verse": 11,
       "phraseWordCounts": [
-        28
+        5,
+        6,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -1571,7 +1688,8 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        24
+        13,
+        11
       ],
       "annotations": [
         {
@@ -1591,7 +1709,9 @@
       "chapter": 3,
       "verse": 13,
       "phraseWordCounts": [
-        18
+        7,
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -1602,7 +1722,8 @@
       "chapter": 3,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        10,
+        9
       ],
       "annotations": [
         {
@@ -1631,7 +1752,9 @@
       "chapter": 3,
       "verse": 16,
       "phraseWordCounts": [
-        26
+        6,
+        8,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1644,7 +1767,8 @@
       "chapter": 3,
       "verse": 17,
       "phraseWordCounts": [
-        21
+        14,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1657,7 +1781,9 @@
       "chapter": 3,
       "verse": 18,
       "phraseWordCounts": [
-        29
+        7,
+        8,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1670,7 +1796,10 @@
       "chapter": 3,
       "verse": 19,
       "phraseWordCounts": [
-        22
+        4,
+        6,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -1692,7 +1821,9 @@
       "chapter": 3,
       "verse": 20,
       "phraseWordCounts": [
-        22
+        7,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -1714,7 +1845,9 @@
       "chapter": 3,
       "verse": 21,
       "phraseWordCounts": [
-        30
+        10,
+        7,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1727,7 +1860,8 @@
       "chapter": 3,
       "verse": 22,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [
         {
@@ -1747,7 +1881,9 @@
       "chapter": 3,
       "verse": 23,
       "phraseWordCounts": [
-        22
+        9,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -1787,7 +1923,8 @@
       "chapter": 3,
       "verse": 25,
       "phraseWordCounts": [
-        18
+        12,
+        6
       ],
       "annotations": [
         {
@@ -1815,7 +1952,10 @@
       "chapter": 3,
       "verse": 26,
       "phraseWordCounts": [
-        37
+        8,
+        19,
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1826,7 +1966,8 @@
       "chapter": 3,
       "verse": 27,
       "phraseWordCounts": [
-        15
+        4,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1837,7 +1978,8 @@
       "chapter": 3,
       "verse": 28,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1848,7 +1990,10 @@
       "chapter": 3,
       "verse": 29,
       "phraseWordCounts": [
-        37
+        6,
+        11,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -1876,7 +2021,8 @@
       "chapter": 3,
       "verse": 30,
       "phraseWordCounts": [
-        8
+        4,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1889,7 +2035,10 @@
       "chapter": 3,
       "verse": 31,
       "phraseWordCounts": [
-        36
+        9,
+        11,
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1900,7 +2049,8 @@
       "chapter": 3,
       "verse": 32,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1931,7 +2081,8 @@
       "chapter": 3,
       "verse": 34,
       "phraseWordCounts": [
-        19
+        12,
+        7
       ],
       "annotations": [
         {
@@ -1958,7 +2109,9 @@
       "chapter": 3,
       "verse": 36,
       "phraseWordCounts": [
-        23
+        8,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -2035,7 +2188,8 @@
       "chapter": 4,
       "verse": 5,
       "phraseWordCounts": [
-        22
+        10,
+        12
       ],
       "annotations": [
         {
@@ -2059,7 +2213,9 @@
       "chapter": 4,
       "verse": 6,
       "phraseWordCounts": [
-        22
+        4,
+        14,
+        4
       ],
       "annotations": [
         {
@@ -2083,7 +2239,8 @@
       "chapter": 4,
       "verse": 7,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2105,7 +2262,10 @@
       "chapter": 4,
       "verse": 9,
       "phraseWordCounts": [
-        31
+        6,
+        10,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -2123,7 +2283,10 @@
       "chapter": 4,
       "verse": 10,
       "phraseWordCounts": [
-        33
+        3,
+        17,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -2141,7 +2304,9 @@
       "chapter": 4,
       "verse": 11,
       "phraseWordCounts": [
-        22
+        4,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -2157,7 +2322,9 @@
       "chapter": 4,
       "verse": 12,
       "phraseWordCounts": [
-        25
+        7,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -2190,7 +2357,8 @@
       "chapter": 4,
       "verse": 14,
       "phraseWordCounts": [
-        30
+        11,
+        19
       ],
       "annotations": [
         {
@@ -2216,7 +2384,9 @@
       "chapter": 4,
       "verse": 15,
       "phraseWordCounts": [
-        25
+        5,
+        5,
+        15
       ],
       "annotations": [
         {
@@ -2232,7 +2402,8 @@
       "chapter": 4,
       "verse": 16,
       "phraseWordCounts": [
-        10
+        3,
+        7
       ],
       "annotations": [
         {
@@ -2248,7 +2419,8 @@
       "chapter": 4,
       "verse": 17,
       "phraseWordCounts": [
-        20
+        6,
+        14
       ],
       "annotations": [
         {
@@ -2268,7 +2440,9 @@
       "chapter": 4,
       "verse": 18,
       "phraseWordCounts": [
-        26
+        8,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -2292,7 +2466,8 @@
       "chapter": 4,
       "verse": 19,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2303,7 +2478,8 @@
       "chapter": 4,
       "verse": 20,
       "phraseWordCounts": [
-        20
+        6,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2314,7 +2490,8 @@
       "chapter": 4,
       "verse": 21,
       "phraseWordCounts": [
-        22
+        5,
+        17
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2325,7 +2502,9 @@
       "chapter": 4,
       "verse": 22,
       "phraseWordCounts": [
-        20
+        8,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -2341,7 +2520,9 @@
       "chapter": 4,
       "verse": 23,
       "phraseWordCounts": [
-        33
+        9,
+        14,
+        10
       ],
       "annotations": [
         {
@@ -2361,7 +2542,8 @@
       "chapter": 4,
       "verse": 24,
       "phraseWordCounts": [
-        14
+        3,
+        11
       ],
       "annotations": [
         {
@@ -2379,7 +2561,8 @@
       "chapter": 4,
       "verse": 25,
       "phraseWordCounts": [
-        20
+        11,
+        9
       ],
       "annotations": [
         {
@@ -2395,7 +2578,8 @@
       "chapter": 4,
       "verse": 26,
       "phraseWordCounts": [
-        12
+        3,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -2406,7 +2590,8 @@
       "chapter": 4,
       "verse": 27,
       "phraseWordCounts": [
-        30
+        15,
+        15
       ],
       "annotations": [
         {
@@ -2426,7 +2611,8 @@
       "chapter": 4,
       "verse": 28,
       "phraseWordCounts": [
-        17
+        5,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2437,7 +2623,8 @@
       "chapter": 4,
       "verse": 29,
       "phraseWordCounts": [
-        16
+        11,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2472,7 +2659,8 @@
       "chapter": 4,
       "verse": 32,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -2483,7 +2671,8 @@
       "chapter": 4,
       "verse": 33,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2494,7 +2683,9 @@
       "chapter": 4,
       "verse": 34,
       "phraseWordCounts": [
-        19
+        4,
+        10,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2507,7 +2698,9 @@
       "chapter": 4,
       "verse": 35,
       "phraseWordCounts": [
-        27
+        11,
+        11,
+        5
       ],
       "annotations": [
         {
@@ -2545,7 +2738,8 @@
       "chapter": 4,
       "verse": 36,
       "phraseWordCounts": [
-        27
+        16,
+        11
       ],
       "annotations": [
         {
@@ -2605,7 +2799,9 @@
       "chapter": 4,
       "verse": 38,
       "phraseWordCounts": [
-        26
+        11,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -2639,7 +2835,9 @@
       "chapter": 4,
       "verse": 39,
       "phraseWordCounts": [
-        22
+        10,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -2657,7 +2855,9 @@
       "chapter": 4,
       "verse": 40,
       "phraseWordCounts": [
-        19
+        7,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2679,7 +2879,10 @@
       "chapter": 4,
       "verse": 42,
       "phraseWordCounts": [
-        34
+        5,
+        10,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -2712,7 +2915,8 @@
       "chapter": 4,
       "verse": 44,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [
         {
@@ -2728,7 +2932,10 @@
       "chapter": 4,
       "verse": 45,
       "phraseWordCounts": [
-        29
+        5,
+        4,
+        14,
+        6
       ],
       "annotations": [
         {
@@ -2752,7 +2959,10 @@
       "chapter": 4,
       "verse": 46,
       "phraseWordCounts": [
-        28
+        7,
+        8,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -2774,7 +2984,9 @@
       "chapter": 4,
       "verse": 47,
       "phraseWordCounts": [
-        30
+        12,
+        13,
+        5
       ],
       "annotations": [
         {
@@ -2800,7 +3012,9 @@
       "chapter": 4,
       "verse": 48,
       "phraseWordCounts": [
-        14
+        7,
+        3,
+        4
       ],
       "annotations": [
         {
@@ -2816,7 +3030,8 @@
       "chapter": 4,
       "verse": 49,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -2836,7 +3051,8 @@
       "chapter": 4,
       "verse": 50,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -2854,7 +3070,9 @@
       "chapter": 4,
       "verse": 51,
       "phraseWordCounts": [
-        19
+        7,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2867,7 +3085,10 @@
       "chapter": 4,
       "verse": 52,
       "phraseWordCounts": [
-        26
+        12,
+        4,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -2893,7 +3114,9 @@
       "chapter": 4,
       "verse": 53,
       "phraseWordCounts": [
-        28
+        4,
+        17,
+        7
       ],
       "annotations": [
         {
@@ -2915,7 +3138,8 @@
       "chapter": 4,
       "verse": 54,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -2926,7 +3150,8 @@
       "chapter": 5,
       "verse": 1,
       "phraseWordCounts": [
-        14
+        3,
+        11
       ],
       "annotations": [
         {
@@ -2942,7 +3167,9 @@
       "chapter": 5,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        11,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -2970,7 +3197,8 @@
       "chapter": 5,
       "verse": 3,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [
         {
@@ -3027,7 +3255,8 @@
       "chapter": 5,
       "verse": 6,
       "phraseWordCounts": [
-        28
+        19,
+        9
       ],
       "annotations": [
         {
@@ -3045,7 +3274,9 @@
       "chapter": 5,
       "verse": 7,
       "phraseWordCounts": [
-        33
+        4,
+        15,
+        14
       ],
       "annotations": [
         {
@@ -3067,7 +3298,8 @@
       "chapter": 5,
       "verse": 8,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -3089,7 +3321,9 @@
       "chapter": 5,
       "verse": 9,
       "phraseWordCounts": [
-        23
+        6,
+        7,
+        10
       ],
       "annotations": [
         {
@@ -3115,7 +3349,9 @@
       "chapter": 5,
       "verse": 10,
       "phraseWordCounts": [
-        25
+        13,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -3139,7 +3375,8 @@
       "chapter": 5,
       "verse": 11,
       "phraseWordCounts": [
-        19
+        12,
+        7
       ],
       "annotations": [
         {
@@ -3159,7 +3396,8 @@
       "chapter": 5,
       "verse": 12,
       "phraseWordCounts": [
-        17
+        4,
+        13
       ],
       "annotations": [
         {
@@ -3175,7 +3413,8 @@
       "chapter": 5,
       "verse": 13,
       "phraseWordCounts": [
-        22
+        11,
+        11
       ],
       "annotations": [
         {
@@ -3195,7 +3434,9 @@
       "chapter": 5,
       "verse": 14,
       "phraseWordCounts": [
-        25
+        11,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -3215,7 +3456,8 @@
       "chapter": 5,
       "verse": 15,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3226,7 +3468,8 @@
       "chapter": 5,
       "verse": 16,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3237,7 +3480,9 @@
       "chapter": 5,
       "verse": 17,
       "phraseWordCounts": [
-        23
+        7,
+        11,
+        5
       ],
       "annotations": [
         {
@@ -3257,7 +3502,10 @@
       "chapter": 5,
       "verse": 18,
       "phraseWordCounts": [
-        32
+        11,
+        7,
+        9,
+        5
       ],
       "annotations": [
         {
@@ -3283,7 +3531,11 @@
       "chapter": 5,
       "verse": 19,
       "phraseWordCounts": [
-        36
+        5,
+        5,
+        7,
+        10,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3296,7 +3548,9 @@
       "chapter": 5,
       "verse": 20,
       "phraseWordCounts": [
-        29
+        12,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -3314,7 +3568,8 @@
       "chapter": 5,
       "verse": 21,
       "phraseWordCounts": [
-        26
+        12,
+        14
       ],
       "annotations": [
         {
@@ -3334,7 +3589,8 @@
       "chapter": 5,
       "verse": 22,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [
         {
@@ -3358,7 +3614,8 @@
       "chapter": 5,
       "verse": 23,
       "phraseWordCounts": [
-        26
+        12,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3369,7 +3626,10 @@
       "chapter": 5,
       "verse": 24,
       "phraseWordCounts": [
-        31
+        5,
+        10,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -3387,7 +3647,10 @@
       "chapter": 5,
       "verse": 25,
       "phraseWordCounts": [
-        31
+        5,
+        8,
+        12,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -3398,7 +3661,8 @@
       "chapter": 5,
       "verse": 26,
       "phraseWordCounts": [
-        20
+        8,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3409,7 +3673,8 @@
       "chapter": 5,
       "verse": 27,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3420,7 +3685,8 @@
       "chapter": 5,
       "verse": 28,
       "phraseWordCounts": [
-        22
+        6,
+        16
       ],
       "annotations": [
         {
@@ -3436,7 +3702,8 @@
       "chapter": 5,
       "verse": 29,
       "phraseWordCounts": [
-        27
+        14,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3447,7 +3714,10 @@
       "chapter": 5,
       "verse": 30,
       "phraseWordCounts": [
-        29
+        6,
+        6,
+        5,
+        12
       ],
       "annotations": [
         {
@@ -3474,7 +3744,8 @@
       "chapter": 5,
       "verse": 32,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [
         {
@@ -3490,7 +3761,8 @@
       "chapter": 5,
       "verse": 33,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3501,7 +3773,8 @@
       "chapter": 5,
       "verse": 34,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [
         {
@@ -3517,7 +3790,8 @@
       "chapter": 5,
       "verse": 35,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [
         {
@@ -3537,7 +3811,10 @@
       "chapter": 5,
       "verse": 36,
       "phraseWordCounts": [
-        33
+        8,
+        11,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -3555,7 +3832,8 @@
       "chapter": 5,
       "verse": 37,
       "phraseWordCounts": [
-        21
+        11,
+        10
       ],
       "annotations": [
         {
@@ -3571,7 +3849,8 @@
       "chapter": 5,
       "verse": 38,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -3587,7 +3866,9 @@
       "chapter": 5,
       "verse": 39,
       "phraseWordCounts": [
-        24
+        5,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -3646,7 +3927,8 @@
       "chapter": 5,
       "verse": 42,
       "phraseWordCounts": [
-        18
+        4,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -3657,7 +3939,9 @@
       "chapter": 5,
       "verse": 43,
       "phraseWordCounts": [
-        26
+        7,
+        6,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -3668,7 +3952,9 @@
       "chapter": 5,
       "verse": 44,
       "phraseWordCounts": [
-        24
+        4,
+        7,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3679,7 +3965,9 @@
       "chapter": 5,
       "verse": 45,
       "phraseWordCounts": [
-        21
+        11,
+        4,
+        6
       ],
       "annotations": [
         {
@@ -3699,7 +3987,9 @@
       "chapter": 5,
       "verse": 46,
       "phraseWordCounts": [
-        13
+        4,
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3712,7 +4002,8 @@
       "chapter": 5,
       "verse": 47,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3725,7 +4016,8 @@
       "chapter": 6,
       "verse": 1,
       "phraseWordCounts": [
-        21
+        4,
+        17
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3736,7 +4028,8 @@
       "chapter": 6,
       "verse": 2,
       "phraseWordCounts": [
-        20
+        8,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3774,7 +4067,9 @@
       "chapter": 6,
       "verse": 5,
       "phraseWordCounts": [
-        26
+        12,
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3787,7 +4082,8 @@
       "chapter": 6,
       "verse": 6,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [
         {
@@ -3805,7 +4101,8 @@
       "chapter": 6,
       "verse": 7,
       "phraseWordCounts": [
-        23
+        3,
+        20
       ],
       "annotations": [
         {
@@ -3840,7 +4137,8 @@
       "chapter": 6,
       "verse": 9,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [
         {
@@ -3866,7 +4164,9 @@
       "chapter": 6,
       "verse": 10,
       "phraseWordCounts": [
-        25
+        7,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -3888,7 +4188,9 @@
       "chapter": 6,
       "verse": 11,
       "phraseWordCounts": [
-        26
+        7,
+        12,
+        7
       ],
       "annotations": [
         {
@@ -3906,7 +4208,10 @@
       "chapter": 6,
       "verse": 12,
       "phraseWordCounts": [
-        24
+        8,
+        5,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -3930,7 +4235,8 @@
       "chapter": 6,
       "verse": 13,
       "phraseWordCounts": [
-        23
+        8,
+        15
       ],
       "annotations": [
         {
@@ -3954,7 +4260,9 @@
       "chapter": 6,
       "verse": 14,
       "phraseWordCounts": [
-        24
+        8,
+        4,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3967,7 +4275,8 @@
       "chapter": 6,
       "verse": 15,
       "phraseWordCounts": [
-        20
+        13,
+        7
       ],
       "annotations": [
         {
@@ -3994,7 +4303,8 @@
       "chapter": 6,
       "verse": 17,
       "phraseWordCounts": [
-        26
+        14,
+        12
       ],
       "annotations": [
         {
@@ -4042,7 +4352,9 @@
       "chapter": 6,
       "verse": 19,
       "phraseWordCounts": [
-        23
+        9,
+        10,
+        4
       ],
       "annotations": [
         {
@@ -4062,7 +4374,8 @@
       "chapter": 6,
       "verse": 20,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4073,7 +4386,8 @@
       "chapter": 6,
       "verse": 21,
       "phraseWordCounts": [
-        21
+        10,
+        11
       ],
       "annotations": [
         {
@@ -4097,7 +4411,9 @@
       "chapter": 6,
       "verse": 22,
       "phraseWordCounts": [
-        40
+        23,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -4113,7 +4429,8 @@
       "chapter": 6,
       "verse": 23,
       "phraseWordCounts": [
-        22
+        6,
+        16
       ],
       "annotations": [
         {
@@ -4129,7 +4446,8 @@
       "chapter": 6,
       "verse": 24,
       "phraseWordCounts": [
-        25
+        12,
+        13
       ],
       "annotations": [
         {
@@ -4149,7 +4467,8 @@
       "chapter": 6,
       "verse": 25,
       "phraseWordCounts": [
-        20
+        11,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4160,7 +4479,10 @@
       "chapter": 6,
       "verse": 26,
       "phraseWordCounts": [
-        30
+        7,
+        5,
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 8,
@@ -4171,7 +4493,10 @@
       "chapter": 6,
       "verse": 27,
       "phraseWordCounts": [
-        35
+        7,
+        8,
+        8,
+        12
       ],
       "annotations": [
         {
@@ -4199,7 +4524,8 @@
       "chapter": 6,
       "verse": 28,
       "phraseWordCounts": [
-        14
+        4,
+        10
       ],
       "annotations": [
         {
@@ -4215,7 +4541,9 @@
       "chapter": 6,
       "verse": 29,
       "phraseWordCounts": [
-        16
+        2,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4226,7 +4554,9 @@
       "chapter": 6,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        4,
+        14,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -4237,7 +4567,9 @@
       "chapter": 6,
       "verse": 31,
       "phraseWordCounts": [
-        20
+        8,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4248,7 +4580,10 @@
       "chapter": 6,
       "verse": 32,
       "phraseWordCounts": [
-        34
+        4,
+        5,
+        12,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 10,
@@ -4259,7 +4594,8 @@
       "chapter": 6,
       "verse": 33,
       "phraseWordCounts": [
-        19
+        13,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4281,7 +4617,10 @@
       "chapter": 6,
       "verse": 35,
       "phraseWordCounts": [
-        26
+        3,
+        6,
+        8,
+        9
       ],
       "annotations": [
         {
@@ -4299,7 +4638,8 @@
       "chapter": 6,
       "verse": 36,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4310,7 +4650,8 @@
       "chapter": 6,
       "verse": 37,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [
         {
@@ -4328,7 +4669,9 @@
       "chapter": 6,
       "verse": 38,
       "phraseWordCounts": [
-        22
+        7,
+        5,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4339,7 +4682,9 @@
       "chapter": 6,
       "verse": 39,
       "phraseWordCounts": [
-        30
+        10,
+        12,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4350,7 +4695,9 @@
       "chapter": 6,
       "verse": 40,
       "phraseWordCounts": [
-        30
+        5,
+        15,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4363,7 +4710,9 @@
       "chapter": 6,
       "verse": 41,
       "phraseWordCounts": [
-        22
+        10,
+        3,
+        9
       ],
       "annotations": [
         {
@@ -4381,7 +4730,9 @@
       "chapter": 6,
       "verse": 42,
       "phraseWordCounts": [
-        26
+        2,
+        14,
+        10
       ],
       "annotations": [
         {
@@ -4397,7 +4748,8 @@
       "chapter": 6,
       "verse": 43,
       "phraseWordCounts": [
-        6
+        4,
+        2
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4410,7 +4762,9 @@
       "chapter": 6,
       "verse": 44,
       "phraseWordCounts": [
-        24
+        6,
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4423,7 +4777,9 @@
       "chapter": 6,
       "verse": 45,
       "phraseWordCounts": [
-        26
+        6,
+        7,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4434,7 +4790,9 @@
       "chapter": 6,
       "verse": 46,
       "phraseWordCounts": [
-        19
+        6,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4445,7 +4803,8 @@
       "chapter": 6,
       "verse": 47,
       "phraseWordCounts": [
-        12
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -4467,7 +4826,8 @@
       "chapter": 6,
       "verse": 49,
       "phraseWordCounts": [
-        11
+        8,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4480,7 +4840,8 @@
       "chapter": 6,
       "verse": 50,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4493,7 +4854,10 @@
       "chapter": 6,
       "verse": 51,
       "phraseWordCounts": [
-        32
+        10,
+        7,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -4511,7 +4875,8 @@
       "chapter": 6,
       "verse": 52,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [
         {
@@ -4531,7 +4896,10 @@
       "chapter": 6,
       "verse": 53,
       "phraseWordCounts": [
-        29
+        4,
+        5,
+        14,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 10,
@@ -4542,7 +4910,8 @@
       "chapter": 6,
       "verse": 54,
       "phraseWordCounts": [
-        21
+        11,
+        10
       ],
       "annotations": [
         {
@@ -4558,7 +4927,8 @@
       "chapter": 6,
       "verse": 55,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [
         {
@@ -4578,7 +4948,8 @@
       "chapter": 6,
       "verse": 56,
       "phraseWordCounts": [
-        15
+        11,
+        4
       ],
       "annotations": [
         {
@@ -4594,7 +4965,8 @@
       "chapter": 6,
       "verse": 57,
       "phraseWordCounts": [
-        26
+        14,
+        12
       ],
       "annotations": [
         {
@@ -4610,7 +4982,9 @@
       "chapter": 6,
       "verse": 58,
       "phraseWordCounts": [
-        24
+        9,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -4637,7 +5011,9 @@
       "chapter": 6,
       "verse": 60,
       "phraseWordCounts": [
-        17
+        8,
+        5,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4648,7 +5024,9 @@
       "chapter": 6,
       "verse": 61,
       "phraseWordCounts": [
-        16
+        8,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -4684,7 +5062,10 @@
       "chapter": 6,
       "verse": 63,
       "phraseWordCounts": [
-        24
+        4,
+        5,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -4702,7 +5083,9 @@
       "chapter": 6,
       "verse": 64,
       "phraseWordCounts": [
-        28
+        10,
+        7,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4713,7 +5096,9 @@
       "chapter": 6,
       "verse": 65,
       "phraseWordCounts": [
-        24
+        5,
+        13,
+        6
       ],
       "annotations": [
         {
@@ -4729,7 +5114,8 @@
       "chapter": 6,
       "verse": 66,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4740,7 +5126,8 @@
       "chapter": 6,
       "verse": 67,
       "phraseWordCounts": [
-        13
+        9,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4751,7 +5138,9 @@
       "chapter": 6,
       "verse": 68,
       "phraseWordCounts": [
-        17
+        4,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4764,7 +5153,8 @@
       "chapter": 6,
       "verse": 69,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4777,7 +5167,9 @@
       "chapter": 6,
       "verse": 70,
       "phraseWordCounts": [
-        17
+        3,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4788,7 +5180,8 @@
       "chapter": 6,
       "verse": 71,
       "phraseWordCounts": [
-        19
+        8,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4799,7 +5192,9 @@
       "chapter": 7,
       "verse": 1,
       "phraseWordCounts": [
-        29
+        7,
+        9,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4826,7 +5221,9 @@
       "chapter": 7,
       "verse": 3,
       "phraseWordCounts": [
-        22
+        5,
+        6,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4837,7 +5234,9 @@
       "chapter": 7,
       "verse": 4,
       "phraseWordCounts": [
-        23
+        12,
+        6,
+        5
       ],
       "annotations": [
         {
@@ -4872,7 +5271,9 @@
       "chapter": 7,
       "verse": 6,
       "phraseWordCounts": [
-        16
+        4,
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4883,7 +5284,8 @@
       "chapter": 7,
       "verse": 7,
       "phraseWordCounts": [
-        17
+        5,
+        12
       ],
       "annotations": [
         {
@@ -4901,7 +5303,9 @@
       "chapter": 7,
       "verse": 8,
       "phraseWordCounts": [
-        21
+        5,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -4928,7 +5332,8 @@
       "chapter": 7,
       "verse": 10,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [
         {
@@ -4944,7 +5349,8 @@
       "chapter": 7,
       "verse": 11,
       "phraseWordCounts": [
-        16
+        13,
+        3
       ],
       "annotations": [
         {
@@ -4960,7 +5366,9 @@
       "chapter": 7,
       "verse": 12,
       "phraseWordCounts": [
-        23
+        9,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -4986,7 +5394,8 @@
       "chapter": 7,
       "verse": 13,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -4997,7 +5406,8 @@
       "chapter": 7,
       "verse": 14,
       "phraseWordCounts": [
-        18
+        6,
+        12
       ],
       "annotations": [
         {
@@ -5017,7 +5427,8 @@
       "chapter": 7,
       "verse": 15,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -5033,7 +5444,9 @@
       "chapter": 7,
       "verse": 16,
       "phraseWordCounts": [
-        16
+        2,
+        6,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5044,7 +5457,9 @@
       "chapter": 7,
       "verse": 17,
       "phraseWordCounts": [
-        25
+        9,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -5062,7 +5477,9 @@
       "chapter": 7,
       "verse": 18,
       "phraseWordCounts": [
-        34
+        11,
+        17,
+        6
       ],
       "annotations": [
         {
@@ -5086,7 +5503,9 @@
       "chapter": 7,
       "verse": 19,
       "phraseWordCounts": [
-        22
+        7,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5097,7 +5516,8 @@
       "chapter": 7,
       "verse": 20,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5108,7 +5528,8 @@
       "chapter": 7,
       "verse": 21,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -5126,7 +5547,9 @@
       "chapter": 7,
       "verse": 22,
       "phraseWordCounts": [
-        25
+        6,
+        12,
+        7
       ],
       "annotations": [
         {
@@ -5156,7 +5579,9 @@
       "chapter": 7,
       "verse": 23,
       "phraseWordCounts": [
-        35
+        10,
+        10,
+        15
       ],
       "annotations": [
         {
@@ -5204,7 +5629,8 @@
       "chapter": 7,
       "verse": 25,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [
         {
@@ -5220,7 +5646,8 @@
       "chapter": 7,
       "verse": 26,
       "phraseWordCounts": [
-        24
+        14,
+        10
       ],
       "annotations": [
         {
@@ -5240,7 +5667,8 @@
       "chapter": 7,
       "verse": 27,
       "phraseWordCounts": [
-        20
+        8,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5251,7 +5679,11 @@
       "chapter": 7,
       "verse": 28,
       "phraseWordCounts": [
-        41
+        10,
+        11,
+        8,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5262,7 +5694,8 @@
       "chapter": 7,
       "verse": 29,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5273,7 +5706,9 @@
       "chapter": 7,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        7,
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5286,7 +5721,8 @@
       "chapter": 7,
       "verse": 31,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5299,7 +5735,8 @@
       "chapter": 7,
       "verse": 32,
       "phraseWordCounts": [
-        23
+        10,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5310,7 +5747,9 @@
       "chapter": 7,
       "verse": 33,
       "phraseWordCounts": [
-        22
+        2,
+        9,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5321,7 +5760,9 @@
       "chapter": 7,
       "verse": 34,
       "phraseWordCounts": [
-        18
+        5,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5332,7 +5773,9 @@
       "chapter": 7,
       "verse": 35,
       "phraseWordCounts": [
-        33
+        6,
+        12,
+        15
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5343,7 +5786,9 @@
       "chapter": 7,
       "verse": 36,
       "phraseWordCounts": [
-        25
+        7,
+        11,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5354,7 +5799,9 @@
       "chapter": 7,
       "verse": 37,
       "phraseWordCounts": [
-        27
+        9,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -5372,7 +5819,9 @@
       "chapter": 7,
       "verse": 38,
       "phraseWordCounts": [
-        17
+        4,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -5390,7 +5839,10 @@
       "chapter": 7,
       "verse": 39,
       "phraseWordCounts": [
-        33
+        6,
+        10,
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5403,7 +5855,9 @@
       "chapter": 7,
       "verse": 40,
       "phraseWordCounts": [
-        15
+        4,
+        5,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5414,7 +5868,8 @@
       "chapter": 7,
       "verse": 41,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -5425,7 +5880,8 @@
       "chapter": 7,
       "verse": 42,
       "phraseWordCounts": [
-        20
+        4,
+        16
       ],
       "annotations": [
         {
@@ -5460,7 +5916,8 @@
       "chapter": 7,
       "verse": 44,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5471,7 +5928,8 @@
       "chapter": 7,
       "verse": 45,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5482,7 +5940,8 @@
       "chapter": 7,
       "verse": 46,
       "phraseWordCounts": [
-        12
+        9,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5814,7 +6273,10 @@
       "chapter": 8,
       "verse": 9,
       "phraseWordCounts": [
-        28
+        13,
+        4,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -5836,7 +6298,9 @@
       "chapter": 8,
       "verse": 10,
       "phraseWordCounts": [
-        15
+        6,
+        4,
+        5
       ],
       "annotations": [
         {
@@ -5854,7 +6318,9 @@
       "chapter": 8,
       "verse": 11,
       "phraseWordCounts": [
-        21
+        5,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5867,7 +6333,10 @@
       "chapter": 8,
       "verse": 12,
       "phraseWordCounts": [
-        31
+        9,
+        7,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -5885,7 +6354,9 @@
       "chapter": 8,
       "verse": 13,
       "phraseWordCounts": [
-        17
+        4,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -5905,7 +6376,10 @@
       "chapter": 8,
       "verse": 14,
       "phraseWordCounts": [
-        40
+        10,
+        4,
+        12,
+        14
       ],
       "annotations": [
         {
@@ -5921,7 +6395,8 @@
       "chapter": 8,
       "verse": 15,
       "phraseWordCounts": [
-        11
+        5,
+        6
       ],
       "annotations": [
         {
@@ -5941,7 +6416,9 @@
       "chapter": 8,
       "verse": 16,
       "phraseWordCounts": [
-        22
+        9,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -5968,7 +6445,8 @@
       "chapter": 8,
       "verse": 18,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5979,7 +6457,9 @@
       "chapter": 8,
       "verse": 19,
       "phraseWordCounts": [
-        28
+        8,
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -5992,7 +6472,10 @@
       "chapter": 8,
       "verse": 20,
       "phraseWordCounts": [
-        30
+        10,
+        8,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -6012,7 +6495,10 @@
       "chapter": 8,
       "verse": 21,
       "phraseWordCounts": [
-        29
+        6,
+        10,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6023,7 +6509,9 @@
       "chapter": 8,
       "verse": 22,
       "phraseWordCounts": [
-        20
+        5,
+        4,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6034,7 +6522,10 @@
       "chapter": 8,
       "verse": 23,
       "phraseWordCounts": [
-        22
+        7,
+        4,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -6264,7 +6755,9 @@
       "chapter": 8,
       "verse": 39,
       "phraseWordCounts": [
-        20
+        6,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -6277,7 +6770,9 @@
       "chapter": 8,
       "verse": 40,
       "phraseWordCounts": [
-        31
+        12,
+        13,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6290,7 +6785,9 @@
       "chapter": 8,
       "verse": 41,
       "phraseWordCounts": [
-        24
+        9,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -6306,7 +6803,9 @@
       "chapter": 8,
       "verse": 42,
       "phraseWordCounts": [
-        30
+        13,
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6317,7 +6816,8 @@
       "chapter": 8,
       "verse": 43,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [
         {
@@ -6333,7 +6833,13 @@
       "chapter": 8,
       "verse": 44,
       "phraseWordCounts": [
-        53
+        7,
+        9,
+        7,
+        5,
+        7,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -6367,7 +6873,8 @@
       "chapter": 8,
       "verse": 45,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6378,7 +6885,8 @@
       "chapter": 8,
       "verse": 46,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -6389,7 +6897,8 @@
       "chapter": 8,
       "verse": 47,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6411,7 +6920,8 @@
       "chapter": 8,
       "verse": 49,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [
         {
@@ -6427,7 +6937,8 @@
       "chapter": 8,
       "verse": 50,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [
         {
@@ -6443,7 +6954,8 @@
       "chapter": 8,
       "verse": 51,
       "phraseWordCounts": [
-        13
+        5,
+        8
       ],
       "annotations": [
         {
@@ -6459,7 +6971,9 @@
       "chapter": 8,
       "verse": 52,
       "phraseWordCounts": [
-        30
+        11,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -6483,7 +6997,9 @@
       "chapter": 8,
       "verse": 53,
       "phraseWordCounts": [
-        20
+        7,
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -6494,7 +7010,9 @@
       "chapter": 8,
       "verse": 54,
       "phraseWordCounts": [
-        24
+        10,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -6510,7 +7028,9 @@
       "chapter": 8,
       "verse": 55,
       "phraseWordCounts": [
-        31
+        9,
+        13,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6521,7 +7041,8 @@
       "chapter": 8,
       "verse": 56,
       "phraseWordCounts": [
-        17
+        11,
+        6
       ],
       "annotations": [
         {
@@ -6537,7 +7058,8 @@
       "chapter": 8,
       "verse": 57,
       "phraseWordCounts": [
-        16
+        11,
+        5
       ],
       "annotations": [
         {
@@ -6553,7 +7075,8 @@
       "chapter": 8,
       "verse": 58,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -6566,7 +7089,8 @@
       "chapter": 8,
       "verse": 59,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [
         {
@@ -6586,7 +7110,8 @@
       "chapter": 9,
       "verse": 1,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6599,7 +7124,9 @@
       "chapter": 9,
       "verse": 2,
       "phraseWordCounts": [
-        17
+        4,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -6617,7 +7144,8 @@
       "chapter": 9,
       "verse": 3,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [
         {
@@ -6639,7 +7167,9 @@
       "chapter": 9,
       "verse": 4,
       "phraseWordCounts": [
-        24
+        6,
+        10,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6650,7 +7180,8 @@
       "chapter": 9,
       "verse": 5,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6661,7 +7192,9 @@
       "chapter": 9,
       "verse": 6,
       "phraseWordCounts": [
-        21
+        8,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -6681,7 +7214,9 @@
       "chapter": 9,
       "verse": 7,
       "phraseWordCounts": [
-        24
+        10,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -6697,7 +7232,8 @@
       "chapter": 9,
       "verse": 8,
       "phraseWordCounts": [
-        22
+        11,
+        11
       ],
       "annotations": [
         {
@@ -6725,7 +7261,9 @@
       "chapter": 9,
       "verse": 9,
       "phraseWordCounts": [
-        21
+        5,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6747,7 +7285,10 @@
       "chapter": 9,
       "verse": 11,
       "phraseWordCounts": [
-        35
+        2,
+        14,
+        9,
+        10
       ],
       "annotations": [
         {
@@ -6763,7 +7304,8 @@
       "chapter": 9,
       "verse": 12,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6785,7 +7327,8 @@
       "chapter": 9,
       "verse": 14,
       "phraseWordCounts": [
-        18
+        15,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6796,7 +7339,9 @@
       "chapter": 9,
       "verse": 15,
       "phraseWordCounts": [
-        28
+        12,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6809,7 +7354,10 @@
       "chapter": 9,
       "verse": 16,
       "phraseWordCounts": [
-        32
+        5,
+        13,
+        10,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6820,7 +7368,10 @@
       "chapter": 9,
       "verse": 17,
       "phraseWordCounts": [
-        28
+        8,
+        7,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6831,7 +7382,8 @@
       "chapter": 9,
       "verse": 18,
       "phraseWordCounts": [
-        22
+        15,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6842,7 +7394,9 @@
       "chapter": 9,
       "verse": 19,
       "phraseWordCounts": [
-        23
+        6,
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6853,7 +7407,8 @@
       "chapter": 9,
       "verse": 20,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6864,7 +7419,9 @@
       "chapter": 9,
       "verse": 21,
       "phraseWordCounts": [
-        25
+        14,
+        2,
+        9
       ],
       "annotations": [
         {
@@ -6880,7 +7437,9 @@
       "chapter": 9,
       "verse": 22,
       "phraseWordCounts": [
-        32
+        12,
+        13,
+        7
       ],
       "annotations": [
         {
@@ -6896,7 +7455,8 @@
       "chapter": 9,
       "verse": 23,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [
         {
@@ -6912,7 +7472,9 @@
       "chapter": 9,
       "verse": 24,
       "phraseWordCounts": [
-        28
+        11,
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6925,7 +7487,9 @@
       "chapter": 9,
       "verse": 25,
       "phraseWordCounts": [
-        24
+        12,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6938,7 +7502,8 @@
       "chapter": 9,
       "verse": 26,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -6949,7 +7514,9 @@
       "chapter": 9,
       "verse": 27,
       "phraseWordCounts": [
-        28
+        12,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6960,7 +7527,9 @@
       "chapter": 9,
       "verse": 28,
       "phraseWordCounts": [
-        18
+        8,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -6984,7 +7553,9 @@
       "chapter": 9,
       "verse": 29,
       "phraseWordCounts": [
-        20
+        7,
+        5,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6995,7 +7566,9 @@
       "chapter": 9,
       "verse": 30,
       "phraseWordCounts": [
-        19
+        7,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -7011,7 +7584,8 @@
       "chapter": 9,
       "verse": 31,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [
         {
@@ -7051,7 +7625,8 @@
       "chapter": 9,
       "verse": 33,
       "phraseWordCounts": [
-        11
+        7,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7062,7 +7637,10 @@
       "chapter": 9,
       "verse": 34,
       "phraseWordCounts": [
-        21
+        4,
+        7,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -7092,7 +7670,9 @@
       "chapter": 9,
       "verse": 35,
       "phraseWordCounts": [
-        23
+        8,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7105,7 +7685,8 @@
       "chapter": 9,
       "verse": 36,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7118,7 +7699,9 @@
       "chapter": 9,
       "verse": 37,
       "phraseWordCounts": [
-        16
+        2,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7131,7 +7714,9 @@
       "chapter": 9,
       "verse": 38,
       "phraseWordCounts": [
-        11
+        4,
+        3,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7144,7 +7729,9 @@
       "chapter": 9,
       "verse": 39,
       "phraseWordCounts": [
-        23
+        10,
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7157,7 +7744,8 @@
       "chapter": 9,
       "verse": 40,
       "phraseWordCounts": [
-        17
+        12,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7168,7 +7756,9 @@
       "chapter": 9,
       "verse": 41,
       "phraseWordCounts": [
-        24
+        2,
+        11,
+        11
       ],
       "annotations": [
         {
@@ -7184,7 +7774,10 @@
       "chapter": 10,
       "verse": 1,
       "phraseWordCounts": [
-        30
+        6,
+        11,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -7215,7 +7808,8 @@
       "chapter": 10,
       "verse": 3,
       "phraseWordCounts": [
-        25
+        14,
+        11
       ],
       "annotations": [
         {
@@ -7239,7 +7833,9 @@
       "chapter": 10,
       "verse": 4,
       "phraseWordCounts": [
-        24
+        8,
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7250,7 +7846,8 @@
       "chapter": 10,
       "verse": 5,
       "phraseWordCounts": [
-        23
+        7,
+        16
       ],
       "annotations": [
         {
@@ -7274,7 +7871,8 @@
       "chapter": 10,
       "verse": 6,
       "phraseWordCounts": [
-        17
+        6,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7285,7 +7883,9 @@
       "chapter": 10,
       "verse": 7,
       "phraseWordCounts": [
-        16
+        4,
+        5,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7298,7 +7898,8 @@
       "chapter": 10,
       "verse": 8,
       "phraseWordCounts": [
-        18
+        10,
+        8
       ],
       "annotations": [
         {
@@ -7322,7 +7923,9 @@
       "chapter": 10,
       "verse": 9,
       "phraseWordCounts": [
-        21
+        4,
+        7,
+        10
       ],
       "annotations": [
         {
@@ -7340,7 +7943,9 @@
       "chapter": 10,
       "verse": 10,
       "phraseWordCounts": [
-        24
+        10,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -7358,7 +7963,8 @@
       "chapter": 10,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        5,
+        10
       ],
       "annotations": [
         {
@@ -7376,7 +7982,9 @@
       "chapter": 10,
       "verse": 12,
       "phraseWordCounts": [
-        36
+        13,
+        14,
+        9
       ],
       "annotations": [
         {
@@ -7420,7 +8028,8 @@
       "chapter": 10,
       "verse": 13,
       "phraseWordCounts": [
-        16
+        4,
+        12
       ],
       "annotations": [
         {
@@ -7444,7 +8053,8 @@
       "chapter": 10,
       "verse": 14,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 6,
@@ -7455,7 +8065,9 @@
       "chapter": 10,
       "verse": 15,
       "phraseWordCounts": [
-        20
+        6,
+        5,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7466,7 +8078,10 @@
       "chapter": 10,
       "verse": 16,
       "phraseWordCounts": [
-        32
+        11,
+        5,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -7482,7 +8097,8 @@
       "chapter": 10,
       "verse": 17,
       "phraseWordCounts": [
-        19
+        6,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7493,7 +8109,11 @@
       "chapter": 10,
       "verse": 18,
       "phraseWordCounts": [
-        36
+        6,
+        9,
+        7,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -7522,7 +8142,9 @@
       "chapter": 10,
       "verse": 20,
       "phraseWordCounts": [
-        14
+        4,
+        6,
+        4
       ],
       "annotations": [
         {
@@ -7542,7 +8164,9 @@
       "chapter": 10,
       "verse": 21,
       "phraseWordCounts": [
-        24
+        3,
+        12,
+        9
       ],
       "annotations": [
         {
@@ -7558,7 +8182,8 @@
       "chapter": 10,
       "verse": 22,
       "phraseWordCounts": [
-        11
+        8,
+        3
       ],
       "annotations": [
         {
@@ -7600,7 +8225,9 @@
       "chapter": 10,
       "verse": 24,
       "phraseWordCounts": [
-        25
+        9,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -7618,7 +8245,9 @@
       "chapter": 10,
       "verse": 25,
       "phraseWordCounts": [
-        22
+        2,
+        9,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7644,7 +8273,8 @@
       "chapter": 10,
       "verse": 27,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7657,7 +8287,9 @@
       "chapter": 10,
       "verse": 28,
       "phraseWordCounts": [
-        19
+        5,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -7675,7 +8307,8 @@
       "chapter": 10,
       "verse": 29,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [
         {
@@ -7722,7 +8355,9 @@
       "chapter": 10,
       "verse": 32,
       "phraseWordCounts": [
-        23
+        5,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -7738,7 +8373,8 @@
       "chapter": 10,
       "verse": 33,
       "phraseWordCounts": [
-        23
+        11,
+        12
       ],
       "annotations": [
         {
@@ -7758,7 +8394,8 @@
       "chapter": 10,
       "verse": 34,
       "phraseWordCounts": [
-        18
+        3,
+        15
       ],
       "annotations": [
         {
@@ -7774,7 +8411,8 @@
       "chapter": 10,
       "verse": 35,
       "phraseWordCounts": [
-        18
+        12,
+        6
       ],
       "annotations": [
         {
@@ -7790,7 +8428,8 @@
       "chapter": 10,
       "verse": 36,
       "phraseWordCounts": [
-        33
+        18,
+        15
       ],
       "annotations": [
         {
@@ -7821,7 +8460,9 @@
       "chapter": 10,
       "verse": 38,
       "phraseWordCounts": [
-        32
+        12,
+        3,
+        17
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -7832,7 +8473,8 @@
       "chapter": 10,
       "verse": 39,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [
         {
@@ -7852,7 +8494,8 @@
       "chapter": 10,
       "verse": 40,
       "phraseWordCounts": [
-        22
+        19,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -7863,7 +8506,9 @@
       "chapter": 10,
       "verse": 41,
       "phraseWordCounts": [
-        23
+        6,
+        8,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7885,7 +8530,8 @@
       "chapter": 11,
       "verse": 1,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7898,7 +8544,9 @@
       "chapter": 11,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        8,
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7909,7 +8557,8 @@
       "chapter": 11,
       "verse": 3,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [
         {
@@ -7925,7 +8574,9 @@
       "chapter": 11,
       "verse": 4,
       "phraseWordCounts": [
-        28
+        6,
+        7,
+        15
       ],
       "annotations": [
         {
@@ -7954,7 +8605,8 @@
       "chapter": 11,
       "verse": 6,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7965,7 +8617,8 @@
       "chapter": 11,
       "verse": 7,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7976,7 +8629,9 @@
       "chapter": 11,
       "verse": 8,
       "phraseWordCounts": [
-        21
+        4,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -7992,7 +8647,9 @@
       "chapter": 11,
       "verse": 9,
       "phraseWordCounts": [
-        25
+        9,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -8024,7 +8681,8 @@
       "chapter": 11,
       "verse": 10,
       "phraseWordCounts": [
-        16
+        11,
+        5
       ],
       "annotations": [
         {
@@ -8040,7 +8698,9 @@
       "chapter": 11,
       "verse": 11,
       "phraseWordCounts": [
-        26
+        11,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -8080,7 +8740,8 @@
       "chapter": 11,
       "verse": 13,
       "phraseWordCounts": [
-        15
+        7,
+        8
       ],
       "annotations": [
         {
@@ -8107,7 +8768,9 @@
       "chapter": 11,
       "verse": 15,
       "phraseWordCounts": [
-        22
+        11,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -8123,7 +8786,8 @@
       "chapter": 11,
       "verse": 16,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [
         {
@@ -8139,7 +8803,8 @@
       "chapter": 11,
       "verse": 17,
       "phraseWordCounts": [
-        16
+        3,
+        13
       ],
       "annotations": [
         {
@@ -8166,7 +8831,8 @@
       "chapter": 11,
       "verse": 19,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [
         {
@@ -8182,7 +8848,9 @@
       "chapter": 11,
       "verse": 20,
       "phraseWordCounts": [
-        18
+        7,
+        6,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8193,7 +8861,8 @@
       "chapter": 11,
       "verse": 21,
       "phraseWordCounts": [
-        16
+        5,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -8219,7 +8888,8 @@
       "chapter": 11,
       "verse": 23,
       "phraseWordCounts": [
-        9
+        4,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8232,7 +8902,8 @@
       "chapter": 11,
       "verse": 24,
       "phraseWordCounts": [
-        15
+        2,
+        13
       ],
       "annotations": [
         {
@@ -8250,7 +8921,9 @@
       "chapter": 11,
       "verse": 25,
       "phraseWordCounts": [
-        23
+        4,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -8268,7 +8941,8 @@
       "chapter": 11,
       "verse": 26,
       "phraseWordCounts": [
-        14
+        10,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8281,7 +8955,9 @@
       "chapter": 11,
       "verse": 27,
       "phraseWordCounts": [
-        22
+        4,
+        7,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -8294,7 +8970,8 @@
       "chapter": 11,
       "verse": 28,
       "phraseWordCounts": [
-        25
+        14,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8305,7 +8982,8 @@
       "chapter": 11,
       "verse": 29,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8316,7 +8994,8 @@
       "chapter": 11,
       "verse": 30,
       "phraseWordCounts": [
-        19
+        8,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8327,7 +9006,9 @@
       "chapter": 11,
       "verse": 31,
       "phraseWordCounts": [
-        35
+        22,
+        3,
+        10
       ],
       "annotations": [
         {
@@ -8351,7 +9032,9 @@
       "chapter": 11,
       "verse": 32,
       "phraseWordCounts": [
-        30
+        11,
+        7,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8364,7 +9047,8 @@
       "chapter": 11,
       "verse": 33,
       "phraseWordCounts": [
-        24
+        16,
+        8
       ],
       "annotations": [
         {
@@ -8390,7 +9074,8 @@
       "chapter": 11,
       "verse": 34,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8423,7 +9108,8 @@
       "chapter": 11,
       "verse": 37,
       "phraseWordCounts": [
-        22
+        5,
+        17
       ],
       "annotations": [
         {
@@ -8439,7 +9125,8 @@
       "chapter": 11,
       "verse": 38,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [
         {
@@ -8459,7 +9146,10 @@
       "chapter": 11,
       "verse": 39,
       "phraseWordCounts": [
-        31
+        6,
+        10,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -8479,7 +9169,9 @@
       "chapter": 11,
       "verse": 40,
       "phraseWordCounts": [
-        19
+        3,
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8490,7 +9182,9 @@
       "chapter": 11,
       "verse": 41,
       "phraseWordCounts": [
-        21
+        6,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -8506,7 +9200,9 @@
       "chapter": 11,
       "verse": 42,
       "phraseWordCounts": [
-        27
+        7,
+        12,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8517,7 +9213,8 @@
       "chapter": 11,
       "verse": 43,
       "phraseWordCounts": [
-        14
+        11,
+        3
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -8530,7 +9227,9 @@
       "chapter": 11,
       "verse": 44,
       "phraseWordCounts": [
-        33
+        5,
+        15,
+        13
       ],
       "annotations": [
         {
@@ -8548,7 +9247,8 @@
       "chapter": 11,
       "verse": 45,
       "phraseWordCounts": [
-        20
+        17,
+        3
       ],
       "annotations": [
         {
@@ -8575,7 +9275,9 @@
       "chapter": 11,
       "verse": 47,
       "phraseWordCounts": [
-        26
+        13,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -8599,7 +9301,9 @@
       "chapter": 11,
       "verse": 48,
       "phraseWordCounts": [
-        28
+        8,
+        5,
+        15
       ],
       "annotations": [
         {
@@ -8619,7 +9323,9 @@
       "chapter": 11,
       "verse": 49,
       "phraseWordCounts": [
-        19
+        6,
+        8,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8630,7 +9336,9 @@
       "chapter": 11,
       "verse": 50,
       "phraseWordCounts": [
-        23
+        10,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -8646,7 +9354,8 @@
       "chapter": 11,
       "verse": 51,
       "phraseWordCounts": [
-        24
+        8,
+        16
       ],
       "annotations": [
         {
@@ -8666,7 +9375,9 @@
       "chapter": 11,
       "verse": 52,
       "phraseWordCounts": [
-        22
+        6,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -8698,7 +9409,10 @@
       "chapter": 11,
       "verse": 54,
       "phraseWordCounts": [
-        32
+        12,
+        9,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -8718,7 +9432,9 @@
       "chapter": 11,
       "verse": 55,
       "phraseWordCounts": [
-        24
+        9,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -8734,7 +9450,10 @@
       "chapter": 11,
       "verse": 56,
       "phraseWordCounts": [
-        29
+        5,
+        12,
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8745,7 +9464,9 @@
       "chapter": 11,
       "verse": 57,
       "phraseWordCounts": [
-        27
+        10,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -8765,7 +9486,9 @@
       "chapter": 12,
       "verse": 1,
       "phraseWordCounts": [
-        19
+        5,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -8778,7 +9501,9 @@
       "chapter": 12,
       "verse": 2,
       "phraseWordCounts": [
-        21
+        8,
+        2,
+        11
       ],
       "annotations": [
         {
@@ -8802,7 +9527,10 @@
       "chapter": 12,
       "verse": 3,
       "phraseWordCounts": [
-        36
+        12,
+        6,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -8836,7 +9564,8 @@
       "chapter": 12,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,

--- a/data/5-hp-niv.json
+++ b/data/5-hp-niv.json
@@ -139,7 +139,8 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        21
+        6,
+        15
       ],
       "annotations": [
         {
@@ -185,7 +186,10 @@
       "chapter": 1,
       "verse": 2,
       "phraseWordCounts": [
-        37
+        12,
+        7,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -207,7 +211,9 @@
       "chapter": 1,
       "verse": 3,
       "phraseWordCounts": [
-        35
+        12,
+        14,
+        9
       ],
       "annotations": [
         {
@@ -225,7 +231,8 @@
       "chapter": 1,
       "verse": 4,
       "phraseWordCounts": [
-        19
+        11,
+        8
       ],
       "annotations": [
         {
@@ -243,7 +250,8 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        24
+        8,
+        16
       ],
       "annotations": [
         {
@@ -261,7 +269,8 @@
       "chapter": 1,
       "verse": 6,
       "phraseWordCounts": [
-        24
+        6,
+        18
       ],
       "annotations": [
         {
@@ -279,7 +288,10 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        35
+        11,
+        12,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -309,7 +321,9 @@
       "chapter": 1,
       "verse": 8,
       "phraseWordCounts": [
-        31
+        9,
+        13,
+        9
       ],
       "annotations": [
         {
@@ -335,7 +349,8 @@
       "chapter": 1,
       "verse": 9,
       "phraseWordCounts": [
-        15
+        10,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -348,7 +363,9 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        5,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -368,7 +385,9 @@
       "chapter": 1,
       "verse": 11,
       "phraseWordCounts": [
-        32
+        8,
+        10,
+        14
       ],
       "annotations": [
         {
@@ -404,7 +423,10 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        49
+        13,
+        12,
+        16,
+        8
       ],
       "annotations": [
         {
@@ -420,7 +442,9 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        28
+        9,
+        11,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -433,7 +457,8 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        17
+        3,
+        14
       ],
       "annotations": [
         {
@@ -451,7 +476,8 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -464,7 +490,8 @@
       "chapter": 1,
       "verse": 16,
       "phraseWordCounts": [
-        10
+        4,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -477,7 +504,8 @@
       "chapter": 1,
       "verse": 17,
       "phraseWordCounts": [
-        22
+        12,
+        10
       ],
       "annotations": [
         {
@@ -499,7 +527,8 @@
       "chapter": 1,
       "verse": 18,
       "phraseWordCounts": [
-        32
+        15,
+        17
       ],
       "annotations": [
         {
@@ -529,7 +558,8 @@
       "chapter": 1,
       "verse": 19,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [
         {
@@ -555,7 +585,8 @@
       "chapter": 1,
       "verse": 20,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -568,7 +599,9 @@
       "chapter": 1,
       "verse": 21,
       "phraseWordCounts": [
-        24
+        6,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -586,7 +619,9 @@
       "chapter": 1,
       "verse": 22,
       "phraseWordCounts": [
-        26
+        10,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -604,7 +639,10 @@
       "chapter": 1,
       "verse": 23,
       "phraseWordCounts": [
-        21
+        6,
+        4,
+        3,
+        8
       ],
       "annotations": [
         {
@@ -630,7 +668,9 @@
       "chapter": 1,
       "verse": 24,
       "phraseWordCounts": [
-        24
+        6,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -668,7 +708,8 @@
       "chapter": 1,
       "verse": 25,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [
         {
@@ -686,7 +727,8 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [
         {
@@ -716,7 +758,8 @@
       "chapter": 2,
       "verse": 2,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -757,7 +800,9 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        19
+        5,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -773,7 +818,9 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        26
+        12,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -801,7 +848,9 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        30
+        5,
+        12,
+        13
       ],
       "annotations": [
         {
@@ -827,7 +876,9 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        25
+        9,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -847,7 +898,9 @@
       "chapter": 2,
       "verse": 8,
       "phraseWordCounts": [
-        30
+        15,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -871,7 +924,9 @@
       "chapter": 2,
       "verse": 9,
       "phraseWordCounts": [
-        33
+        15,
+        8,
+        10
       ],
       "annotations": [
         {
@@ -905,7 +960,8 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        26
+        14,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -916,7 +972,9 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        20
+        9,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -940,7 +998,9 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        30
+        7,
+        8,
+        15
       ],
       "annotations": [
         {
@@ -964,7 +1024,8 @@
       "chapter": 2,
       "verse": 13,
       "phraseWordCounts": [
-        18
+        10,
+        8
       ],
       "annotations": [
         {
@@ -990,7 +1051,8 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        21
+        3,
+        18
       ],
       "annotations": [
         {
@@ -1016,7 +1078,8 @@
       "chapter": 2,
       "verse": 15,
       "phraseWordCounts": [
-        18
+        5,
+        13
       ],
       "annotations": [
         {
@@ -1042,7 +1105,9 @@
       "chapter": 2,
       "verse": 16,
       "phraseWordCounts": [
-        19
+        4,
+        11,
+        4
       ],
       "annotations": [
         {
@@ -1058,7 +1123,10 @@
       "chapter": 2,
       "verse": 17,
       "phraseWordCounts": [
-        15
+        5,
+        5,
+        2,
+        3
       ],
       "annotations": [
         {
@@ -1078,7 +1146,9 @@
       "chapter": 2,
       "verse": 18,
       "phraseWordCounts": [
-        27
+        11,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -1100,7 +1170,8 @@
       "chapter": 2,
       "verse": 19,
       "phraseWordCounts": [
-        20
+        14,
+        6
       ],
       "annotations": [
         {
@@ -1128,7 +1199,8 @@
       "chapter": 2,
       "verse": 20,
       "phraseWordCounts": [
-        34
+        18,
+        16
       ],
       "annotations": [
         {
@@ -1154,7 +1226,9 @@
       "chapter": 2,
       "verse": 21,
       "phraseWordCounts": [
-        21
+        5,
+        5,
+        11
       ],
       "annotations": [
         {
@@ -1176,7 +1250,8 @@
       "chapter": 2,
       "verse": 22,
       "phraseWordCounts": [
-        12
+        4,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1189,7 +1264,9 @@
       "chapter": 2,
       "verse": 23,
       "phraseWordCounts": [
-        27
+        11,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -1219,7 +1296,9 @@
       "chapter": 2,
       "verse": 24,
       "phraseWordCounts": [
-        29
+        11,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -1237,7 +1316,8 @@
       "chapter": 2,
       "verse": 25,
       "phraseWordCounts": [
-        20
+        7,
+        13
       ],
       "annotations": [
         {
@@ -1259,7 +1339,9 @@
       "chapter": 3,
       "verse": 1,
       "phraseWordCounts": [
-        35
+        11,
+        11,
+        13
       ],
       "annotations": [
         {
@@ -1295,7 +1377,8 @@
       "chapter": 3,
       "verse": 3,
       "phraseWordCounts": [
-        21
+        8,
+        13
       ],
       "annotations": [
         {
@@ -1345,7 +1428,9 @@
       "chapter": 3,
       "verse": 4,
       "phraseWordCounts": [
-        26
+        9,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -1379,7 +1464,8 @@
       "chapter": 3,
       "verse": 5,
       "phraseWordCounts": [
-        28
+        21,
+        7
       ],
       "annotations": [
         {
@@ -1399,7 +1485,8 @@
       "chapter": 3,
       "verse": 6,
       "phraseWordCounts": [
-        27
+        10,
+        17
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1410,7 +1497,10 @@
       "chapter": 3,
       "verse": 7,
       "phraseWordCounts": [
-        40
+        13,
+        9,
+        11,
+        7
       ],
       "annotations": [
         {
@@ -1444,7 +1534,10 @@
       "chapter": 3,
       "verse": 8,
       "phraseWordCounts": [
-        15
+        4,
+        4,
+        3,
+        4
       ],
       "annotations": [
         {
@@ -1474,7 +1567,9 @@
       "chapter": 3,
       "verse": 9,
       "phraseWordCounts": [
-        30
+        10,
+        7,
+        13
       ],
       "annotations": [
         {
@@ -1492,7 +1587,9 @@
       "chapter": 3,
       "verse": 10,
       "phraseWordCounts": [
-        21
+        9,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -1514,7 +1611,8 @@
       "chapter": 3,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [
         {
@@ -1532,7 +1630,9 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        30
+        10,
+        8,
+        12
       ],
       "annotations": [
         {
@@ -1569,7 +1669,9 @@
       "chapter": 3,
       "verse": 14,
       "phraseWordCounts": [
-        22
+        13,
+        5,
+        4
       ],
       "annotations": [
         {
@@ -1585,7 +1687,9 @@
       "chapter": 3,
       "verse": 15,
       "phraseWordCounts": [
-        37
+        8,
+        22,
+        7
       ],
       "annotations": [
         {
@@ -1615,7 +1719,8 @@
       "chapter": 3,
       "verse": 16,
       "phraseWordCounts": [
-        22
+        4,
+        18
       ],
       "annotations": [
         {
@@ -1631,7 +1736,8 @@
       "chapter": 3,
       "verse": 17,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -1642,7 +1748,11 @@
       "chapter": 3,
       "verse": 18,
       "phraseWordCounts": [
-        31
+        7,
+        5,
+        5,
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1655,7 +1765,8 @@
       "chapter": 3,
       "verse": 19,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -1675,7 +1786,10 @@
       "chapter": 3,
       "verse": 20,
       "phraseWordCounts": [
-        35
+        7,
+        9,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -1699,7 +1813,10 @@
       "chapter": 3,
       "verse": 21,
       "phraseWordCounts": [
-        36
+        10,
+        8,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -1739,7 +1856,9 @@
       "chapter": 3,
       "verse": 22,
       "phraseWordCounts": [
-        20
+        5,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -1759,7 +1878,9 @@
       "chapter": 4,
       "verse": 1,
       "phraseWordCounts": [
-        24
+        7,
+        7,
+        10
       ],
       "annotations": [
         {
@@ -1785,7 +1906,8 @@
       "chapter": 4,
       "verse": 2,
       "phraseWordCounts": [
-        24
+        17,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1798,7 +1920,8 @@
       "chapter": 4,
       "verse": 3,
       "phraseWordCounts": [
-        25
+        15,
+        10
       ],
       "annotations": [
         {
@@ -1852,7 +1975,9 @@
       "chapter": 4,
       "verse": 4,
       "phraseWordCounts": [
-        20
+        9,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -1878,7 +2003,8 @@
       "chapter": 4,
       "verse": 5,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -1891,7 +2017,9 @@
       "chapter": 4,
       "verse": 6,
       "phraseWordCounts": [
-        41
+        16,
+        15,
+        10
       ],
       "annotations": [
         {
@@ -1911,7 +2039,9 @@
       "chapter": 4,
       "verse": 7,
       "phraseWordCounts": [
-        19
+        7,
+        7,
+        5
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -1924,7 +2054,8 @@
       "chapter": 4,
       "verse": 8,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [
         {
@@ -1964,7 +2095,8 @@
       "chapter": 4,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [
         {
@@ -1986,7 +2118,10 @@
       "chapter": 4,
       "verse": 11,
       "phraseWordCounts": [
-        53
+        16,
+        12,
+        12,
+        13
       ],
       "annotations": [
         {
@@ -2008,7 +2143,8 @@
       "chapter": 4,
       "verse": 12,
       "phraseWordCounts": [
-        26
+        18,
+        8
       ],
       "annotations": [
         {
@@ -2036,7 +2172,8 @@
       "chapter": 4,
       "verse": 13,
       "phraseWordCounts": [
-        22
+        11,
+        11
       ],
       "annotations": [
         {
@@ -2056,7 +2193,9 @@
       "chapter": 4,
       "verse": 14,
       "phraseWordCounts": [
-        24
+        10,
+        3,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -2067,7 +2206,8 @@
       "chapter": 4,
       "verse": 15,
       "phraseWordCounts": [
-        23
+        18,
+        5
       ],
       "annotations": [
         {
@@ -2091,7 +2231,9 @@
       "chapter": 4,
       "verse": 16,
       "phraseWordCounts": [
-        19
+        7,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -2107,7 +2249,8 @@
       "chapter": 4,
       "verse": 17,
       "phraseWordCounts": [
-        32
+        11,
+        21
       ],
       "annotations": [
         {
@@ -2131,7 +2274,8 @@
       "chapter": 4,
       "verse": 18,
       "phraseWordCounts": [
-        20
+        11,
+        9
       ],
       "annotations": [
         {
@@ -2147,7 +2291,9 @@
       "chapter": 4,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        9,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -2169,7 +2315,9 @@
       "chapter": 5,
       "verse": 1,
       "phraseWordCounts": [
-        27
+        5,
+        12,
+        10
       ],
       "annotations": [
         {
@@ -2199,7 +2347,9 @@
       "chapter": 5,
       "verse": 2,
       "phraseWordCounts": [
-        36
+        10,
+        18,
+        8
       ],
       "annotations": [
         {
@@ -2241,7 +2391,8 @@
       "chapter": 5,
       "verse": 3,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -2267,7 +2418,8 @@
       "chapter": 5,
       "verse": 4,
       "phraseWordCounts": [
-        18
+        6,
+        12
       ],
       "annotations": [
         {
@@ -2289,7 +2441,10 @@
       "chapter": 5,
       "verse": 5,
       "phraseWordCounts": [
-        34
+        13,
+        10,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -2335,7 +2490,8 @@
       "chapter": 5,
       "verse": 6,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -2361,7 +2517,8 @@
       "chapter": 5,
       "verse": 7,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [
         {
@@ -2387,7 +2544,8 @@
       "chapter": 5,
       "verse": 8,
       "phraseWordCounts": [
-        21
+        6,
+        15
       ],
       "annotations": [
         {
@@ -2421,7 +2579,8 @@
       "chapter": 5,
       "verse": 9,
       "phraseWordCounts": [
-        25
+        7,
+        18
       ],
       "annotations": [
         {
@@ -2447,7 +2606,10 @@
       "chapter": 5,
       "verse": 10,
       "phraseWordCounts": [
-        33
+        6,
+        9,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -2484,7 +2646,10 @@
       "chapter": 5,
       "verse": 12,
       "phraseWordCounts": [
-        34
+        12,
+        6,
+        12,
+        4
       ],
       "annotations": [
         {
@@ -2512,7 +2677,8 @@
       "chapter": 5,
       "verse": 13,
       "phraseWordCounts": [
-        19
+        13,
+        6
       ],
       "annotations": [
         {
@@ -2536,7 +2702,8 @@
       "chapter": 5,
       "verse": 14,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [
         {
@@ -2552,7 +2719,9 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        30
+        9,
+        13,
+        8
       ],
       "annotations": [
         {
@@ -2574,7 +2743,8 @@
       "chapter": 1,
       "verse": 2,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2587,7 +2757,8 @@
       "chapter": 1,
       "verse": 3,
       "phraseWordCounts": [
-        27
+        13,
+        14
       ],
       "annotations": [
         {
@@ -2605,7 +2776,9 @@
       "chapter": 1,
       "verse": 4,
       "phraseWordCounts": [
-        34
+        12,
+        11,
+        11
       ],
       "annotations": [
         {
@@ -2627,7 +2800,8 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        17
+        13,
+        4
       ],
       "annotations": [
         {
@@ -2645,7 +2819,9 @@
       "chapter": 1,
       "verse": 6,
       "phraseWordCounts": [
-        12
+        4,
+        4,
+        4
       ],
       "annotations": [
         {
@@ -2671,7 +2847,8 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        10
+        5,
+        5
       ],
       "annotations": [
         {
@@ -2705,7 +2882,8 @@
       "chapter": 1,
       "verse": 8,
       "phraseWordCounts": [
-        26
+        9,
+        17
       ],
       "annotations": [
         {
@@ -2743,7 +2921,8 @@
       "chapter": 1,
       "verse": 9,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [
         {
@@ -2769,7 +2948,8 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        24
+        14,
+        10
       ],
       "annotations": [
         {
@@ -2791,7 +2971,8 @@
       "chapter": 1,
       "verse": 11,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -2811,7 +2992,8 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        24
+        9,
+        15
       ],
       "annotations": [
         {
@@ -2827,7 +3009,8 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [
         {
@@ -2851,7 +3034,8 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        20
+        10,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -2862,7 +3046,8 @@
       "chapter": 1,
       "verse": 15,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [
         {
@@ -2878,7 +3063,9 @@
       "chapter": 1,
       "verse": 16,
       "phraseWordCounts": [
-        29
+        8,
+        14,
+        7
       ],
       "annotations": [
         {
@@ -2902,7 +3089,10 @@
       "chapter": 1,
       "verse": 17,
       "phraseWordCounts": [
-        33
+        9,
+        11,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -2918,7 +3108,8 @@
       "chapter": 1,
       "verse": 18,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [
         {
@@ -2934,7 +3125,10 @@
       "chapter": 1,
       "verse": 19,
       "phraseWordCounts": [
-        41
+        10,
+        10,
+        9,
+        12
       ],
       "annotations": [
         {
@@ -2978,7 +3172,8 @@
       "chapter": 1,
       "verse": 20,
       "phraseWordCounts": [
-        19
+        5,
+        14
       ],
       "annotations": [
         {
@@ -3000,7 +3195,9 @@
       "chapter": 1,
       "verse": 21,
       "phraseWordCounts": [
-        26
+        10,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -3022,7 +3219,11 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        37
+        9,
+        9,
+        6,
+        8,
+        5
       ],
       "annotations": [
         {
@@ -3076,7 +3277,8 @@
       "chapter": 2,
       "verse": 2,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [
         {
@@ -3102,7 +3304,9 @@
       "chapter": 2,
       "verse": 3,
       "phraseWordCounts": [
-        26
+        11,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -3134,7 +3338,9 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        26
+        10,
+        5,
+        11
       ],
       "annotations": [
         {
@@ -3156,7 +3362,9 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        27
+        8,
+        9,
+        10
       ],
       "annotations": [
         {
@@ -3190,7 +3398,8 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        28
+        14,
+        14
       ],
       "annotations": [
         {
@@ -3220,7 +3429,8 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [
         {
@@ -3254,7 +3464,8 @@
       "chapter": 2,
       "verse": 8,
       "phraseWordCounts": [
-        24
+        10,
+        14
       ],
       "annotations": [
         {
@@ -3272,7 +3483,9 @@
       "chapter": 2,
       "verse": 9,
       "phraseWordCounts": [
-        27
+        4,
+        11,
+        12
       ],
       "annotations": [
         {
@@ -3294,7 +3507,9 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        30
+        17,
+        3,
+        10
       ],
       "annotations": [
         {
@@ -3334,7 +3549,10 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        25
+        3,
+        7,
+        7,
+        8
       ],
       "annotations": [
         {
@@ -3358,7 +3576,10 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        32
+        10,
+        8,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -3390,7 +3611,10 @@
       "chapter": 2,
       "verse": 13,
       "phraseWordCounts": [
-        37
+        13,
+        10,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -3434,7 +3658,9 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        21
+        9,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -3470,7 +3696,9 @@
       "chapter": 2,
       "verse": 15,
       "phraseWordCounts": [
-        24
+        9,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -3498,7 +3726,9 @@
       "chapter": 2,
       "verse": 16,
       "phraseWordCounts": [
-        25
+        7,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -3530,7 +3760,8 @@
       "chapter": 2,
       "verse": 17,
       "phraseWordCounts": [
-        18
+        12,
+        6
       ],
       "annotations": [
         {
@@ -3558,7 +3789,9 @@
       "chapter": 2,
       "verse": 18,
       "phraseWordCounts": [
-        29
+        7,
+        9,
+        13
       ],
       "annotations": [
         {
@@ -3590,7 +3823,9 @@
       "chapter": 2,
       "verse": 19,
       "phraseWordCounts": [
-        20
+        4,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -3612,7 +3847,10 @@
       "chapter": 2,
       "verse": 20,
       "phraseWordCounts": [
-        39
+        9,
+        8,
+        9,
+        13
       ],
       "annotations": [
         {
@@ -3638,7 +3876,8 @@
       "chapter": 2,
       "verse": 21,
       "phraseWordCounts": [
-        36
+        15,
+        21
       ],
       "annotations": [
         {
@@ -3654,7 +3893,9 @@
       "chapter": 2,
       "verse": 22,
       "phraseWordCounts": [
-        25
+        6,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -3698,7 +3939,9 @@
       "chapter": 3,
       "verse": 1,
       "phraseWordCounts": [
-        24
+        10,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -3726,7 +3969,9 @@
       "chapter": 3,
       "verse": 2,
       "phraseWordCounts": [
-        27
+        5,
+        10,
+        12
       ],
       "annotations": [
         {
@@ -3746,7 +3991,9 @@
       "chapter": 3,
       "verse": 3,
       "phraseWordCounts": [
-        20
+        5,
+        8,
+        7
       ],
       "annotations": [
         {
@@ -3768,7 +4015,9 @@
       "chapter": 3,
       "verse": 4,
       "phraseWordCounts": [
-        25
+        3,
+        6,
+        16
       ],
       "annotations": [
         {
@@ -3790,7 +4039,9 @@
       "chapter": 3,
       "verse": 5,
       "phraseWordCounts": [
-        26
+        4,
+        11,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -3821,7 +4072,9 @@
       "chapter": 3,
       "verse": 7,
       "phraseWordCounts": [
-        25
+        4,
+        9,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3832,7 +4085,9 @@
       "chapter": 3,
       "verse": 8,
       "phraseWordCounts": [
-        27
+        9,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -3854,7 +4109,10 @@
       "chapter": 3,
       "verse": 9,
       "phraseWordCounts": [
-        30
+        13,
+        6,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -3884,7 +4142,10 @@
       "chapter": 3,
       "verse": 10,
       "phraseWordCounts": [
-        37
+        11,
+        7,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -3906,7 +4167,9 @@
       "chapter": 3,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        8,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -3919,7 +4182,9 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        33
+        13,
+        12,
+        8
       ],
       "annotations": [
         {
@@ -3949,7 +4214,9 @@
       "chapter": 3,
       "verse": 13,
       "phraseWordCounts": [
-        21
+        6,
+        12,
+        3
       ],
       "annotations": [
         {
@@ -3967,7 +4234,9 @@
       "chapter": 3,
       "verse": 14,
       "phraseWordCounts": [
-        24
+        4,
+        7,
+        13
       ],
       "annotations": [
         {
@@ -3985,7 +4254,9 @@
       "chapter": 3,
       "verse": 15,
       "phraseWordCounts": [
-        25
+        9,
+        9,
+        7
       ],
       "annotations": [
         {
@@ -4009,7 +4280,11 @@
       "chapter": 3,
       "verse": 16,
       "phraseWordCounts": [
-        41
+        9,
+        6,
+        10,
+        6,
+        10
       ],
       "annotations": [
         {
@@ -4045,7 +4320,10 @@
       "chapter": 3,
       "verse": 17,
       "phraseWordCounts": [
-        32
+        8,
+        4,
+        14,
+        6
       ],
       "annotations": [
         {
@@ -4071,7 +4349,8 @@
       "chapter": 3,
       "verse": 18,
       "phraseWordCounts": [
-        23
+        14,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4084,7 +4363,8 @@
       "chapter": 1,
       "verse": 1,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4097,7 +4377,9 @@
       "chapter": 1,
       "verse": 2,
       "phraseWordCounts": [
-        28
+        13,
+        7,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4110,7 +4392,10 @@
       "chapter": 1,
       "verse": 3,
       "phraseWordCounts": [
-        41
+        15,
+        7,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -4148,7 +4433,8 @@
       "chapter": 1,
       "verse": 4,
       "phraseWordCounts": [
-        19
+        9,
+        10
       ],
       "annotations": [
         {
@@ -4166,7 +4452,9 @@
       "chapter": 1,
       "verse": 5,
       "phraseWordCounts": [
-        33
+        10,
+        10,
+        13
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4179,7 +4467,8 @@
       "chapter": 1,
       "verse": 6,
       "phraseWordCounts": [
-        18
+        12,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4192,7 +4481,8 @@
       "chapter": 1,
       "verse": 7,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -4210,7 +4500,9 @@
       "chapter": 1,
       "verse": 8,
       "phraseWordCounts": [
-        27
+        6,
+        10,
+        11
       ],
       "annotations": [
         {
@@ -4236,7 +4528,8 @@
       "chapter": 1,
       "verse": 9,
       "phraseWordCounts": [
-        25
+        7,
+        18
       ],
       "annotations": [
         {
@@ -4266,7 +4559,9 @@
       "chapter": 1,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        3,
+        11,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4279,7 +4574,8 @@
       "chapter": 1,
       "verse": 11,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [
         {
@@ -4301,7 +4597,9 @@
       "chapter": 1,
       "verse": 12,
       "phraseWordCounts": [
-        26
+        8,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -4327,7 +4625,8 @@
       "chapter": 1,
       "verse": 13,
       "phraseWordCounts": [
-        24
+        9,
+        15
       ],
       "annotations": [
         {
@@ -4343,7 +4642,8 @@
       "chapter": 1,
       "verse": 14,
       "phraseWordCounts": [
-        14
+        6,
+        8
       ],
       "annotations": [
         {
@@ -4361,7 +4661,8 @@
       "chapter": 2,
       "verse": 1,
       "phraseWordCounts": [
-        20
+        13,
+        7
       ],
       "annotations": [
         {
@@ -4379,7 +4680,8 @@
       "chapter": 2,
       "verse": 2,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [
         {
@@ -4399,7 +4701,9 @@
       "chapter": 2,
       "verse": 3,
       "phraseWordCounts": [
-        29
+        11,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -4419,7 +4723,8 @@
       "chapter": 2,
       "verse": 4,
       "phraseWordCounts": [
-        23
+        11,
+        12
       ],
       "annotations": [
         {
@@ -4451,7 +4756,8 @@
       "chapter": 2,
       "verse": 5,
       "phraseWordCounts": [
-        18
+        13,
+        5
       ],
       "annotations": [
         {
@@ -4467,7 +4773,9 @@
       "chapter": 2,
       "verse": 6,
       "phraseWordCounts": [
-        27
+        9,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -4491,7 +4799,8 @@
       "chapter": 2,
       "verse": 7,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [
         {
@@ -4511,7 +4820,10 @@
       "chapter": 2,
       "verse": 8,
       "phraseWordCounts": [
-        31
+        6,
+        5,
+        9,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4522,7 +4834,10 @@
       "chapter": 2,
       "verse": 9,
       "phraseWordCounts": [
-        39
+        5,
+        11,
+        10,
+        13
       ],
       "annotations": [
         {
@@ -4548,7 +4863,10 @@
       "chapter": 2,
       "verse": 10,
       "phraseWordCounts": [
-        32
+        8,
+        5,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -4566,7 +4884,8 @@
       "chapter": 2,
       "verse": 11,
       "phraseWordCounts": [
-        29
+        18,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4579,7 +4898,9 @@
       "chapter": 2,
       "verse": 12,
       "phraseWordCounts": [
-        20
+        2,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -4597,7 +4918,8 @@
       "chapter": 2,
       "verse": 13,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [
         {
@@ -4615,7 +4937,10 @@
       "chapter": 2,
       "verse": 14,
       "phraseWordCounts": [
-        35
+        7,
+        6,
+        18,
+        4
       ],
       "annotations": [
         {
@@ -4659,7 +4984,8 @@
       "chapter": 2,
       "verse": 16,
       "phraseWordCounts": [
-        11
+        8,
+        3
       ],
       "annotations": [
         {
@@ -4681,7 +5007,9 @@
       "chapter": 2,
       "verse": 17,
       "phraseWordCounts": [
-        43
+        15,
+        16,
+        12
       ],
       "annotations": [
         {
@@ -4703,7 +5031,8 @@
       "chapter": 2,
       "verse": 18,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4716,7 +5045,9 @@
       "chapter": 3,
       "verse": 1,
       "phraseWordCounts": [
-        25
+        11,
+        5,
+        9
       ],
       "annotations": [
         {
@@ -4738,7 +5069,8 @@
       "chapter": 3,
       "verse": 2,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4751,7 +5083,8 @@
       "chapter": 3,
       "verse": 3,
       "phraseWordCounts": [
-        24
+        10,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4764,7 +5097,8 @@
       "chapter": 3,
       "verse": 4,
       "phraseWordCounts": [
-        14
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4777,7 +5111,8 @@
       "chapter": 3,
       "verse": 5,
       "phraseWordCounts": [
-        22
+        10,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -4790,7 +5125,9 @@
       "chapter": 3,
       "verse": 6,
       "phraseWordCounts": [
-        30
+        10,
+        5,
+        15
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4803,7 +5140,8 @@
       "chapter": 3,
       "verse": 7,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4816,7 +5154,8 @@
       "chapter": 3,
       "verse": 8,
       "phraseWordCounts": [
-        19
+        5,
+        14
       ],
       "annotations": [
         {
@@ -4834,7 +5173,8 @@
       "chapter": 3,
       "verse": 9,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4847,7 +5187,8 @@
       "chapter": 3,
       "verse": 10,
       "phraseWordCounts": [
-        24
+        9,
+        15
       ],
       "annotations": [
         {
@@ -4863,7 +5204,8 @@
       "chapter": 3,
       "verse": 11,
       "phraseWordCounts": [
-        15
+        8,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -4874,7 +5216,8 @@
       "chapter": 3,
       "verse": 12,
       "phraseWordCounts": [
-        22
+        6,
+        16
       ],
       "annotations": [
         {
@@ -4896,7 +5239,9 @@
       "chapter": 3,
       "verse": 13,
       "phraseWordCounts": [
-        23
+        5,
+        7,
+        11
       ],
       "annotations": [
         {
@@ -4930,7 +5275,8 @@
       "chapter": 3,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [
         {
@@ -4952,7 +5298,9 @@
       "chapter": 3,
       "verse": 15,
       "phraseWordCounts": [
-        22
+        5,
+        6,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -4963,7 +5311,8 @@
       "chapter": 3,
       "verse": 16,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [
         {
@@ -4983,7 +5332,9 @@
       "chapter": 3,
       "verse": 17,
       "phraseWordCounts": [
-        22
+        9,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -4999,7 +5350,8 @@
       "chapter": 3,
       "verse": 18,
       "phraseWordCounts": [
-        19
+        13,
+        6
       ],
       "annotations": [
         {
@@ -5015,7 +5367,8 @@
       "chapter": 3,
       "verse": 19,
       "phraseWordCounts": [
-        14
+        10,
+        4
       ],
       "annotations": [
         {
@@ -5031,7 +5384,8 @@
       "chapter": 4,
       "verse": 1,
       "phraseWordCounts": [
-        26
+        10,
+        16
       ],
       "annotations": [
         {
@@ -5049,7 +5403,9 @@
       "chapter": 4,
       "verse": 2,
       "phraseWordCounts": [
-        37
+        15,
+        11,
+        11
       ],
       "annotations": [
         {
@@ -5067,7 +5423,10 @@
       "chapter": 4,
       "verse": 3,
       "phraseWordCounts": [
-        41
+        8,
+        5,
+        15,
+        13
       ],
       "annotations": [
         {
@@ -5089,7 +5448,8 @@
       "chapter": 4,
       "verse": 4,
       "phraseWordCounts": [
-        22
+        12,
+        10
       ],
       "annotations": [
         {
@@ -5117,7 +5477,8 @@
       "chapter": 4,
       "verse": 5,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [
         {
@@ -5133,7 +5494,8 @@
       "chapter": 4,
       "verse": 6,
       "phraseWordCounts": [
-        31
+        11,
+        20
       ],
       "annotations": [
         {
@@ -5153,7 +5515,10 @@
       "chapter": 4,
       "verse": 7,
       "phraseWordCounts": [
-        38
+        9,
+        12,
+        6,
+        11
       ],
       "annotations": [
         {
@@ -5177,7 +5542,8 @@
       "chapter": 4,
       "verse": 8,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [
         {
@@ -5211,7 +5577,8 @@
       "chapter": 4,
       "verse": 10,
       "phraseWordCounts": [
-        17
+        11,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5224,7 +5591,8 @@
       "chapter": 4,
       "verse": 11,
       "phraseWordCounts": [
-        22
+        10,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5237,7 +5605,9 @@
       "chapter": 4,
       "verse": 12,
       "phraseWordCounts": [
-        34
+        9,
+        16,
+        9
       ],
       "annotations": [
         {
@@ -5283,7 +5653,8 @@
       "chapter": 4,
       "verse": 13,
       "phraseWordCounts": [
-        26
+        9,
+        17
       ],
       "annotations": [
         {
@@ -5305,7 +5676,8 @@
       "chapter": 4,
       "verse": 14,
       "phraseWordCounts": [
-        27
+        18,
+        9
       ],
       "annotations": [
         {
@@ -5323,7 +5695,8 @@
       "chapter": 4,
       "verse": 15,
       "phraseWordCounts": [
-        36
+        16,
+        20
       ],
       "annotations": [
         {
@@ -5349,7 +5722,8 @@
       "chapter": 4,
       "verse": 16,
       "phraseWordCounts": [
-        27
+        10,
+        17
       ],
       "annotations": [
         {
@@ -5367,7 +5741,8 @@
       "chapter": 5,
       "verse": 1,
       "phraseWordCounts": [
-        28
+        21,
+        7
       ],
       "annotations": [
         {
@@ -5393,7 +5768,8 @@
       "chapter": 5,
       "verse": 2,
       "phraseWordCounts": [
-        22
+        15,
+        7
       ],
       "annotations": [
         {
@@ -5415,7 +5791,8 @@
       "chapter": 5,
       "verse": 3,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -5428,7 +5805,9 @@
       "chapter": 5,
       "verse": 4,
       "phraseWordCounts": [
-        20
+        8,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5441,7 +5820,9 @@
       "chapter": 5,
       "verse": 5,
       "phraseWordCounts": [
-        32
+        17,
+        9,
+        6
       ],
       "annotations": [
         {
@@ -5459,7 +5840,8 @@
       "chapter": 5,
       "verse": 6,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -5472,7 +5854,9 @@
       "chapter": 5,
       "verse": 7,
       "phraseWordCounts": [
-        37
+        8,
+        20,
+        9
       ],
       "annotations": [
         {
@@ -5502,7 +5886,8 @@
       "chapter": 5,
       "verse": 8,
       "phraseWordCounts": [
-        11
+        4,
+        7
       ],
       "annotations": [
         {
@@ -5524,7 +5909,9 @@
       "chapter": 5,
       "verse": 9,
       "phraseWordCounts": [
-        16
+        4,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -5558,7 +5945,9 @@
       "chapter": 5,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        7,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -5574,7 +5963,9 @@
       "chapter": 5,
       "verse": 12,
       "phraseWordCounts": [
-        32
+        11,
+        15,
+        6
       ],
       "annotations": [
         {
@@ -5600,7 +5991,8 @@
       "chapter": 5,
       "verse": 13,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [
         {
@@ -5626,7 +6018,8 @@
       "chapter": 5,
       "verse": 14,
       "phraseWordCounts": [
-        19
+        7,
+        12
       ],
       "annotations": [
         {
@@ -5656,7 +6049,10 @@
       "chapter": 6,
       "verse": 1,
       "phraseWordCounts": [
-        34
+        10,
+        6,
+        13,
+        5
       ],
       "annotations": [
         {
@@ -5694,7 +6090,10 @@
       "chapter": 6,
       "verse": 2,
       "phraseWordCounts": [
-        17
+        4,
+        5,
+        5,
+        3
       ],
       "annotations": [
         {
@@ -5740,7 +6139,9 @@
       "chapter": 6,
       "verse": 4,
       "phraseWordCounts": [
-        23
+        10,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -5756,7 +6157,8 @@
       "chapter": 6,
       "verse": 5,
       "phraseWordCounts": [
-        17
+        10,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -5767,7 +6169,9 @@
       "chapter": 6,
       "verse": 6,
       "phraseWordCounts": [
-        30
+        11,
+        13,
+        6
       ],
       "annotations": [
         {
@@ -5795,7 +6199,9 @@
       "chapter": 6,
       "verse": 7,
       "phraseWordCounts": [
-        28
+        10,
+        13,
+        5
       ],
       "annotations": [
         {
@@ -5835,7 +6241,9 @@
       "chapter": 6,
       "verse": 8,
       "phraseWordCounts": [
-        23
+        9,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -5867,7 +6275,9 @@
       "chapter": 6,
       "verse": 9,
       "phraseWordCounts": [
-        25
+        8,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -5883,7 +6293,9 @@
       "chapter": 6,
       "verse": 10,
       "phraseWordCounts": [
-        28
+        4,
+        13,
+        11
       ],
       "annotations": [
         {
@@ -5901,7 +6313,8 @@
       "chapter": 6,
       "verse": 11,
       "phraseWordCounts": [
-        24
+        14,
+        10
       ],
       "annotations": [
         {
@@ -5923,7 +6336,8 @@
       "chapter": 6,
       "verse": 12,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [
         {
@@ -5941,7 +6355,9 @@
       "chapter": 6,
       "verse": 13,
       "phraseWordCounts": [
-        22
+        7,
+        11,
+        4
       ],
       "annotations": [
         {
@@ -5957,7 +6373,8 @@
       "chapter": 6,
       "verse": 14,
       "phraseWordCounts": [
-        11
+        6,
+        5
       ],
       "annotations": [
         {
@@ -5984,7 +6401,9 @@
       "chapter": 6,
       "verse": 16,
       "phraseWordCounts": [
-        21
+        7,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -6008,7 +6427,8 @@
       "chapter": 6,
       "verse": 17,
       "phraseWordCounts": [
-        26
+        20,
+        6
       ],
       "annotations": [
         {
@@ -6030,7 +6450,10 @@
       "chapter": 6,
       "verse": 18,
       "phraseWordCounts": [
-        35
+        5,
+        13,
+        13,
+        4
       ],
       "annotations": [
         {
@@ -6060,7 +6483,8 @@
       "chapter": 6,
       "verse": 19,
       "phraseWordCounts": [
-        21
+        13,
+        8
       ],
       "annotations": [
         {
@@ -6078,7 +6502,9 @@
       "chapter": 6,
       "verse": 20,
       "phraseWordCounts": [
-        21
+        9,
+        7,
+        5
       ],
       "annotations": [
         {
@@ -6100,7 +6526,9 @@
       "chapter": 7,
       "verse": 1,
       "phraseWordCounts": [
-        25
+        6,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -6134,7 +6562,9 @@
       "chapter": 7,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        8,
+        8,
+        9
       ],
       "annotations": [
         {
@@ -6164,7 +6594,10 @@
       "chapter": 7,
       "verse": 3,
       "phraseWordCounts": [
-        24
+        6,
+        8,
+        5,
+        5
       ],
       "annotations": [
         {
@@ -6190,7 +6623,8 @@
       "chapter": 7,
       "verse": 4,
       "phraseWordCounts": [
-        17
+        6,
+        11
       ],
       "annotations": [
         {
@@ -6210,7 +6644,10 @@
       "chapter": 7,
       "verse": 5,
       "phraseWordCounts": [
-        32
+        11,
+        7,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -6230,7 +6667,9 @@
       "chapter": 7,
       "verse": 6,
       "phraseWordCounts": [
-        24
+        10,
+        7,
+        7
       ],
       "annotations": [
         {
@@ -6278,7 +6717,8 @@
       "chapter": 7,
       "verse": 8,
       "phraseWordCounts": [
-        25
+        12,
+        13
       ],
       "annotations": [
         {
@@ -6314,7 +6754,8 @@
       "chapter": 7,
       "verse": 10,
       "phraseWordCounts": [
-        14
+        5,
+        9
       ],
       "annotations": [
         {
@@ -6334,7 +6775,11 @@
       "chapter": 7,
       "verse": 11,
       "phraseWordCounts": [
-        43
+        10,
+        11,
+        10,
+        6,
+        6
       ],
       "annotations": [
         {
@@ -6360,7 +6805,8 @@
       "chapter": 7,
       "verse": 12,
       "phraseWordCounts": [
-        12
+        6,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6371,7 +6817,8 @@
       "chapter": 7,
       "verse": 13,
       "phraseWordCounts": [
-        24
+        12,
+        12
       ],
       "annotations": [
         {
@@ -6403,7 +6850,8 @@
       "chapter": 7,
       "verse": 14,
       "phraseWordCounts": [
-        21
+        10,
+        11
       ],
       "annotations": [
         {
@@ -6430,7 +6878,9 @@
       "chapter": 7,
       "verse": 16,
       "phraseWordCounts": [
-        28
+        6,
+        11,
+        11
       ],
       "annotations": [
         {
@@ -6462,7 +6912,8 @@
       "chapter": 7,
       "verse": 17,
       "phraseWordCounts": [
-        14
+        4,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 4,
@@ -6497,7 +6948,9 @@
       "chapter": 7,
       "verse": 19,
       "phraseWordCounts": [
-        19
+        6,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -6515,7 +6968,8 @@
       "chapter": 7,
       "verse": 20,
       "phraseWordCounts": [
-        13
+        7,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -6526,7 +6980,9 @@
       "chapter": 7,
       "verse": 21,
       "phraseWordCounts": [
-        29
+        13,
+        10,
+        6
       ],
       "annotations": [
         {
@@ -6542,7 +6998,8 @@
       "chapter": 7,
       "verse": 22,
       "phraseWordCounts": [
-        13
+        4,
+        9
       ],
       "annotations": [
         {
@@ -6560,7 +7017,8 @@
       "chapter": 7,
       "verse": 23,
       "phraseWordCounts": [
-        16
+        8,
+        8
       ],
       "annotations": [
         {
@@ -6586,7 +7044,8 @@
       "chapter": 7,
       "verse": 24,
       "phraseWordCounts": [
-        10
+        5,
+        5
       ],
       "annotations": [
         {
@@ -6604,7 +7063,8 @@
       "chapter": 7,
       "verse": 25,
       "phraseWordCounts": [
-        22
+        14,
+        8
       ],
       "annotations": [
         {
@@ -6622,7 +7082,8 @@
       "chapter": 7,
       "verse": 26,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [
         {
@@ -6652,7 +7113,10 @@
       "chapter": 7,
       "verse": 27,
       "phraseWordCounts": [
-        40
+        15,
+        5,
+        8,
+        12
       ],
       "annotations": [
         {
@@ -6670,7 +7134,9 @@
       "chapter": 7,
       "verse": 28,
       "phraseWordCounts": [
-        29
+        12,
+        11,
+        6
       ],
       "annotations": [
         {
@@ -6692,7 +7158,9 @@
       "chapter": 8,
       "verse": 1,
       "phraseWordCounts": [
-        33
+        11,
+        7,
+        15
       ],
       "annotations": [
         {
@@ -6710,7 +7178,8 @@
       "chapter": 8,
       "verse": 2,
       "phraseWordCounts": [
-        20
+        6,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6723,7 +7192,8 @@
       "chapter": 8,
       "verse": 3,
       "phraseWordCounts": [
-        25
+        11,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -6736,7 +7206,9 @@
       "chapter": 8,
       "verse": 4,
       "phraseWordCounts": [
-        24
+        11,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -6752,7 +7224,9 @@
       "chapter": 8,
       "verse": 5,
       "phraseWordCounts": [
-        46
+        16,
+        14,
+        16
       ],
       "annotations": [
         {
@@ -6772,7 +7246,10 @@
       "chapter": 8,
       "verse": 6,
       "phraseWordCounts": [
-        36
+        8,
+        5,
+        14,
+        9
       ],
       "annotations": [
         {
@@ -6790,7 +7267,8 @@
       "chapter": 8,
       "verse": 7,
       "phraseWordCounts": [
-        19
+        11,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -6803,7 +7281,10 @@
       "chapter": 8,
       "verse": 8,
       "phraseWordCounts": [
-        34
+        9,
+        7,
+        12,
+        6
       ],
       "annotations": [
         {
@@ -6825,7 +7306,10 @@
       "chapter": 8,
       "verse": 9,
       "phraseWordCounts": [
-        43
+        12,
+        13,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -6843,7 +7327,11 @@
       "chapter": 8,
       "verse": 10,
       "phraseWordCounts": [
-        43
+        18,
+        8,
+        6,
+        5,
+        6
       ],
       "annotations": [
         {
@@ -6861,7 +7349,10 @@
       "chapter": 8,
       "verse": 11,
       "phraseWordCounts": [
-        29
+        7,
+        8,
+        6,
+        8
       ],
       "annotations": [
         {
@@ -6901,7 +7392,8 @@
       "chapter": 8,
       "verse": 13,
       "phraseWordCounts": [
-        21
+        12,
+        9
       ],
       "annotations": [
         {
@@ -6938,7 +7430,9 @@
       "chapter": 9,
       "verse": 2,
       "phraseWordCounts": [
-        25
+        5,
+        14,
+        6
       ],
       "annotations": [
         {
@@ -6986,7 +7480,10 @@
       "chapter": 9,
       "verse": 4,
       "phraseWordCounts": [
-        34
+        14,
+        8,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -7034,7 +7531,8 @@
       "chapter": 9,
       "verse": 5,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [
         {
@@ -7066,7 +7564,8 @@
       "chapter": 9,
       "verse": 6,
       "phraseWordCounts": [
-        20
+        7,
+        13
       ],
       "annotations": [
         {
@@ -7098,7 +7597,10 @@
       "chapter": 9,
       "verse": 7,
       "phraseWordCounts": [
-        34
+        9,
+        6,
+        4,
+        15
       ],
       "annotations": [
         {
@@ -7114,7 +7616,9 @@
       "chapter": 9,
       "verse": 8,
       "phraseWordCounts": [
-        29
+        7,
+        13,
+        9
       ],
       "annotations": [
         {
@@ -7138,7 +7642,8 @@
       "chapter": 9,
       "verse": 9,
       "phraseWordCounts": [
-        26
+        8,
+        18
       ],
       "annotations": [
         {
@@ -7162,7 +7667,8 @@
       "chapter": 9,
       "verse": 10,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [
         {
@@ -7194,7 +7700,9 @@
       "chapter": 9,
       "verse": 11,
       "phraseWordCounts": [
-        43
+        16,
+        9,
+        18
       ],
       "annotations": [
         {
@@ -7212,7 +7720,9 @@
       "chapter": 9,
       "verse": 12,
       "phraseWordCounts": [
-        31
+        13,
+        14,
+        4
       ],
       "annotations": [
         {
@@ -7238,7 +7748,8 @@
       "chapter": 9,
       "verse": 13,
       "phraseWordCounts": [
-        27
+        19,
+        8
       ],
       "annotations": [
         {
@@ -7276,7 +7787,10 @@
       "chapter": 9,
       "verse": 14,
       "phraseWordCounts": [
-        36
+        4,
+        15,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -7298,7 +7812,10 @@
       "chapter": 9,
       "verse": 15,
       "phraseWordCounts": [
-        42
+        11,
+        11,
+        8,
+        12
       ],
       "annotations": [
         {
@@ -7316,7 +7833,8 @@
       "chapter": 9,
       "verse": 16,
       "phraseWordCounts": [
-        19
+        6,
+        13
       ],
       "annotations": [
         {
@@ -7332,7 +7850,8 @@
       "chapter": 9,
       "verse": 17,
       "phraseWordCounts": [
-        23
+        11,
+        12
       ],
       "annotations": [
         {
@@ -7374,7 +7893,9 @@
       "chapter": 9,
       "verse": 19,
       "phraseWordCounts": [
-        36
+        13,
+        15,
+        8
       ],
       "annotations": [
         {
@@ -7402,7 +7923,8 @@
       "chapter": 9,
       "verse": 20,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7429,7 +7951,8 @@
       "chapter": 9,
       "verse": 22,
       "phraseWordCounts": [
-        22
+        12,
+        10
       ],
       "annotations": [
         {
@@ -7451,7 +7974,9 @@
       "chapter": 9,
       "verse": 23,
       "phraseWordCounts": [
-        27
+        4,
+        13,
+        10
       ],
       "annotations": [
         {
@@ -7469,7 +7994,9 @@
       "chapter": 9,
       "verse": 24,
       "phraseWordCounts": [
-        32
+        20,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -7491,7 +8018,8 @@
       "chapter": 9,
       "verse": 25,
       "phraseWordCounts": [
-        30
+        11,
+        19
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -7504,7 +8032,9 @@
       "chapter": 9,
       "verse": 26,
       "phraseWordCounts": [
-        38
+        15,
+        13,
+        10
       ],
       "annotations": [
         {
@@ -7534,7 +8064,8 @@
       "chapter": 9,
       "verse": 27,
       "phraseWordCounts": [
-        14
+        8,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7547,7 +8078,9 @@
       "chapter": 9,
       "verse": 28,
       "phraseWordCounts": [
-        34
+        12,
+        7,
+        15
       ],
       "annotations": [
         {
@@ -7565,7 +8098,9 @@
       "chapter": 10,
       "verse": 1,
       "phraseWordCounts": [
-        40
+        17,
+        15,
+        8
       ],
       "annotations": [
         {
@@ -7591,7 +8126,9 @@
       "chapter": 10,
       "verse": 2,
       "phraseWordCounts": [
-        28
+        8,
+        10,
+        10
       ],
       "annotations": [
         {
@@ -7656,7 +8193,9 @@
       "chapter": 10,
       "verse": 5,
       "phraseWordCounts": [
-        23
+        9,
+        7,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7687,7 +8226,9 @@
       "chapter": 10,
       "verse": 7,
       "phraseWordCounts": [
-        24
+        6,
+        8,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7700,7 +8241,9 @@
       "chapter": 10,
       "verse": 8,
       "phraseWordCounts": [
-        30
+        15,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -7720,7 +8263,8 @@
       "chapter": 10,
       "verse": 9,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [
         {
@@ -7736,7 +8280,9 @@
       "chapter": 10,
       "verse": 10,
       "phraseWordCounts": [
-        21
+        4,
+        5,
+        12
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7749,7 +8295,9 @@
       "chapter": 10,
       "verse": 11,
       "phraseWordCounts": [
-        25
+        11,
+        8,
+        6
       ],
       "annotations": [
         {
@@ -7779,7 +8327,8 @@
       "chapter": 10,
       "verse": 12,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7810,7 +8359,8 @@
       "chapter": 10,
       "verse": 14,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7823,7 +8373,8 @@
       "chapter": 10,
       "verse": 15,
       "phraseWordCounts": [
-        12
+        9,
+        3
       ],
       "annotations": [
         {
@@ -7839,7 +8390,9 @@
       "chapter": 10,
       "verse": 16,
       "phraseWordCounts": [
-        31
+        15,
+        8,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 7,
@@ -7850,7 +8403,8 @@
       "chapter": 10,
       "verse": 17,
       "phraseWordCounts": [
-        13
+        3,
+        10
       ],
       "annotations": [
         {
@@ -7866,7 +8420,8 @@
       "chapter": 10,
       "verse": 18,
       "phraseWordCounts": [
-        13
+        6,
+        7
       ],
       "annotations": [
         {
@@ -7882,7 +8437,8 @@
       "chapter": 10,
       "verse": 19,
       "phraseWordCounts": [
-        19
+        4,
+        15
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -7895,7 +8451,8 @@
       "chapter": 10,
       "verse": 20,
       "phraseWordCounts": [
-        16
+        12,
+        4
       ],
       "annotations": [
         {
@@ -7926,7 +8483,10 @@
       "chapter": 10,
       "verse": 22,
       "phraseWordCounts": [
-        37
+        6,
+        12,
+        11,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -7939,7 +8499,8 @@
       "chapter": 10,
       "verse": 23,
       "phraseWordCounts": [
-        15
+        9,
+        6
       ],
       "annotations": [
         {
@@ -7975,7 +8536,10 @@
       "chapter": 10,
       "verse": 25,
       "phraseWordCounts": [
-        27
+        5,
+        8,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -8005,7 +8569,9 @@
       "chapter": 10,
       "verse": 26,
       "phraseWordCounts": [
-        21
+        6,
+        9,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8016,7 +8582,8 @@
       "chapter": 10,
       "verse": 27,
       "phraseWordCounts": [
-        18
+        7,
+        11
       ],
       "annotations": [
         {
@@ -8044,7 +8611,9 @@
       "chapter": 10,
       "verse": 28,
       "phraseWordCounts": [
-        18
+        7,
+        3,
+        8
       ],
       "annotations": [
         {
@@ -8060,7 +8629,10 @@
       "chapter": 10,
       "verse": 29,
       "phraseWordCounts": [
-        43
+        12,
+        8,
+        15,
+        8
       ],
       "annotations": [
         {
@@ -8104,7 +8676,9 @@
       "chapter": 10,
       "verse": 30,
       "phraseWordCounts": [
-        22
+        6,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -8140,7 +8714,9 @@
       "chapter": 10,
       "verse": 32,
       "phraseWordCounts": [
-        20
+        4,
+        6,
+        10
       ],
       "annotations": [
         {
@@ -8162,7 +8738,8 @@
       "chapter": 10,
       "verse": 33,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [
         {
@@ -8206,7 +8783,9 @@
       "chapter": 10,
       "verse": 34,
       "phraseWordCounts": [
-        26
+        7,
+        8,
+        11
       ],
       "annotations": [
         {
@@ -8248,7 +8827,8 @@
       "chapter": 10,
       "verse": 35,
       "phraseWordCounts": [
-        12
+        7,
+        5
       ],
       "annotations": [
         {
@@ -8270,7 +8850,9 @@
       "chapter": 10,
       "verse": 36,
       "phraseWordCounts": [
-        21
+        4,
+        10,
+        7
       ],
       "annotations": [
         {
@@ -8288,7 +8870,8 @@
       "chapter": 10,
       "verse": 37,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [
         {
@@ -8306,7 +8889,8 @@
       "chapter": 10,
       "verse": 38,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [
         {
@@ -8324,7 +8908,8 @@
       "chapter": 10,
       "verse": 39,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [
         {
@@ -8346,7 +8931,8 @@
       "chapter": 11,
       "verse": 1,
       "phraseWordCounts": [
-        17
+        9,
+        8
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8377,7 +8963,8 @@
       "chapter": 11,
       "verse": 3,
       "phraseWordCounts": [
-        25
+        12,
+        13
       ],
       "annotations": [
         {
@@ -8395,7 +8982,9 @@
       "chapter": 11,
       "verse": 4,
       "phraseWordCounts": [
-        36
+        11,
+        14,
+        11
       ],
       "annotations": [
         {
@@ -8413,7 +9002,9 @@
       "chapter": 11,
       "verse": 5,
       "phraseWordCounts": [
-        39
+        15,
+        11,
+        13
       ],
       "annotations": [
         {
@@ -8435,7 +9026,9 @@
       "chapter": 11,
       "verse": 6,
       "phraseWordCounts": [
-        29
+        9,
+        11,
+        9
       ],
       "annotations": [
         {
@@ -8465,7 +9058,8 @@
       "chapter": 11,
       "verse": 7,
       "phraseWordCounts": [
-        39
+        20,
+        19
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -8478,7 +9072,8 @@
       "chapter": 11,
       "verse": 8,
       "phraseWordCounts": [
-        30
+        20,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 5,
@@ -8491,7 +9086,8 @@
       "chapter": 11,
       "verse": 9,
       "phraseWordCounts": [
-        35
+        17,
+        18
       ],
       "annotations": [
         {
@@ -8517,7 +9113,8 @@
       "chapter": 11,
       "verse": 10,
       "phraseWordCounts": [
-        16
+        10,
+        6
       ],
       "annotations": [
         {
@@ -8535,7 +9132,8 @@
       "chapter": 11,
       "verse": 11,
       "phraseWordCounts": [
-        25
+        15,
+        10
       ],
       "annotations": [
         {
@@ -8561,7 +9159,9 @@
       "chapter": 11,
       "verse": 12,
       "phraseWordCounts": [
-        31
+        12,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -8599,7 +9199,10 @@
       "chapter": 11,
       "verse": 13,
       "phraseWordCounts": [
-        37
+        11,
+        7,
+        10,
+        9
       ],
       "annotations": [
         {
@@ -8621,7 +9224,8 @@
       "chapter": 11,
       "verse": 14,
       "phraseWordCounts": [
-        16
+        6,
+        10
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -8634,7 +9238,8 @@
       "chapter": 11,
       "verse": 15,
       "phraseWordCounts": [
-        18
+        11,
+        7
       ],
       "annotations": [
         {
@@ -8656,7 +9261,9 @@
       "chapter": 11,
       "verse": 16,
       "phraseWordCounts": [
-        29
+        11,
+        10,
+        8
       ],
       "annotations": [
         {
@@ -8674,7 +9281,8 @@
       "chapter": 11,
       "verse": 17,
       "phraseWordCounts": [
-        27
+        12,
+        15
       ],
       "annotations": [
         {
@@ -8692,7 +9300,8 @@
       "chapter": 11,
       "verse": 18,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [
         {
@@ -8714,7 +9323,8 @@
       "chapter": 11,
       "verse": 19,
       "phraseWordCounts": [
-        23
+        9,
+        14
       ],
       "annotations": [
         {
@@ -8753,7 +9363,8 @@
       "chapter": 11,
       "verse": 21,
       "phraseWordCounts": [
-        23
+        12,
+        11
       ],
       "annotations": [
         {
@@ -8787,7 +9398,9 @@
       "chapter": 11,
       "verse": 22,
       "phraseWordCounts": [
-        26
+        8,
+        9,
+        9
       ],
       "annotations": [
         {
@@ -8821,7 +9434,9 @@
       "chapter": 11,
       "verse": 23,
       "phraseWordCounts": [
-        30
+        13,
+        8,
+        9
       ],
       "annotations": [
         {
@@ -8867,7 +9482,8 @@
       "chapter": 11,
       "verse": 24,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [
         {
@@ -8893,7 +9509,8 @@
       "chapter": 11,
       "verse": 25,
       "phraseWordCounts": [
-        20
+        11,
+        9
       ],
       "annotations": [
         {
@@ -8919,7 +9536,9 @@
       "chapter": 11,
       "verse": 26,
       "phraseWordCounts": [
-        25
+        8,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -8949,7 +9568,8 @@
       "chapter": 11,
       "verse": 27,
       "phraseWordCounts": [
-        19
+        10,
+        9
       ],
       "annotations": [
         {
@@ -8979,7 +9599,8 @@
       "chapter": 11,
       "verse": 28,
       "phraseWordCounts": [
-        25
+        11,
+        14
       ],
       "annotations": [
         {
@@ -9009,7 +9630,8 @@
       "chapter": 11,
       "verse": 29,
       "phraseWordCounts": [
-        24
+        13,
+        11
       ],
       "annotations": [
         {
@@ -9043,7 +9665,8 @@
       "chapter": 11,
       "verse": 30,
       "phraseWordCounts": [
-        17
+        7,
+        10
       ],
       "annotations": [
         {
@@ -9077,7 +9700,9 @@
       "chapter": 11,
       "verse": 31,
       "phraseWordCounts": [
-        18
+        5,
+        5,
+        8
       ],
       "annotations": [
         {
@@ -9103,7 +9728,10 @@
       "chapter": 11,
       "verse": 32,
       "phraseWordCounts": [
-        26
+        6,
+        7,
+        6,
+        7
       ],
       "annotations": [
         {
@@ -9141,7 +9769,9 @@
       "chapter": 11,
       "verse": 33,
       "phraseWordCounts": [
-        18
+        5,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -9183,7 +9813,9 @@
       "chapter": 11,
       "verse": 34,
       "phraseWordCounts": [
-        29
+        13,
+        6,
+        10
       ],
       "annotations": [
         {
@@ -9221,7 +9853,9 @@
       "chapter": 11,
       "verse": 35,
       "phraseWordCounts": [
-        28
+        9,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -9243,7 +9877,8 @@
       "chapter": 11,
       "verse": 36,
       "phraseWordCounts": [
-        10
+        5,
+        5
       ],
       "annotations": [
         {
@@ -9273,7 +9908,11 @@
       "chapter": 11,
       "verse": 37,
       "phraseWordCounts": [
-        29
+        7,
+        5,
+        6,
+        7,
+        4
       ],
       "annotations": [
         {
@@ -9311,7 +9950,9 @@
       "chapter": 11,
       "verse": 38,
       "phraseWordCounts": [
-        22
+        7,
+        6,
+        9
       ],
       "annotations": [
         {
@@ -9345,7 +9986,8 @@
       "chapter": 11,
       "verse": 39,
       "phraseWordCounts": [
-        16
+        7,
+        9
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -9358,7 +10000,8 @@
       "chapter": 11,
       "verse": 40,
       "phraseWordCounts": [
-        19
+        8,
+        11
       ],
       "annotations": [
         {
@@ -9376,7 +10019,10 @@
       "chapter": 12,
       "verse": 1,
       "phraseWordCounts": [
-        38
+        12,
+        7,
+        7,
+        12
       ],
       "annotations": [
         {
@@ -9422,7 +10068,10 @@
       "chapter": 12,
       "verse": 2,
       "phraseWordCounts": [
-        36
+        5,
+        6,
+        13,
+        12
       ],
       "annotations": [
         {
@@ -9448,7 +10097,8 @@
       "chapter": 12,
       "verse": 3,
       "phraseWordCounts": [
-        18
+        8,
+        10
       ],
       "annotations": [
         {
@@ -9474,7 +10124,8 @@
       "chapter": 12,
       "verse": 4,
       "phraseWordCounts": [
-        17
+        5,
+        12
       ],
       "annotations": [
         {
@@ -9494,7 +10145,9 @@
       "chapter": 12,
       "verse": 5,
       "phraseWordCounts": [
-        39
+        18,
+        12,
+        9
       ],
       "annotations": [
         {
@@ -9532,7 +10185,8 @@
       "chapter": 12,
       "verse": 6,
       "phraseWordCounts": [
-        17
+        8,
+        9
       ],
       "annotations": [
         {
@@ -9562,7 +10216,9 @@
       "chapter": 12,
       "verse": 7,
       "phraseWordCounts": [
-        20
+        4,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -9586,7 +10242,9 @@
       "chapter": 12,
       "verse": 8,
       "phraseWordCounts": [
-        21
+        9,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -9610,7 +10268,9 @@
       "chapter": 12,
       "verse": 9,
       "phraseWordCounts": [
-        29
+        10,
+        6,
+        13
       ],
       "annotations": [
         {
@@ -9640,7 +10300,9 @@
       "chapter": 12,
       "verse": 10,
       "phraseWordCounts": [
-        27
+        11,
+        7,
+        9
       ],
       "annotations": [
         {
@@ -9674,7 +10336,9 @@
       "chapter": 12,
       "verse": 11,
       "phraseWordCounts": [
-        28
+        9,
+        11,
+        8
       ],
       "annotations": [
         {
@@ -9734,7 +10398,8 @@
       "chapter": 12,
       "verse": 13,
       "phraseWordCounts": [
-        17
+        6,
+        11
       ],
       "annotations": [
         {
@@ -9764,7 +10429,8 @@
       "chapter": 12,
       "verse": 14,
       "phraseWordCounts": [
-        21
+        13,
+        8
       ],
       "annotations": [
         {
@@ -9782,7 +10448,8 @@
       "chapter": 12,
       "verse": 15,
       "phraseWordCounts": [
-        26
+        13,
+        13
       ],
       "annotations": [
         {
@@ -9824,7 +10491,9 @@
       "chapter": 12,
       "verse": 16,
       "phraseWordCounts": [
-        25
+        7,
+        5,
+        13
       ],
       "annotations": [
         {
@@ -9860,7 +10529,10 @@
       "chapter": 12,
       "verse": 17,
       "phraseWordCounts": [
-        30
+        11,
+        3,
+        8,
+        8
       ],
       "annotations": [
         {
@@ -9876,7 +10548,8 @@
       "chapter": 12,
       "verse": 18,
       "phraseWordCounts": [
-        22
+        17,
+        5
       ],
       "annotations": [
         {
@@ -9896,7 +10569,8 @@
       "chapter": 12,
       "verse": 19,
       "phraseWordCounts": [
-        25
+        11,
+        14
       ],
       "annotations": [
         {
@@ -9924,7 +10598,9 @@
       "chapter": 12,
       "verse": 20,
       "phraseWordCounts": [
-        21
+        8,
+        7,
+        6
       ],
       "annotations": [
         {
@@ -9944,7 +10620,8 @@
       "chapter": 12,
       "verse": 21,
       "phraseWordCounts": [
-        13
+        8,
+        5
       ],
       "annotations": [
         {
@@ -9964,7 +10641,10 @@
       "chapter": 12,
       "verse": 22,
       "phraseWordCounts": [
-        29
+        7,
+        7,
+        3,
+        12
       ],
       "annotations": [
         {
@@ -10000,7 +10680,10 @@
       "chapter": 12,
       "verse": 23,
       "phraseWordCounts": [
-        29
+        6,
+        6,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -10020,7 +10703,8 @@
       "chapter": 12,
       "verse": 24,
       "phraseWordCounts": [
-        23
+        8,
+        15
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10031,7 +10715,9 @@
       "chapter": 12,
       "verse": 25,
       "phraseWordCounts": [
-        41
+        11,
+        14,
+        16
       ],
       "annotations": [
         {
@@ -10055,7 +10741,9 @@
       "chapter": 12,
       "verse": 26,
       "phraseWordCounts": [
-        26
+        8,
+        5,
+        13
       ],
       "annotations": [
         {
@@ -10075,7 +10763,9 @@
       "chapter": 12,
       "verse": 27,
       "phraseWordCounts": [
-        24
+        12,
+        4,
+        8
       ],
       "annotations": [
         {
@@ -10107,7 +10797,9 @@
       "chapter": 12,
       "verse": 28,
       "phraseWordCounts": [
-        24
+        11,
+        4,
+        9
       ],
       "annotations": [
         {
@@ -10173,7 +10865,8 @@
       "chapter": 13,
       "verse": 2,
       "phraseWordCounts": [
-        22
+        8,
+        14
       ],
       "annotations": [],
       "ftvWordCount": 3,
@@ -10186,7 +10879,8 @@
       "chapter": 13,
       "verse": 3,
       "phraseWordCounts": [
-        26
+        15,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 1,
@@ -10199,7 +10893,9 @@
       "chapter": 13,
       "verse": 4,
       "phraseWordCounts": [
-        23
+        6,
+        6,
+        11
       ],
       "annotations": [
         {
@@ -10233,7 +10929,9 @@
       "chapter": 13,
       "verse": 5,
       "phraseWordCounts": [
-        30
+        16,
+        4,
+        10
       ],
       "annotations": [
         {
@@ -10263,7 +10961,10 @@
       "chapter": 13,
       "verse": 6,
       "phraseWordCounts": [
-        22
+        5,
+        5,
+        5,
+        7
       ],
       "annotations": [
         {
@@ -10285,7 +10986,9 @@
       "chapter": 13,
       "verse": 7,
       "phraseWordCounts": [
-        23
+        11,
+        8,
+        4
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10316,7 +11019,10 @@
       "chapter": 13,
       "verse": 9,
       "phraseWordCounts": [
-        37
+        11,
+        11,
+        5,
+        10
       ],
       "annotations": [
         {
@@ -10342,7 +11048,8 @@
       "chapter": 13,
       "verse": 10,
       "phraseWordCounts": [
-        17
+        4,
+        13
       ],
       "annotations": [
         {
@@ -10362,7 +11069,8 @@
       "chapter": 13,
       "verse": 11,
       "phraseWordCounts": [
-        25
+        17,
+        8
       ],
       "annotations": [
         {
@@ -10386,7 +11094,8 @@
       "chapter": 13,
       "verse": 12,
       "phraseWordCounts": [
-        18
+        9,
+        9
       ],
       "annotations": [
         {
@@ -10406,7 +11115,8 @@
       "chapter": 13,
       "verse": 13,
       "phraseWordCounts": [
-        14
+        9,
+        5
       ],
       "annotations": [
         {
@@ -10426,7 +11136,8 @@
       "chapter": 13,
       "verse": 14,
       "phraseWordCounts": [
-        20
+        9,
+        11
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10437,7 +11148,8 @@
       "chapter": 13,
       "verse": 15,
       "phraseWordCounts": [
-        22
+        13,
+        9
       ],
       "annotations": [
         {
@@ -10463,7 +11175,8 @@
       "chapter": 13,
       "verse": 16,
       "phraseWordCounts": [
-        19
+        12,
+        7
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10476,7 +11189,10 @@
       "chapter": 13,
       "verse": 17,
       "phraseWordCounts": [
-        45
+        10,
+        13,
+        13,
+        9
       ],
       "annotations": [
         {
@@ -10498,7 +11214,9 @@
       "chapter": 13,
       "verse": 18,
       "phraseWordCounts": [
-        20
+        3,
+        9,
+        8
       ],
       "annotations": [
         {
@@ -10518,7 +11236,8 @@
       "chapter": 13,
       "verse": 19,
       "phraseWordCounts": [
-        15
+        6,
+        9
       ],
       "annotations": [
         {
@@ -10538,7 +11257,9 @@
       "chapter": 13,
       "verse": 20,
       "phraseWordCounts": [
-        28
+        6,
+        16,
+        6
       ],
       "annotations": [],
       "ftvWordCount": 2,
@@ -10551,7 +11272,9 @@
       "chapter": 13,
       "verse": 21,
       "phraseWordCounts": [
-        32
+        9,
+        11,
+        12
       ],
       "annotations": [
         {
@@ -10573,7 +11296,8 @@
       "chapter": 13,
       "verse": 22,
       "phraseWordCounts": [
-        23
+        13,
+        10
       ],
       "annotations": [
         {
@@ -10593,7 +11317,8 @@
       "chapter": 13,
       "verse": 23,
       "phraseWordCounts": [
-        24
+        12,
+        12
       ],
       "annotations": [
         {
@@ -10613,7 +11338,8 @@
       "chapter": 13,
       "verse": 24,
       "phraseWordCounts": [
-        16
+        9,
+        7
       ],
       "annotations": [
         {

--- a/data/5-hp-niv.json
+++ b/data/5-hp-niv.json
@@ -1,0 +1,11184 @@
+{
+  "year": 5,
+  "books": [
+    "Hebrews",
+    "1 Peter",
+    "2 Peter"
+  ],
+  "chapters": [
+    {
+      "book": "1 Peter",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "1 Peter",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "1 Peter",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "1 Peter",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 19
+    },
+    {
+      "book": "1 Peter",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "2 Peter",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "2 Peter",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "2 Peter",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "Hebrews",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "Hebrews",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "Hebrews",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 19
+    },
+    {
+      "book": "Hebrews",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "Hebrews",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "Hebrews",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 20
+    },
+    {
+      "book": "Hebrews",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 28
+    },
+    {
+      "book": "Hebrews",
+      "number": 8,
+      "start_verse": 1,
+      "end_verse": 13
+    },
+    {
+      "book": "Hebrews",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 28
+    },
+    {
+      "book": "Hebrews",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 39
+    },
+    {
+      "book": "Hebrews",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 40
+    },
+    {
+      "book": "Hebrews",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "Hebrews",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 25
+    }
+  ],
+  "verses": [
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        53
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Peter",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Peter",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 20,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 21,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 22,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 24,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 25,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 26,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 27,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 7,
+      "verse": 28,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 1,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 5,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 6,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 8,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 9,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 40,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 10,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 11,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 12,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 8,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 9,
+      "verse": 28,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 21,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 22,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 23,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 25,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 26,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 27,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 28,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 29,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 31,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 32,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 33,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 34,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 35,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 36,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 37,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 38,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 10,
+      "verse": 39,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 34,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 35,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 36,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 37,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 38,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 39,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 11,
+      "verse": 40,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 22,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 23,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 24,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 25,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 26,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 28,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 12,
+      "verse": 29,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 17,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 21,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 22,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Hebrews",
+      "chapter": 13,
+      "verse": 25,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    }
+  ],
+  "headings": [
+    {
+      "book": "1 Peter",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 2
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 1,
+      "startVerse": 3,
+      "endChapter": 1,
+      "endVerse": 12
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 1,
+      "startVerse": 13,
+      "endChapter": 1,
+      "endVerse": 21
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 1,
+      "startVerse": 22,
+      "endChapter": 2,
+      "endVerse": 3
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 2,
+      "startVerse": 4,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 12
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 2,
+      "startVerse": 13,
+      "endChapter": 2,
+      "endVerse": 17
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 2,
+      "startVerse": 18,
+      "endChapter": 2,
+      "endVerse": 25
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 6
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 3,
+      "startVerse": 7,
+      "endChapter": 3,
+      "endVerse": 7
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 3,
+      "startVerse": 8,
+      "endChapter": 3,
+      "endVerse": 12
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 3,
+      "startVerse": 13,
+      "endChapter": 3,
+      "endVerse": 17
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 3,
+      "startVerse": 18,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 4,
+      "startVerse": 12,
+      "endChapter": 4,
+      "endVerse": 19
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 4
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 5,
+      "startVerse": 5,
+      "endChapter": 5,
+      "endVerse": 11
+    },
+    {
+      "book": "1 Peter",
+      "startChapter": 5,
+      "startVerse": 12,
+      "endChapter": 5,
+      "endVerse": 14
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 4
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 1,
+      "startVerse": 5,
+      "endChapter": 1,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 1,
+      "startVerse": 12,
+      "endChapter": 1,
+      "endVerse": 15
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 1,
+      "startVerse": 16,
+      "endChapter": 1,
+      "endVerse": 21
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 3
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 2,
+      "startVerse": 4,
+      "endChapter": 2,
+      "endVerse": 11
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 2,
+      "startVerse": 12,
+      "endChapter": 2,
+      "endVerse": 17
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 2,
+      "startVerse": 18,
+      "endChapter": 2,
+      "endVerse": 22
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 9
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 3,
+      "startVerse": 10,
+      "endChapter": 3,
+      "endVerse": 13
+    },
+    {
+      "book": "2 Peter",
+      "startChapter": 3,
+      "startVerse": 14,
+      "endChapter": 3,
+      "endVerse": 18
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 4
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 1,
+      "startVerse": 5,
+      "endChapter": 1,
+      "endVerse": 14
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 4
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 2,
+      "startVerse": 5,
+      "endChapter": 2,
+      "endVerse": 9
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 2,
+      "startVerse": 10,
+      "endChapter": 2,
+      "endVerse": 18
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 6
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 3,
+      "startVerse": 7,
+      "endChapter": 3,
+      "endVerse": 15
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 3,
+      "startVerse": 16,
+      "endChapter": 3,
+      "endVerse": 19
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 10
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 4,
+      "startVerse": 11,
+      "endChapter": 4,
+      "endVerse": 13
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 4,
+      "startVerse": 14,
+      "endChapter": 4,
+      "endVerse": 16
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 4
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 5,
+      "startVerse": 5,
+      "endChapter": 5,
+      "endVerse": 11
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 5,
+      "startVerse": 12,
+      "endChapter": 5,
+      "endVerse": 14
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 8
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 6,
+      "startVerse": 9,
+      "endChapter": 6,
+      "endVerse": 12
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 6,
+      "startVerse": 13,
+      "endChapter": 6,
+      "endVerse": 20
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 10
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 7,
+      "startVerse": 11,
+      "endChapter": 7,
+      "endVerse": 19
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 7,
+      "startVerse": 20,
+      "endChapter": 7,
+      "endVerse": 28
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 8,
+      "startVerse": 1,
+      "endChapter": 8,
+      "endVerse": 6
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 8,
+      "startVerse": 7,
+      "endChapter": 8,
+      "endVerse": 13
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 5
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 9,
+      "startVerse": 6,
+      "endChapter": 9,
+      "endVerse": 10
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 9,
+      "startVerse": 11,
+      "endChapter": 9,
+      "endVerse": 15
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 9,
+      "startVerse": 16,
+      "endChapter": 9,
+      "endVerse": 22
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 9,
+      "startVerse": 23,
+      "endChapter": 9,
+      "endVerse": 28
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 4
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 10,
+      "startVerse": 5,
+      "endChapter": 10,
+      "endVerse": 10
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 10,
+      "startVerse": 11,
+      "endChapter": 10,
+      "endVerse": 18
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 10,
+      "startVerse": 19,
+      "endChapter": 10,
+      "endVerse": 25
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 10,
+      "startVerse": 26,
+      "endChapter": 10,
+      "endVerse": 39
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 3
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 4,
+      "endChapter": 11,
+      "endVerse": 7
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 8,
+      "endChapter": 11,
+      "endVerse": 12
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 13,
+      "endChapter": 11,
+      "endVerse": 16
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 17,
+      "endChapter": 11,
+      "endVerse": 22
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 23,
+      "endChapter": 11,
+      "endVerse": 29
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 11,
+      "startVerse": 30,
+      "endChapter": 11,
+      "endVerse": 40
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 2
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 12,
+      "startVerse": 3,
+      "endChapter": 12,
+      "endVerse": 11
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 12,
+      "startVerse": 12,
+      "endChapter": 12,
+      "endVerse": 17
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 12,
+      "startVerse": 18,
+      "endChapter": 12,
+      "endVerse": 24
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 12,
+      "startVerse": 25,
+      "endChapter": 12,
+      "endVerse": 29
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 6
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 13,
+      "startVerse": 7,
+      "endChapter": 13,
+      "endVerse": 17
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 13,
+      "startVerse": 18,
+      "endChapter": 13,
+      "endVerse": 19
+    },
+    {
+      "book": "Hebrews",
+      "startChapter": 13,
+      "startVerse": 20,
+      "endChapter": 13,
+      "endVerse": 25
+    }
+  ]
+}

--- a/data/6-ot-survey-niv.json
+++ b/data/6-ot-survey-niv.json
@@ -1,0 +1,15536 @@
+{
+  "year": 6,
+  "books": [
+    "Genesis",
+    "Exodus",
+    "Deuteronomy",
+    "Joshua",
+    "Judges",
+    "1 Samuel",
+    "2 Samuel",
+    "Job",
+    "Psalms",
+    "Proverbs",
+    "Isaiah",
+    "Jeremiah",
+    "Daniel",
+    "Joel",
+    "Jonah",
+    "Micah",
+    "Habakkuk",
+    "Zephaniah"
+  ],
+  "chapters": [
+    {
+      "book": "1 Samuel",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 13
+    },
+    {
+      "book": "1 Samuel",
+      "number": 17,
+      "start_verse": 1,
+      "end_verse": 58
+    },
+    {
+      "book": "1 Samuel",
+      "number": 18,
+      "start_verse": 1,
+      "end_verse": 4
+    },
+    {
+      "book": "2 Samuel",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "Daniel",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Daniel",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 30
+    },
+    {
+      "book": "Deuteronomy",
+      "number": 1,
+      "start_verse": 19,
+      "end_verse": 40
+    },
+    {
+      "book": "Deuteronomy",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 9
+    },
+    {
+      "book": "Exodus",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Exodus",
+      "number": 12,
+      "start_verse": 21,
+      "end_verse": 42
+    },
+    {
+      "book": "Exodus",
+      "number": 13,
+      "start_verse": 17,
+      "end_verse": 22
+    },
+    {
+      "book": "Exodus",
+      "number": 14,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Exodus",
+      "number": 17,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "Exodus",
+      "number": 20,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "Genesis",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Genesis",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Genesis",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "Genesis",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Genesis",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 9
+    },
+    {
+      "book": "Genesis",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 8
+    },
+    {
+      "book": "Genesis",
+      "number": 22,
+      "start_verse": 1,
+      "end_verse": 19
+    },
+    {
+      "book": "Genesis",
+      "number": 50,
+      "start_verse": 15,
+      "end_verse": 26
+    },
+    {
+      "book": "Habakkuk",
+      "number": 3,
+      "start_verse": 17,
+      "end_verse": 19
+    },
+    {
+      "book": "Isaiah",
+      "number": 1,
+      "start_verse": 16,
+      "end_verse": 18
+    },
+    {
+      "book": "Isaiah",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 8
+    },
+    {
+      "book": "Isaiah",
+      "number": 40,
+      "start_verse": 27,
+      "end_verse": 31
+    },
+    {
+      "book": "Isaiah",
+      "number": 53,
+      "start_verse": 1,
+      "end_verse": 12
+    },
+    {
+      "book": "Isaiah",
+      "number": 55,
+      "start_verse": 6,
+      "end_verse": 11
+    },
+    {
+      "book": "Jeremiah",
+      "number": 31,
+      "start_verse": 31,
+      "end_verse": 37
+    },
+    {
+      "book": "Job",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Joel",
+      "number": 2,
+      "start_verse": 12,
+      "end_verse": 32
+    },
+    {
+      "book": "Jonah",
+      "number": 1,
+      "start_verse": 17,
+      "end_verse": 17
+    },
+    {
+      "book": "Jonah",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 10
+    },
+    {
+      "book": "Joshua",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 9
+    },
+    {
+      "book": "Joshua",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "Joshua",
+      "number": 23,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "Judges",
+      "number": 2,
+      "start_verse": 7,
+      "end_verse": 23
+    },
+    {
+      "book": "Micah",
+      "number": 4,
+      "start_verse": 5,
+      "end_verse": 5
+    },
+    {
+      "book": "Micah",
+      "number": 5,
+      "start_verse": 2,
+      "end_verse": 2
+    },
+    {
+      "book": "Micah",
+      "number": 6,
+      "start_verse": 8,
+      "end_verse": 8
+    },
+    {
+      "book": "Micah",
+      "number": 7,
+      "start_verse": 18,
+      "end_verse": 19
+    },
+    {
+      "book": "Proverbs",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 35
+    },
+    {
+      "book": "Psalms",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 6
+    },
+    {
+      "book": "Psalms",
+      "number": 19,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "Psalms",
+      "number": 23,
+      "start_verse": 1,
+      "end_verse": 6
+    },
+    {
+      "book": "Psalms",
+      "number": 32,
+      "start_verse": 1,
+      "end_verse": 11
+    },
+    {
+      "book": "Psalms",
+      "number": 46,
+      "start_verse": 1,
+      "end_verse": 11
+    },
+    {
+      "book": "Psalms",
+      "number": 51,
+      "start_verse": 1,
+      "end_verse": 19
+    },
+    {
+      "book": "Psalms",
+      "number": 91,
+      "start_verse": 1,
+      "end_verse": 16
+    },
+    {
+      "book": "Psalms",
+      "number": 103,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Psalms",
+      "number": 139,
+      "start_verse": 1,
+      "end_verse": 24
+    },
+    {
+      "book": "Psalms",
+      "number": 145,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Zephaniah",
+      "number": 3,
+      "start_verse": 16,
+      "end_verse": 17
+    }
+  ],
+  "verses": [
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 1,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 2,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 8,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 9,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 10,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 12,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 14,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 15,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 20,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 21,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 25,
+      "phraseWordCounts": [
+        51
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 48,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 26,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 28,
+      "phraseWordCounts": [
+        57
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 29,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 30,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 31,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 32,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 33,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 34,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 35,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 36,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 37,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 38,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 39,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 40,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 41,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 42,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 43,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 44,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 45,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 46,
+      "phraseWordCounts": [
+        52
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 47,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 48,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 49,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 50,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 51,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 52,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 53,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 54,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 55,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 56,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 57,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 17,
+      "verse": 58,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 18,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 18,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 18,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "1 Samuel",
+      "chapter": 18,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "2 Samuel",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        62
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 26,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 27,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 28,
+      "phraseWordCounts": [
+        50
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 29,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Daniel",
+      "chapter": 3,
+      "verse": 30,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 32,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 33,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 34,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 35,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 36,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 37,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 38,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 39,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 1,
+      "verse": 40,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Deuteronomy",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        53
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 46,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 22,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 23,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 24,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 25,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 26,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 27,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 28,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 29,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 30,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 31,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 32,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 34,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 35,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 36,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 37,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 38,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 39,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 40,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 41,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 12,
+      "verse": 42,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 17,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 18,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 19,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 20,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 21,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 13,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 1,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 4,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 5,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 11,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 14,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 16,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 20,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 21,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 22,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 23,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 24,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 25,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 26,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 27,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 28,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 29,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 14,
+      "verse": 31,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 1,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 3,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 5,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 6,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 7,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 8,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 9,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 12,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 13,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 17,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 1,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 3,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 5,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 8,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 9,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 10,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 11,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 13,
+      "phraseWordCounts": [
+        4
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 14,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 15,
+      "phraseWordCounts": [
+        4
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 16,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Exodus",
+      "chapter": 20,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 10,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        48
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 6,
+      "verse": 22,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 3,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 6,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 7,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 9,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 13,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 14,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 15,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 16,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 17,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 22,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 17,
+      "phraseWordCounts": [
+        50
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 49,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 20,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 22,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 23,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 24,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 25,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Genesis",
+      "chapter": 50,
+      "verse": 26,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Habakkuk",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Habakkuk",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Habakkuk",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "verse": 28,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "verse": 29,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "verse": 30,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 40,
+      "verse": 31,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 3,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 7,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 8,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 10,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 11,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 53,
+      "verse": 12,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 6,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 7,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 10,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Isaiah",
+      "chapter": 55,
+      "verse": 11,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 31,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 32,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 33,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 34,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 35,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 36,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Jeremiah",
+      "chapter": 31,
+      "verse": 37,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 47,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 48,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 12,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 12,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Job",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 31,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joel",
+      "chapter": 2,
+      "verse": 32,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Jonah",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 42,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 43,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 1,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 4,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 5,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 7,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 11,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 12,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 13,
+      "phraseWordCounts": [
+        52
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 14,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 44,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 15,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Joshua",
+      "chapter": 23,
+      "verse": 16,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Judges",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Micah",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Micah",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Micah",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Micah",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Micah",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 28,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 29,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 30,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 31,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 32,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 33,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 34,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Proverbs",
+      "chapter": 3,
+      "verse": 35,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 1,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 12,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 19,
+      "verse": 14,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 1,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 23,
+      "verse": 6,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 1,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 5,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 6,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 8,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 32,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 7,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 46,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 2,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 3,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 5,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 14,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 15,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 51,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 5,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 6,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 9,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 10,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 12,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 91,
+      "verse": 16,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 2,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 3,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 5,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 6,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 8,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 11,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 12,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 14,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 15,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 16,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 19,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 20,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 21,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 103,
+      "verse": 22,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 1,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 3,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 4,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 5,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 9,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 13,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 16,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 17,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 18,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 139,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 4,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 6,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 13,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 16,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 17,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 20,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Psalms",
+      "chapter": 145,
+      "verse": 21,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Zephaniah",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Zephaniah",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    }
+  ],
+  "headings": [
+    {
+      "book": "1 Samuel",
+      "startChapter": 16,
+      "startVerse": 1,
+      "endChapter": 16,
+      "endVerse": 13
+    },
+    {
+      "book": "1 Samuel",
+      "startChapter": 17,
+      "startVerse": 1,
+      "endChapter": 17,
+      "endVerse": 58
+    },
+    {
+      "book": "1 Samuel",
+      "startChapter": 18,
+      "startVerse": 1,
+      "endChapter": 18,
+      "endVerse": 16
+    },
+    {
+      "book": "2 Samuel",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 17
+    },
+    {
+      "book": "Daniel",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 21
+    },
+    {
+      "book": "Daniel",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 7
+    },
+    {
+      "book": "Daniel",
+      "startChapter": 3,
+      "startVerse": 8,
+      "endChapter": 3,
+      "endVerse": 18
+    },
+    {
+      "book": "Daniel",
+      "startChapter": 3,
+      "startVerse": 19,
+      "endChapter": 3,
+      "endVerse": 25
+    },
+    {
+      "book": "Daniel",
+      "startChapter": 3,
+      "startVerse": 26,
+      "endChapter": 3,
+      "endVerse": 30
+    },
+    {
+      "book": "Deuteronomy",
+      "startChapter": 1,
+      "startVerse": 19,
+      "endChapter": 1,
+      "endVerse": 33
+    },
+    {
+      "book": "Deuteronomy",
+      "startChapter": 1,
+      "startVerse": 34,
+      "endChapter": 1,
+      "endVerse": 46
+    },
+    {
+      "book": "Deuteronomy",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 9
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 22
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 28
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 12,
+      "startVerse": 29,
+      "endChapter": 12,
+      "endVerse": 30
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 12,
+      "startVerse": 31,
+      "endChapter": 12,
+      "endVerse": 42
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 13,
+      "startVerse": 17,
+      "endChapter": 13,
+      "endVerse": 22
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 14,
+      "startVerse": 1,
+      "endChapter": 14,
+      "endVerse": 31
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 17,
+      "startVerse": 1,
+      "endChapter": 17,
+      "endVerse": 7
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 17,
+      "startVerse": 8,
+      "endChapter": 17,
+      "endVerse": 16
+    },
+    {
+      "book": "Exodus",
+      "startChapter": 20,
+      "startVerse": 1,
+      "endChapter": 20,
+      "endVerse": 17
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 7
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 2,
+      "startVerse": 8,
+      "endChapter": 2,
+      "endVerse": 25
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 24
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 8
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 6,
+      "startVerse": 9,
+      "endChapter": 6,
+      "endVerse": 12
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 6,
+      "startVerse": 13,
+      "endChapter": 6,
+      "endVerse": 22
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 9
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 9
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 22,
+      "startVerse": 1,
+      "endChapter": 22,
+      "endVerse": 19
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 50,
+      "startVerse": 15,
+      "endChapter": 50,
+      "endVerse": 21
+    },
+    {
+      "book": "Genesis",
+      "startChapter": 50,
+      "startVerse": 22,
+      "endChapter": 50,
+      "endVerse": 26
+    },
+    {
+      "book": "Habakkuk",
+      "startChapter": 3,
+      "startVerse": 17,
+      "endChapter": 3,
+      "endVerse": 19
+    },
+    {
+      "book": "Isaiah",
+      "startChapter": 1,
+      "startVerse": 2,
+      "endChapter": 1,
+      "endVerse": 20
+    },
+    {
+      "book": "Isaiah",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 13
+    },
+    {
+      "book": "Isaiah",
+      "startChapter": 40,
+      "startVerse": 1,
+      "endChapter": 40,
+      "endVerse": 31
+    },
+    {
+      "book": "Isaiah",
+      "startChapter": 52,
+      "startVerse": 13,
+      "endChapter": 53,
+      "endVerse": 12
+    },
+    {
+      "book": "Isaiah",
+      "startChapter": 55,
+      "startVerse": 1,
+      "endChapter": 55,
+      "endVerse": 13
+    },
+    {
+      "book": "Jeremiah",
+      "startChapter": 31,
+      "startVerse": 31,
+      "endChapter": 31,
+      "endVerse": 40
+    },
+    {
+      "book": "Job",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 5
+    },
+    {
+      "book": "Job",
+      "startChapter": 1,
+      "startVerse": 6,
+      "endChapter": 1,
+      "endVerse": 12
+    },
+    {
+      "book": "Job",
+      "startChapter": 1,
+      "startVerse": 13,
+      "endChapter": 1,
+      "endVerse": 22
+    },
+    {
+      "book": "Joel",
+      "startChapter": 2,
+      "startVerse": 12,
+      "endChapter": 2,
+      "endVerse": 17
+    },
+    {
+      "book": "Joel",
+      "startChapter": 2,
+      "startVerse": 28,
+      "endChapter": 2,
+      "endVerse": 32
+    },
+    {
+      "book": "Jonah",
+      "startChapter": 1,
+      "startVerse": 17,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Joshua",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 9
+    },
+    {
+      "book": "Joshua",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 24
+    },
+    {
+      "book": "Joshua",
+      "startChapter": 23,
+      "startVerse": 1,
+      "endChapter": 23,
+      "endVerse": 16
+    },
+    {
+      "book": "Judges",
+      "startChapter": 2,
+      "startVerse": 7,
+      "endChapter": 2,
+      "endVerse": 10
+    },
+    {
+      "book": "Judges",
+      "startChapter": 2,
+      "startVerse": 11,
+      "endChapter": 2,
+      "endVerse": 23
+    },
+    {
+      "book": "Micah",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 5
+    },
+    {
+      "book": "Micah",
+      "startChapter": 5,
+      "startVerse": 2,
+      "endChapter": 5,
+      "endVerse": 4
+    },
+    {
+      "book": "Micah",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 8
+    },
+    {
+      "book": "Micah",
+      "startChapter": 7,
+      "startVerse": 14,
+      "endChapter": 7,
+      "endVerse": 20
+    },
+    {
+      "book": "Proverbs",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 35
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 6
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 19,
+      "startVerse": 1,
+      "endChapter": 19,
+      "endVerse": 14
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 23,
+      "startVerse": 1,
+      "endChapter": 23,
+      "endVerse": 6
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 32,
+      "startVerse": 1,
+      "endChapter": 32,
+      "endVerse": 11
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 46,
+      "startVerse": 1,
+      "endChapter": 46,
+      "endVerse": 11
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 51,
+      "startVerse": 1,
+      "endChapter": 51,
+      "endVerse": 19
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 91,
+      "startVerse": 1,
+      "endChapter": 91,
+      "endVerse": 16
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 103,
+      "startVerse": 1,
+      "endChapter": 103,
+      "endVerse": 22
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 139,
+      "startVerse": 1,
+      "endChapter": 139,
+      "endVerse": 24
+    },
+    {
+      "book": "Psalms",
+      "startChapter": 145,
+      "startVerse": 1,
+      "endChapter": 145,
+      "endVerse": 21
+    },
+    {
+      "book": "Zephaniah",
+      "startChapter": 3,
+      "startVerse": 14,
+      "endChapter": 3,
+      "endVerse": 20
+    }
+  ]
+}

--- a/data/7-rj-niv.json
+++ b/data/7-rj-niv.json
@@ -1,0 +1,12114 @@
+{
+  "year": 7,
+  "books": [
+    "Romans",
+    "James"
+  ],
+  "chapters": [
+    {
+      "book": "James",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 27
+    },
+    {
+      "book": "James",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 26
+    },
+    {
+      "book": "James",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 18
+    },
+    {
+      "book": "James",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 17
+    },
+    {
+      "book": "James",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 20
+    },
+    {
+      "book": "Romans",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 32
+    },
+    {
+      "book": "Romans",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 29
+    },
+    {
+      "book": "Romans",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Romans",
+      "number": 4,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Romans",
+      "number": 5,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Romans",
+      "number": 6,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Romans",
+      "number": 7,
+      "start_verse": 1,
+      "end_verse": 25
+    },
+    {
+      "book": "Romans",
+      "number": 8,
+      "start_verse": 1,
+      "end_verse": 39
+    },
+    {
+      "book": "Romans",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "Romans",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Romans",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 36
+    },
+    {
+      "book": "Romans",
+      "number": 12,
+      "start_verse": 1,
+      "end_verse": 21
+    },
+    {
+      "book": "Romans",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 14
+    },
+    {
+      "book": "Romans",
+      "number": 14,
+      "start_verse": 1,
+      "end_verse": 23
+    },
+    {
+      "book": "Romans",
+      "number": 15,
+      "start_verse": 1,
+      "end_verse": 33
+    },
+    {
+      "book": "Romans",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 27
+    }
+  ],
+  "verses": [
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "James",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        48
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 1,
+      "verse": 32,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 27,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 23,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 25,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 26,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 28,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 30,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 3,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 3,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 8,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 11,
+      "phraseWordCounts": [
+        46
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 12,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 15,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 16,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 17,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 20,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 21,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 22,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 23,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 4,
+      "verse": 25,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 4,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 5,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 6,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 7,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 8,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 10,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 11,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 14,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 15,
+      "phraseWordCounts": [
+        44
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 16,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 17,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 18,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 19,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 5,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 1,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 4,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 6,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 7,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 9,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 10,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 11,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 13,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 16,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 17,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 19,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 20,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 21,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 22,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 6,
+      "verse": 23,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 1,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 2,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 3,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 4,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 6,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 7,
+      "phraseWordCounts": [
+        47
+      ],
+      "annotations": [
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 8,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 13,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 18,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 22,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 23,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 24,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 7,
+      "verse": 25,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 2,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 3,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 4,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 5,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 8,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 9,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 11,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 13,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 14,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 15,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 16,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 22,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 23,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 25,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 26,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 27,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 28,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 29,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 31,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 32,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 33,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 34,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 35,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 36,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 37,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 38,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 8,
+      "verse": 39,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 28,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 29,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 31,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 32,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 9,
+      "verse": 33,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 19,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 20,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 10,
+      "verse": 21,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 34,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 35,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 11,
+      "verse": 36,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 1,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 2,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 3,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 5,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 6,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 7,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 8,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 9,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 10,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 11,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 12,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 14,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 15,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 16,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 17,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 20,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 12,
+      "verse": 21,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 1,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 3,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 4,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 6,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 8,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 10,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 12,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 14,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 17,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 19,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 20,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 22,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 14,
+      "verse": 23,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 1,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 3,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 4,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 10,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 11,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 12,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 13,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 14,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 16,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 17,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 18,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 19,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 20,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 21,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 24,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 25,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 26,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 27,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 28,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 30,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 31,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 32,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 15,
+      "verse": 33,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 25,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 26,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Romans",
+      "chapter": 16,
+      "verse": 27,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    }
+  ],
+  "headings": [
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 1
+    },
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 2,
+      "endChapter": 1,
+      "endVerse": 8
+    },
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 9,
+      "endChapter": 1,
+      "endVerse": 11
+    },
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 12,
+      "endChapter": 1,
+      "endVerse": 18
+    },
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 19,
+      "endChapter": 1,
+      "endVerse": 20
+    },
+    {
+      "book": "James",
+      "startChapter": 1,
+      "startVerse": 21,
+      "endChapter": 1,
+      "endVerse": 27
+    },
+    {
+      "book": "James",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 13
+    },
+    {
+      "book": "James",
+      "startChapter": 2,
+      "startVerse": 14,
+      "endChapter": 2,
+      "endVerse": 26
+    },
+    {
+      "book": "James",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 12
+    },
+    {
+      "book": "James",
+      "startChapter": 3,
+      "startVerse": 13,
+      "endChapter": 3,
+      "endVerse": 18
+    },
+    {
+      "book": "James",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 6
+    },
+    {
+      "book": "James",
+      "startChapter": 4,
+      "startVerse": 7,
+      "endChapter": 4,
+      "endVerse": 10
+    },
+    {
+      "book": "James",
+      "startChapter": 4,
+      "startVerse": 11,
+      "endChapter": 4,
+      "endVerse": 12
+    },
+    {
+      "book": "James",
+      "startChapter": 4,
+      "startVerse": 13,
+      "endChapter": 4,
+      "endVerse": 17
+    },
+    {
+      "book": "James",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 6
+    },
+    {
+      "book": "James",
+      "startChapter": 5,
+      "startVerse": 7,
+      "endChapter": 5,
+      "endVerse": 12
+    },
+    {
+      "book": "James",
+      "startChapter": 5,
+      "startVerse": 13,
+      "endChapter": 5,
+      "endVerse": 18
+    },
+    {
+      "book": "James",
+      "startChapter": 5,
+      "startVerse": 19,
+      "endChapter": 5,
+      "endVerse": 20
+    },
+    {
+      "book": "Romans",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 7
+    },
+    {
+      "book": "Romans",
+      "startChapter": 1,
+      "startVerse": 8,
+      "endChapter": 1,
+      "endVerse": 15
+    },
+    {
+      "book": "Romans",
+      "startChapter": 1,
+      "startVerse": 16,
+      "endChapter": 1,
+      "endVerse": 17
+    },
+    {
+      "book": "Romans",
+      "startChapter": 1,
+      "startVerse": 18,
+      "endChapter": 1,
+      "endVerse": 32
+    },
+    {
+      "book": "Romans",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 16
+    },
+    {
+      "book": "Romans",
+      "startChapter": 2,
+      "startVerse": 17,
+      "endChapter": 2,
+      "endVerse": 24
+    },
+    {
+      "book": "Romans",
+      "startChapter": 2,
+      "startVerse": 25,
+      "endChapter": 2,
+      "endVerse": 29
+    },
+    {
+      "book": "Romans",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 8
+    },
+    {
+      "book": "Romans",
+      "startChapter": 3,
+      "startVerse": 9,
+      "endChapter": 3,
+      "endVerse": 20
+    },
+    {
+      "book": "Romans",
+      "startChapter": 3,
+      "startVerse": 21,
+      "endChapter": 3,
+      "endVerse": 26
+    },
+    {
+      "book": "Romans",
+      "startChapter": 3,
+      "startVerse": 27,
+      "endChapter": 3,
+      "endVerse": 31
+    },
+    {
+      "book": "Romans",
+      "startChapter": 4,
+      "startVerse": 1,
+      "endChapter": 4,
+      "endVerse": 4
+    },
+    {
+      "book": "Romans",
+      "startChapter": 4,
+      "startVerse": 5,
+      "endChapter": 4,
+      "endVerse": 8
+    },
+    {
+      "book": "Romans",
+      "startChapter": 4,
+      "startVerse": 9,
+      "endChapter": 4,
+      "endVerse": 12
+    },
+    {
+      "book": "Romans",
+      "startChapter": 4,
+      "startVerse": 13,
+      "endChapter": 4,
+      "endVerse": 25
+    },
+    {
+      "book": "Romans",
+      "startChapter": 5,
+      "startVerse": 1,
+      "endChapter": 5,
+      "endVerse": 5
+    },
+    {
+      "book": "Romans",
+      "startChapter": 5,
+      "startVerse": 6,
+      "endChapter": 5,
+      "endVerse": 11
+    },
+    {
+      "book": "Romans",
+      "startChapter": 5,
+      "startVerse": 12,
+      "endChapter": 5,
+      "endVerse": 21
+    },
+    {
+      "book": "Romans",
+      "startChapter": 6,
+      "startVerse": 1,
+      "endChapter": 6,
+      "endVerse": 14
+    },
+    {
+      "book": "Romans",
+      "startChapter": 6,
+      "startVerse": 15,
+      "endChapter": 6,
+      "endVerse": 23
+    },
+    {
+      "book": "Romans",
+      "startChapter": 7,
+      "startVerse": 1,
+      "endChapter": 7,
+      "endVerse": 6
+    },
+    {
+      "book": "Romans",
+      "startChapter": 7,
+      "startVerse": 7,
+      "endChapter": 7,
+      "endVerse": 12
+    },
+    {
+      "book": "Romans",
+      "startChapter": 7,
+      "startVerse": 13,
+      "endChapter": 7,
+      "endVerse": 25
+    },
+    {
+      "book": "Romans",
+      "startChapter": 8,
+      "startVerse": 1,
+      "endChapter": 8,
+      "endVerse": 11
+    },
+    {
+      "book": "Romans",
+      "startChapter": 8,
+      "startVerse": 12,
+      "endChapter": 8,
+      "endVerse": 17
+    },
+    {
+      "book": "Romans",
+      "startChapter": 8,
+      "startVerse": 18,
+      "endChapter": 8,
+      "endVerse": 30
+    },
+    {
+      "book": "Romans",
+      "startChapter": 8,
+      "startVerse": 31,
+      "endChapter": 8,
+      "endVerse": 39
+    },
+    {
+      "book": "Romans",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 5
+    },
+    {
+      "book": "Romans",
+      "startChapter": 9,
+      "startVerse": 6,
+      "endChapter": 9,
+      "endVerse": 13
+    },
+    {
+      "book": "Romans",
+      "startChapter": 9,
+      "startVerse": 14,
+      "endChapter": 9,
+      "endVerse": 29
+    },
+    {
+      "book": "Romans",
+      "startChapter": 9,
+      "startVerse": 30,
+      "endChapter": 9,
+      "endVerse": 33
+    },
+    {
+      "book": "Romans",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 13
+    },
+    {
+      "book": "Romans",
+      "startChapter": 10,
+      "startVerse": 14,
+      "endChapter": 10,
+      "endVerse": 21
+    },
+    {
+      "book": "Romans",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 10
+    },
+    {
+      "book": "Romans",
+      "startChapter": 11,
+      "startVerse": 11,
+      "endChapter": 11,
+      "endVerse": 36
+    },
+    {
+      "book": "Romans",
+      "startChapter": 12,
+      "startVerse": 1,
+      "endChapter": 12,
+      "endVerse": 2
+    },
+    {
+      "book": "Romans",
+      "startChapter": 12,
+      "startVerse": 3,
+      "endChapter": 12,
+      "endVerse": 8
+    },
+    {
+      "book": "Romans",
+      "startChapter": 12,
+      "startVerse": 9,
+      "endChapter": 12,
+      "endVerse": 21
+    },
+    {
+      "book": "Romans",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 7
+    },
+    {
+      "book": "Romans",
+      "startChapter": 13,
+      "startVerse": 8,
+      "endChapter": 13,
+      "endVerse": 10
+    },
+    {
+      "book": "Romans",
+      "startChapter": 13,
+      "startVerse": 11,
+      "endChapter": 13,
+      "endVerse": 14
+    },
+    {
+      "book": "Romans",
+      "startChapter": 14,
+      "startVerse": 1,
+      "endChapter": 14,
+      "endVerse": 13
+    },
+    {
+      "book": "Romans",
+      "startChapter": 14,
+      "startVerse": 14,
+      "endChapter": 14,
+      "endVerse": 23
+    },
+    {
+      "book": "Romans",
+      "startChapter": 15,
+      "startVerse": 1,
+      "endChapter": 15,
+      "endVerse": 6
+    },
+    {
+      "book": "Romans",
+      "startChapter": 15,
+      "startVerse": 7,
+      "endChapter": 15,
+      "endVerse": 13
+    },
+    {
+      "book": "Romans",
+      "startChapter": 15,
+      "startVerse": 14,
+      "endChapter": 15,
+      "endVerse": 21
+    },
+    {
+      "book": "Romans",
+      "startChapter": 15,
+      "startVerse": 22,
+      "endChapter": 15,
+      "endVerse": 33
+    },
+    {
+      "book": "Romans",
+      "startChapter": 16,
+      "startVerse": 1,
+      "endChapter": 16,
+      "endVerse": 2
+    },
+    {
+      "book": "Romans",
+      "startChapter": 16,
+      "startVerse": 3,
+      "endChapter": 16,
+      "endVerse": 16
+    },
+    {
+      "book": "Romans",
+      "startChapter": 16,
+      "startVerse": 17,
+      "endChapter": 16,
+      "endVerse": 20
+    },
+    {
+      "book": "Romans",
+      "startChapter": 16,
+      "startVerse": 21,
+      "endChapter": 16,
+      "endVerse": 24
+    },
+    {
+      "book": "Romans",
+      "startChapter": 16,
+      "startVerse": 25,
+      "endChapter": 16,
+      "endVerse": 27
+    }
+  ]
+}

--- a/data/8-luke-niv.json
+++ b/data/8-luke-niv.json
@@ -1,0 +1,15352 @@
+{
+  "year": 8,
+  "books": [
+    "Luke"
+  ],
+  "chapters": [
+    {
+      "book": "Luke",
+      "number": 1,
+      "start_verse": 1,
+      "end_verse": 80
+    },
+    {
+      "book": "Luke",
+      "number": 2,
+      "start_verse": 1,
+      "end_verse": 52
+    },
+    {
+      "book": "Luke",
+      "number": 3,
+      "start_verse": 1,
+      "end_verse": 22
+    },
+    {
+      "book": "Luke",
+      "number": 9,
+      "start_verse": 1,
+      "end_verse": 62
+    },
+    {
+      "book": "Luke",
+      "number": 10,
+      "start_verse": 1,
+      "end_verse": 42
+    },
+    {
+      "book": "Luke",
+      "number": 11,
+      "start_verse": 1,
+      "end_verse": 54
+    },
+    {
+      "book": "Luke",
+      "number": 13,
+      "start_verse": 1,
+      "end_verse": 35
+    },
+    {
+      "book": "Luke",
+      "number": 14,
+      "start_verse": 1,
+      "end_verse": 35
+    },
+    {
+      "book": "Luke",
+      "number": 15,
+      "start_verse": 1,
+      "end_verse": 32
+    },
+    {
+      "book": "Luke",
+      "number": 16,
+      "start_verse": 1,
+      "end_verse": 31
+    },
+    {
+      "book": "Luke",
+      "number": 17,
+      "start_verse": 1,
+      "end_verse": 37
+    },
+    {
+      "book": "Luke",
+      "number": 18,
+      "start_verse": 1,
+      "end_verse": 43
+    },
+    {
+      "book": "Luke",
+      "number": 19,
+      "start_verse": 1,
+      "end_verse": 48
+    },
+    {
+      "book": "Luke",
+      "number": 21,
+      "start_verse": 1,
+      "end_verse": 38
+    },
+    {
+      "book": "Luke",
+      "number": 22,
+      "start_verse": 1,
+      "end_verse": 71
+    },
+    {
+      "book": "Luke",
+      "number": 23,
+      "start_verse": 1,
+      "end_verse": 56
+    },
+    {
+      "book": "Luke",
+      "number": 24,
+      "start_verse": 1,
+      "end_verse": 53
+    }
+  ],
+  "verses": [
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 3,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 4,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 5,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 7,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 8,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 10,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 13,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 14,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 15,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 16,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 17,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 18,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 19,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 20,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 22,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 23,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 24,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 25,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 26,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 27,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 28,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 29,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 30,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 31,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 32,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 33,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 34,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 35,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 36,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 37,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 38,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 39,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 40,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 41,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 42,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 43,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 44,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 45,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 46,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 47,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 48,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 49,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 50,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 51,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 52,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 53,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 54,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 55,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 56,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 57,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 58,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 59,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 60,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 61,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 62,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 63,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 64,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 65,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 66,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 67,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 68,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 69,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 70,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 71,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 72,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 73,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 74,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 75,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 76,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 77,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 78,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 79,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 1,
+      "verse": 80,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 2,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 3,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 4,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 5,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 6,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 7,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 8,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 10,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 14,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 15,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 16,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 18,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 19,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 20,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 22,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 23,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 24,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 25,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 26,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 27,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 28,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 29,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 30,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 31,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 32,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 33,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 34,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 35,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 36,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 37,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 38,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 39,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 40,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 41,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 42,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 43,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 44,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 45,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 46,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 47,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 48,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 49,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 50,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 51,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 2,
+      "verse": 52,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 1,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 2,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 4,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 5,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 6,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 8,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 9,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 10,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 11,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 12,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 13,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 14,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 16,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 17,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 3,
+      "verse": 22,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 2,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 4,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 7,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 8,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 9,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 10,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 12,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 13,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 15,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 17,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 19,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 21,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 22,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 23,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 24,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 26,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 27,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 28,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 29,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 30,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 31,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 32,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 33,
+      "phraseWordCounts": [
+        43
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 34,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 35,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 36,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 37,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 38,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 39,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 40,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 41,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 42,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 43,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 44,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 45,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 46,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 47,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 48,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 49,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 50,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 51,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 52,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 53,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 54,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 55,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 56,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 57,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 58,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 59,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 60,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 61,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 9,
+      "verse": 62,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 1,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 3,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 4,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 5,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 7,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 8,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 9,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 10,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 11,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 12,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 13,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 14,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 16,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 17,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 18,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 19,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 20,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 21,
+      "phraseWordCounts": [
+        49
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 22,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 23,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 24,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 25,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 26,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 27,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 28,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 29,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 30,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 31,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 32,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 33,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 34,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 35,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 30,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 36,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 37,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 38,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 39,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 40,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 41,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 10,
+      "verse": 42,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 1,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 2,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 3,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 5,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 6,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 7,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 8,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 9,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 12,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 13,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 14,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 15,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 16,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 18,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 19,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 20,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 21,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 22,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 24,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 25,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 26,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 27,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 28,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 29,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 30,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 31,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 32,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 33,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 34,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 35,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 36,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 37,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 38,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 39,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 40,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 41,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 42,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 35,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 43,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 44,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 45,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 46,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 47,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 48,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 49,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 50,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 51,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 52,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 53,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 11,
+      "verse": 54,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 1,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 2,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 3,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 4,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 5,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 6,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 7,
+      "phraseWordCounts": [
+        41
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 8,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 10,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 11,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 12,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 14,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 15,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 16,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 17,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 18,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 21,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 22,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 23,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 25,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 26,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 28,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 29,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 30,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 31,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 32,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 33,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 34,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 13,
+      "verse": 35,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 2,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 4,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 5,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 6,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 9,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 10,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 11,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 12,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 41,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 13,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 14,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 17,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 19,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 20,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 21,
+      "phraseWordCounts": [
+        45
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 22,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 24,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 25,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 26,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 27,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 28,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 29,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 30,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 31,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 36,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 32,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 33,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 34,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 14,
+      "verse": 35,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 1,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 3,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 4,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 5,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 6,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 7,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 9,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 10,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 11,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 12,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 13,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 14,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 15,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 16,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 17,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 18,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 19,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 20,
+      "phraseWordCounts": [
+        42
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 40,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 21,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 22,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 23,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 24,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 27,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 29,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 15,
+      "verse": 32,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 1,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 2,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 3,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 5,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 6,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 7,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 8,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 11,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 12,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 13,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 14,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 15,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 17,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 18,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 19,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 20,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 21,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 22,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 23,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 24,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 25,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 26,
+      "phraseWordCounts": [
+        37
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 27,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 29,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 16,
+      "verse": 31,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 1,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 4,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 5,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 6,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 7,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 7,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 9,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 10,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 12,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 13,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 14,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 15,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 16,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 17,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 19,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 20,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 21,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 22,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 23,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 24,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 25,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 26,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 27,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 28,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 29,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 30,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 31,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 32,
+      "phraseWordCounts": [
+        3
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 33,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 34,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 35,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 36,
+      "phraseWordCounts": [],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 17,
+      "verse": 37,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 1,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 2,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 3,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 4,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 7,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 8,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 9,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 10,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 11,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 12,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 13,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 14,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 15,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 16,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 17,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 18,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 20,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 21,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 22,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 23,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 24,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 25,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 26,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 27,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 28,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 29,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 30,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 31,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 32,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 33,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 34,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 35,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 36,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 37,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 38,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 39,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 40,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 41,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 42,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 18,
+      "verse": 43,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 1,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 2,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 3,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 5,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 6,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 7,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 8,
+      "phraseWordCounts": [
+        40
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 28,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 39,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 10,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 11,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 12,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 13,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 14,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 15,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 29,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 16,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 17,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 18,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 19,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 20,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 21,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 22,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 38,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 23,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 24,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 25,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 26,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 27,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 28,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 29,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 30,
+      "phraseWordCounts": [
+        31
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 31,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 32,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 33,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 34,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 35,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 36,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 37,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 38,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 39,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 40,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 41,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 42,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 43,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 44,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 45,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 46,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 47,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 19,
+      "verse": 48,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 1,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 2,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 4,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 5,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 6,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 7,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 8,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 9,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 10,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 11,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 12,
+      "phraseWordCounts": [
+        39
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 31,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 13,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 14,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 15,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 16,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 17,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 18,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 19,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 20,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 21,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 22,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 23,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 24,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 25,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 26,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 27,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 28,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 29,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 30,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 31,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 32,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 33,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 34,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 35,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 36,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 37,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 21,
+      "verse": 38,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 2,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 3,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 4,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 5,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 6,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 7,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 8,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 9,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 10,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 24,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 11,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 12,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 13,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 14,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 15,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 16,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 17,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 18,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 8,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 19,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 20,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 21,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 22,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 23,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 24,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 25,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 26,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 27,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 28,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 29,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 30,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 31,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 32,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 33,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 34,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 35,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 36,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 37,
+      "phraseWordCounts": [
+        32
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 29,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 38,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 39,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 40,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 41,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 42,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 43,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 44,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 45,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 46,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 47,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 27,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 48,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 49,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 50,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 51,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 52,
+      "phraseWordCounts": [
+        34
+      ],
+      "annotations": [
+        {
+          "wordIndex": 23,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 33,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 53,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 54,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 55,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 56,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 57,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 58,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 59,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 60,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 61,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 26,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 62,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 63,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 64,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 65,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 66,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 67,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 68,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 69,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 70,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 22,
+      "verse": 71,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 1,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 2,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 23,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 3,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 4,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 5,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 6,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 7,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 8,
+      "phraseWordCounts": [
+        38
+      ],
+      "annotations": [
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 37,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 9,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 10,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 11,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 12,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 13,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 14,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 32,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 15,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 16,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 17,
+      "phraseWordCounts": [],
+      "annotations": [],
+      "ftvWordCount": null,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 18,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 19,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 0,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 20,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 21,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 22,
+      "phraseWordCounts": [
+        36
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 25,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 34,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 23,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 24,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 25,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 26,
+      "phraseWordCounts": [
+        33
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 27,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 28,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 29,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 30,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 31,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 32,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 33,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 34,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 35,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 36,
+      "phraseWordCounts": [
+        13
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 37,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 38,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 39,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 40,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 41,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 42,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 43,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 44,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 45,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 7,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 46,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [
+        {
+          "wordIndex": 21,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 47,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 48,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 49,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 50,
+      "phraseWordCounts": [
+        17
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 6,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 51,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 52,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 53,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 54,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 55,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 23,
+      "verse": 56,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 19,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 1,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 2,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 3,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 4,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 5,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 6,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 7,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 8,
+      "phraseWordCounts": [
+        5
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 9,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 10,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 11,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 12,
+      "phraseWordCounts": [
+        30
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 14,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 13,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 14,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 15,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 15,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 16,
+      "phraseWordCounts": [
+        7
+      ],
+      "annotations": [
+        {
+          "wordIndex": 5,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 17,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 17,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 18,
+      "phraseWordCounts": [
+        27
+      ],
+      "annotations": [
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 19,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 20,
+      "phraseWordCounts": [
+        18
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 21,
+      "phraseWordCounts": [
+        29
+      ],
+      "annotations": [
+        {
+          "wordIndex": 13,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 22,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 1,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 23,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 24,
+      "phraseWordCounts": [
+        24
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 25,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 10,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 26,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 1,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 27,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 28,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 18,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 29,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 4,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 30,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 31,
+      "phraseWordCounts": [
+        15
+      ],
+      "annotations": [
+        {
+          "wordIndex": 7,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 32,
+      "phraseWordCounts": [
+        25
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 33,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 34,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 35,
+      "phraseWordCounts": [
+        22
+      ],
+      "annotations": [
+        {
+          "wordIndex": 14,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 36,
+      "phraseWordCounts": [
+        20
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 37,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [
+        {
+          "wordIndex": 9,
+          "kind": "boldItalic"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 38,
+      "phraseWordCounts": [
+        16
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 39,
+      "phraseWordCounts": [
+        28
+      ],
+      "annotations": [
+        {
+          "wordIndex": 11,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 16,
+          "kind": "boldItalic"
+        },
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        },
+        {
+          "wordIndex": 22,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 40,
+      "phraseWordCounts": [
+        12
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 41,
+      "phraseWordCounts": [
+        23
+      ],
+      "annotations": [
+        {
+          "wordIndex": 12,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 42,
+      "phraseWordCounts": [
+        8
+      ],
+      "annotations": [
+        {
+          "wordIndex": 6,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 2,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 43,
+      "phraseWordCounts": [
+        10
+      ],
+      "annotations": [],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 44,
+      "phraseWordCounts": [
+        35
+      ],
+      "annotations": [
+        {
+          "wordIndex": 34,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 5,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 45,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 46,
+      "phraseWordCounts": [
+        21
+      ],
+      "annotations": [],
+      "ftvWordCount": 5,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 47,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [],
+      "ftvWordCount": 2,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 48,
+      "phraseWordCounts": [
+        6
+      ],
+      "annotations": [
+        {
+          "wordIndex": 2,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 49,
+      "phraseWordCounts": [
+        26
+      ],
+      "annotations": [
+        {
+          "wordIndex": 20,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 50,
+      "phraseWordCounts": [
+        19
+      ],
+      "annotations": [
+        {
+          "wordIndex": 8,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": []
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 51,
+      "phraseWordCounts": [
+        14
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 4,
+      "clubs": [
+        150
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 52,
+      "phraseWordCounts": [
+        11
+      ],
+      "annotations": [],
+      "ftvWordCount": 3,
+      "clubs": [
+        300
+      ]
+    },
+    {
+      "book": "Luke",
+      "chapter": 24,
+      "verse": 53,
+      "phraseWordCounts": [
+        9
+      ],
+      "annotations": [
+        {
+          "wordIndex": 3,
+          "kind": "bold"
+        }
+      ],
+      "ftvWordCount": 3,
+      "clubs": []
+    }
+  ],
+  "headings": [
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 1,
+      "endChapter": 1,
+      "endVerse": 4
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 5,
+      "endChapter": 1,
+      "endVerse": 25
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 26,
+      "endChapter": 1,
+      "endVerse": 38
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 39,
+      "endChapter": 1,
+      "endVerse": 45
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 46,
+      "endChapter": 1,
+      "endVerse": 56
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 57,
+      "endChapter": 1,
+      "endVerse": 58
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 59,
+      "endChapter": 1,
+      "endVerse": 66
+    },
+    {
+      "book": "Luke",
+      "startChapter": 1,
+      "startVerse": 67,
+      "endChapter": 1,
+      "endVerse": 80
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 1,
+      "endChapter": 2,
+      "endVerse": 7
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 8,
+      "endChapter": 2,
+      "endVerse": 20
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 21,
+      "endChapter": 2,
+      "endVerse": 21
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 22,
+      "endChapter": 2,
+      "endVerse": 24
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 25,
+      "endChapter": 2,
+      "endVerse": 35
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 36,
+      "endChapter": 2,
+      "endVerse": 38
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 39,
+      "endChapter": 2,
+      "endVerse": 40
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 41,
+      "endChapter": 2,
+      "endVerse": 50
+    },
+    {
+      "book": "Luke",
+      "startChapter": 2,
+      "startVerse": 51,
+      "endChapter": 2,
+      "endVerse": 52
+    },
+    {
+      "book": "Luke",
+      "startChapter": 3,
+      "startVerse": 1,
+      "endChapter": 3,
+      "endVerse": 6
+    },
+    {
+      "book": "Luke",
+      "startChapter": 3,
+      "startVerse": 7,
+      "endChapter": 3,
+      "endVerse": 20
+    },
+    {
+      "book": "Luke",
+      "startChapter": 3,
+      "startVerse": 21,
+      "endChapter": 3,
+      "endVerse": 22
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 1,
+      "endChapter": 9,
+      "endVerse": 6
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 7,
+      "endChapter": 9,
+      "endVerse": 9
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 10,
+      "endChapter": 9,
+      "endVerse": 17
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 18,
+      "endChapter": 9,
+      "endVerse": 20
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 21,
+      "endChapter": 9,
+      "endVerse": 22
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 23,
+      "endChapter": 9,
+      "endVerse": 27
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 28,
+      "endChapter": 9,
+      "endVerse": 36
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 37,
+      "endChapter": 9,
+      "endVerse": 42
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 43,
+      "endChapter": 9,
+      "endVerse": 45
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 46,
+      "endChapter": 9,
+      "endVerse": 48
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 49,
+      "endChapter": 9,
+      "endVerse": 50
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 51,
+      "endChapter": 9,
+      "endVerse": 56
+    },
+    {
+      "book": "Luke",
+      "startChapter": 9,
+      "startVerse": 57,
+      "endChapter": 9,
+      "endVerse": 62
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 1,
+      "endChapter": 10,
+      "endVerse": 12
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 13,
+      "endChapter": 10,
+      "endVerse": 16
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 17,
+      "endChapter": 10,
+      "endVerse": 20
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 21,
+      "endChapter": 10,
+      "endVerse": 24
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 25,
+      "endChapter": 10,
+      "endVerse": 37
+    },
+    {
+      "book": "Luke",
+      "startChapter": 10,
+      "startVerse": 38,
+      "endChapter": 10,
+      "endVerse": 42
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 1,
+      "endChapter": 11,
+      "endVerse": 4
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 5,
+      "endChapter": 11,
+      "endVerse": 8
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 9,
+      "endChapter": 11,
+      "endVerse": 13
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 14,
+      "endChapter": 11,
+      "endVerse": 23
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 24,
+      "endChapter": 11,
+      "endVerse": 26
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 27,
+      "endChapter": 11,
+      "endVerse": 28
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 29,
+      "endChapter": 11,
+      "endVerse": 32
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 33,
+      "endChapter": 11,
+      "endVerse": 36
+    },
+    {
+      "book": "Luke",
+      "startChapter": 11,
+      "startVerse": 37,
+      "endChapter": 11,
+      "endVerse": 54
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 1,
+      "endChapter": 13,
+      "endVerse": 5
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 6,
+      "endChapter": 13,
+      "endVerse": 9
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 10,
+      "endChapter": 13,
+      "endVerse": 17
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 18,
+      "endChapter": 13,
+      "endVerse": 19
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 20,
+      "endChapter": 13,
+      "endVerse": 21
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 22,
+      "endChapter": 13,
+      "endVerse": 33
+    },
+    {
+      "book": "Luke",
+      "startChapter": 13,
+      "startVerse": 34,
+      "endChapter": 13,
+      "endVerse": 35
+    },
+    {
+      "book": "Luke",
+      "startChapter": 14,
+      "startVerse": 1,
+      "endChapter": 14,
+      "endVerse": 6
+    },
+    {
+      "book": "Luke",
+      "startChapter": 14,
+      "startVerse": 7,
+      "endChapter": 14,
+      "endVerse": 14
+    },
+    {
+      "book": "Luke",
+      "startChapter": 14,
+      "startVerse": 15,
+      "endChapter": 14,
+      "endVerse": 24
+    },
+    {
+      "book": "Luke",
+      "startChapter": 14,
+      "startVerse": 25,
+      "endChapter": 14,
+      "endVerse": 33
+    },
+    {
+      "book": "Luke",
+      "startChapter": 14,
+      "startVerse": 34,
+      "endChapter": 14,
+      "endVerse": 35
+    },
+    {
+      "book": "Luke",
+      "startChapter": 15,
+      "startVerse": 1,
+      "endChapter": 15,
+      "endVerse": 7
+    },
+    {
+      "book": "Luke",
+      "startChapter": 15,
+      "startVerse": 8,
+      "endChapter": 15,
+      "endVerse": 10
+    },
+    {
+      "book": "Luke",
+      "startChapter": 15,
+      "startVerse": 11,
+      "endChapter": 15,
+      "endVerse": 32
+    },
+    {
+      "book": "Luke",
+      "startChapter": 16,
+      "startVerse": 1,
+      "endChapter": 16,
+      "endVerse": 13
+    },
+    {
+      "book": "Luke",
+      "startChapter": 16,
+      "startVerse": 14,
+      "endChapter": 16,
+      "endVerse": 18
+    },
+    {
+      "book": "Luke",
+      "startChapter": 16,
+      "startVerse": 19,
+      "endChapter": 16,
+      "endVerse": 31
+    },
+    {
+      "book": "Luke",
+      "startChapter": 17,
+      "startVerse": 1,
+      "endChapter": 17,
+      "endVerse": 4
+    },
+    {
+      "book": "Luke",
+      "startChapter": 17,
+      "startVerse": 5,
+      "endChapter": 17,
+      "endVerse": 10
+    },
+    {
+      "book": "Luke",
+      "startChapter": 17,
+      "startVerse": 11,
+      "endChapter": 17,
+      "endVerse": 19
+    },
+    {
+      "book": "Luke",
+      "startChapter": 17,
+      "startVerse": 20,
+      "endChapter": 17,
+      "endVerse": 37
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 1,
+      "endChapter": 18,
+      "endVerse": 8
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 9,
+      "endChapter": 18,
+      "endVerse": 14
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 15,
+      "endChapter": 18,
+      "endVerse": 17
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 18,
+      "endChapter": 18,
+      "endVerse": 23
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 24,
+      "endChapter": 18,
+      "endVerse": 30
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 31,
+      "endChapter": 18,
+      "endVerse": 34
+    },
+    {
+      "book": "Luke",
+      "startChapter": 18,
+      "startVerse": 35,
+      "endChapter": 18,
+      "endVerse": 43
+    },
+    {
+      "book": "Luke",
+      "startChapter": 19,
+      "startVerse": 1,
+      "endChapter": 19,
+      "endVerse": 10
+    },
+    {
+      "book": "Luke",
+      "startChapter": 19,
+      "startVerse": 11,
+      "endChapter": 19,
+      "endVerse": 27
+    },
+    {
+      "book": "Luke",
+      "startChapter": 19,
+      "startVerse": 28,
+      "endChapter": 19,
+      "endVerse": 40
+    },
+    {
+      "book": "Luke",
+      "startChapter": 19,
+      "startVerse": 41,
+      "endChapter": 19,
+      "endVerse": 44
+    },
+    {
+      "book": "Luke",
+      "startChapter": 19,
+      "startVerse": 45,
+      "endChapter": 19,
+      "endVerse": 48
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 1,
+      "endChapter": 21,
+      "endVerse": 4
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 5,
+      "endChapter": 21,
+      "endVerse": 6
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 7,
+      "endChapter": 21,
+      "endVerse": 19
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 20,
+      "endChapter": 21,
+      "endVerse": 24
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 25,
+      "endChapter": 21,
+      "endVerse": 28
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 29,
+      "endChapter": 21,
+      "endVerse": 33
+    },
+    {
+      "book": "Luke",
+      "startChapter": 21,
+      "startVerse": 34,
+      "endChapter": 21,
+      "endVerse": 38
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 1,
+      "endChapter": 22,
+      "endVerse": 6
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 7,
+      "endChapter": 22,
+      "endVerse": 13
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 14,
+      "endChapter": 22,
+      "endVerse": 23
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 24,
+      "endChapter": 22,
+      "endVerse": 30
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 31,
+      "endChapter": 22,
+      "endVerse": 34
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 35,
+      "endChapter": 22,
+      "endVerse": 38
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 39,
+      "endChapter": 22,
+      "endVerse": 46
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 47,
+      "endChapter": 22,
+      "endVerse": 53
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 54,
+      "endChapter": 22,
+      "endVerse": 62
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 63,
+      "endChapter": 22,
+      "endVerse": 65
+    },
+    {
+      "book": "Luke",
+      "startChapter": 22,
+      "startVerse": 66,
+      "endChapter": 22,
+      "endVerse": 71
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 1,
+      "endChapter": 23,
+      "endVerse": 5
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 6,
+      "endChapter": 23,
+      "endVerse": 12
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 13,
+      "endChapter": 23,
+      "endVerse": 25
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 26,
+      "endChapter": 23,
+      "endVerse": 43
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 44,
+      "endChapter": 23,
+      "endVerse": 49
+    },
+    {
+      "book": "Luke",
+      "startChapter": 23,
+      "startVerse": 50,
+      "endChapter": 23,
+      "endVerse": 56
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 1,
+      "endChapter": 24,
+      "endVerse": 12
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 13,
+      "endChapter": 24,
+      "endVerse": 27
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 28,
+      "endChapter": 24,
+      "endVerse": 35
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 36,
+      "endChapter": 24,
+      "endVerse": 43
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 44,
+      "endChapter": 24,
+      "endVerse": 49
+    },
+    {
+      "book": "Luke",
+      "startChapter": 24,
+      "startVerse": 50,
+      "endChapter": 24,
+      "endVerse": 53
+    }
+  ]
+}

--- a/docs/decks.md
+++ b/docs/decks.md
@@ -1,0 +1,166 @@
+# Deck inventory & split provenance
+
+One row per `data/<N>-*.json`. NKJV files are the canonical decks; `-niv` suffixes are translation
+side-decks against api.bible NIV 2011 (bibleId `78a9f6124f344018-01`).
+
+Every NKJV deck has been through multiple iterative passes — the splitter pipeline evolved during
+their construction (deterministic auditor + LLM splitter + LLM judge), and verses got re-scored,
+re-split, and judge-gated across releases. The NIV side-decks are newer and have only been through
+the v0.5 pipeline as documented below.
+
+`multi-split %` is the share of verses with at least one boundary; the balance are short verses
+(single phrase is the correct call) — not unsplit defects. `0 / N` in the FTV-mismatch /
+keyword-flag columns means the deterministic auditors (`tools/find_ftvs.py --audit`,
+`tools/find_keywords.py`) report no disagreement with the deck's `ftvWordCount` / `annotations`.
+"Ambig" counts verses with no unique opening prefix across the deck — duplicate salutations and
+refrains where the deck's `ftvWordCount` is intentionally `null`.
+
+## Year decks
+
+| File                     | Tx   | Books                                    | Verses | Multi-split % | Split method                                                                                                                       | FTV / Ambig                                             | Keyword flags |
+| ------------------------ | ---- | ---------------------------------------- | ------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------- |
+| `1-gepc.json`            | NKJV | Gal, Eph, Php, Col                       | 503    | 94%           | Phases 1 + 3                                                                                                                       | 0 / 0                                                   | 0             |
+| `2-nt-survey.json`       | NKJV | Mt, Acts, 1Th, 1Tim, 2Tim, Tit, 1Jn, Rev | 812    | 94%           | Phases 1 + 3                                                                                                                       | 0 / 0                                                   | 0             |
+| `3-corinthians.json`     | NKJV | 1–2 Cor                                  | 694    | 92%           | Phases 1 + 2 + 3 (one of the two most-iterated decks)                                                                              | 0 / 2 (1 Cor 1:3, 2 Cor 1:2 — Pauline salutation)       | 0             |
+| `4-john.json`            | NKJV | John                                     | 879    | 92%           | Phases 1 + 2 + 3 (one of the two most-iterated decks)                                                                              | 0 / 0                                                   | 0             |
+| `5-hp.json`              | NKJV | Heb, 1–2 Pet                             | 469    | 97%           | Phases 1 + 3                                                                                                                       | 0 / 0                                                   | 0             |
+| `6-ot-survey.json`       | NKJV | (OT survey, 18 books)                    | 780    | 97%           | Phases 1 + 3                                                                                                                       | 0 / 2 (Ps 46:7, 46:11 — refrain, marked `0` not `null`) | 0             |
+| `7-rj.json`              | NKJV | Rom, Jas                                 | 541    | 94%           | Phases 1 + 3                                                                                                                       | 0 / 0                                                   | 0             |
+| `8-luke.json`            | NKJV | Luke                                     | 791    | 95%           | Phases 1 + 3                                                                                                                       | 0 / 0                                                   | 0             |
+| `1-gepc-niv.json`        | NIV  | Gal, Eph, Php, Col                       | 503    | 0%            | **Placeholder** (no splits yet)                                                                                                    | 0 / 3                                                   | 0             |
+| `2-nt-survey-niv.json`   | NIV  | Mt, Acts, … Rev                          | 812    | 0%            | **Placeholder**                                                                                                                    | 0 / 0                                                   | 0             |
+| `3-corinthians-niv.json` | NIV  | 1–2 Cor                                  | 694    | 0%            | **Placeholder**                                                                                                                    | 0 / 2 (1 Cor 1:3, 2 Cor 1:2)                            | 0             |
+| `4-john-niv.json`        | NIV  | John                                     | 879    | 51%           | **Partial force-fresh single pass** (Sonnet subagents, 34 of 59 batches completed; weekly limit cut off batches 14, 22, 24, 36–58) | 0 / 0                                                   | 0             |
+| `5-hp-niv.json`          | NIV  | Heb, 1–2 Pet                             | 469    | 93%           | **Force-fresh single pass** (Sonnet subagents, 32 batches all completed)                                                           | 0 / 0                                                   | 0             |
+| `6-ot-survey-niv.json`   | NIV  | (OT survey, 18 books)                    | 780    | 0%            | **Placeholder**                                                                                                                    | 0 / 3 (Ex 14:1 new to NIV, Ps 46:7, 46:11)              | 0             |
+| `7-rj-niv.json`          | NIV  | Rom, Jas                                 | 541    | 0%            | **Placeholder**                                                                                                                    | 0 / 0                                                   | 0             |
+| `8-luke-niv.json`        | NIV  | Luke                                     | 791    | 0%            | **Placeholder**                                                                                                                    | 0 / 2                                                   | 0             |
+
+## Methodology
+
+### NKJV — multi-pass (current state)
+
+Each NKJV deck has been through three phases as the pipeline matured. The shipping form of the
+splitter loop is the v0.5 form described in `.claude/skills/phrase-splitter/SKILL.md`: deterministic
+auditor scores each verse, LLM splitter proposes alternatives, deterministic re-audit, then an LLM
+judge picks A (keep) or B (replace) per verse. Stability lives only in the judge's tie-break rule.
+Prior versions (pre-v0.5) shaped many of the current boundaries; the per-deck histories below record
+which passes touched each one.
+
+#### Phase 1 — foundational seed + alignment
+
+Touched all 8 decks. From oldest to newest:
+
+| Commit                                                       | Effect                                                                                        |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `014b2f8` `feat: commit structural corinthians.json`         | First deck (1–2 Cor); structural-only shape.                                                  |
+| `340e121` `refactor: name deck file by year (3-corinthians)` | Year-numbered filenames; `.gitignore` whitelist generalised.                                  |
+| `e22cc90` `feat: seed john (year 4) deck file`               | Second deck (John, year 4).                                                                   |
+| `d529d6c` `feat: annotations from rule, not book body`       | Annotations re-derived from the keyword rule, not the printed quizbook.                       |
+| `8c1ad0b` `feat: seed deck files for years 1, 2, 5, 6, 7, 8` | Remaining six year-decks bootstrapped from the 2026-05-08 colpkg.                             |
+| `9b2ecc6` `fix: bring all 8 deck files into rule-alignment`  | `find_keywords.py` + `find_ftvs.py` clean across every deck.                                  |
+| `c49f0fd` `fix: regenerate decks via content-based pipeline` | `init_deck.py` rewritten to align by content (token-stream positions), not Anki HTML offsets. |
+| `0f28234` `fix: refresh decks from latest colpkg`            | Decks re-pulled from the 2026-05-12 14:35 colpkg with the new tokeniser.                      |
+
+Per-deck structural fixes during this phase:
+
+* `4-john` — `76c31d3 fix: add missing John 13:10 to year 4 deck`.
+* `5-hp` — `114f361 feat: expand year 5 deck to full chapters`.
+* `6-ot-survey` — `ef4481f feat: expand year 6 (OT Survey) to full material` and
+  `5edf8ea fix: extend Micah 7 range to 18-19 in year 6 full`.
+* `7-rj` — `a967bf1 feat: expand year 7 (RJ) to full chapters`.
+
+#### Phase 2 — per-deck iterative resplits
+
+Only `3-corinthians` and `4-john` went through this — they were the two earliest decks and absorbed
+the pipeline's evolution before it stabilised. The other six skipped straight from phase 1 to phase
+3.
+
+`3-corinthians` (year 3, 1–2 Cor):
+
+| Commit                                                  | Effect                                                                                                                   |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `4171e49` `fix: resplit phrases in year 3`              | 347 verses rewritten — 30 drift cases, 141 placeholder-only verses (all of 2 Cor 7–13), ~160 out-of-band phrase lengths. |
+| `7a4942c` `fix: merge verb-clause splits in year 3`     | Auditor-flagged verb + content-clause severances rejoined across 9 verses.                                               |
+| `37e114b` `fix(tools): resplit 1 Cor 1-8 from scratch`  | First force-fresh quarter.                                                                                               |
+| `ea5541a` `fix(tools): resplit 1 Cor 9-16 from scratch` | Second quarter.                                                                                                          |
+| `4a7cea7` `fix(tools): resplit 2 Cor 1-7 from scratch`  | Third quarter.                                                                                                           |
+| `a5af0b9` `fix(tools): resplit 2 Cor 8-13 from scratch` | Fourth quarter.                                                                                                          |
+| `793ac49` `fix(tools): second pass 1-2 Cor with judge`  | Pre-v0.5 judge gate over the four resplit quarters.                                                                      |
+
+`4-john` (year 4, John):
+
+| Commit                                                      | Effect                                                                                                                      |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `8e25605` `fix: split phrases in year 4`                    | First bulk split — 814 verses rewritten across 54 subagent batches.                                                         |
+| `b781d57` `fix(tools): resplit john 1:3 to keep clause`     | Specific fix establishing the restrictive-clause pattern.                                                                   |
+| `79d74cc` `fix(tools): resplit john restrictive clauses`    | 101 verses where restrictive relatives or verb content clauses had been severed.                                            |
+| `faa8a27` `fix(tools): resplit John 1-5 from scratch`       | First force-fresh fifth.                                                                                                    |
+| `0967010` `fix(tools): resplit John 6-10 from scratch`      | Second fifth.                                                                                                               |
+| `6b28396` `fix(tools): resplit John 11-15 from scratch`     | Third fifth.                                                                                                                |
+| `22e1722` `fix(tools): resplit John 16-21 from scratch`     | Fourth fifth.                                                                                                               |
+| `faff832` `fix(tools): 2nd-pass resplit on worst 20 verses` | Pre-v0.5 judge gate over the 20 highest-signal verses post-resplit. Splitter accepted 6 boundary changes, kept 14 verbatim. |
+
+#### Phase 3 — standard v0.5 three-pass loop
+
+Touched all 8 decks identically (same SPLIT_PROMPT + JUDGE_PROMPT), in this order:
+
+| Pass | Splitter | Judge | Purpose                                                              |
+| ---- | -------- | ----- | -------------------------------------------------------------------- |
+| 1    | Sonnet   | —     | Fresh split per verse (no judge — calibration pass).                 |
+| 2    | Sonnet   | Opus  | Sonnet proposes, Opus judges A/B against the pass-1 split.           |
+| 3    | Opus     | Opus  | Opus proposes against the pass-2 split, Opus judges A/B. Final ship. |
+
+Per-deck commit pairs (newest to oldest within each deck):
+
+| Deck            | Pass 1 (split) | Pass 2 (s+o-judge) | Pass 3 (opus+opus) |
+| --------------- | -------------- | ------------------ | ------------------ |
+| `1-gepc`        | `053796c`      | `8a25567`          | `62c1a68`          |
+| `2-nt-survey`   | `61f924f`      | `aa73ad6`          | `9c89dd7`          |
+| `3-corinthians` | `c78aa53`      | `ff84fa6`          | `340b85e`          |
+| `4-john`        | `d98079b`      | `b6d2ec6`          | `64a4ba6`          |
+| `5-hp`          | `92ce8a9`      | `7bc4756`          | `043c876`          |
+| `6-ot-survey`   | `419219d`      | `e582971`          | `affef9c`          |
+| `7-rj`          | `3fafbf2`      | `9ddfbba`          | `6213d4c`          |
+| `8-luke`        | `4f38d53`      | `ef8a1e0`          | `ebffcf3`          |
+
+### Side-decks (any non-source translation) — same pipeline as NKJV
+
+The same `tools/split_phrases.py` + `tools/evaluate_phrases.py` + `tools/find_ftvs.py` +
+`tools/find_keywords.py` chain handles any translation via `--bible <bibleId>`. The only
+translation-shaped script is `tools/init_side_deck.py`, which clones the source deck's structural
+fields against a different bibleId and writes single-phrase placeholder splits + `annotations: []` +
+`ftvWordCount: null`.
+
+The bootstrap → finished flow:
+
+1. `tools/init_side_deck.py --source data/N-x.json --out data/N-x-niv.json --bible <id>`
+2. `tools/find_ftvs.py data/N-x-niv.json --bible <id> --out /tmp/ftv.json` → write the computed
+   `shortest_unique_prefix_words` back into the deck's `ftvWordCount` (verses with no unique prefix
+   stay `null`).
+3. `tools/apply_keyword_annotations.py data/N-x-niv.json --bible <id>` — derives `annotations`
+   deterministically from the keyword / context-key rules over the target's canonical text.
+4. `tools/evaluate_phrases.py data/N-x-niv.json --bible <id> --all --out /tmp/eval.json` →
+   `tools/split_phrases.py --deck data/N-x-niv.json --bible <id> print-prompt --all-verses --no-current --no-signals --outdir /tmp/batches --batch-size 15`
+   — emits batched force-fresh prompts (no current split or signal context).
+5. Dispatch parallel splitter subagents per
+   `.claude/skills/phrase-splitter/references/splitter-agent-instructions.md` (small batches, Sonnet
+   for speed or Opus for peak quality).
+6. `tools/split_phrases.py --deck data/N-x-niv.json --bible <id> apply --input /tmp/proposals.json`
+   — validates word-count sum AND a byte-exact rejoin; falls back to a smart-quote splice when the
+   only divergence is ASCII vs curly quotes (a Sonnet quirk on translations).
+7. Force-fresh skips the judge step (no current to compare against). On a second pass — once the
+   side-deck has real splits — re-run `evaluate_phrases.py` against the side-deck, follow the
+   standard v0.5 audit-flagged split + judge + apply loop.
+
+NIV-omitted verses (e.g. John 5:4, Acts 15:34, Rom 16:24, Luke 17:36 / 23:17 — bracketed or
+footnoted in the NIV) keep their NKJV reference in the deck but carry an empty `phraseWordCounts`
+array. They're skipped by all renderers + auditors.
+
+### What "placeholder" means
+
+A placeholder NIV deck has every verse's `phraseWordCounts` initialised to a single-element array
+equal to the canonical NIV token count — i.e. the whole verse is one phrase. The deck is
+structurally valid: it renders, audits clean, and round-trips through every tool. It just doesn't
+slice verses into memorisation chunks yet. Running the splitter pipeline against the placeholder
+advances it to a real split without touching FTVs or annotations.

--- a/tools/apply_keyword_annotations.py
+++ b/tools/apply_keyword_annotations.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Derive a deck's ``annotations`` from the keyword / context-key rules.
+
+The rules in ``tools/find_keywords.py`` are deterministic over the
+canonical text:
+
+* a word appearing in exactly one verse is a keyword (``bold``);
+* a word appearing in two or more verses within the same book,
+  whose first-and-last occurrences are within ``CONTEXT_RADIUS``
+  verses, is a context key (``boldItalic``);
+* anything else is plain.
+
+That means the auditor's "expected" markup _is_ the correct
+annotation set. This script walks every verse, classifies every
+word, and writes ``{wordIndex, kind}`` entries back into the deck —
+overwriting any existing ``annotations`` array. Use it to populate a
+side-deck where annotations weren't carried over from the source
+(e.g. ``init_niv_deck.py``, which drops NKJV-indexed annotations).
+
+After running, ``tools/find_keywords.py`` against the same deck
+should report ``Flagged: 0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from phrase_splitter.apibible import (  # noqa: E402
+    DEFAULT_DB_PATH,
+    DEFAULT_NKJV_ID,
+    extract_chapter_verses,
+    get_chapter_html,
+    open_cache,
+)
+from phrase_splitter.helpers import normalise_word as _normalise  # noqa: E402
+from find_keywords import (  # noqa: E402
+    MARKUP_BOLD,
+    MARKUP_BOLD_ITALIC,
+    MARKUP_PLAIN,
+    build_word_index,
+    classify_word,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("deck")
+    ap.add_argument("--bible", default=DEFAULT_NKJV_ID)
+    ap.add_argument("--db", default=DEFAULT_DB_PATH)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    with open(args.deck, encoding="utf-8") as f:
+        deck = json.load(f)
+    conn = open_cache(args.db)
+    occurrences, verse_index = build_word_index(deck, conn, args.bible)
+    expected = {w: classify_word(occurrences[w], verse_index) for w in occurrences}
+
+    chapter_cache: Dict[tuple, Dict[int, List[str]]] = {}
+    n_keyword = n_context = 0
+    for v in deck["verses"]:
+        ckey = (v["book"], v["chapter"])
+        if ckey not in chapter_cache:
+            html = get_chapter_html(conn, v["book"], v["chapter"], bible_id=args.bible)
+            chapter_cache[ckey] = extract_chapter_verses(html, v["book"], v["chapter"])
+        tokens = chapter_cache[ckey].get(v["verse"], [])
+        annotations: List[Dict[str, Any]] = []
+        for i, tok in enumerate(tokens):
+            n = _normalise(tok)
+            if not n:
+                continue
+            kind = expected.get(n, MARKUP_PLAIN)
+            if kind == MARKUP_PLAIN:
+                continue
+            annotations.append({"wordIndex": i, "kind": kind})
+            if kind == MARKUP_BOLD:
+                n_keyword += 1
+            elif kind == MARKUP_BOLD_ITALIC:
+                n_context += 1
+        v["annotations"] = annotations
+
+    print(
+        f"derived {n_keyword} keyword + {n_context} context-key annotation entries",
+        file=sys.stderr,
+    )
+    if args.dry_run:
+        return 0
+    with open(args.deck, "w", encoding="utf-8") as f:
+        json.dump(deck, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/init_side_deck.py
+++ b/tools/init_side_deck.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Bootstrap a translation side-deck from an existing structural deck.
+
+Mirrors the source deck's structural fields (``year``, ``books``,
+``chapters``, ``headings``, per-verse ``book``, ``chapter``,
+``verse``, ``clubs``) and replaces the verse-specific data with
+target-translation values:
+
+* ``phraseWordCounts`` — single-phrase placeholder covering the
+  whole target-translation verse (the splitter pipeline refines this
+  next).
+* ``annotations`` — dropped: the source's ``wordIndex`` values index
+  the source-translation token stream and don't transfer. Run
+  ``tools/apply_keyword_annotations.py`` after this script to derive
+  the target's annotations from the same rules.
+* ``ftvWordCount`` — left as ``null`` (the schema's "unknown / not
+  set" sentinel — ``0`` would trip ``tools/evaluate_phrases.py``'s
+  out-of-range check). Run ``tools/find_ftvs.py`` to compute real
+  values.
+
+``--bible`` is required — picks the target translation. NKJV decks
+are bootstrapped from Anki via ``tools/init_deck.py``; this script is
+for everything else (e.g. ``78a9f6124f344018-01`` for NIV 2011).
+
+Canonical tokens come from the existing chapter-level
+``get_chapter_html`` path with ``include-verse-numbers=true``: the
+``/passages/<chapter-id>`` endpoint returns NKJV-shaped
+``data-sid``/``class="v"`` markup across translations, so
+``extract_chapter_verses`` works unchanged. Tokenisation matches the
+runtime renderer's via the same strip+tokenise helpers used by every
+other audit tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any, Dict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from phrase_splitter.apibible import (  # noqa: E402
+    DEFAULT_DB_PATH,
+    extract_chapter_verses,
+    get_chapter_html,
+    open_cache,
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", required=True, help="path to source structural deck")
+    ap.add_argument("--out", required=True, help="path to write the side-deck")
+    ap.add_argument(
+        "--bible", required=True,
+        help="target translation bibleId (e.g. 78a9f6124f344018-01 for NIV 2011)",
+    )
+    ap.add_argument("--db", default=DEFAULT_DB_PATH)
+    args = ap.parse_args()
+
+    with open(args.source, encoding="utf-8") as f:
+        src = json.load(f)
+    conn = open_cache(args.db)
+
+    chapter_tokens: Dict[tuple, Dict[int, list]] = {}
+    out_verses = []
+    missing: list = []
+    for v in src["verses"]:
+        book, ch, vno = v["book"], v["chapter"], v["verse"]
+        ckey = (book, ch)
+        if ckey not in chapter_tokens:
+            html = get_chapter_html(conn, book, ch, bible_id=args.bible)
+            chapter_tokens[ckey] = extract_chapter_verses(html, book, ch)
+        tokens = chapter_tokens[ckey].get(vno, [])
+        if not tokens:
+            missing.append(f"{book} {ch}:{vno}")
+        out_verses.append(
+            {
+                "book": book,
+                "chapter": ch,
+                "verse": vno,
+                "phraseWordCounts": [len(tokens)] if tokens else [],
+                "annotations": [],
+                "ftvWordCount": None,
+                "clubs": v.get("clubs", []),
+            }
+        )
+
+    out: Dict[str, Any] = {
+        "year": src["year"],
+        "books": src["books"],
+        "chapters": src["chapters"],
+        "verses": out_verses,
+        "headings": src.get("headings", []),
+    }
+    with open(args.out, "w", encoding="utf-8") as f:
+        json.dump(out, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+    if missing:
+        print(
+            f"WARN {len(missing)} verses had no canonical text "
+            f"(first: {missing[0]})",
+            file=sys.stderr,
+        )
+    print(
+        f"wrote {args.out}  ({len(out_verses)} verses across "
+        f"{len(chapter_tokens)} chapters)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/split_phrases.py
+++ b/tools/split_phrases.py
@@ -177,7 +177,15 @@ def _signals_for_ref(
 def cmd_print_prompt(args: argparse.Namespace) -> None:
     with open(args.deck, encoding="utf-8") as f:
         deck = json.load(f)
-    refs, report_data = _collect_refs(args.refs, args.from_report, args.top)
+    if args.all_verses:
+        if args.refs or args.from_report or args.top is not None:
+            raise SystemExit("--all-verses is exclusive with --refs / --from-report / --top")
+        refs = [
+            f"{v['book']} {v['chapter']}:{v['verse']}" for v in deck.get("verses", [])
+        ]
+        report_data = None
+    else:
+        refs, report_data = _collect_refs(args.refs, args.from_report, args.top)
     by_ref = _verse_by_ref(deck)
 
     report_by_ref: Optional[Dict[str, Dict[str, Any]]] = None
@@ -216,12 +224,55 @@ def cmd_print_prompt(args: argparse.Namespace) -> None:
             prompts.append({
                 "ref": ref,
                 "prompt": format_split_prompt(text, current_split, signals_block),
+                "n_words": len(tokens),
+                "text": text,
             })
     finally:
         conn.close()
 
+    if args.outdir:
+        if args.batch_size < 1:
+            raise SystemExit("--batch-size must be a positive integer")
+        os.makedirs(args.outdir, exist_ok=True)
+        # Clear stale batch + index files from a prior run so a smaller
+        # second pass doesn't leave orphan batches that look like results.
+        for stale in os.listdir(args.outdir):
+            if stale == "manifest.json" or stale == "verse_text.json" or (
+                stale.startswith("batch_") and stale.endswith(".json")
+            ):
+                os.remove(os.path.join(args.outdir, stale))
+        manifest = []
+        bs = args.batch_size
+        for i in range(0, len(prompts), bs):
+            batch = prompts[i : i + bs]
+            idx = i // bs
+            path = os.path.join(args.outdir, f"batch_{idx:02d}.json")
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(
+                    [
+                        {"ref": e["ref"], "prompt": e["prompt"], "n_words": e["n_words"]}
+                        for e in batch
+                    ],
+                    f, ensure_ascii=False, indent=2,
+                )
+                f.write("\n")
+            manifest.append(
+                {"batch": idx, "path": path, "refs": [e["ref"] for e in batch]}
+            )
+        with open(os.path.join(args.outdir, "manifest.json"), "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        with open(os.path.join(args.outdir, "verse_text.json"), "w", encoding="utf-8") as f:
+            json.dump({e["ref"]: e["text"] for e in prompts}, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        sys.stderr.write(f"wrote {len(manifest)} batches → {args.outdir}/\n")
+        return
+
     if args.json:
-        json.dump(prompts, sys.stdout, indent=2, ensure_ascii=False)
+        json.dump(
+            [{"ref": e["ref"], "prompt": e["prompt"]} for e in prompts],
+            sys.stdout, indent=2, ensure_ascii=False,
+        )
         sys.stdout.write("\n")
     else:
         divider = "\n" + "=" * 72 + "\n"
@@ -233,6 +284,40 @@ def cmd_print_prompt(args: argparse.Namespace) -> None:
 
 def _word_count(s: str) -> int:
     return len(s.split())
+
+
+# When the LLM has copied from canonical text byte-for-byte, the rejoin
+# matches. When it has rendered an ASCII ``'`` / ``"`` in place of the
+# canonical curly form, this fallback restores the canonical bytes while
+# keeping the splitter's phrase boundaries. Anything beyond a quote-only
+# mismatch (paraphrase, dropped punctuation, etc.) returns None and the
+# apply step fails the ref.
+_QUOTE_EQUIV = {"'": "‘’", '"': "“”"}
+
+
+def _splice_smart_quotes(phrases: List[str], canonical_text: str) -> Optional[List[str]]:
+    rejoin = " ".join(phrases)
+    if len(rejoin) != len(canonical_text):
+        return None
+    patched_chars: List[str] = []
+    for r, t in zip(rejoin, canonical_text):
+        if r == t:
+            patched_chars.append(r)
+        elif r in _QUOTE_EQUIV and t in _QUOTE_EQUIV[r]:
+            patched_chars.append(t)
+        else:
+            return None
+    patched = "".join(patched_chars)
+    out: List[str] = []
+    pos = 0
+    for i, p in enumerate(phrases):
+        out.append(patched[pos : pos + len(p)])
+        pos += len(p)
+        if i + 1 < len(phrases):
+            if patched[pos] != " ":
+                return None
+            pos += 1
+    return out
 
 
 def cmd_judge_pairs(args: argparse.Namespace) -> None:
@@ -401,6 +486,19 @@ def cmd_apply(args: argparse.Namespace) -> None:
             if errs:
                 failures.append({"ref": ref, "errors": errs})
                 continue
+            # Byte-exact rejoin check: " ".join(phrases) must equal the
+            # canonical text. Fall back to a smart-quote splice when the
+            # only divergence is ASCII vs curly quotes (a Sonnet quirk on
+            # force-fresh translations).
+            canonical_text = " ".join(tokens)
+            if " ".join(phrases) != canonical_text:
+                patched = _splice_smart_quotes(phrases, canonical_text)
+                if patched is None:
+                    failures.append(
+                        {"ref": ref, "errors": ["phrases don't rejoin to canonical text"]}
+                    )
+                    continue
+                phrases = patched
             new_pwc = [_word_count(p) for p in phrases]
             if verse.get("phraseWordCounts") == new_pwc:
                 skipped += 1
@@ -445,6 +543,12 @@ def main() -> None:
     pp = sub.add_parser("print-prompt", help="Emit LLM prompts for the given refs")
     pp.add_argument("--refs", help="Comma-separated refs")
     pp.add_argument("--from-report", help="Read refs from an evaluator report JSON")
+    pp.add_argument(
+        "--all-verses",
+        action="store_true",
+        help="Emit one prompt per verse in the deck (force-fresh pass against a "
+        "side-deck whose phraseWordCounts are placeholders)",
+    )
     pp.add_argument("--top", type=int, help="With --from-report, only the top N refs")
     pp.add_argument(
         "--json",
@@ -460,6 +564,18 @@ def main() -> None:
         "--no-signals",
         action="store_true",
         help="Omit the Signals block (use when iterating on prompt wording)",
+    )
+    pp.add_argument(
+        "--outdir",
+        help="Write batched prompt files to this directory: batch_NN.json + "
+        "manifest.json + verse_text.json (consumed by parallel splitter subagents). "
+        "Implies --json.",
+    )
+    pp.add_argument(
+        "--batch-size",
+        type=int,
+        default=15,
+        help="Refs per batch when --outdir is set (default 15).",
     )
     pp.set_defaults(func=cmd_print_prompt)
 

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,7 @@
 extend-exclude = [
     "crates/wasm/pkg/",
     "data/",
+    "docs/decks.md", # commit-SHA tables trigger false positives (e.g. `ba` inside `64a4ba6`)
 ]
 
 [default]


### PR DESCRIPTION
## Summary

- Translation-agnostic side-deck pipeline: `init_side_deck.py`, `apply_keyword_annotations.py`, and extensions to `split_phrases.py` (`print-prompt --all-verses + --outdir`, `apply` byte-rejoin + smart-quote splice).
- Eight NIV 2011 side-decks committed alongside the NKJV decks. All 8 carry real `ftvWordCount` + `annotations`; `5-hp-niv` has full force-fresh splits, `4-john-niv` has partial splits (445/879 — weekly Sonnet limit cut the run short), the other six are placeholder-only and ready for splitter passes.
- `docs/decks.md` — per-deck inventory + phase-by-phase split provenance from `git log` (Phase 1 foundational, Phase 2 iterative resplits on `3-corinthians` + `4-john` only, Phase 3 standard v0.5 three-pass).

## Test plan

- [x] `find_ftvs.py --audit` clean on all 8 NIV decks (0 mismatches).
- [x] `find_keywords.py` clean on all 8 NIV decks (0 flags).
- [x] `split_phrases.py apply` re-applies saved proposals as no-ops (rejoin + smart-quote splice fallback both work).
- [x] `init_side_deck.py` requires `--bible`; rejects mis-specified runs.
- [ ] CI rust + typos + dprint on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)