### PR TITLE
feat: per-user target retention (#17)

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,14 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Target retention slider in /material settings
+
+The "Session" panel in the year settings (`/material`) gains a **Target retention** range slider
+(70–97%, default 90%). Higher values train more reviews + tighter recall; lower values mean fewer
+reviews + more lapses. The knob writes to `YearSettings.desiredRetention` (new) and triggers a
+cached-engine + render-cache invalidate on save so subsequent sessions schedule under the new
+target. Carries `engine`-affecting status alongside the scope toggles.
+
 ## [0.1.17] — 2026-05-28
 
 ### Dashboard activity heatmap

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -160,6 +160,9 @@ export interface YearSettings {
   clubCardScope: TierScope
   chapterListScope: ChapterListScope
   lessonBatchSize: number
+  /** FSRS target retention in `[0.7, 0.97]`. Higher = more reviews +
+   *  better recall; lower = fewer reviews + more lapses. */
+  desiredRetention: number
 }
 
 export interface ClubView {

--- a/apps/web/src/views/MaterialView.vue
+++ b/apps/web/src/views/MaterialView.vue
@@ -166,11 +166,10 @@ function reviewBehindNew(s: YearSettings): boolean {
   return TIER_SCOPE_RANK[s.reviewScope] < TIER_SCOPE_RANK[s.newScope]
 }
 
-/** Settings that drive the WASM engine's MaterialConfig — change to
- *  any of these means the engine + render cache must be rebuilt.
- *  `lessonBatchSize` is intentionally excluded: it's a session-size
- *  knob the engine doesn't consume, so flipping it shouldn't wipe a
- *  full deck's render cache. */
+/** Settings that affect engine construction — flipping any of these
+ *  means the cached WasmEngine + render cache must be rebuilt so the
+ *  next session uses the new value. `lessonBatchSize` is intentionally
+ *  excluded; it's a session-size knob the engine doesn't consume. */
 const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
   'headingCard',
   'headingPassageCard',
@@ -179,6 +178,7 @@ const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
   'reviewScope',
   'clubCardScope',
   'chapterListScope',
+  'desiredRetention',
 ]
 
 function affectsEngine(draft: YearSettings, current: YearSettings): boolean {
@@ -208,6 +208,13 @@ async function onSave(card: YearCard) {
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)
     card.saving = false
+  }
+}
+
+function onRetentionInput(card: YearCard, event: Event) {
+  const pct = Number((event.target as HTMLInputElement).value)
+  if (Number.isFinite(pct)) {
+    card.draft.desiredRetention = pct / 100
   }
 }
 
@@ -447,6 +454,26 @@ onMounted(refresh)
               :disabled="selected.saving"
             />
           </label>
+
+          <label class="range-row">
+            <span class="range-label">
+              Target retention
+              <span class="range-value">{{ Math.round(selected.draft.desiredRetention * 100) }}%</span>
+            </span>
+            <input
+              :value="Math.round(selected.draft.desiredRetention * 100)"
+              type="range"
+              min="70"
+              max="97"
+              step="1"
+              :disabled="selected.saving"
+              @input="onRetentionInput(selected, $event)"
+            />
+          </label>
+          <p class="scope-fineprint">
+            Higher target → more reviews + stronger recall. Lower → fewer reviews + more lapses.
+            FSRS recommends 80–95%.
+          </p>
 
           <button
             type="button"
@@ -708,6 +735,30 @@ h2 {
   font-size: 0.9rem;
   width: 4rem;
   font-variant-numeric: tabular-nums;
+}
+
+.range-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.range-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.range-value {
+  color: var(--color-accent);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.range-row input[type='range'] {
+  width: 100%;
+  accent-color: var(--color-accent);
 }
 
 .save-button {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,16 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### Per-(user, material) target retention
+
+`user_year_settings` gains a `desired_retention` REAL NOT NULL DEFAULT 0.9 column (migration
+`0018_user_year_desired_retention`). `EngineStore.load` reads the per-row value and passes it to
+`new WasmEngine(..., retention, ...)` instead of the previously hardcoded
+`DEFAULT_DESIRED_RETENTION` 0.9. `GET /api/years` returns the value in `settings.desiredRetention`;
+`POST /api/years/:materialId/settings` accepts it (bounded [0.7, 0.97] — FSRS-author recommended
+range, above 0.97 explodes review count, below 0.7 lets too much fade). The settings endpoint
+already invalidates the cached engine on save, so saved changes take effect on the next request.
+
 ## [0.1.18] — 2026-05-28
 
 ### `GET /api/activity` — daily review + memorize counts

--- a/packages/api/migrations/0018_user_year_desired_retention.sql
+++ b/packages/api/migrations/0018_user_year_desired_retention.sql
@@ -1,0 +1,6 @@
+-- Per-(user, material) FSRS target retention. Was hardcoded at 0.9 in the
+-- API's `DEFAULT_DESIRED_RETENTION`; now persisted per row so the user can
+-- tune memory↔workload via the settings UI. Bounded to [0.7, 0.97] at
+-- the API layer (FSRS-author recommendation: above 0.97 explodes review
+-- count for marginal recall gains; below 0.7 lets too much fade).
+ALTER TABLE `user_year_settings` ADD COLUMN `desired_retention` real DEFAULT 0.9 NOT NULL;

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779100000000,
       "tag": "0017_heading_card_split",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1779200000000,
+      "tag": "0018_user_year_desired_retention",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -115,6 +115,10 @@ export const userMaterials = sqliteTable(
 // Per-tier effective status is derived: a tier covered by active_scope
 // is Active; covered only by maintenance_scope is Maintenance; covered
 // by neither is Paused.
+//
+// `desired_retention` is read alongside `MaterialConfig` and threaded
+// as a separate ctor arg to `new WasmEngine(...)`, not part of the
+// MaterialConfig JSON.
 export const userYearSettings = sqliteTable(
   'user_year_settings',
   {
@@ -130,6 +134,7 @@ export const userYearSettings = sqliteTable(
     clubCardScope: text('club_card_scope').notNull(),
     chapterListScope: text('chapter_list_scope').notNull(),
     lessonBatchSize: integer('lesson_batch_size').notNull(),
+    desiredRetention: real('desired_retention').notNull().default(0.9),
     updatedAt: integer('updated_at').notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.userId, t.materialId] }) }),

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -86,6 +86,25 @@ export interface TestStateEntry {
   pending_relearn: boolean;
 }
 
+/** Per-(user, material) target retention. Falls back to the
+ *  `EngineStore` default when the user has no `user_year_settings`
+ *  row yet (the pre-enrollment picker case). The settings endpoint
+ *  invalidates the cached engine on save, so a saved change takes
+ *  effect on the next `load()`. */
+function readDesiredRetention(db: DB, key: EngineKey, fallback: number): number {
+  const row = db
+    .select({ desiredRetention: schema.userYearSettings.desiredRetention })
+    .from(schema.userYearSettings)
+    .where(
+      and(
+        eq(schema.userYearSettings.userId, key.userId),
+        eq(schema.userYearSettings.materialId, key.materialId),
+      ),
+    )
+    .get();
+  return row?.desiredRetention ?? fallback;
+}
+
 /**
  * Build a JSON-encoded `MaterialConfig` for this user × material from
  * the picker table. No row means defaults (the WASM constructor uses
@@ -299,7 +318,7 @@ export class EngineStore {
       materialJson,
       configJson,
       JSON.stringify(testStates),
-      this.desiredRetention,
+      readDesiredRetention(this.db, key, this.desiredRetention),
       BigInt(this.now()),
     );
 
@@ -338,7 +357,7 @@ export class EngineStore {
       configJson,
       // Empty persisted states — we'll replay the full log on top.
       '[]',
-      this.desiredRetention,
+      readDesiredRetention(this.db, key, this.desiredRetention),
       BigInt(this.now()),
     );
 

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -25,6 +25,7 @@ interface YearsResponse {
       clubCardScope: TierScope;
       chapterListScope: ChapterListScope;
       lessonBatchSize: number;
+      desiredRetention: number;
     };
     clubs: Record<'150' | '300' | 'full', { status: ClubStatus; cardCount: number }>;
   }>;
@@ -92,6 +93,7 @@ describe('years routes', () => {
       clubCardScope: 'off',
       chapterListScope: 'up150',
       lessonBatchSize: 3,
+      desiredRetention: 0.9,
     });
     for (const tier of ['150', '300', 'full'] as const) {
       expect(year.clubs[tier].status).toBe('active');

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -27,6 +27,11 @@ const DEFAULT_LESSON_BATCH_SIZE = 3;
 const MIN_LESSON_BATCH_SIZE = 1;
 const MAX_LESSON_BATCH_SIZE = 10;
 
+// FSRS-author recommended bounds: below 0.7 lets too much fade between
+// reviews; above 0.97 explodes review count for marginal recall gains.
+const MIN_DESIRED_RETENTION = 0.7;
+const MAX_DESIRED_RETENTION = 0.97;
+
 interface YearSettings {
   headingCard: boolean;
   headingPassageCard: boolean;
@@ -36,6 +41,7 @@ interface YearSettings {
   clubCardScope: TierScope;
   chapterListScope: ChapterListScope;
   lessonBatchSize: number;
+  desiredRetention: number;
 }
 
 interface ClubView {
@@ -76,6 +82,7 @@ interface SettingsBody {
   clubCardScope?: string;
   chapterListScope?: string;
   lessonBatchSize?: number;
+  desiredRetention?: number;
 }
 
 interface ClubCounts {
@@ -105,6 +112,18 @@ function ensureBatchSize(value: unknown): number {
   if (value < MIN_LESSON_BATCH_SIZE || value > MAX_LESSON_BATCH_SIZE) {
     throw new ValidationError(
       `lessonBatchSize must be between ${MIN_LESSON_BATCH_SIZE} and ${MAX_LESSON_BATCH_SIZE}`,
+    );
+  }
+  return value;
+}
+
+function ensureRetention(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ValidationError('desiredRetention must be a number');
+  }
+  if (value < MIN_DESIRED_RETENTION || value > MAX_DESIRED_RETENTION) {
+    throw new ValidationError(
+      `desiredRetention must be between ${MIN_DESIRED_RETENTION} and ${MAX_DESIRED_RETENTION}`,
     );
   }
   return value;
@@ -153,6 +172,7 @@ const ENROLLED_DEFAULTS: YearSettings = {
   clubCardScope: 'off',
   chapterListScope: 'up150',
   lessonBatchSize: DEFAULT_LESSON_BATCH_SIZE,
+  desiredRetention: 0.9,
 };
 
 const UNENROLLED_DEFAULTS: YearSettings = {
@@ -187,6 +207,7 @@ function readYearSettings(
     clubCardScope: row.clubCardScope as TierScope,
     chapterListScope: row.chapterListScope as ChapterListScope,
     lessonBatchSize: row.lessonBatchSize,
+    desiredRetention: row.desiredRetention,
   };
 }
 
@@ -316,6 +337,7 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
           ensureEnum(v, 'chapterListScope', CHAPTER_LIST_SCOPES),
         ),
         lessonBatchSize: pick('lessonBatchSize', ensureBatchSize),
+        desiredRetention: pick('desiredRetention', ensureRetention),
       };
     } catch (err) {
       if (err instanceof ValidationError) return c.json({ error: err.message }, 400);


### PR DESCRIPTION
Closes #17.

## Summary

\`DEFAULT_DESIRED_RETENTION = 0.9\` was hardcoded in \`packages/api/src/lib/engine.ts\` and threaded through \`new WasmEngine(...)\` for every user. Now per-(user, material) on \`user_year_settings.desired_retention\`, with a slider in /material settings.

## Changes

- **Migration** \`0018_user_year_desired_retention\` adds the \`desired_retention REAL NOT NULL DEFAULT 0.9\` column on \`user_year_settings\`. Journal entry idx 18 added.
- **Schema** (\`packages/api/src/db/schema.ts\`): drizzle field on \`userYearSettings\`.
- **Years route** (\`packages/api/src/routes/years.ts\`): \`YearSettings.desiredRetention\`, \`SettingsBody.desiredRetention\`, \`ensureRetention\` validator with [0.7, 0.97] bounds (FSRS-author recommendation — above 0.97 explodes review count, below 0.7 lets too much fade), \`ENROLLED_DEFAULTS\` updated, \`readYearSettings\` reads the column, POST handler accepts + persists.
- **Engine plumbing** (\`packages/api/src/lib/engine.ts\`): new \`readDesiredRetention(db, key, fallback)\` helper used by both \`load\` and \`rebuildFromEvents\` ctor sites. The \`EngineStore\` constructor-level \`desiredRetention\` becomes the fallback when no row exists.
- **Web type** (\`apps/web/src/api.ts\`): \`YearSettings.desiredRetention: number\`.
- **Web UI** (\`apps/web/src/views/MaterialView.vue\`): 70–97% range slider in the Session panel; \`desiredRetention\` added to \`ENGINE_AFFECTING_SETTINGS\` so saves invalidate the cached engine + render cache.

## Test plan

- [ ] Required CI green (rust, typos, dprint)
- [ ] Existing 101 api tests pass (locally green; updated \`years.test.ts\` shape assertion)
- [ ] Smoke: slider in /material moves smoothly; saved value persists across page reload; next \`/review\` session uses the new target
- [ ] Smoke: setting < 70 or > 97 via direct POST returns 400 with the validator message