### PR TITLE
feat: standalone HP/CCL/orphan in /memorize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,35 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.18] — 2026-05-28
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — `graduate_verse` narrows to the unconditional verse-bound kinds; new
+  `graduate_card` flips a single card. HP, CCL, and conditional verse-bound kinds graduate per-card
+  now.
+* `verse-vault-wasm@0.5.0` — `memorize_session` returns `{ verses, orphans }`; HP/CCL ids surface
+  via `hpCardId` / `cclCardId` on each verse-entry; orphan conditional cards live in the top-level
+  `orphans` list (per-kind cap = the year's `lessonBatchSize`). New `WasmEngine.graduate_card`
+  export.
+
+### Standalone HP / CCL / orphan in /memorize
+
+`MemorizeView` walks each session item as its own reading / drill / graduation step. Verses remain
+verse-oriented; `HeadingPassage` (after the heading's first verse), `ChapterClubList` (after the
+chapter's last verse), and conditional verse-bound cards on already-Active verses (distributed
+round-robin) each get their own step-1 "Already memorized / Next" choice, drill slot in step 2 (flat
+shuffle now, not per-verse interleave), and step-3 "Graduate / Not yet" prompt. Verse graduation
+emits `graduate_verse` plus a `graduate_card` per conditional card it drilled; standalone
+graduations go straight to `graduate_card`.
+
+### Per-card graduation persistence
+
+`engineStore.submitCardGraduation` queues a `graduateCard` sync event and writes the card id into
+the local snapshot's new `graduatedCardIds` field. Engine boot replays both `graduatedVerseIds`
+(`graduate_verse`) and `graduatedCardIds` (`graduate_card`) so the cached in-memory engine matches
+what the server's `EngineStore.load` would produce.
+
 ### Target retention slider in /material settings
 
 The "Session" panel in the year settings (`/material`) gains a **Target retention** range slider

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -194,16 +194,31 @@ export interface YearsResponse {
 
 export interface MemorizeSessionVerse {
   verseId: number
-  /** Every per-verse card to drill, in builder order. */
+  /** Verse-bound cards drilled with this verse, in builder order.
+   *  HP / CCL surface separately via the slots below; orphans live
+   *  at the top level of `MemorizeSessionResponse`. */
   cardIds: number[]
-  /** Card id of the verse's Recitation, when emitted. Used as the
-   *  anchor render for the session-opening + closing walkthroughs so
-   *  the verse displays without a PhraseFill's phrase-0 highlight. */
+  /** Subset of `cardIds` that need an explicit `graduate_card` on
+   *  step-3 verse graduation. `graduate_verse` already flips the
+   *  rest. Omitted (treat as []) when the verse has no conditional
+   *  kinds emitted. */
+  conditionalCardIds?: number[]
+  /** Recitation render — verse text without a PhraseFill's
+   *  phrase-0 highlight. Null when the deck doesn't emit one. */
   recitationCardId: number | null
+  /** HeadingPassage placed after this verse in the reading walkthrough. */
+  hpCardId?: number
+  /** ChapterClubList placed after this verse. */
+  cclCardId?: number
 }
 
 export interface MemorizeSessionResponse {
   verses: MemorizeSessionVerse[]
+  /** Standalone meta cards that don't anchor to a session-verse:
+   *  HP/CCL overflow plus conditional verse-bound cards
+   *  (Ftv / VerseInHeading / VerseInClub) on already-Active verses.
+   *  Capped per kind at the year's `lessonBatchSize`. */
+  orphans: number[]
 }
 
 export interface MaterialStatus {
@@ -225,6 +240,7 @@ export interface ApiClient {
   getNextReviewCard(materialId: string): Promise<{ cardId: number | null }>
   getMemorizeSession(materialId: string, max: number): Promise<MemorizeSessionResponse>
   graduateVerse(materialId: string, verseId: number): Promise<{ graduated: number }>
+  graduateCard(materialId: string, cardId: number): Promise<{ graduated: boolean }>
   getCardRender(materialId: string, cardId: number): Promise<CardRender>
   submitReview(materialId: string, cardId: number, grade: Grade): Promise<ReviewResponse>
   getStats(materialId: string): Promise<StatsResponse>
@@ -278,6 +294,8 @@ export function createApiClient(apiUrl: string): ApiClient {
       ),
     graduateVerse: (materialId, verseId) =>
       request('POST', '/api/cards/memorize/graduate', { materialId, verseId }),
+    graduateCard: (materialId, cardId) =>
+      request('POST', '/api/cards/memorize/graduate-card', { materialId, cardId }),
     getCardRender: (materialId, cardId) =>
       request('GET', `/api/cards/${cardId}?materialId=${encodeURIComponent(materialId)}`),
     submitReview: (materialId, cardId, grade) =>

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -194,6 +194,13 @@ export function useEngine() {
     return count
   }
 
+  async function submitCardGraduation(materialId: string, cardId: number) {
+    const flipped = await engineStore.submitCardGraduation(materialId, cardId, nowSecs())
+    await refreshCounts()
+    scheduleFlush()
+    return flipped
+  }
+
   function nextReviewCard(materialId: string): number | null {
     return engineStore.nextReviewCard(materialId, nowSecs())
   }
@@ -269,6 +276,7 @@ export function useEngine() {
     invalidate,
     submitGrade,
     submitGraduation,
+    submitCardGraduation,
     nextReviewCard,
     memorizeSession,
     newCardCount,

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -124,6 +124,7 @@ export async function loadEngine(
       materialData: fetched.snapshot.materialData,
       fetchedAt: nowSecs,
       graduatedVerseIds: fetched.graduatedVerseIds,
+      graduatedCardIds: fetched.graduatedCardIds,
     }
     testStates = fetched.testStates
     await idb.putSnapshot(snapshot)
@@ -137,7 +138,7 @@ export async function loadEngine(
     desiredRetention: DEFAULT_DESIRED_RETENTION,
     nowSecs,
   })
-  applyGraduations(engine, snapshot.graduatedVerseIds)
+  applyGraduations(engine, snapshot.graduatedVerseIds, snapshot.graduatedCardIds)
 
   const session: EngineSession = {
     materialId,
@@ -160,6 +161,7 @@ async function refetchSyncState(session: EngineSession, nowSecs: number): Promis
     materialData: fetched.snapshot.materialData,
     fetchedAt: nowSecs,
     graduatedVerseIds: fetched.graduatedVerseIds,
+    graduatedCardIds: fetched.graduatedCardIds,
   })
   await idb.replaceAllTestStates(session.materialId, fetched.testStates)
   // Snapshot version moved — invalidate the render cache wholesale; the
@@ -175,16 +177,19 @@ async function refetchSyncState(session: EngineSession, nowSecs: number): Promis
     desiredRetention: DEFAULT_DESIRED_RETENTION,
     nowSecs,
   })
-  applyGraduations(session.engine, fetched.graduatedVerseIds)
+  applyGraduations(session.engine, fetched.graduatedVerseIds, fetched.graduatedCardIds)
   session.snapshotVersion = fetched.snapshot.version
 }
 
-/** Flip each graduated verse from `New` to `Active`. Cards default to
- *  `New` when the engine is built from materialData + testStates, so
- *  this call mirrors what `EngineStore.load` does server-side and
- *  keeps the in-memory engine consistent across page reloads. */
-function applyGraduations(engine: WasmEngine, verseIds: number[] | undefined): void {
+/** Replay the user's graduation log onto a freshly-built engine so its
+ *  card state matches what `EngineStore.load` produces server-side. */
+function applyGraduations(
+  engine: WasmEngine,
+  verseIds: number[] | undefined,
+  cardIds: number[] | undefined,
+): void {
   for (const id of verseIds ?? []) engine.graduate_verse(id)
+  for (const id of cardIds ?? []) engine.graduate_card(id)
 }
 
 /** Apply a review grade locally and queue the event for sync. Returns
@@ -269,6 +274,44 @@ async function persistLocalGraduation(materialId: string, verseId: number): Prom
   await idb.putSnapshot({ ...snapshot, graduatedVerseIds: [...ids, verseId] })
 }
 
+/** Apply a single-card graduation locally and queue the event for
+ *  sync. Returns whether the card transitioned `New → Active` (false
+ *  on already-Active or unknown card). */
+export async function submitCardGraduation(
+  materialId: string,
+  cardId: number,
+  nowSecs: number,
+): Promise<boolean> {
+  const session = requireSession(materialId, 'submitCardGraduation')
+  const flipped = session.engine.graduate_card(cardId)
+
+  void idb
+    .appendQueuedEvent({
+      materialId,
+      kind: 'graduateCard',
+      clientEventId: crypto.randomUUID(),
+      timestampSecs: nowSecs,
+      snapshotVersion: session.snapshotVersion,
+      cardId,
+    })
+    .catch((e) => {
+      console.warn('engineStore.submitCardGraduation: queue append failed', e)
+    })
+
+  void persistLocalCardGraduation(materialId, cardId).catch((e) => {
+    console.warn('engineStore.submitCardGraduation: snapshot update failed', e)
+  })
+
+  return flipped
+}
+
+async function persistLocalCardGraduation(materialId: string, cardId: number): Promise<void> {
+  const snapshot = (await idb.getSnapshot(materialId))!
+  const ids = snapshot.graduatedCardIds ?? []
+  if (ids.includes(cardId)) return
+  await idb.putSnapshot({ ...snapshot, graduatedCardIds: [...ids, cardId] })
+}
+
 /** Look up the next due review card. */
 export function nextReviewCard(materialId: string, nowSecs: number): number | null {
   const session = requireSession(materialId, 'nextReviewCard')
@@ -279,19 +322,25 @@ export function nextReviewCard(materialId: string, nowSecs: number): number | nu
 interface MemorizeSessionEntry {
   verseId: number
   cardIds: number[]
+  conditionalCardIds?: number[]
   recitationCardId: number | null
+  hpCardId?: number
+  cclCardId?: number
 }
 
-/** Build a memorize session payload locally. The WASM engine returns
- *  a raw JSON array of `{ verseId, cardIds, recitationCardId }`; wrap
- *  it as `{ verses: [...] }` so the shape matches what the server's
- *  `/api/cards/memorize/session` route returns. */
+/** Build a memorize session payload locally. Mirrors the server's
+ *  `/api/cards/memorize/session` route. See `MemorizeSessionResponse`
+ *  in `@/api` for field semantics. */
 export function memorizeSession(
   materialId: string,
   limit: number,
-): { verses: MemorizeSessionEntry[] } {
+): { verses: MemorizeSessionEntry[]; orphans: number[] } {
   const session = requireSession(materialId, 'memorizeSession')
-  return { verses: JSON.parse(session.engine.memorize_session(limit)) }
+  const parsed = JSON.parse(session.engine.memorize_session(limit)) as {
+    verses: MemorizeSessionEntry[]
+    orphans?: number[]
+  }
+  return { verses: parsed.verses, orphans: parsed.orphans ?? [] }
 }
 
 export function newCardCount(materialId: string): number {
@@ -391,6 +440,15 @@ async function doFlush(
         timestampSecs: q.timestampSecs,
         snapshotVersion: q.snapshotVersion,
         verseId: q.verseId,
+      }
+    }
+    if (q.kind === 'graduateCard') {
+      return {
+        kind: 'graduateCard',
+        clientEventId: q.clientEventId,
+        timestampSecs: q.timestampSecs,
+        snapshotVersion: q.snapshotVersion,
+        cardId: q.cardId,
       }
     }
     return {

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -166,6 +166,10 @@ export interface SnapshotRow {
    *  written before the field existed read back as undefined and are
    *  treated as an empty list. */
   graduatedVerseIds?: number[]
+  /** Card ids graduated individually — HP, CCL, and the conditional
+   *  verse-bound kinds since `verse-vault-core@0.5.0`. Same lifecycle
+   *  + back-compat treatment as `graduatedVerseIds`. */
+  graduatedCardIds?: number[]
 }
 
 export async function getSnapshot(materialId: string): Promise<SnapshotRow | undefined> {

--- a/apps/web/src/lib/engine/types.ts
+++ b/apps/web/src/lib/engine/types.ts
@@ -87,6 +87,10 @@ export interface SyncStateResponse {
    *  build so the in-memory engine matches the user's actual progress
    *  across page reloads. */
   graduatedVerseIds: number[]
+  /** Card ids the user has graduated individually — HP, CCL, and the
+   *  conditional verse-bound kinds. Applied via `engine.graduate_card`
+   *  alongside the verse-bulk replay. */
+  graduatedCardIds: number[]
 }
 
 /** One queued event in `POST /api/sync/:materialId/events`. Mirrors the
@@ -106,6 +110,13 @@ export type SyncEventUpload =
       timestampSecs: number
       snapshotVersion: number
       verseId: number
+    }
+  | {
+      kind: 'graduateCard'
+      clientEventId: string
+      timestampSecs: number
+      snapshotVersion: number
+      cardId: number
     }
 
 /** POST /api/sync/:materialId/events body. */

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -13,28 +13,46 @@ import { buildMaterialConfig } from '@/lib/engine/types'
 // action methods routes work to the right engine.
 const engine = useEngine()
 
-// One session walks three phases: read every verse first, drill every
-// card (shuffled by verse), then walk the verses again and graduate
-// each one. None of this is FSRS-graded — memorize stays pure-intro.
+// One session walks three phases: read every item first, drill every
+// card in random order, then walk the items again and graduate each
+// one. None of this is FSRS-graded — memorize stays pure-intro.
 type Phase = 'reading_start' | 'drilling' | 'reading_end' | 'done'
 
-interface SessionVerse extends MemorizeSessionVerse {
+interface VerseItem {
+  kind: 'verse'
   materialId: string
-  /** Anchor render used during reading_start and reading_end: the
-   *  verse's Recitation when available, falling back to the first
-   *  drill card. Recitation avoids the phrase-0 highlight a PhraseFill
-   *  would impose. */
+  verseId: number
+  cardIds: number[]
+  /** Subset of `cardIds` that need an explicit graduate_card on
+   *  step-3 graduation; graduate_verse handles the rest. */
+  conditionalCardIds: number[]
+  /** Card id used to fetch the reading-walkthrough anchor render
+   *  (Recitation when emitted, else the first drill card). */
+  anchorCardId: number | null
   anchor: CardRender | null
   graduated: boolean
 }
 
-interface DrillEntry {
+interface StandaloneItem {
+  kind: 'standalone'
   materialId: string
-  verseId: number
   cardId: number
+  slot: 'hp' | 'ccl' | 'orphan'
+  anchor: CardRender | null
+  graduated: boolean
 }
 
-const verses = ref<SessionVerse[]>([])
+type ReadingItem = VerseItem | StandaloneItem
+
+interface DrillEntry {
+  materialId: string
+  cardId: number
+  /** Index into `items` so a step-1 "Already memorized" on an item
+   *  can drop every drill entry sourced from that item in one filter. */
+  itemIdx: number
+}
+
+const items = ref<ReadingItem[]>([])
 const phase = ref<Phase>('reading_start')
 const readingIndex = ref(0)
 const drillQueue = ref<DrillEntry[]>([])
@@ -45,26 +63,25 @@ const error = ref<string | null>(null)
 const loading = ref(false)
 const submitting = ref(false)
 
-const empty = computed(() => phase.value !== 'done' && verses.value.length === 0)
-const totalVerses = computed(() => verses.value.length)
+const empty = computed(() => phase.value !== 'done' && items.value.length === 0)
+const totalItems = computed(() => items.value.length)
 const remainingDrillCards = computed(() => drillQueue.value.length)
 
-const currentReadingVerse = computed<SessionVerse | null>(() =>
-  verses.value[readingIndex.value] ?? null,
+const currentReadingItem = computed<ReadingItem | null>(() =>
+  items.value[readingIndex.value] ?? null,
 )
-const onLastReading = computed(() => readingIndex.value === verses.value.length - 1)
+const onLastReading = computed(() => readingIndex.value === items.value.length - 1)
 const currentDrill = computed<DrillEntry | null>(() => drillQueue.value[0] ?? null)
+const graduatedCount = computed(
+  () => items.value.filter((i) => i.kind === 'verse' && i.graduated).length,
+)
 
-/** Interleave per-verse card lists so verses appear in random order
- *  while each verse's cards stay in builder order. */
-function interleaveByVerse(byVerse: DrillEntry[][]): DrillEntry[] {
-  const pools: DrillEntry[][] = byVerse.map((c) => [...c]).filter((c) => c.length > 0)
-  const out: DrillEntry[] = []
-  while (pools.length > 0) {
-    const i = Math.floor(Math.random() * pools.length)
-    const next = pools[i]!.shift()!
-    out.push(next)
-    if (pools[i]!.length === 0) pools.splice(i, 1)
+/** Fisher–Yates shuffle, non-mutating. */
+function shuffle<T>(arr: T[]): T[] {
+  const out = arr.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i]!, out[j]!] = [out[j]!, out[i]!]
   }
   return out
 }
@@ -72,7 +89,7 @@ function interleaveByVerse(byVerse: DrillEntry[][]): DrillEntry[] {
 async function buildSession() {
   // Each enrolled year contributes up to its lessonBatchSize verses.
   // Reading walkthroughs stay in collection order so opening + closing
-  // reads expose verses in the same shape.
+  // reads expose items in the same shape.
   const yearsRes = await api.getYears()
   const eligibleYears = yearsRes.years.filter(
     (y) => y.enrolled && y.settings.newScope !== 'off' && y.newCardCount > 0,
@@ -83,52 +100,97 @@ async function buildSession() {
   await Promise.all(
     eligibleYears.map((y) => engine.init(y.materialId, buildMaterialConfig(y.settings))),
   )
-  const sessions: { materialId: string; verses: MemorizeSessionVerse[] }[] = eligibleYears.map(
-    (y) => ({
-      materialId: y.materialId,
-      verses: engine.memorizeSession(y.materialId, y.settings.lessonBatchSize).verses,
-    }),
-  )
-  const collected: SessionVerse[] = []
-  for (const { materialId, verses: ys } of sessions) {
+  const sessions: {
+    materialId: string
+    verses: MemorizeSessionVerse[]
+    orphans: number[]
+  }[] = eligibleYears.map((y) => {
+    const s = engine.memorizeSession(y.materialId, y.settings.lessonBatchSize)
+    return { materialId: y.materialId, verses: s.verses, orphans: s.orphans }
+  })
+  // Flatten the session into reading items: each verse anchors its
+  // own item with HP / CCL items appended after it; top-level orphan
+  // cards (the verse-less standalone overflow) follow at the end of
+  // the year's chunk. The drill queue is a flat shuffle across every
+  // card the user will encounter.
+  const collected: ReadingItem[] = []
+  const drillPool: DrillEntry[] = []
+  for (const { materialId, verses: ys, orphans } of sessions) {
     for (const v of ys) {
-      if (v.cardIds.length === 0) continue
+      if (v.cardIds.length === 0 && v.hpCardId === undefined && v.cclCardId === undefined) {
+        continue
+      }
+      const verseIdx = collected.length
       collected.push({
+        kind: 'verse',
         materialId,
         verseId: v.verseId,
         cardIds: v.cardIds,
-        recitationCardId: v.recitationCardId,
+        conditionalCardIds: v.conditionalCardIds ?? [],
+        anchorCardId: v.recitationCardId ?? v.cardIds[0] ?? null,
         anchor: null,
         graduated: false,
       })
+      for (const cardId of v.cardIds) {
+        drillPool.push({ materialId, cardId, itemIdx: verseIdx })
+      }
+      if (v.hpCardId !== undefined) {
+        const idx = collected.length
+        collected.push({
+          kind: 'standalone',
+          materialId,
+          cardId: v.hpCardId,
+          slot: 'hp',
+          anchor: null,
+          graduated: false,
+        })
+        drillPool.push({ materialId, cardId: v.hpCardId, itemIdx: idx })
+      }
+      if (v.cclCardId !== undefined) {
+        const idx = collected.length
+        collected.push({
+          kind: 'standalone',
+          materialId,
+          cardId: v.cclCardId,
+          slot: 'ccl',
+          anchor: null,
+          graduated: false,
+        })
+        drillPool.push({ materialId, cardId: v.cclCardId, itemIdx: idx })
+      }
+    }
+    for (const orphanId of orphans) {
+      const idx = collected.length
+      collected.push({
+        kind: 'standalone',
+        materialId,
+        cardId: orphanId,
+        slot: 'orphan',
+        anchor: null,
+        graduated: false,
+      })
+      drillPool.push({ materialId, cardId: orphanId, itemIdx: idx })
     }
   }
-  verses.value = collected
+  items.value = collected
 
-  // Pre-fetch anchor renders so the reading walkthroughs don't pause
-  // for a round trip per verse. Prefer Recitation to avoid the phrase-0
-  // highlight a PhraseFill render would impose. Renders come from the
-  // engine's IDB-cached + lazy network path.
+  // Pre-fetch every reading anchor in parallel via the engine's
+  // IDB-cached + lazy network path.
   await Promise.all(
-    collected.map(async (v) => {
-      const anchorId = v.recitationCardId ?? v.cardIds[0]
-      if (anchorId === undefined || anchorId === null) return
-      v.anchor = await engine.getCardRender(v.materialId, anchorId)
+    collected.map(async (item) => {
+      const anchorId = item.kind === 'verse' ? item.anchorCardId : item.cardId
+      if (anchorId === null) return
+      item.anchor = await engine.getCardRender(item.materialId, anchorId)
     }),
   )
 
-  // Verses interleave; cards within a verse keep builder order on the
-  // initial pass so the user doesn't see card 2 before card 1.
-  const byVerse: DrillEntry[][] = collected.map((v) =>
-    v.cardIds.map((cardId) => ({ materialId: v.materialId, verseId: v.verseId, cardId })),
-  )
-  const drill = interleaveByVerse(byVerse)
+  const drill = shuffle(drillPool)
   drillQueue.value = drill
   totalDrillCards.value = drill.length
 }
 
 async function startDrilling() {
-  // If every verse was already-memorized'd in the read-through, there's
+  // If every item was already-memorized'd in the read-through, there's
   // nothing to drill and nothing to re-confirm — skip straight to done.
   if (drillQueue.value.length === 0) {
     phase.value = 'done'
@@ -174,12 +236,28 @@ async function gradeGood() {
   await loadDrillCard()
 }
 
-/** Position the reading_end cursor at the first verse that still needs
- *  a closing read — already-memorized verses got their graduation up
- *  front in reading_start and don't need re-confirmation. If everything
- *  was front-loaded, jump straight to done. */
+/** Graduate one reading item and drop its drill entries. */
+async function graduateItem(item: ReadingItem, itemIdx: number): Promise<void> {
+  if (item.kind === 'verse') {
+    await Promise.all([
+      engine.submitGraduation(item.materialId, item.verseId),
+      ...item.conditionalCardIds.map((id) => engine.submitCardGraduation(item.materialId, id)),
+    ])
+  } else {
+    await engine.submitCardGraduation(item.materialId, item.cardId)
+  }
+  item.graduated = true
+  drillQueue.value = drillQueue.value.filter((e) => e.itemIdx !== itemIdx)
+  totalDrillCards.value = drillQueue.value.length
+}
+
+/** Position the reading_end cursor at the first item that still
+ *  needs a closing read — already-memorized items got their
+ *  graduation up front in reading_start and don't need
+ *  re-confirmation. If everything was front-loaded, jump straight
+ *  to done. */
 function enterReadingEnd() {
-  const first = verses.value.findIndex((v) => !v.graduated)
+  const first = items.value.findIndex((i) => !i.graduated)
   if (first === -1) {
     phase.value = 'done'
     return
@@ -196,22 +274,15 @@ function advanceReadingStart() {
   readingIndex.value += 1
 }
 
-/** Reading-start opt-out: the user already knows this verse, so
- *  graduate it immediately, drop its cards from the drill queue, and
- *  advance. Equivalent to running through drilling + reading_end's
- *  Graduate without actually doing them. */
+/** Reading-start opt-out: the user already knows this item, so
+ *  graduate it immediately, drop its drill entries, and advance. */
 async function alreadyMemorizedCurrentReadingStart() {
-  const v = currentReadingVerse.value
-  if (!v || submitting.value) return
+  const item = currentReadingItem.value
+  if (!item || submitting.value) return
   submitting.value = true
   error.value = null
   try {
-    await engine.submitGraduation(v.materialId, v.verseId)
-    v.graduated = true
-    drillQueue.value = drillQueue.value.filter(
-      (e) => !(e.materialId === v.materialId && e.verseId === v.verseId),
-    )
-    totalDrillCards.value = drillQueue.value.length
+    await graduateItem(item, readingIndex.value)
     advanceReadingStart()
   } catch (err) {
     error.value = formatError(err)
@@ -221,13 +292,12 @@ async function alreadyMemorizedCurrentReadingStart() {
 }
 
 async function graduateCurrentReadingEnd() {
-  const v = currentReadingVerse.value
-  if (!v || submitting.value) return
+  const item = currentReadingItem.value
+  if (!item || submitting.value) return
   submitting.value = true
   error.value = null
   try {
-    await engine.submitGraduation(v.materialId, v.verseId)
-    v.graduated = true
+    await graduateItem(item, readingIndex.value)
     advanceReadingEnd()
   } catch (err) {
     error.value = formatError(err)
@@ -240,12 +310,12 @@ function skipCurrentReadingEnd() {
   advanceReadingEnd()
 }
 
-/** Step to the next non-graduated verse, or done if none remain. Skips
- *  over verses already-memorized in reading_start so the user isn't
- *  asked twice. */
+/** Step to the next non-graduated item, or done if none remain.
+ *  Skips items already-memorized in reading_start so the user
+ *  isn't asked twice. */
 function advanceReadingEnd() {
-  for (let i = readingIndex.value + 1; i < verses.value.length; i++) {
-    if (!verses.value[i]!.graduated) {
+  for (let i = readingIndex.value + 1; i < items.value.length; i++) {
+    if (!items.value[i]!.graduated) {
       readingIndex.value = i
       return
     }
@@ -253,7 +323,12 @@ function advanceReadingEnd() {
   phase.value = 'done'
 }
 
-const graduatedCount = computed(() => verses.value.filter((v) => v.graduated).length)
+function readingLabel(item: ReadingItem): string {
+  if (item.kind === 'verse') return 'Verse'
+  if (item.slot === 'hp') return 'Heading passage'
+  if (item.slot === 'ccl') return 'Chapter list'
+  return 'Extra card'
+}
 
 function formatError(err: unknown): string {
   if (err instanceof Error) return err.message
@@ -264,7 +339,7 @@ onMounted(async () => {
   try {
     loading.value = true
     await buildSession()
-    if (verses.value.length === 0) return
+    if (items.value.length === 0) return
   } catch (err) {
     error.value = formatError(err)
   } finally {
@@ -285,13 +360,13 @@ function onKeydown(e: KeyboardEvent) {
   if (engine.staleSummary.value || submitting.value) return
 
   if (e.key === 'Enter') {
-    if (phase.value === 'reading_start' && currentReadingVerse.value?.anchor) {
+    if (phase.value === 'reading_start' && currentReadingItem.value?.anchor) {
       e.preventDefault()
       advanceReadingStart()
     } else if (phase.value === 'drilling' && drillCard.value && !drillRevealed.value) {
       e.preventDefault()
       revealDrill()
-    } else if (phase.value === 'reading_end' && currentReadingVerse.value?.anchor) {
+    } else if (phase.value === 'reading_end' && currentReadingItem.value?.anchor) {
       e.preventDefault()
       void graduateCurrentReadingEnd()
     }
@@ -325,7 +400,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
   <div class="memorize">
     <div v-if="error" class="banner banner-error">{{ error }}</div>
 
-    <div v-if="loading && verses.length === 0" class="status">Loading…</div>
+    <div v-if="loading && items.length === 0" class="status">Loading…</div>
 
     <div v-else-if="phase === 'done'" class="done">
       <h2>Memorized {{ graduatedCount }} verse{{ graduatedCount === 1 ? '' : 's' }}</h2>
@@ -343,13 +418,14 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
 
     <!-- Reading walkthrough (used at both ends of the session). -->
     <div
-      v-else-if="phase === 'reading_start' && currentReadingVerse?.anchor"
+      v-else-if="phase === 'reading_start' && currentReadingItem?.anchor"
       class="card"
     >
       <div class="meta">
-        Read it through · Verse {{ readingIndex + 1 }} of {{ totalVerses }}
+        Read it through · {{ readingLabel(currentReadingItem) }} {{ readingIndex + 1 }} of
+        {{ totalItems }}
       </div>
-      <CardPrompt :card="currentReadingVerse.anchor" :revealed="true" />
+      <CardPrompt :card="currentReadingItem.anchor" :revealed="true" />
       <div class="actions">
         <div class="read-actions">
           <button
@@ -360,7 +436,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
             Already memorized
           </button>
           <button class="primary" :disabled="submitting" @click="advanceReadingStart">
-            {{ onLastReading ? 'Start drilling' : 'Next verse' }}
+            {{ onLastReading ? 'Start drilling' : 'Next' }}
           </button>
         </div>
       </div>
@@ -393,13 +469,14 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
     </div>
 
     <div
-      v-else-if="phase === 'reading_end' && currentReadingVerse?.anchor"
+      v-else-if="phase === 'reading_end' && currentReadingItem?.anchor"
       class="card"
     >
       <div class="meta">
-        Read it once more · Verse {{ readingIndex + 1 }} of {{ totalVerses }}
+        Read it once more · {{ readingLabel(currentReadingItem) }} {{ readingIndex + 1 }} of
+        {{ totalItems }}
       </div>
-      <CardPrompt :card="currentReadingVerse.anchor" :revealed="true" />
+      <CardPrompt :card="currentReadingItem.anchor" :revealed="true" />
       <div class="actions">
         <div class="grades">
           <button
@@ -511,8 +588,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
 }
 
 /* Side-by-side action row for reading_start: a muted "Already
-   memorized" escape hatch sits next to the primary "Next verse /
-   Start drilling" action so users can skip drilling verses they
+   memorized" escape hatch sits next to the primary "Next /
+   Start drilling" action so users can skip drilling items they
    already know without it being the dominant click target. */
 .read-actions {
   display: grid;

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,35 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-28
+
+`graduate_verse` narrows to the unconditional verse-bound set. Conditional kinds (`Ftv`,
+`VerseInHeading`, `VerseInClub`) and the multi-verse pseudos (`HeadingPassage`, `ChapterClubList`)
+are no longer flipped by a verse's graduation — they need explicit `graduate_card` events. This lets
+the memorize flow surface each of them as a standalone session item the learner reads, drills, and
+graduates independently of the verse they anchor to. A settings flip after the host verse was first
+graduated then produces a visible orphan instead of a silently transitively-Active card the user
+never engaged with. MAJOR per the state-semantics rubric — replay of an existing `graduate_verse`
+log produces a different end state (previously transitively-graduated Ftv / VerseInHeading /
+VerseInClub / HP / CCL stay `New` until an explicit `graduate_card` is replayed).
+
+### Added
+
+* `ReviewEngine::graduate_card(card_id) -> bool` — flips a single `New` card to `Active`, returning
+  whether a transition happened. Idempotent. Used by the memorize flow to graduate every kind that
+  `graduate_verse` no longer touches.
+
+### Changed
+
+* `ReviewEngine::graduate_verse` flips only the unconditional verse-bound kinds: `PhraseFill`,
+  `Recitation`, `Citation`, `VerseAtVerseRef`, `VerseInChapter`, `VerseInBook`. These always exist
+  for any verse with content and reliably represent "the user memorized this verse." The conditional
+  kinds (`Ftv`, `VerseInHeading`, `VerseInClub`) and the multi-verse pseudos (`HeadingPassage`,
+  `ChapterClubList`) are deliberately skipped — their emission depends on the per-year settings
+  (`ftv`, `heading_card`, `club_card_scope`, `heading_passage_card`, `chapter_list_scope`), and
+  flipping one on after the host verse was first graduated would otherwise silently
+  transitively-Active the newly emitted card.
+
 ## [0.4.0] — 2026-05-28
 
 Tier status (`Active` / `Maintenance` / `Paused`) becomes a **runtime filter** instead of a

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -1,7 +1,23 @@
 use std::collections::HashMap;
 
 use crate::builder::BuildResult;
-use crate::card::{Card, CardState, VerseAtoms};
+use crate::card::{Card, CardKind, CardState, VerseAtoms};
+
+/// Card kinds flipped to `Active` in bulk by `graduate_verse` — the
+/// unconditional verse-bound set. Conditional kinds (Ftv,
+/// VerseInHeading, VerseInClub) and multi-verse pseudos
+/// (HeadingPassage, ChapterClubList) need `graduate_card`.
+pub fn is_bulk_graduable(kind: &CardKind) -> bool {
+    matches!(
+        kind,
+        CardKind::PhraseFill { .. }
+            | CardKind::Recitation
+            | CardKind::Citation
+            | CardKind::VerseAtVerseRef
+            | CardKind::VerseInChapter
+            | CardKind::VerseInBook
+    )
+}
 use crate::fsrs_bridge::FsrsBridge;
 use crate::material_config::{ClubStatus, MaterialConfig};
 use crate::render::VerseRender;
@@ -155,19 +171,52 @@ impl ReviewEngine {
         }
     }
 
-    /// Flip every `New` card whose `verse_id` matches to `Active`. Returns
-    /// the number of cards that transitioned. Idempotent: a second call on
-    /// the same verse_id returns 0. The memorize-session graduation step
-    /// uses this to "introduce" every card the verse owns in one go.
+    /// Flip every `New` unconditional verse-bound card whose `verse_id`
+    /// matches to `Active`. Returns the number of cards that transitioned.
+    /// Idempotent: a second call on the same verse_id returns 0.
+    ///
+    /// Unconditional kinds: `PhraseFill`, `Recitation`, `Citation`,
+    /// `VerseAtVerseRef`, `VerseInChapter`, `VerseInBook`. These always
+    /// exist for any verse with content and reliably represent "the user
+    /// memorized this verse."
+    ///
+    /// Conditional kinds (`Ftv`, `VerseInHeading`, `VerseInClub`) and
+    /// the multi-verse pseudos (`HeadingPassage`, `ChapterClubList`) are
+    /// deliberately skipped. Their emission depends on settings
+    /// (`ftv`, `heading_card`, `club_card_scope`, `heading_passage_card`,
+    /// `chapter_list_scope`), so flipping a setting on after a verse was
+    /// first graduated would otherwise silently transitively-Active the
+    /// newly emitted card without the user ever engaging with it. The
+    /// memorize flow surfaces these as standalone session items and
+    /// graduates them via `graduate_card`.
     pub fn graduate_verse(&mut self, verse_id: u32) -> usize {
         let mut count = 0;
         for card in self.cards.iter_mut().filter(|c| c.verse_id == verse_id) {
+            if !is_bulk_graduable(&card.kind) {
+                continue;
+            }
             if matches!(card.state, CardState::New) {
                 card.state = CardState::Active;
                 count += 1;
             }
         }
         count
+    }
+
+    /// Flip a single `New` card to `Active`. Returns true on transition,
+    /// false when the card is unknown or already non-`New` (idempotent).
+    /// Used by the memorize flow to graduate `HeadingPassage` and
+    /// `ChapterClubList` cards independently of their attach verse.
+    pub fn graduate_card(&mut self, card_id: crate::types::CardId) -> bool {
+        let Some(card) = self.cards.iter_mut().find(|c| c.id == card_id) else {
+            return false;
+        };
+        if matches!(card.state, CardState::New) {
+            card.state = CardState::Active;
+            true
+        } else {
+            false
+        }
     }
 
     /// Flip every card in the deck to `Active`. Convenience for tests and

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -530,10 +530,102 @@ mod tests {
         assert!(count > 0);
         // Idempotent.
         assert_eq!(engine.graduate_verse(0), 0);
-        // After graduation /memorize empties for that verse and /review
-        // sees the cards.
+        // graduate_verse flips the unconditional set. Conditional kinds
+        // (here: Ftv) still need explicit graduate_card. Once everything
+        // is flipped /memorize empties and /review sees the cards.
+        let conditional_ids: Vec<crate::types::CardId> = engine
+            .cards
+            .iter()
+            .filter(|c| matches!(c.state, CardState::New))
+            .map(|c| c.id)
+            .collect();
+        for id in conditional_ids {
+            engine.graduate_card(id);
+        }
         assert!(next_memorize_card(&engine, 0).is_none());
         assert!(next_card(&engine, 86400 * 400).is_some());
+    }
+
+    #[test]
+    fn graduate_verse_skips_conditional_kinds_and_pseudos() {
+        // Two-verse Club150 chapter with a heading covering both, plus
+        // FTVs and the conditional meta-location toggles enabled. The
+        // builder emits Ftv, VerseInHeading, VerseInClub, plus the
+        // multi-verse pseudos HeadingPassage and ChapterClubList.
+        // graduate_verse must leave every conditional / pseudo card
+        // `New` — they're standalone session items now.
+        let m: MaterialData = serde_json::from_str(
+            r#"{
+                "year": 3,
+                "books": ["John"],
+                "chapters": [
+                    {"book": "John", "number": 3, "start_verse": 16, "end_verse": 17}
+                ],
+                "verses": [
+                    {"book": "John", "chapter": 3, "verse": 16, "phraseWordCounts": [2, 2], "annotations": [], "ftvWordCount": 2, "clubs": [150]},
+                    {"book": "John", "chapter": 3, "verse": 17, "phraseWordCounts": [2, 3], "annotations": [], "ftvWordCount": 2, "clubs": [150]}
+                ],
+                "headings": [{
+                    "book": "John",
+                    "startChapter": 3, "startVerse": 16,
+                    "endChapter": 3, "endVerse": 17
+                }]
+            }"#,
+        )
+        .unwrap();
+        let config = crate::material_config::MaterialConfig {
+            heading_card: true,
+            club_card_scope: crate::material_config::TierScope::All,
+            ..crate::material_config::MaterialConfig::default()
+        };
+        let r = crate::builder::build_with_config(&m, &config, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+
+        let conditional_ids: Vec<(crate::types::CardId, CardKind)> = engine
+            .cards
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c.kind,
+                    CardKind::Ftv { .. }
+                        | CardKind::VerseInHeading { .. }
+                        | CardKind::VerseInClub { .. }
+                        | CardKind::HeadingPassage { .. }
+                        | CardKind::ChapterClubList { .. }
+                )
+            })
+            .map(|c| (c.id, c.kind))
+            .collect();
+        assert!(
+            !conditional_ids.is_empty(),
+            "expected at least one conditional/pseudo card in this fixture"
+        );
+
+        // Graduate both real verses; every conditional / pseudo card
+        // stays `New`.
+        engine.graduate_verse(0);
+        engine.graduate_verse(1);
+        for (id, kind) in &conditional_ids {
+            assert!(
+                matches!(engine.card(*id).unwrap().state, CardState::New),
+                "{kind:?} ({id:?}) should still be New after graduate_verse"
+            );
+        }
+
+        // graduate_card flips each one. Idempotent on a second call.
+        for (id, _) in &conditional_ids {
+            assert!(engine.graduate_card(*id));
+            assert!(!engine.graduate_card(*id));
+            assert!(matches!(engine.card(*id).unwrap().state, CardState::Active));
+        }
+    }
+
+    #[test]
+    fn graduate_card_returns_false_for_unknown_id() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        assert!(!engine.graduate_card(crate::types::CardId(u32::MAX)));
     }
 
     #[test]

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,39 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.5.0] — 2026-05-28
+
+Lockstep bump for `verse-vault-core@0.5.0` (per-card graduations). `WasmEngine.memorize_session`
+reshapes to surface `HeadingPassage`, `ChapterClubList`, and orphan conditional cards as standalone
+session items the web client walks through steps 1 / 2 / 3 of the memorize flow.
+`WasmEngine.graduate_card` is exposed so those cards graduate independently of any `graduate_verse`
+call. MAJOR per this changelog's rubric — `memorize_session`'s top-level shape changes from
+`Entry[]` to `{ verses: Entry[], orphans: number[] }`, and HP/CCL ids no longer fold into
+`Entry.cardIds`.
+
+### Added
+
+* `WasmEngine.graduate_card(card_id) -> bool` — exposes `ReviewEngine::graduate_card`. Returns
+  whether the card transitioned `New → Active`. Idempotent.
+* `memorize_session` `Entry.hpCardId` / `Entry.cclCardId: number | undefined` — the `HeadingPassage`
+  / `ChapterClubList` card placed immediately after this verse in the reading walkthrough. Omitted
+  (not `null`) when no card attaches here.
+* `memorize_session` top-level `orphans: number[]` — standalone cards that don't anchor to a
+  session-verse: HP/CCL overflow plus conditional verse-bound kinds (`Ftv`, `VerseInHeading`,
+  `VerseInClub`) `New` on already-Active verses (deduped by `heading_idx` / `tier`). Each kind is
+  capped at the call's `limit`, so a session with no fresh verses still honours the configured
+  session max via orphans alone. Omitted when empty.
+
+### Changed
+
+* `memorize_session` returns `{ verses, orphans }` instead of a bare array.
+* `memorize_session` `Entry.cardIds` no longer includes `HeadingPassage` or `ChapterClubList` ids;
+  those live in `hpCardId` / `cclCardId`. Verse-bound conditional kinds on fresh session-verses
+  still appear here (drilled alongside the verse), but graduate independently via `graduate_card`.
+* `memorize_session` `verse_order` now only includes verses with at least one `New` unconditional
+  verse-bound card. A verse whose only `New` cards are conditional orphans (post-settings-flip)
+  doesn't anchor a session-verse; its cards distribute through the top-level `orphans` list.
+
 ## [0.4.0] — 2026-05-28
 
 Lockstep bump for `verse-vault-core@0.4.0`. `WasmEngine.new_card_count` now delegates to the core

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -414,34 +414,74 @@ impl WasmEngine {
     /// for graduation.
     ///
     /// Same per-card filtering rules as `memorize_progression`, plus
-    /// session-scoped pseudo-card placement: a `VerseInHeading` heading
-    /// is drilled on the first verse that introduces it within this
-    /// batch; `HeadingPassage` and `ChapterClubList` cards are attached
-    /// to a session-verse when their trigger conditions are met (any
-    /// heading member started for HP, all chapter+tier members started
-    /// for CCL), capped at one of each kind per verse so backlog cards
-    /// spread instead of piling on a single attach point.
+    /// session-scoped placement of standalone meta cards:
+    ///
+    /// * `HeadingPassage` placed via the per-entry `hp_card_id` slot —
+    ///   HP attaches to its heading's first session-verse, or to any
+    ///   session-verse with capacity (orphan / catch-up).
+    /// * `ChapterClubList` via `ccl_card_id` — CCL attaches to the
+    ///   chapter+tier's last in-session member (or capacity).
+    /// * Conditional verse-bound kinds (`Ftv`, `VerseInHeading`,
+    ///   `VerseInClub`) New on a verse whose unconditional content is
+    ///   already Active surface as orphans in `orphan_card_ids`
+    ///   (deduped by heading_idx / club tier so one per kind per
+    ///   session, round-robined across session-verses).
+    ///
+    /// The web client treats all of those slots as their own reading
+    /// / drill / graduation steps. Graduation goes through
+    /// `graduate_card`, not the host verse's `graduate_verse`.
     pub fn memorize_session(&self, limit: u32) -> Result<String, JsError> {
         use std::collections::{HashMap, HashSet};
         use verse_vault_core::card::{CardKind, CardState};
+        use verse_vault_core::element::ClubTier;
+        use verse_vault_core::engine::is_bulk_graduable;
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Entry {
             verse_id: u32,
+            /// Verse-bound cards drilled with this verse.
             card_ids: Vec<u32>,
-            /// Card id of the verse's Recitation, when emitted. The web
-            /// client uses this to render the whole verse as a plain
-            /// reading prompt during the session's opening + closing
-            /// walkthroughs, avoiding the phrase-0 highlight that a
-            /// PhraseFill render would impose.
+            /// Subset of `card_ids` that need an explicit `graduate_card`
+            /// on step-3 verse graduation. `graduate_verse` already flips
+            /// the rest. Empty when the verse has no conditional kinds
+            /// emitted (Ftv/VerseInHeading/VerseInClub).
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            conditional_card_ids: Vec<u32>,
+            /// Card id of the verse's Recitation, when emitted. The
+            /// reading walkthrough uses this to render the verse text
+            /// without a PhraseFill's phrase-0 highlight.
             recitation_card_id: Option<u32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            hp_card_id: Option<u32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            ccl_card_id: Option<u32>,
+        }
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Session {
+            verses: Vec<Entry>,
+            /// Standalone cards that don't anchor to a session-verse:
+            /// HP/CCL whose attach point overflowed `verse_order` plus
+            /// conditional verse-bound orphans (Ftv/VerseInHeading/
+            /// VerseInClub New on Active verses). Per-kind cap = `limit`.
+            #[serde(skip_serializing_if = "Vec::is_empty")]
+            orphans: Vec<u32>,
         }
         let cards = &self.engine.cards;
 
+        // "Fresh" verses — those with at least one New unconditional
+        // verse-bound card (the set `graduate_verse` flips). Orphan-only
+        // verses (where every New card is a conditional kind on a verse
+        // whose content was already graduated) deliberately don't anchor
+        // a session-verse; their conditional cards distribute into the
+        // orphan slot below.
         let mut seen_verses: HashSet<u32> = HashSet::new();
         let mut verse_order: Vec<u32> = Vec::new();
         for card in cards.iter() {
             if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            if !is_bulk_graduable(&card.kind) {
                 continue;
             }
             if seen_verses.insert(card.verse_id) {
@@ -588,8 +628,9 @@ impl WasmEngine {
         let mut session_headings: HashSet<u16> = HashSet::new();
         let mut entries: Vec<Entry> = Vec::with_capacity(verse_order.len());
 
-        for verse_id in verse_order {
+        for &verse_id in &verse_order {
             let mut card_ids: Vec<u32> = Vec::new();
+            let mut conditional_card_ids: Vec<u32> = Vec::new();
             for card in cards.iter().filter(|c| c.verse_id == verse_id) {
                 match card.kind {
                     CardKind::ChapterClubList { .. }
@@ -606,17 +647,18 @@ impl WasmEngine {
                         });
                         if !already_introduced && session_headings.insert(heading_idx) {
                             card_ids.push(card.id.0);
+                            conditional_card_ids.push(card.id.0);
                         }
+                    }
+                    CardKind::Ftv { .. } | CardKind::VerseInClub { .. } => {
+                        card_ids.push(card.id.0);
+                        conditional_card_ids.push(card.id.0);
                     }
                     _ => card_ids.push(card.id.0),
                 }
             }
-            if let Some(&c) = hp_assigned.get(&verse_id) {
-                card_ids.push(c);
-            }
-            if let Some(&c) = ccl_assigned.get(&verse_id) {
-                card_ids.push(c);
-            }
+            let hp_card_id = hp_assigned.get(&verse_id).copied();
+            let ccl_card_id = ccl_assigned.get(&verse_id).copied();
             let recitation_card_id = cards
                 .iter()
                 .find(|c| c.verse_id == verse_id && matches!(c.kind, CardKind::Recitation))
@@ -624,20 +666,121 @@ impl WasmEngine {
             entries.push(Entry {
                 verse_id,
                 card_ids,
+                conditional_card_ids,
                 recitation_card_id,
+                hp_card_id,
+                ccl_card_id,
             });
         }
 
-        serde_json::to_string(&entries)
-            .map_err(|e| JsError::new(&format!("session serialise error: {e}")))
+        // Build the top-level orphan pool. Five sources, each capped
+        // at `limit` so the session honours the configured max even
+        // when there are no fresh verses to anchor against:
+        //
+        //   * HP overflow (`hp_pending` minus what fit in `verse_order`).
+        //   * CCL overflow (same).
+        //   * Conditional verse-bound kinds (Ftv / VerseInHeading /
+        //     VerseInClub) New on a verse that isn't a session-verse —
+        //     deduped by `heading_idx` / `tier` so multiple orphans of
+        //     the same heading/tier collapse to one.
+        let cap = limit as usize;
+        let mut orphans: Vec<u32> = Vec::new();
+        // HP overflow: ids in `hp_pending` that didn't end up in
+        // `hp_assigned` after the second pass. Budget caps total HP
+        // (placed + overflow) at `limit` per session.
+        let hp_placed_ids: HashSet<u32> = hp_assigned.values().copied().collect();
+        let hp_budget = cap.saturating_sub(hp_placed_ids.len());
+        for &id in hp_pending
+            .iter()
+            .filter(|id| !hp_placed_ids.contains(id))
+            .take(hp_budget)
+        {
+            orphans.push(id);
+        }
+        // CCL overflow, same shape.
+        let ccl_placed_ids: HashSet<u32> = ccl_assigned.values().copied().collect();
+        let ccl_budget = cap.saturating_sub(ccl_placed_ids.len());
+        for &id in ccl_pending
+            .iter()
+            .filter(|id| !ccl_placed_ids.contains(id))
+            .take(ccl_budget)
+        {
+            orphans.push(id);
+        }
+        // Conditional orphans. Each kind capped at `limit`; dedup by
+        // heading_idx / tier so we don't burn the cap on multiple
+        // orphans for the same heading or club.
+        let mut ftv_count = 0usize;
+        let mut vih_count = 0usize;
+        let mut vic_count = 0usize;
+        let mut seen_orphan_headings: HashSet<u16> = HashSet::new();
+        let mut seen_orphan_tiers: HashSet<ClubTier> = HashSet::new();
+        for card in cards.iter() {
+            if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            if session_verses.contains(&card.verse_id) {
+                continue;
+            }
+            match card.kind {
+                CardKind::Ftv { .. } if ftv_count < cap => {
+                    orphans.push(card.id.0);
+                    ftv_count += 1;
+                }
+                CardKind::VerseInHeading { heading_idx }
+                    if seen_orphan_headings.insert(heading_idx) && vih_count < cap =>
+                {
+                    orphans.push(card.id.0);
+                    vih_count += 1;
+                }
+                CardKind::VerseInClub { tier }
+                    if seen_orphan_tiers.insert(tier) && vic_count < cap =>
+                {
+                    orphans.push(card.id.0);
+                    vic_count += 1;
+                }
+                _ => {}
+            }
+        }
+
+        serde_json::to_string(&Session {
+            verses: entries,
+            orphans,
+        })
+        .map_err(|e| JsError::new(&format!("session serialise error: {e}")))
     }
 
-    /// Flip every `New` card belonging to `verse_id` to `Active`. Returns
-    /// the number of cards transitioned. Idempotent. Called by the
-    /// `/memorize` flow after the learner walks the per-verse progression
-    /// and confirms.
+    /// Flip every `New` verse-bound card belonging to `verse_id` to
+    /// `Active`. Returns the number of cards transitioned. Idempotent.
+    /// Called by the `/memorize` flow after the learner walks the
+    /// per-verse progression and confirms.
+    ///
+    /// HeadingPassage and ChapterClubList cards anchored to the same
+    /// verse_id are deliberately skipped — they surface as standalone
+    /// session items in the `memorize_session` shape and graduate via
+    /// `graduate_card`. See `verse-vault-core@0.5.0` for the state
+    /// semantics.
     pub fn graduate_verse(&mut self, verse_id: u32) -> u32 {
         self.engine.graduate_verse(verse_id) as u32
+    }
+
+    /// Flip a single `New` card to `Active` and return whether the
+    /// transition happened (false on unknown card id or already
+    /// non-`New`). Idempotent. Used by the `/memorize` flow to
+    /// graduate HeadingPassage / ChapterClubList cards independently
+    /// of their attach verse.
+    pub fn graduate_card(&mut self, card_id: u32) -> bool {
+        self.engine
+            .graduate_card(verse_vault_core::types::CardId(card_id))
+    }
+
+    /// True when `card_id` belongs to this material's deck. Cheap
+    /// existence probe — the API uses it to distinguish 404 from
+    /// "already graduated" on the per-card graduation endpoint.
+    pub fn has_card(&self, card_id: u32) -> bool {
+        self.engine
+            .card(verse_vault_core::types::CardId(card_id))
+            .is_some()
     }
 
     /// Count of `New` cards eligible for the memorize queue. Drives

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -228,6 +228,157 @@ fn material_config_json_parses_and_filters_emission() {
     );
 }
 
+// Two-verse Club150 chapter with a heading covering both: builder emits
+// one HeadingPassage card and one ChapterClubList card alongside the
+// per-verse content cards.
+const MATERIAL_HP_CCL_JSON: &str = r#"{
+    "year": 3,
+    "books": ["John"],
+    "chapters": [{"book": "John", "number": 3, "start_verse": 16, "end_verse": 17}],
+    "verses": [
+        {"book": "John", "chapter": 3, "verse": 16, "phraseWordCounts": [2, 2], "annotations": [], "clubs": [150]},
+        {"book": "John", "chapter": 3, "verse": 17, "phraseWordCounts": [2, 3], "annotations": [], "clubs": [150]}
+    ],
+    "headings": [{
+        "book": "John",
+        "startChapter": 3, "startVerse": 16,
+        "endChapter": 3, "endVerse": 17
+    }]
+}"#;
+
+#[test]
+fn memorize_session_surfaces_hp_and_ccl_as_standalone_slots() {
+    let engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    let json = engine.memorize_session(10).unwrap();
+    let session: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = session["verses"].as_array().unwrap();
+    let any_hp = entries
+        .iter()
+        .filter_map(|e| e.get("hpCardId").and_then(|v| v.as_u64()))
+        .next();
+    let any_ccl = entries
+        .iter()
+        .filter_map(|e| e.get("cclCardId").and_then(|v| v.as_u64()))
+        .next();
+    assert!(any_hp.is_some(), "expected an hpCardId slot in {json}");
+    assert!(any_ccl.is_some(), "expected a cclCardId slot in {json}");
+    // The HP/CCL ids must not also appear inside any verse's cardIds —
+    // they're surfaced as their own session items now.
+    let all_card_ids: Vec<u64> = entries
+        .iter()
+        .flat_map(|e| e["cardIds"].as_array().unwrap().iter())
+        .map(|v| v.as_u64().unwrap())
+        .collect();
+    assert!(
+        !all_card_ids.contains(&any_hp.unwrap()),
+        "hp card surfaced inside cardIds"
+    );
+    assert!(
+        !all_card_ids.contains(&any_ccl.unwrap()),
+        "ccl card surfaced inside cardIds"
+    );
+}
+
+#[test]
+fn memorize_session_surfaces_orphan_conditional_cards() {
+    // Turn on club_card_scope so VerseInClub cards exist on the Club150
+    // verses. Graduate verse 0 — only its unconditional cards flip,
+    // leaving its VerseInClub `New`. memorize_session must then
+    // surface that orphan as a standalone item on verse 1's entry;
+    // verse 0 no longer anchors a session-verse since it has no fresh
+    // unconditional content.
+    let config_json = r#"{
+        "heading_card": false,
+        "heading_passage_card": true,
+        "ftv": true,
+        "new_scope": "all",
+        "review_scope": "all",
+        "club_card_scope": "all",
+        "chapter_list_scope": "up150",
+        "clubs": {"Club150": "Active"}
+    }"#;
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", 0.9, 0).unwrap();
+    engine.graduate_verse(0);
+    let json = engine.memorize_session(10).unwrap();
+    let session: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = session["verses"].as_array().unwrap();
+    assert_eq!(
+        entries.len(),
+        1,
+        "only verse 1 should anchor a session-verse: {json}"
+    );
+    assert_eq!(entries[0]["verseId"], 1);
+    let orphans = session["orphans"]
+        .as_array()
+        .expect("top-level orphans array should be present");
+    assert!(
+        !orphans.is_empty(),
+        "expected verse 0's orphan VerseInClub to surface: {json}"
+    );
+}
+
+#[test]
+fn memorize_session_surfaces_orphans_when_no_fresh_verses() {
+    // Graduate BOTH verses, then enable VerseInClub via the config so
+    // their VerseInClub cards exist as orphans on already-Active
+    // verses. With no fresh verses left, the session has no
+    // verse-anchored entries — orphans must still surface so the user
+    // can engage with them up to the configured per-session cap.
+    let config_json = r#"{
+        "heading_card": false,
+        "heading_passage_card": true,
+        "ftv": true,
+        "new_scope": "all",
+        "review_scope": "all",
+        "club_card_scope": "all",
+        "chapter_list_scope": "up150",
+        "clubs": {"Club150": "Active"}
+    }"#;
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", 0.9, 0).unwrap();
+    engine.graduate_verse(0);
+    engine.graduate_verse(1);
+    let json = engine.memorize_session(3).unwrap();
+    let session: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = session["verses"].as_array().unwrap();
+    assert!(
+        entries.is_empty(),
+        "no fresh verses should be anchored: {json}"
+    );
+    let orphans = session["orphans"]
+        .as_array()
+        .expect("top-level orphans should be present when verse_order is empty");
+    assert!(
+        !orphans.is_empty(),
+        "expected orphans to surface even without fresh verses: {json}"
+    );
+}
+
+#[test]
+fn graduate_card_flips_one_card_and_is_idempotent() {
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    let json = engine.memorize_session(10).unwrap();
+    let session: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let entries = session["verses"].as_array().unwrap();
+    let hp_id = entries
+        .iter()
+        .filter_map(|e| e.get("hpCardId").and_then(|v| v.as_u64()))
+        .next()
+        .map(|x| x as u32)
+        .expect("hpCardId slot");
+    assert!(engine.graduate_card(hp_id));
+    assert!(!engine.graduate_card(hp_id));
+    // graduate_verse on either verse must NOT flip the HP card —
+    // it stays Active from the explicit graduate_card above. We can't
+    // re-check the HP state through the wire shape here, but a second
+    // graduate_card returns false (already Active), and a fresh engine
+    // confirms graduate_verse alone leaves the HP New.
+    let mut engine2 = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    engine2.graduate_verse(0);
+    engine2.graduate_verse(1);
+    // HP is still New, so graduate_card returns true.
+    assert!(engine2.graduate_card(hp_id));
+}
+
 #[test]
 fn card_count_by_club_returns_buckets_for_full_tier_material() {
     let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,39 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.19] — 2026-05-28
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — `graduate_verse` narrows to the unconditional verse-bound kinds; new
+  `graduate_card` flips a single card. HP, CCL, and conditional verse-bound kinds graduate per-card
+  now. Existing event replay produces a different end state for previously transitively-graduated
+  cards (they revert to New and re-surface in the next memorize session).
+* `verse-vault-wasm@0.5.0` — `memorize_session` returns `{ verses, orphans }`; HP/CCL ids surface
+  via `hpCardId` / `cclCardId` on each verse-entry instead of `cardIds`; orphan conditional cards
+  live in the top-level `orphans` list (per-kind cap = `limit`). New `WasmEngine.graduate_card`
+  export.
+
+### Per-card graduations
+
+New `graduated_cards` table (migration `0019_graduated_cards`) backs the per-card graduation path.
+`graduate_verse` flips only the unconditional verse-bound kinds (per `verse-vault-core@0.5.0`); HP,
+CCL, and the conditional verse-bound kinds (Ftv, VerseInHeading, VerseInClub) graduate via the new
+path.
+
+* **Engine load + rebuild** replay both tables: `graduate_verse` from `graduated_verses` then
+  `graduate_card` from `graduated_cards`. Existing data with conditional kinds previously flipped
+  transitively reverts on load — those cards surface as orphans in the next memorize session and
+  graduate explicitly.
+* **`POST /api/sync/:materialId/events`** accepts a new event kind:
+  `{ kind: 'graduateCard', cardId }`. Same client-event-id dedup, same `accepted` / `duplicates`
+  accounting as `graduate`.
+* **`GET /api/sync/:materialId/state`** gains `graduatedCardIds: number[]` alongside the existing
+  `graduatedVerseIds`, so fat clients can replay both paths after a fresh build.
+* **`POST /api/cards/memorize/graduate-card`** — single-card-graduation endpoint for the web
+  client's standalone HP / CCL / orphan items. Mirrors `/memorize/graduate`'s response shape
+  (`{ graduated: boolean }`).
+
 ### Per-(user, material) target retention
 
 `user_year_settings` gains a `desired_retention` REAL NOT NULL DEFAULT 0.9 column (migration

--- a/packages/api/migrations/0019_graduated_cards.sql
+++ b/packages/api/migrations/0019_graduated_cards.sql
@@ -1,0 +1,15 @@
+-- Per-card graduation log. Cards reach `Active` either through the
+-- bulk-flip path (`graduate_verse` flips the unconditional verse-bound
+-- kinds) or through this per-card path: HeadingPassage, ChapterClubList,
+-- and the conditional verse-bound kinds (Ftv, VerseInHeading,
+-- VerseInClub) all graduate individually via `graduate_card`. On engine
+-- load we replay both tables so a fresh engine matches the user's
+-- progress regardless of which path each card took.
+CREATE TABLE `graduated_cards` (
+	`user_id` text NOT NULL,
+	`material_id` text NOT NULL,
+	`card_id` integer NOT NULL,
+	`graduated_at_secs` integer NOT NULL,
+	PRIMARY KEY(`user_id`, `material_id`, `card_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1779200000000,
       "tag": "0018_user_year_desired_retention",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1779300000000,
+      "tag": "0019_graduated_cards",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -235,9 +235,13 @@ export const testStates = sqliteTable(
 );
 
 // Per-user verse-graduation log. Drives the engine's `CardState::Active`
-// flip after a user walks the memorize progression for a verse. Cards
-// rebuilt from MaterialData start as `New`; on engine load we apply
-// `graduate_verse(verseId)` for every row in this table.
+// flip for the unconditional verse-bound kinds after a user walks the
+// memorize progression for a verse. Cards rebuilt from MaterialData
+// start as `New`; on engine load we apply `graduate_verse(verseId)`
+// for every row in this table. Conditional and multi-verse kinds
+// (Ftv, VerseInHeading, VerseInClub, HeadingPassage, ChapterClubList)
+// graduate via the per-card path in `graduated_cards` instead — see
+// `verse-vault-core@0.5.0` for why.
 export const graduatedVerses = sqliteTable(
   'graduated_verses',
   {
@@ -250,6 +254,25 @@ export const graduatedVerses = sqliteTable(
   },
   (t) => ({
     pk: primaryKey({ columns: [t.userId, t.materialId, t.verseId] }),
+  }),
+);
+
+// Per-card graduation log. Backs the per-card path for HeadingPassage,
+// ChapterClubList, and the conditional verse-bound kinds. On engine
+// load we apply `graduate_card(cardId)` for every row alongside the
+// `graduate_verse` replay from `graduated_verses`.
+export const graduatedCards = sqliteTable(
+  'graduated_cards',
+  {
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    materialId: text('material_id').notNull(),
+    cardId: integer('card_id').notNull(),
+    graduatedAtSecs: integer('graduated_at_secs').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.materialId, t.cardId] }),
   }),
 );
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -213,6 +213,26 @@ export function readGraduatedVerseIds(db: DB, key: EngineKey): number[] {
     .map((r) => r.verseId);
 }
 
+/** Card ids the user has graduated individually for this material —
+ *  HeadingPassage, ChapterClubList, and the conditional verse-bound
+ *  kinds that don't ride along with `graduate_verse`. Replayed by
+ *  `EngineStore.load` + `rebuildFromEvents` alongside the verse
+ *  graduations, and surfaced on the sync /state response so fat
+ *  clients can replay the same way after a fresh build. */
+export function readGraduatedCardIds(db: DB, key: EngineKey): number[] {
+  return db
+    .select({ cardId: schema.graduatedCards.cardId })
+    .from(schema.graduatedCards)
+    .where(
+      and(
+        eq(schema.graduatedCards.userId, key.userId),
+        eq(schema.graduatedCards.materialId, key.materialId),
+      ),
+    )
+    .all()
+    .map((r) => r.cardId);
+}
+
 export function readTestStateEntries(
   db: DB,
   key: EngineKey,
@@ -324,8 +344,14 @@ export class EngineStore {
 
     // Cards built from MaterialData start as `New`; apply every recorded
     // graduation so the in-memory engine matches the user's actual progress.
+    // Verse-bulk first, then per-card — order doesn't matter for state
+    // (graduate_card is a single-card no-op once Active) but it mirrors
+    // the persistence ordering.
     for (const verseId of readGraduatedVerseIds(this.db, key)) {
       engine.graduate_verse(verseId);
+    }
+    for (const cardId of readGraduatedCardIds(this.db, key)) {
+      engine.graduate_card(cardId);
     }
 
     const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
@@ -369,6 +395,9 @@ export class EngineStore {
     // matters for parity with the live-load path, not correctness.
     for (const verseId of readGraduatedVerseIds(this.db, key)) {
       engine.graduate_verse(verseId);
+    }
+    for (const cardId of readGraduatedCardIds(this.db, key)) {
+      engine.graduate_card(cardId);
     }
 
     // Chronological replay. Tiebreak on clientEventId so two events with

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -4,7 +4,7 @@ import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 
 import type { DB } from '../db/client.js';
-import { graduatedVerses } from '../db/schema.js';
+import { graduatedCards, graduatedVerses } from '../db/schema.js';
 import { ApibibleCache, DEFAULT_NKJV_BIBLE_ID } from '../lib/apibible-cache.js';
 import { EngineStore, NotEnrolledError, type TestStateEntry } from '../lib/engine.js';
 import { bookCodeOf } from '../lib/book-codes.js';
@@ -109,11 +109,11 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
       if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
       throw err;
     }
-    const verses = JSON.parse(loaded.engine.memorize_session(max)) as {
-      verseId: number;
-      cardIds: number[];
-    }[];
-    return c.json({ verses });
+    const session = JSON.parse(loaded.engine.memorize_session(max)) as {
+      verses: { verseId: number; cardIds: number[] }[];
+      orphans?: number[];
+    };
+    return c.json({ verses: session.verses, orphans: session.orphans ?? [] });
   });
 
   app.get('/:cardId{[0-9]+}', async (c) => {
@@ -286,6 +286,66 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
         .onConflictDoNothing()
         .run();
       return c.json({ graduated: count });
+    });
+  });
+
+  app.post('/memorize/graduate-card', async (c) => {
+    let body: { materialId?: string; cardId?: number };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid JSON body' }, 400);
+    }
+    if (typeof body.materialId !== 'string') {
+      return c.json({ error: 'materialId required' }, 400);
+    }
+    if (typeof body.cardId !== 'number' || !Number.isInteger(body.cardId)) {
+      return c.json({ error: 'cardId required (integer)' }, 400);
+    }
+    const user = getUser(c);
+    const materialId = body.materialId;
+    const cardId = body.cardId;
+    const key = { userId: user.id, materialId };
+    let loaded;
+    try {
+      loaded = await deps.engines.load(key);
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
+      throw err;
+    }
+
+    const nowSecs = now();
+    return deps.engines.withLock(key, async () => {
+      const flipped = loaded.engine.graduate_card(cardId);
+      if (!flipped) {
+        // Distinguish "already graduated" (idempotent, row exists) from
+        // "unknown card" (404). `graduated_cards` plus the verse-bulk
+        // path together cover every graduated card; check both.
+        const existingCard = deps.db
+          .select({ cardId: graduatedCards.cardId })
+          .from(graduatedCards)
+          .where(
+            and(
+              eq(graduatedCards.userId, user.id),
+              eq(graduatedCards.materialId, materialId),
+              eq(graduatedCards.cardId, cardId),
+            ),
+          )
+          .get();
+        if (existingCard) return c.json({ graduated: false });
+        // Not in graduated_cards. Either the card_id doesn't exist or
+        // its verse was bulk-graduated via graduate_verse (no-op here).
+        if (!loaded.engine.has_card(cardId)) {
+          return c.json({ error: 'Unknown card' }, 404);
+        }
+        return c.json({ graduated: false });
+      }
+      deps.db
+        .insert(graduatedCards)
+        .values({ userId: user.id, materialId, cardId, graduatedAtSecs: nowSecs })
+        .onConflictDoNothing()
+        .run();
+      return c.json({ graduated: true });
     });
   });
 

--- a/packages/api/src/routes/sync.test.ts
+++ b/packages/api/src/routes/sync.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { graduatedVerses, reviewEvents, testStates } from '../db/schema.js';
+import { graduatedCards, graduatedVerses, reviewEvents, testStates } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
 import { type TestApp, createTestApp, signUpTestUser } from '../test-utils.js';
 
@@ -24,6 +24,7 @@ interface StateResponse {
   testStates: TestStateWire[];
   lastEventId: string | null;
   graduatedVerseIds: number[];
+  graduatedCardIds: number[];
 }
 
 interface UploadResponse {
@@ -324,6 +325,58 @@ describe('sync routes', () => {
     });
     const stateBody = (await stateRes.json()) as StateResponse;
     expect(stateBody.graduatedVerseIds).toEqual([0]);
+  });
+
+  it('accepts a graduateCard event and writes graduatedCards', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie, userId } = await enroll(test, 'alice@example.com');
+
+    // card_id 0 belongs to the first verse's first card; for the wire
+    // protocol test the kind doesn't matter — graduate_card flips any
+    // New card to Active.
+    const grad = {
+      kind: 'graduateCard' as const,
+      clientEventId: randomUUID(),
+      timestampSecs: 1_700_000_000,
+      snapshotVersion: 1,
+      cardId: 0,
+    };
+    const res = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [grad] }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as UploadResponse;
+    expect(body.accepted).toBe(1);
+    expect(body.duplicates).toBe(0);
+
+    const rows = test.db.select().from(graduatedCards).all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].userId).toBe(userId);
+    expect(rows[0].cardId).toBe(0);
+
+    // Re-applying the graduation is a no-op (graduate_card returns
+    // false once the card is Active). Same accounting as graduate.
+    const grad2 = { ...grad, clientEventId: randomUUID() };
+    const res2 = await test.app.request(`/api/sync/${MATERIAL_ID}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({ events: [grad2] }),
+    });
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as UploadResponse;
+    expect(body2.accepted).toBe(0);
+    expect(body2.duplicates).toBe(1);
+
+    // /state surfaces graduatedCardIds alongside graduatedVerseIds so
+    // a fresh client engine can re-apply both paths.
+    const stateRes = await test.app.request(`/api/sync/${MATERIAL_ID}/state`, {
+      headers: { cookie },
+    });
+    const stateBody = (await stateRes.json()) as StateResponse;
+    expect(stateBody.graduatedCardIds).toEqual([0]);
   });
 
   it('triggers a rebuild when an older event arrives after a newer one', async () => {

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -8,6 +8,7 @@ import {
   NotEnrolledError,
   type TestStateEntry,
   getLatestSnapshot,
+  readGraduatedCardIds,
   readGraduatedVerseIds,
   readTestStateEntries,
 } from '../lib/engine.js';
@@ -46,7 +47,12 @@ interface GraduateEventUpload extends BaseEventUpload {
   verseId: number;
 }
 
-type SyncEventUpload = ReviewEventUpload | GraduateEventUpload;
+interface GraduateCardEventUpload extends BaseEventUpload {
+  kind: 'graduateCard';
+  cardId: number;
+}
+
+type SyncEventUpload = ReviewEventUpload | GraduateEventUpload | GraduateCardEventUpload;
 
 interface UploadBody {
   events: SyncEventUpload[];
@@ -66,7 +72,7 @@ interface TestUpdateWire {
   kind: 'Root' | 'Sub';
 }
 
-function eventKind(e: SyncEventUpload): 'review' | 'graduate' {
+function eventKind(e: SyncEventUpload): 'review' | 'graduate' | 'graduateCard' {
   return e.kind ?? 'review';
 }
 
@@ -94,10 +100,13 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       testStates: readTestStateEntries(deps.db, key),
       lastEventId: latestEventId(deps.db, user.id, materialId),
       // Cards default to `New` when the client constructs the engine
-      // from materialData + testStates; ship the graduation log so the
+      // from materialData + testStates; ship the graduation logs so the
       // client can flip the right cards to `Active` after build,
-      // mirroring what `EngineStore.load` does server-side.
+      // mirroring what `EngineStore.load` does server-side. Two paths:
+      // `graduate_verse` for the unconditional verse-bound kinds, and
+      // `graduate_card` for HP / CCL / conditional kinds.
       graduatedVerseIds: readGraduatedVerseIds(deps.db, key),
+      graduatedCardIds: readGraduatedCardIds(deps.db, key),
     });
   });
 
@@ -261,14 +270,16 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       const touchedKeys = new Set<string>();
       const reviewEventInputs: ReviewEventInput[] = [];
       const graduations: { verseId: number; timestampSecs: number }[] = [];
+      const cardGraduations: { cardId: number; timestampSecs: number }[] = [];
       // Graduate events whose `engine.graduate_verse` returned 0 (verse was
       // already Active before this batch) are counted alongside
       // clientEventId duplicates: they're no-ops the client should not
-      // expect to flip any cards.
+      // expect to flip any cards. Same accounting for graduateCard.
       let graduateNoops = 0;
 
       for (const e of fresh) {
-        if (eventKind(e) === 'graduate') {
+        const kind = eventKind(e);
+        if (kind === 'graduate') {
           const ge = e as GraduateEventUpload;
           // On the in-order path we apply to the cached engine for the
           // no-op count. On the rebuild path the cached engine is about
@@ -277,6 +288,11 @@ export function syncRoutes(deps: SyncRoutesDeps) {
           const count = loaded.engine.graduate_verse(ge.verseId);
           if (count === 0) graduateNoops += 1;
           graduations.push({ verseId: ge.verseId, timestampSecs: ge.timestampSecs });
+        } else if (kind === 'graduateCard') {
+          const gc = e as GraduateCardEventUpload;
+          const flipped = loaded.engine.graduate_card(gc.cardId);
+          if (!flipped) graduateNoops += 1;
+          cardGraduations.push({ cardId: gc.cardId, timestampSecs: gc.timestampSecs });
         } else {
           const re = e as ReviewEventUpload;
           if (!outOfOrder) {
@@ -324,6 +340,17 @@ export function syncRoutes(deps: SyncRoutesDeps) {
                 userId: user.id,
                 materialId,
                 verseId: g.verseId,
+                graduatedAtSecs: g.timestampSecs,
+              })
+              .onConflictDoNothing()
+              .run();
+          }
+          for (const g of cardGraduations) {
+            tx.insert(schema.graduatedCards)
+              .values({
+                userId: user.id,
+                materialId,
+                cardId: g.cardId,
                 graduatedAtSecs: g.timestampSecs,
               })
               .onConflictDoNothing()
@@ -423,6 +450,11 @@ function validateUpload(e: SyncEventUpload, nowSecs: number): string | null {
     const ge = e as GraduateEventUpload;
     if (!Number.isInteger(ge.verseId) || ge.verseId < 0) {
       return 'verseId must be a non-negative integer';
+    }
+  } else if (kind === 'graduateCard') {
+    const gc = e as GraduateCardEventUpload;
+    if (!Number.isInteger(gc.cardId) || gc.cardId < 0) {
+      return 'cardId must be a non-negative integer';
     }
   } else {
     return `unknown event kind: ${String((e as { kind: unknown }).kind)}`;


### PR DESCRIPTION
## Summary

- `verse-vault-core@0.5.0` — `graduate_verse` narrows to the unconditional verse-bound kinds (PhraseFill, Recitation, Citation, VerseAtVerseRef, VerseInChapter, VerseInBook); new `graduate_card` flips one card; `is_bulk_graduable` exposed.
- `verse-vault-wasm@0.5.0` — `memorize_session` returns `{ verses, orphans }`; each verse entry carries `hpCardId` / `cclCardId` / `conditionalCardIds`; per-kind cap = `limit` (the year's `lessonBatchSize`). New `WasmEngine.graduate_card` + `has_card` exports.
- `@verse-vault/api@0.1.19` — new `graduated_cards` table (migration 0019), `POST /api/sync/:materialId/events` accepts `{ kind: 'graduateCard', cardId }`, `/state` exposes `graduatedCardIds`, new `POST /api/cards/memorize/graduate-card`.
- `@verse-vault/web@0.1.18` — `MemorizeView` walks each session item independently. HP (after the heading's first verse), CCL (after the chapter's last verse), and orphan conditional cards (top-level, distributed per year) each get their own step-1 "Already memorized / Next", step-2 drill slot (flat shuffle), and step-3 "Graduate / Not yet" prompt. Verse graduation emits `graduate_verse` plus `graduate_card` events for the entry's `conditionalCardIds` (in parallel); standalone items go straight to `graduate_card`.

**Existing-data regression** (intentional): on engine load, the new `graduate_verse` replay no longer flips Ftv / VerseInHeading / VerseInClub / HP / CCL. Cards previously transitively-graduated revert to `New` and surface in the next memorize session for explicit re-engagement.

**Orphan-only sessions** (no fresh verses): the per-kind cap defaults to the year's `lessonBatchSize` so orphans from a settings flip still surface up to the configured session max even when no new verses are queued.

## Test plan

- [x] `cargo test` — 130+ tests passing
- [x] `cargo clippy` clean
- [x] `pnpm --filter @verse-vault/api run test` — 102 tests passing
- [x] `pnpm --filter @verse-vault/web run type-check` clean
- [x] `node crates/wasm/test-smoke.js` — smoke green
- [ ] **Manual UI smoke** — not done in this session; needs a `pnpm --filter @verse-vault/web dev` walkthrough of the new memorize flow:
  - [ ] Step 1: verse + HP/CCL/orphan each show their own page
  - [ ] Step 2: flat shuffle across verse cards + standalone items
  - [ ] Step 3: graduate each item; verse emits `graduate_verse` + parallel `graduate_card` per conditional; standalone goes straight to `graduate_card`
  - [ ] Settings-flip orphan path: graduate a verse, toggle `heading_card` on, re-enter `/memorize` → new VerseInHeading surfaces as orphan
  - [ ] Orphan-only session (year fully memorized + setting flipped): orphans surface up to `lessonBatchSize` even with no fresh verses