### PR TITLE
feat(api): EngineStore eviction (LRU + idle TTL)

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,43 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.20] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### EngineStore eviction (closes #13)
+
+`EngineStore.cache` was an unbounded `Map` — every (user, material) pair ever loaded stayed resident
+until process restart, holding a Rust-side `WasmEngine` whose heap the JS GC can't reclaim. Fine at
+single-dev scale, monotone RAM growth at multi-user scale.
+
+* **LRU cap** (default 128 entries). On cache insert with the cap reached, the entry with the oldest
+  `lastUsedAt` is evicted to make room. Cache hits bump `lastUsedAt` so the recently-used set
+  survives pressure.
+* **Idle TTL** (default 7200 s = 2 h). A background reaper walks the cache every
+  `reaperIntervalSecs` (default 60 s) and evicts entries idle past the TTL. 2 h is long enough to
+  bridge a within-visit pause (lunch break between memorize and review) and short enough to clean up
+  between typical inter-visit gaps (~12 h for once-a-day users).
+* **Refcounted handles + deferred `free()`.** `EngineStore.load()` returns a `Disposable`
+  `LoadedEngine`; route handlers bind it with `using` so dispose fires at scope exit and the cache
+  entry's refcount drops. `drainPendingFree` only calls `engine.free()` when refcount is zero AND
+  the 30 s grace period has elapsed — the refcount pin guarantees correctness even if a handler
+  stashes a handle across a slow `await` (api.bible fetch), and the grace period catches any code
+  path that escapes the `using` contract by mistake. New `tryLoad(key)` returns `null` instead of
+  throwing `NotEnrolledError`, which composes with `using` more naturally than the prior try/catch
+  pattern.
+* **Reaper lifecycle**: `EngineStore.start()` is called from `src/index.ts` (production entry
+  point), not `createApp`, so tests using `createTestApp` don't accumulate one `setInterval` per app
+  instance. `createApp` returns `{ app, engines }` so the entry point can reach the store.
+  `.unref()` on the timer keeps SIGTERM exits clean even without an explicit `stop()`.
+
+User-visible effect: none. An evicted user's next request rebuilds the engine from disk state via
+the existing cold-load path (~50 ms). At launch scale this prevents the "server lasts a day before
+needing a restart" failure mode; at single-dev scale it's invisible.
+
 ## [0.1.19] — 2026-05-28
 
 ### Bundled algorithm contract

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -36,6 +36,12 @@ export interface AppDeps {
 
 export function createApp(deps: AppDeps) {
   const auth = createAuth(deps.db, deps.authEnv);
+  // EngineStore's idle reaper is intentionally NOT started here.
+  // `createApp` constructs the wiring; lifecycle hooks (start the
+  // reaper, listen on a port) live in the production entry point
+  // (`src/index.ts`). Tests reach in via `createTestApp` and
+  // construct their own short-lived processes, so they neither need
+  // nor want a 60 s setInterval per `createApp` call.
   const engines = new EngineStore(deps.db, undefined, deps.now);
   const apibibleCache = deps.bibleApiKey
     ? new ApibibleCache(deps.db, deps.bibleApiKey, deps.now)
@@ -117,5 +123,5 @@ export function createApp(deps: AppDeps) {
   app.route('/api/stats', statsRoutes({ db: deps.db, engines, now: deps.now }));
   app.route('/api/activity', activityRoutes({ db: deps.db, now: deps.now }));
 
-  return app;
+  return { app, engines };
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -30,7 +30,7 @@ const authEnv = {
 const dbPath = process.env.DATABASE_PATH ?? resolve(import.meta.dirname, '../data/verse-vault.db');
 runMigrations(dbPath);
 
-const app = createApp({
+const { app, engines } = createApp({
   db: createDb(dbPath),
   authEnv,
   // BIBLE_API_KEY (or API_BIBLE_KEY) gates the api.bible cache. Without
@@ -45,6 +45,11 @@ const app = createApp({
     ? (process.env.RENDER_DIALECT as 'american' | 'british' | 'canadian')
     : 'canadian',
 });
+
+// Start the EngineStore idle reaper here, not in createApp — tests
+// spin up many short-lived apps via createTestApp and don't want a
+// 60 s setInterval accumulating per call.
+engines.start();
 
 const port = Number(process.env.PORT ?? 3000);
 serve({ fetch: app.fetch, port }, (info) => {

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -1,6 +1,7 @@
 import { and, eq } from 'drizzle-orm';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import type { DB } from '../db/client.js';
 import { graphSnapshots, testStates as testStatesTable } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
 import { createTestDb, createTestUser } from '../test-utils.js';
@@ -304,5 +305,228 @@ describe('EngineStore', () => {
     await Promise.all([first, second]);
     expect(order).toEqual([1, 2, 3, 4]);
     store.clear();
+  });
+});
+
+describe('EngineStore eviction', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  function seed(db: DB, userId: string, materialId = 'nkjv-cor') {
+    seedUserWithFixture({ db, userId, materialId });
+  }
+
+  it('LRU evicts the least-recently-used entry when over the cap', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+    seed(test.db, 'u2');
+    seed(test.db, 'u3');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock, undefined, { maxEntries: 2 });
+
+    clock = 100;
+    const u1Orig = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    clock = 200;
+    const u2Orig = await store.load({ userId: 'u2', materialId: 'nkjv-cor' });
+    clock = 300;
+    await store.load({ userId: 'u3', materialId: 'nkjv-cor' });
+
+    // Inserting u3 with the cache full at maxEntries=2 should evict u1
+    // (oldest lastUsedAt=100). u2 was used at 200 so it survives.
+    clock = 400;
+    const u1Reload = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(u1Reload.engine).not.toBe(u1Orig.engine);
+    // The reload of u1 also evicts the LRU at this point (u2@200 since
+    // u3@300 is newer), so testing u2 here would also see a fresh engine.
+    // The u1 != u1Orig check above is enough to confirm LRU eviction
+    // happened on the first u3 insert. u2Orig kept just to anchor the
+    // setup ordering.
+    void u2Orig;
+    store.clear();
+  });
+
+  it('cache hit bumps lastUsedAt so the recently-used entry survives eviction', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+    seed(test.db, 'u2');
+    seed(test.db, 'u3');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock, undefined, { maxEntries: 2 });
+
+    clock = 100;
+    const u1Orig = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    clock = 200;
+    await store.load({ userId: 'u2', materialId: 'nkjv-cor' });
+    clock = 300;
+    // Cache hit on u1 should bump its lastUsedAt to 300, making u2 the LRU.
+    await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    clock = 400;
+    await store.load({ userId: 'u3', materialId: 'nkjv-cor' });
+
+    // u2 was the LRU (lastUsed=200) so it should have been evicted, not u1.
+    clock = 500;
+    const u1AfterPressure = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(u1AfterPressure.engine).toBe(u1Orig.engine);
+    store.clear();
+  });
+
+  it('reap() evicts entries idle past idleTtlSecs', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+      idleTtlSecs: 50,
+    });
+
+    clock = 100;
+    const u1Orig = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+
+    // Within TTL — reap is a no-op.
+    clock = 140;
+    store.reap();
+    const u1Within = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(u1Within.engine).toBe(u1Orig.engine);
+
+    // Past TTL — reap evicts.
+    clock = 300;
+    store.reap();
+    clock = 400;
+    const u1Past = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    expect(u1Past.engine).not.toBe(u1Orig.engine);
+    store.clear();
+  });
+
+  it('evicted engines defer free() until the grace period elapses', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+      idleTtlSecs: 50,
+    });
+
+    clock = 100;
+    const handle = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    // Dispose synchronously so refcount drops to 0; the test exercises
+    // the grace-period gate, not the refcount-pin path.
+    handle[Symbol.dispose]();
+
+    // Past TTL → evicts to pending. Grace period (30s) hasn't elapsed.
+    clock = 200;
+    store.reap();
+    expect((store as unknown as { pendingFree: unknown[] }).pendingFree.length).toBe(1);
+
+    // Still within grace at +29s after eviction. Another reap doesn't drain.
+    clock = 229;
+    store.reap();
+    expect((store as unknown as { pendingFree: unknown[] }).pendingFree.length).toBe(1);
+
+    // Past grace at +31s. Reap drains the pending entry.
+    clock = 231;
+    store.reap();
+    expect((store as unknown as { pendingFree: unknown[] }).pendingFree.length).toBe(0);
+
+    store.clear();
+  });
+
+  it('invalidate() defers free() via pendingFree', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock);
+
+    const handle = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    handle[Symbol.dispose]();
+
+    store.invalidate({ userId: 'u1', materialId: 'nkjv-cor' });
+    // Cache entry gone; engine sits in pendingFree, not freed yet.
+    const internal = store as unknown as {
+      cache: Map<string, unknown>;
+      pendingFree: unknown[];
+    };
+    expect(internal.cache.size).toBe(0);
+    expect(internal.pendingFree.length).toBe(1);
+
+    // Past grace → next reap drains it.
+    clock = 200;
+    store.reap();
+    expect(internal.pendingFree.length).toBe(0);
+
+    store.clear();
+  });
+
+  it('live LoadedEngine handle pins entry against free even past grace', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seed(test.db, 'u1');
+
+    let clock = 100;
+    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+      idleTtlSecs: 50,
+    });
+
+    clock = 100;
+    const held = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+    const internal = store as unknown as { pendingFree: unknown[] };
+
+    // Evict at clock=200 (past TTL). evictedAt is recorded as 200.
+    clock = 200;
+    store.reap();
+    expect(internal.pendingFree.length).toBe(1);
+
+    // Advance well past grace. Drain still skips because refcount > 0.
+    clock = 1000;
+    store.reap();
+    expect(internal.pendingFree.length).toBe(1);
+
+    // Underlying engine is still callable through the pinned handle.
+    expect(() => held.engine.new_card_count()).not.toThrow();
+
+    // Disposing the handle drops refcount → opportunistic drain fires
+    // inside the release path. At clock=1000, evictedAt=200 is past
+    // grace (cutoff=970), and refcount is now 0, so the entry frees.
+    held[Symbol.dispose]();
+    expect(internal.pendingFree.length).toBe(0);
+
+    store.clear();
+  });
+
+  it('start() and stop() are idempotent; clear() stops the reaper', () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+
+    // Pick a long interval so the timer never actually fires under the test.
+    const store = new EngineStore(test.db, 0.9, () => 0, undefined, {
+      reaperIntervalSecs: 3600,
+    });
+
+    const internal = store as unknown as { reaperHandle: NodeJS.Timeout | null };
+    expect(internal.reaperHandle).toBeNull();
+
+    store.start();
+    expect(internal.reaperHandle).not.toBeNull();
+    store.start();
+    expect(internal.reaperHandle).not.toBeNull();
+
+    store.stop();
+    expect(internal.reaperHandle).toBeNull();
+    store.stop();
+    expect(internal.reaperHandle).toBeNull();
+
+    store.start();
+    store.clear();
+    expect(internal.reaperHandle).toBeNull();
   });
 });

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -52,9 +52,29 @@ const DEFAULT_DESIRED_RETENTION = 0.9;
 
 export type EngineKey = UserMaterial;
 
-export interface LoadedEngine {
+/** Reference-counted handle returned by `EngineStore.load`. Implements
+ *  `Symbol.dispose` so callers use `using` to bind it:
+ *
+ *      using loaded = await engines.load(key);
+ *      loaded.engine.next_review_card(...);
+ *
+ *  The cache entry's refcount tracks live handles; eviction queues the
+ *  entry but `engine.free()` doesn't fire until both the grace period
+ *  elapses AND refcount reaches zero. Holding a handle across a slow
+ *  `await` is safe — the WASM heap is pinned until dispose. */
+export interface LoadedEngine extends Disposable {
+  readonly engine: WasmEngine;
+  readonly snapshotVersion: number;
+}
+
+/** Internal cache entry. The refcount tracks outstanding `LoadedEngine`
+ *  handles returned from `load`; eviction can move an entry to
+ *  `pendingFree`, but `drainPendingFree` won't call `engine.free()` until
+ *  refcount drops to zero. */
+interface CacheEntry {
   engine: WasmEngine;
   snapshotVersion: number;
+  refcount: number;
 }
 
 /** Thrown by `EngineStore.load` when the caller isn't enrolled in the material. */
@@ -267,11 +287,40 @@ export function readTestStateEntries(
     });
 }
 
+export interface EvictionOptions {
+  /** Hard cap on cached engines. The least-recently-used entry is
+   *  evicted to make room when a `load()` would otherwise exceed this.
+   *  Sized as a safety net for unexpected concurrent peaks; the idle
+   *  TTL does the day-to-day cleanup. */
+  maxEntries?: number;
+  /** Cached engines whose last use is older than this many seconds are
+   *  evicted on the next reaper tick. Should comfortably exceed a
+   *  typical visit duration (so we don't churn mid-session) while
+   *  staying well below the inter-visit gap (so dormant users don't
+   *  pile up in RAM). */
+  idleTtlSecs?: number;
+  /** How often the reaper walks the cache. */
+  reaperIntervalSecs?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 128;
+const DEFAULT_IDLE_TTL_SECS = 7200;
+const DEFAULT_REAPER_INTERVAL_SECS = 60;
+
+/** Evicted engines wait this long before `engine.free()` is called on
+ *  them. Bridges in-flight requests that captured a `LoadedEngine`
+ *  reference before eviction so their next `engine.method()` call
+ *  doesn't hit a freed WASM handle. The longest realistic request path
+ *  (api.bible cache fetch + DB transaction) comfortably fits in 30 s. */
+const PENDING_FREE_GRACE_SECS = 30;
+
 /**
  * Per-(user, material) engine cache + serialisation.
  *
  * Cache: WasmEngine instances live across requests so we don't re-parse the
- * MaterialData blob on every call.
+ * MaterialData blob on every call. Bounded by an LRU cap + idle TTL —
+ * see `EvictionOptions`. The reaper has to be started explicitly via
+ * `start()` so tests can drive eviction synchronously via `reap()`.
  *
  * Serialisation: `WasmEngine.replay_event` is `&mut self` at the WASM
  * boundary. Two concurrent reviews for the same (user, material) — e.g.
@@ -281,8 +330,20 @@ export function readTestStateEntries(
  * enough for single-tab usage.
  */
 export class EngineStore {
-  private readonly cache = new Map<string, LoadedEngine>();
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly lastUsedAt = new Map<string, number>();
   private readonly tails = new Map<string, Promise<unknown>>();
+  /** Entries that have left the cache but whose `engine.free()` is
+   *  deferred until **both** the grace period elapses **and** their
+   *  refcount drops to zero. Two safety mechanisms in one queue:
+   *  refcount tracks live `LoadedEngine` handles (request-scoped), the
+   *  grace period catches handles that escape — e.g. a future code
+   *  change that stashes a `LoadedEngine` somewhere it shouldn't. */
+  private readonly pendingFree: { entry: CacheEntry; evictedAt: number }[] = [];
+  private reaperHandle: NodeJS.Timeout | null = null;
+  private readonly maxEntries: number;
+  private readonly idleTtlSecs: number;
+  private readonly reaperIntervalSecs: number;
 
   constructor(
     private readonly db: DB,
@@ -292,8 +353,23 @@ export class EngineStore {
      *  inject a stub to drive snapshot-bump scenarios; production
      *  defaults to the on-disk loader. */
     private readonly loadBundledJson: (id: string) => string = getMaterialJson,
-  ) {}
+    options: EvictionOptions = {},
+  ) {
+    this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.idleTtlSecs = options.idleTtlSecs ?? DEFAULT_IDLE_TTL_SECS;
+    this.reaperIntervalSecs = options.reaperIntervalSecs ?? DEFAULT_REAPER_INTERVAL_SECS;
+  }
 
+  /**
+   * Resolve the cached engine for `(user, material)`, building it from
+   * disk on a cold miss. Returns a `LoadedEngine` handle that pins the
+   * underlying `WasmEngine` against deferred-free for as long as the
+   * handle is alive — callers MUST bind it with `using` so dispose
+   * fires at scope exit:
+   *
+   *     using loaded = await engines.load(key);
+   *     loaded.engine.next_review_card(...);
+   */
   async load(key: EngineKey): Promise<LoadedEngine> {
     // Detect content updates before consulting the cache: bundled
     // materialData changes need to bump the user's snapshot and drop
@@ -328,8 +404,12 @@ export class EngineStore {
       };
     }
 
-    const cached = this.cache.get(userMaterialKey(key));
-    if (cached) return cached;
+    const k = userMaterialKey(key);
+    const cached = this.cache.get(k);
+    if (cached) {
+      this.lastUsedAt.set(k, this.now());
+      return this.acquire(cached);
+    }
 
     const materialJson = snapshot.materialData.toString('utf8');
     const testStates = readTestStateEntries(this.db, key, materialJson);
@@ -354,9 +434,26 @@ export class EngineStore {
       engine.graduate_card(cardId);
     }
 
-    const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
-    this.cache.set(userMaterialKey(key), loaded);
-    return loaded;
+    return this.cacheInsert(k, { engine, snapshotVersion: snapshot.version, refcount: 0 });
+  }
+
+  /** Convenience wrapper that returns `null` instead of throwing
+   *  `NotEnrolledError`. Lets route handlers handle the not-enrolled
+   *  case with a guard + early-return before binding the result to a
+   *  `using` declaration:
+   *
+   *      const raw = await engines.tryLoad(key);
+   *      if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+   *      using loaded = raw;
+   *      loaded.engine.next_review_card(...);
+   */
+  async tryLoad(key: EngineKey): Promise<LoadedEngine | null> {
+    try {
+      return await this.load(key);
+    } catch (err) {
+      if (err instanceof NotEnrolledError) return null;
+      throw err;
+    }
   }
 
   /**
@@ -436,25 +533,30 @@ export class EngineStore {
       writeTestStates(tx, key.userId, key.materialId, rebuiltStates, { onConflict: false });
     });
 
-    // Replace the cached engine. invalidate() frees the old one if any.
+    // Replace the cached engine. invalidate() defers free on the old one if any.
     this.invalidate(key);
-    const loaded: LoadedEngine = { engine, snapshotVersion: snapshot.version };
-    this.cache.set(userMaterialKey(key), loaded);
-    return loaded;
+    return this.cacheInsert(userMaterialKey(key), {
+      engine,
+      snapshotVersion: snapshot.version,
+      refcount: 0,
+    });
   }
 
   /**
    * Drop the cached engine for this key. The next `load` rebuilds from
    * fresh DB state — used after material-picker writes change either the
    * per-year toggles or the per-club paused set.
+   *
+   * Routes through `evictToPending` so the old engine sits in the
+   * deferred-free queue rather than being released synchronously.
+   * Matches the LRU + TTL eviction paths and removes a load-bearing
+   * "every caller holds withLock" convention from the contract — a
+   * future request handler that holds a `LoadedEngine` reference
+   * across an await won't crash on the next `engine.method()` call if
+   * a settings change invalidates the entry in the meantime.
    */
   invalidate(key: EngineKey): void {
-    const k = userMaterialKey(key);
-    const cached = this.cache.get(k);
-    if (cached) {
-      cached.engine.free();
-      this.cache.delete(k);
-    }
+    this.evictToPending(userMaterialKey(key));
   }
 
   /**
@@ -474,9 +576,143 @@ export class EngineStore {
     return next;
   }
 
+  /** Start the background idle reaper. Idempotent. Production calls
+   *  this from `src/index.ts` (after `createApp` returns); tests
+   *  prefer driving `reap()` directly so eviction is deterministic. */
+  start(): void {
+    if (this.reaperHandle !== null) return;
+    const handle = setInterval(() => this.reap(), this.reaperIntervalSecs * 1000);
+    // unref so the timer doesn't keep the process alive on its own —
+    // SIGTERM exits cleanly even if `stop()` is never called.
+    handle.unref();
+    this.reaperHandle = handle;
+  }
+
+  /** Stop the background idle reaper. Idempotent. */
+  stop(): void {
+    if (this.reaperHandle === null) return;
+    clearInterval(this.reaperHandle);
+    this.reaperHandle = null;
+  }
+
+  /** Walk the cache, evict entries idle past the TTL, then free any
+   *  previously-evicted engines whose grace period has elapsed.
+   *  Exposed (not private) so tests can drive eviction deterministically
+   *  with an injected clock. */
+  reap(): void {
+    const cutoff = this.now() - this.idleTtlSecs;
+    const idleKeys: string[] = [];
+    for (const [k, t] of this.lastUsedAt) {
+      // Strict `<` matches the "older than" wording of `idleTtlSecs`:
+      // an entry used at exactly `cutoff` is at TTL, not past it.
+      if (t < cutoff) idleKeys.push(k);
+    }
+    for (const k of idleKeys) this.evictToPending(k);
+    this.drainPendingFree();
+  }
+
+  /** Insert into the cache. Single call site for `cache.set` +
+   *  `lastUsedAt.set` so the two maps can't drift, and the LRU
+   *  eviction trigger lives next to the insertion that triggers it.
+   *  Bumps refcount via `acquire` so the caller's returned handle
+   *  pins the freshly-built entry against eviction-then-free races. */
+  private cacheInsert(k: string, entry: CacheEntry): LoadedEngine {
+    this.evictLruIfFull();
+    this.cache.set(k, entry);
+    this.lastUsedAt.set(k, this.now());
+    return this.acquire(entry);
+  }
+
+  /** Bump refcount and wrap as a `Disposable` `LoadedEngine`. `Symbol.dispose`
+   *  decrements; when refcount hits zero we opportunistically drain
+   *  `pendingFree` so an entry whose grace already elapsed gets freed
+   *  the moment its last reference goes away. */
+  private acquire(entry: CacheEntry): LoadedEngine {
+    entry.refcount += 1;
+    const release = () => {
+      entry.refcount -= 1;
+      if (entry.refcount === 0) this.drainPendingFree();
+    };
+    return {
+      get engine() {
+        return entry.engine;
+      },
+      get snapshotVersion() {
+        return entry.snapshotVersion;
+      },
+      [Symbol.dispose]: release,
+    };
+  }
+
+  /** Evict the least-recently-used entry until the cache is under the
+   *  cap. Called from each cache insertion path. Opportunistically
+   *  drains `pendingFree` first so a burst of LRU evictions doesn't let
+   *  the deferred-free queue accumulate between reaper ticks.
+   *
+   *  Iterates `cache.keys()` rather than `lastUsedAt` so the loop can
+   *  only see authoritative entries — a `lastUsedAt` entry without a
+   *  matching `cache` entry (shouldn't happen, but a future code change
+   *  could introduce a window) wouldn't make this spin. A `cache`
+   *  entry missing its `lastUsedAt` row is treated as oldest. */
+  private evictLruIfFull(): void {
+    this.drainPendingFree();
+    while (this.cache.size >= this.maxEntries) {
+      let oldestKey: string | null = null;
+      let oldestTime = Infinity;
+      for (const k of this.cache.keys()) {
+        const t = this.lastUsedAt.get(k) ?? -Infinity;
+        if (t < oldestTime) {
+          oldestTime = t;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey === null) break;
+      this.evictToPending(oldestKey);
+    }
+  }
+
+  /** Move a cached entry to the pending-free queue without freeing.
+   *  An in-flight request may still hold the `LoadedEngine` reference;
+   *  `drainPendingFree` calls `free()` only when both the grace
+   *  period has elapsed AND refcount is zero. */
+  private evictToPending(k: string): void {
+    const entry = this.cache.get(k);
+    if (!entry) return;
+    this.pendingFree.push({ entry, evictedAt: this.now() });
+    this.cache.delete(k);
+    this.lastUsedAt.delete(k);
+  }
+
+  /** Free entries whose grace period has elapsed AND have refcount 0.
+   *  Held entries (refcount > 0) stay queued until the last `LoadedEngine`
+   *  handle disposes — `acquire`'s dispose calls back here so freeing
+   *  happens promptly once the last reference goes. Walks the full
+   *  queue (no early-exit) since refcount can stall the head. */
+  private drainPendingFree(): void {
+    const cutoff = this.now() - PENDING_FREE_GRACE_SECS;
+    const kept: typeof this.pendingFree = [];
+    for (const item of this.pendingFree) {
+      if (item.evictedAt > cutoff || item.entry.refcount > 0) {
+        kept.push(item);
+      } else {
+        item.entry.engine.free();
+      }
+    }
+    this.pendingFree.length = 0;
+    this.pendingFree.push(...kept);
+  }
+
+  /** Tear everything down. Force-frees every WASM handle regardless of
+   *  refcount — only safe when no in-flight request still holds a
+   *  `LoadedEngine`. Production never calls this; tests do at end of
+   *  each case to drop the WASM heap. */
   clear(): void {
-    for (const loaded of this.cache.values()) loaded.engine.free();
+    this.stop();
+    for (const entry of this.cache.values()) entry.engine.free();
     this.cache.clear();
+    this.lastUsedAt.clear();
     this.tails.clear();
+    for (const item of this.pendingFree) item.entry.engine.free();
+    this.pendingFree.length = 0;
   }
 }

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -6,7 +6,7 @@ import { Hono } from 'hono';
 import type { DB } from '../db/client.js';
 import { graduatedCards, graduatedVerses } from '../db/schema.js';
 import { ApibibleCache, DEFAULT_NKJV_BIBLE_ID } from '../lib/apibible-cache.js';
-import { EngineStore, NotEnrolledError, type TestStateEntry } from '../lib/engine.js';
+import { EngineStore, type TestStateEntry } from '../lib/engine.js';
 import { bookCodeOf } from '../lib/book-codes.js';
 import { type ComposedRender, composeRender } from '../lib/render.js';
 import { type Grade, persistEngineState } from '../lib/review-log.js';
@@ -85,13 +85,9 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const materialId = c.req.query('materialId');
     if (!materialId) return c.json({ error: 'materialId required' }, 400);
     const user = getUser(c);
-    let loaded;
-    try {
-      loaded = await deps.engines.load({ userId: user.id, materialId });
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad({ userId: user.id, materialId });
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
     const cardId = loaded.engine.next_review_card(BigInt(now()));
     return c.json({ cardId: cardId ?? null });
   });
@@ -102,13 +98,9 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const maxRaw = Number(c.req.query('max') ?? '1');
     const max = Number.isFinite(maxRaw) ? Math.max(1, Math.min(50, Math.floor(maxRaw))) : 1;
     const user = getUser(c);
-    let loaded;
-    try {
-      loaded = await deps.engines.load({ userId: user.id, materialId });
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad({ userId: user.id, materialId });
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
     const session = JSON.parse(loaded.engine.memorize_session(max)) as {
       verses: { verseId: number; cardIds: number[] }[];
       orphans?: number[];
@@ -121,13 +113,9 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     if (!materialId) return c.json({ error: 'materialId required' }, 400);
     const cardId = Number(c.req.param('cardId'));
     const user = getUser(c);
-    let loaded;
-    try {
-      loaded = await deps.engines.load({ userId: user.id, materialId });
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad({ userId: user.id, materialId });
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
     let renderWire: CardRenderWire;
     try {
       renderWire = JSON.parse(loaded.engine.get_card_render(cardId)) as CardRenderWire;
@@ -177,16 +165,15 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     }
     const user = getUser(c);
     const key = { userId: user.id, materialId: body.materialId };
-    let loaded;
-    try {
-      loaded = await deps.engines.load(key);
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad(key);
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
 
     const nowSecs = now();
-    return deps.engines.withLock(key, async () => {
+    // `return await` so the `using` dispose fires after the withLock
+    // callback resolves, not when the outer function returns the
+    // pending promise (which would drop refcount mid-callback).
+    return await deps.engines.withLock(key, async () => {
       let updates: TestUpdateWire[];
       try {
         updates = JSON.parse(
@@ -249,16 +236,12 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const materialId = body.materialId;
     const verseId = body.verseId;
     const key = { userId: user.id, materialId };
-    let loaded;
-    try {
-      loaded = await deps.engines.load(key);
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad(key);
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
 
     const nowSecs = now();
-    return deps.engines.withLock(key, async () => {
+    return await deps.engines.withLock(key, async () => {
       const count = loaded.engine.graduate_verse(verseId);
       if (count === 0) {
         // Two cases collapse to a zero count: (a) already-graduated
@@ -306,16 +289,12 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const materialId = body.materialId;
     const cardId = body.cardId;
     const key = { userId: user.id, materialId };
-    let loaded;
-    try {
-      loaded = await deps.engines.load(key);
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad(key);
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
 
     const nowSecs = now();
-    return deps.engines.withLock(key, async () => {
+    return await deps.engines.withLock(key, async () => {
       const flipped = loaded.engine.graduate_card(cardId);
       if (!flipped) {
         // Distinguish "already graduated" (idempotent, row exists) from

--- a/packages/api/src/routes/materials.ts
+++ b/packages/api/src/routes/materials.ts
@@ -143,13 +143,9 @@ export function materialsRoutes(deps: MaterialsRoutesDeps) {
       return c.json({ error: 'offlineMode not enabled for this material' }, 403);
     }
 
-    let loaded;
-    try {
-      loaded = await deps.engines.load({ userId: user.id, materialId });
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad({ userId: user.id, materialId });
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
     const wires = JSON.parse(loaded.engine.all_card_renders()) as CardRenderWire[];
 
     // No cache → degrade to the bare wire entries so test deps that

--- a/packages/api/src/routes/stats.ts
+++ b/packages/api/src/routes/stats.ts
@@ -74,7 +74,7 @@ export function statsRoutes(deps: StatsRoutesDeps) {
     let cardDistribution: StabilityHistogram = EMPTY_HISTOGRAM;
     let verseDistribution: StabilityHistogram = EMPTY_HISTOGRAM;
     try {
-      const loaded = await deps.engines.load({ userId: user.id, materialId });
+      using loaded = await deps.engines.load({ userId: user.id, materialId });
       const nowSecs = BigInt(now());
       reviewsDueCount = loaded.engine.due_review_count(nowSecs);
       newVerseCount = loaded.engine.new_verse_count();

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -5,7 +5,6 @@ import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
 import {
   EngineStore,
-  NotEnrolledError,
   type TestStateEntry,
   getLatestSnapshot,
   readGraduatedCardIds,
@@ -136,13 +135,9 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       return c.json(unchangedResponse(deps.db, key, 0, 0));
     }
 
-    let loaded;
-    try {
-      loaded = await deps.engines.load(key);
-    } catch (err) {
-      if (err instanceof NotEnrolledError) return c.json({ error: 'Not enrolled' }, 404);
-      throw err;
-    }
+    const raw = await deps.engines.tryLoad(key);
+    if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
+    using loaded = raw;
     for (const e of events) {
       if (e.snapshotVersion !== loaded.snapshotVersion) {
         return c.json({ error: 'Snapshot version mismatch — re-fetch state before syncing' }, 409);
@@ -266,7 +261,10 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       }
     }
 
-    return deps.engines.withLock(key, async () => {
+    // `return await` so the outer `using loaded` disposes after the
+    // lock callback resolves, not when the function returns the
+    // pending promise.
+    return await deps.engines.withLock(key, async () => {
       const touchedKeys = new Set<string>();
       const reviewEventInputs: ReviewEventInput[] = [];
       const graduations: { verseId: number; timestampSecs: number }[] = [];
@@ -373,7 +371,7 @@ export function syncRoutes(deps: SyncRoutesDeps) {
         // Rebuild from the full log. testStates table is wiped and
         // re-written inside rebuildFromEvents; the in-memory engine is
         // replaced too. Use the new engine to source the response.
-        const rebuilt = deps.engines.rebuildFromEvents(key);
+        using rebuilt = deps.engines.rebuildFromEvents(key);
         resultStates = JSON.parse(rebuilt.engine.export_test_states()) as TestStateEntry[];
       } else {
         resultStates = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -244,7 +244,7 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
       let newCardCount = 0;
       if (enrolled) {
         try {
-          const loaded = await deps.engines.load({ userId: user.id, materialId: material.id });
+          using loaded = await deps.engines.load({ userId: user.id, materialId: material.id });
           counts = JSON.parse(loaded.engine.card_count_by_club()) as ClubCounts;
           newCardCount = loaded.engine.new_card_count();
         } catch (err) {

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -39,8 +39,11 @@ export function createTestDb(): TestDb {
 
 export function createTestApp() {
   const test = createTestDb();
-  const app = createApp({ db: test.db, authEnv: TEST_AUTH_ENV });
-  return { app, ...test };
+  // Pull `engines` so tests can clear() / inspect it if they want.
+  // We deliberately don't call `engines.start()` here — tests run in
+  // milliseconds and have no use for the 60 s idle reaper.
+  const { app, engines } = createApp({ db: test.db, authEnv: TEST_AUTH_ENV });
+  return { app, engines, ...test };
 }
 
 export type TestApp = ReturnType<typeof createTestApp>;


### PR DESCRIPTION
## Summary

Closes #13. `EngineStore.cache` was an unbounded `Map` — every (user, material) pair ever loaded stayed resident until process restart, holding a Rust-side `WasmEngine` whose heap the JS GC can't reclaim. Invisible at single-dev scale; monotone RAM growth at multi-user scale.

This PR bounds the cache with two mechanisms and adds compiler-enforced safety against use-after-free:

### Eviction policy

- **LRU cap** (default 128 entries). Evicts the oldest `lastUsedAt` to make room on insert. Cache hits bump the timestamp so the recently-used set survives pressure. Loop iterates `cache.keys()` (authoritative) with missing `lastUsedAt` treated as oldest — can't spin if the maps drift.
- **Idle TTL** (default 7200 s / 2 h). Background reaper walks the cache every 60 s and evicts entries idle past the TTL. Long enough to bridge within-visit pauses (lunch break between memorize and review), short enough to clear dormant users between typical inter-visit gaps. Uses strict `<` so "older than TTL" reads correctly.
- **Reaper lifecycle**: `engines.start()` is called from `src/index.ts` (production entry), **not** `createApp`, so `createTestApp` doesn't accumulate one `setInterval` per app instance. `createApp` returns `{ app, engines }` so the entry point can reach the store. `.unref()` keeps SIGTERM exits clean.

### Refcount-enforced safety

`EngineStore.load()` returns a `Disposable` `LoadedEngine`; route handlers bind it with `using`:

```ts
const raw = await deps.engines.tryLoad(key);
if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
using loaded = raw;
const cardId = loaded.engine.next_review_card(BigInt(now()));
return c.json({ cardId });
```

The cache entry's refcount tracks live handles. `drainPendingFree` only calls `engine.free()` when refcount is **zero** AND the 30 s grace period has elapsed. Two safety mechanisms:

- **Refcount pin** guarantees correctness even if a handler stashes a handle across a slow `await` (e.g. api.bible fetch).
- **Grace period** catches any code path that escapes the `using` contract by mistake.

`invalidate()` also routes through the deferred-free queue (was synchronous before), so settings-change paths no longer rely on the load-bearing "every caller holds `withLock`" convention.

POST handlers use `return await deps.engines.withLock(...)` so `using` disposes after the lock callback resolves, not when the outer function returns the pending promise.

The new `tryLoad(key)` returns `null` instead of throwing `NotEnrolledError` — composes with `using` declarations more naturally than the prior try/catch pattern.

### User-visible effect

None. An evicted user's next request rebuilds the engine from disk via the existing cold-load path (~50 ms).

## Test plan

- [x] `pnpm --filter @verse-vault/api run type-check` — clean
- [x] 7 new vitest cases in `engine.test.ts > EngineStore eviction`:
  - LRU evicts the least-recently-used entry when over the cap
  - Cache hit bumps `lastUsedAt` so the recently-used entry survives eviction
  - `reap()` evicts entries idle past `idleTtlSecs`
  - Evicted engines defer `free()` until the grace period elapses
  - `invalidate()` defers `free()` via pendingFree
  - **Live `LoadedEngine` handle pins entry against free even past grace**
  - `start()` / `stop()` idempotent; `clear()` stops the reaper
- [x] Full vitest suite passes (109/109 — 7 new + 102 existing)
- [ ] Manual smoke at deploy time: bounce the API service, verify it stays up under normal review traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)