### PR TITLE
chore: release web 0.1.17 + api 0.1.18 (heatmap)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,18 +9,25 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.17] — 2026-05-28
+
 ### Dashboard activity heatmap
 
 * **GitHub-contributions-style calendar grid** of past activity, inspired by the Anki "Review
   Heatmap" addon and the WaniKani Heatmap userscript (Kumirei's #377336). Lives between the
   stability tiles and the "by year →" link.
 * **Two series, toggleable.** A pill switches between **reviews** (grade events from
-  `review_events`, green palette) and **memorize** (verse graduations from `graduated_verses`, blue
-  palette) — the verse-vault analogue of WK's reviews/lessons split.
-* **September-anchored academic year picker.** `‹ 2025–26 ›` walks back through prior academic years
+  `review_events`, green palette) and **memorize** (verse graduations from `graduated_verses`,
+  accent-blue palette) — the verse-vault analogue of WK's reviews/lessons split.
+* **September-anchored academic-year picker.** `‹ 2025–26 ›` walks back through prior academic years
   (Sep 1 → Aug 31). Disabled at the edges (no earlier data / current year).
-* **Stats caption** mirrors the Anki + WK panels: current streak, best streak in the visible year,
-  peak day, total events, active days.
+* **Stats caption**: `current streak · best streak · total days · today · peak · total` — `today`
+  hides on past academic-year views since "today" can't exist in the window. Unit (reviews / verses
+  memorised) flips with the toggle.
+* **Single-letter day labels** (`S M T W T F S`) on the left so every row is named.
+* **Month labels centred on their dominant column run.** Each month is labelled once at the midpoint
+  of the columns where it owns 4+ of 7 days, dodging the Aug/Sep collision at the academic-year
+  edge.
 * **Forecast** of upcoming reviews (both reference implementations include this) is deferred —
   tracked in #69.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,12 +10,15 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.18] — 2026-05-28
+
 ### `GET /api/activity` — daily review + memorize counts
 
 New endpoint returning per-day UTC aggregates of `review_events` (the "reviews" series) and
 `graduated_verses` (the "memorize" series), capped at 1825 days (~5 academic years). Drives the
 dashboard's new activity heatmap. Both series are sparse (no-activity days omitted); the client
-zero-fills the calendar grid. Authenticated users only.
+zero-fills the calendar grid. Authenticated users only. Bundled algorithm contract unchanged
+(`verse-vault-core@0.4.0`, `verse-vault-wasm@0.4.0`).
 
 ## [0.1.17] — 2026-05-28
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Ships the activity heatmap (PR #70) to production.

* `@verse-vault/api` 0.1.17 → 0.1.18 — `GET /api/activity` endpoint (per-day review + memorize counts).
* `@verse-vault/web` 0.1.16 → 0.1.17 — dashboard activity heatmap (calendar grid, reviews/memorize toggle, September-anchored year picker).

Bundled algorithm contract unchanged: `verse-vault-core@0.4.0` / `verse-vault-wasm@0.4.0`.

## Test plan

- [ ] Required CI green (rust, typos, dprint)
- [ ] `deploy-api.yml` fires on merge, rsyncs to VPS
- [ ] `deploy-web.yml` fires on merge, ships to Cloudflare Pages
- [ ] Post-deploy: dashboard renders heatmap, toggle + year picker work