### PR TITLE
docs: clarify when to rebase onto master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,12 +92,17 @@ dprint check          # formatting for docs (also runs via lint-staged)
   `chore: merge <branch-name>`. For local merges, set this via `git merge --no-ff -m "..."`. For
   PRs, pass `--subject "chore: merge <branch>"` to `gh pr merge` (or edit before confirming) —
   GitHub's default `Merge pull request #N from …` template doesn't conform.
-* **master is branch-protected.** GitHub blocks merge until: (a) the three required CI checks
-  (`rust`, `typos`, `dprint`) pass on the PR head, and (b) the PR branch is up-to-date with master
-  (forces a refresh-from-master when something else lands between PR open + merge). Net effect: the
-  merge commit's content is always equivalent to a SHA that CI already validated, so the deploy
-  workflows that fire on master push can't race a broken merge. Owner can `--admin` bypass
-  (`gh pr merge <N> --admin --merge ...`) for true hotfixes; do that consciously, not by default.
+* **master is branch-protected.** GitHub blocks merge until the three required CI checks (`rust`,
+  `typos`, `dprint`) pass on the PR head. Net effect: the merge commit's content is always
+  equivalent to a SHA that CI already validated, so the deploy workflows that fire on master push
+  can't race a broken merge. Owner can `--admin` bypass (`gh pr merge <N> --admin --merge ...`) for
+  true hotfixes; do that consciously, not by default.
+* **Rebase onto current master only for version-bump PRs.** PRs that bump a package version
+  (`crates/{core,wasm}/Cargo.toml`, `packages/api/package.json`, `apps/web/package.json`,
+  `deploy/vv-router/package.json`) need their branch up-to-date with master so the deploy-time
+  `tools/check-contract-versions.sh --ci` check (run against master, not the PR head) stays
+  consistent with the version being shipped. Non-version PRs merge fine even when master has
+  advanced — skip the pre-emptive rebase.
 
 ### Rewriting history
 


### PR DESCRIPTION
## Summary

Corrects the CLAUDE.md "Merging PRs" section. The old wording claimed GitHub blocks merge until the PR branch is up-to-date with master as a blanket rule; in practice that only matters for PRs that bump a package version (where the deploy-time `check-contract-versions.sh --ci` check, run against master, needs to see consistent versions/CHANGELOGs). Non-version PRs merge cleanly even when master has advanced.

Split that point off into its own bullet so the "skip the pre-emptive rebase" guidance is unmissable.

## Test plan

- [x] CLAUDE.md still readable as a sequence (Merging PRs → Rewriting history flow)
- [ ] CI: typos / dprint / rust pass on the PR head

🤖 Generated with [Claude Code](https://claude.com/claude-code)