### PR TITLE
perf(api): skip full export on review hot path

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,41 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.21] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Drop full-catalog `export_test_states` on the review-write path (closes #15)
+
+`POST /api/cards/review` and the in-order branch of `POST /api/sync/:materialId/events` previously
+called `engine.export_test_states()` after each `replay_event`, parsed the full per-(user, material)
+test-state catalog, then filtered to the handful of tests actually touched — just to decide which
+rows to upsert. For a real deck (~6 000 test_states on `nkjv-cor`) that's ~6 000 entries serialised
+on the WASM side, ferried across the bindgen boundary, and re-parsed in JS — every single review,
+for ~5 rows of actual change.
+
+`WasmEngine.replay_event` already returns the post-update state for each touched test on the wire
+(`TestUpdateWire.after` includes `pending_relearn`, courtesy of `wasm-bindgen`'s serde derive). Read
+it directly:
+
+* New `changedStatesFromUpdates(updates: TestUpdateWire[]): TestStateEntry[]` helper in
+  `lib/engine.ts` maps the updates straight to `TestStateEntry[]` for `writeTestStates`.
+  Last-write-wins on duplicate test keys (matters for `sync.ts` which can replay several events
+  hitting the same test in one lock callback) — same result the prior export-then-filter would have
+  produced.
+* `cards.ts` POST `/review` and `sync.ts` POST `/events` (in-order path) use the new helper.
+* `sync.ts` still serialises the full catalog **once** per in-order request for the response payload
+  (thin clients wholesale-replace their cache); cutting that requires a wire-shape change and is out
+  of scope here. cards.ts has no equivalent response export, so its hot path is now fully free of
+  the full-catalog serialise. Sync goes from two full exports per in-order request to one.
+* The rebuild path in `sync.ts` and `engine.ts` still calls `export_test_states` — it's
+  reconstructing state from the full event log, so a full export is correct there.
+
+Bundled algorithm contract unchanged. No wire-format break (the field was already there).
+
 ## [0.1.20] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -6,7 +6,13 @@ import { graphSnapshots, testStates as testStatesTable } from '../db/schema.js';
 import { seedUserWithFixture } from '../test-fixtures.js';
 import { createTestDb, createTestUser } from '../test-utils.js';
 import { enrollUser } from './enrollment.js';
-import { EngineStore, NotEnrolledError, type TestStateEntry } from './engine.js';
+import {
+  EngineStore,
+  NotEnrolledError,
+  changedStatesFromUpdates,
+  type TestStateEntry,
+  type TestUpdateWire,
+} from './engine.js';
 
 function fixtureMaterial(phraseWordCounts: number[]): string {
   return JSON.stringify({
@@ -528,5 +534,102 @@ describe('EngineStore eviction', () => {
     store.start();
     store.clear();
     expect(internal.reaperHandle).toBeNull();
+  });
+});
+
+describe('changedStatesFromUpdates', () => {
+  function mkUpdate(testKind: string, position: number, pendingRelearn: boolean): TestUpdateWire {
+    return {
+      key: { kind: testKind, element: { kind: 'Phrase', verse_id: 0, position } },
+      kind: 'Root',
+      before: {
+        stability: 1,
+        difficulty: 5,
+        last_seen_secs: 0,
+        last_base_secs: 0,
+        last_root_secs: 0,
+        pending_relearn: false,
+      },
+      after: {
+        stability: 2.5,
+        difficulty: 4.8,
+        last_seen_secs: 86400,
+        last_base_secs: 86400,
+        last_root_secs: 86400,
+        pending_relearn: pendingRelearn,
+      },
+    };
+  }
+
+  it('maps each update to a TestStateEntry carrying the post-update state', () => {
+    const updates = [mkUpdate('PhraseFromContext', 0, false), mkUpdate('VerseChapter', 1, true)];
+    const changed = changedStatesFromUpdates(updates);
+    expect(changed).toHaveLength(2);
+    expect(changed[0]).toEqual({
+      element: { kind: 'Phrase', verse_id: 0, position: 0 },
+      test_kind: 'PhraseFromContext',
+      stability: 2.5,
+      difficulty: 4.8,
+      last_seen_secs: 86400,
+      last_base_secs: 86400,
+      last_root_secs: 86400,
+      pending_relearn: false,
+    });
+    expect(changed[1].pending_relearn).toBe(true);
+  });
+
+  it('collapses duplicate test keys to the last update (last-write-wins)', () => {
+    // Same key, different `after` values — only the last should land in
+    // the result. Mirrors what the prior export-then-filter approach
+    // would have produced (DB row = final cached engine state).
+    const first = mkUpdate('PhraseFromContext', 0, true);
+    const second = mkUpdate('PhraseFromContext', 0, false);
+    second.after.stability = 99;
+
+    const changed = changedStatesFromUpdates([first, second]);
+    expect(changed).toHaveLength(1);
+    expect(changed[0].stability).toBe(99);
+    expect(changed[0].pending_relearn).toBe(false);
+  });
+
+  it('returns an empty array for an empty updates list', () => {
+    expect(changedStatesFromUpdates([])).toEqual([]);
+  });
+
+  it('dedups elements regardless of object-field insertion order', () => {
+    // Two semantically-equal ElementIds with different field orders —
+    // could happen if a future TS caller constructs them field-by-field
+    // (Rust serde is stable-order today, but the helper is a public
+    // export with no compile-time guarantee on caller layout).
+    const updateA: TestUpdateWire = {
+      key: { kind: 'PhraseFromContext', element: { kind: 'Phrase', verse_id: 0, position: 1 } },
+      kind: 'Root',
+      before: {
+        stability: 1,
+        difficulty: 5,
+        last_seen_secs: 0,
+        last_base_secs: 0,
+        last_root_secs: 0,
+        pending_relearn: false,
+      },
+      after: {
+        stability: 1.5,
+        difficulty: 5,
+        last_seen_secs: 100,
+        last_base_secs: 100,
+        last_root_secs: 100,
+        pending_relearn: false,
+      },
+    };
+    const updateB: TestUpdateWire = {
+      key: { kind: 'PhraseFromContext', element: { position: 1, verse_id: 0, kind: 'Phrase' } },
+      kind: 'Root',
+      before: updateA.before,
+      after: { ...updateA.after, stability: 9.9 },
+    };
+
+    const changed = changedStatesFromUpdates([updateA, updateB]);
+    expect(changed).toHaveLength(1);
+    expect(changed[0].stability).toBe(9.9);
   });
 });

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -106,6 +106,96 @@ export interface TestStateEntry {
   pending_relearn: boolean;
 }
 
+/** State payload embedded in `TestUpdateWire.before` / `.after`. Same
+ *  fields as `TestStateEntry` minus the `element` + `test_kind` key
+ *  (which live on `TestUpdateWire.key`). Wire shape mirrors the Rust
+ *  `verse-vault-core::TestState`. `pending_relearn` is always emitted
+ *  because no field carries `#[serde(skip_serializing_if)]`
+ *  (`#[serde(default)]` on the Rust side governs the *deserialization*
+ *  direction only — it doesn't suppress emission). If a future
+ *  contributor adds `skip_serializing_if` to trim wire size, this
+ *  type and `changedStatesFromUpdates` will silently drop the field
+ *  on the persist path — guard with a test, not a comment.
+ *
+ *  Defined as a `Pick` so a future core field added to `TestState`
+ *  shows up structurally on both sides without manual sync. */
+export type TestUpdateState = Pick<
+  TestStateEntry,
+  | 'stability'
+  | 'difficulty'
+  | 'last_seen_secs'
+  | 'last_base_secs'
+  | 'last_root_secs'
+  | 'pending_relearn'
+>;
+
+/** Wire-format mirror of `verse-vault-core::TestUpdate`. Emitted by
+ *  `WasmEngine.replay_event(...)`. `kind` is the update flavour
+ *  (`Root` for atomic-card full FSRS step, `Sub` for composite-card
+ *  Bayesian-share sub-update). `key` identifies which test was touched
+ *  and round-trips through the database opaquely. */
+export interface TestUpdateWire {
+  key: { kind: string; element: unknown };
+  kind: 'Root' | 'Sub';
+  before: TestUpdateState;
+  after: TestUpdateState;
+}
+
+/** Convert one-or-more `replay_event` returns into the
+ *  `TestStateEntry[]` shape that `writeTestStates` consumes. Reads
+ *  each touched test's post-update state straight from `update.after`,
+ *  bypassing the prior full-catalog `export_test_states()` + filter.
+ *
+ *  Within a single `replay_event` call the core never emits duplicate
+ *  keys — atomic cards return 1 update for 1 key, composite cards
+ *  return N updates for N distinct contained tests (Bayesian
+ *  decomposition; see `crates/core/src/engine.rs`). Duplicates only
+ *  arise when sync.ts replays several events touching the same test
+ *  in one batch; those events were sorted by
+ *  `(timestampSecs, clientEventId)` before replay, so the
+ *  chronologically last update is the most recent. Map-based
+ *  last-write-wins preserves that order and matches the final cached
+ *  engine state byte-for-byte.
+ *
+ *  Element-key dedup is order-insensitive: `canonicalizeKey` sorts
+ *  fields recursively before serialising, so two `ElementId` objects
+ *  carrying the same fields in different insertion order collapse to
+ *  one map entry. Today's only producer is Rust serde (stable field
+ *  order), but the helper is exported as a public surface and a
+ *  future TS caller could feed in elements built field-by-field. */
+export function changedStatesFromUpdates(updates: TestUpdateWire[]): TestStateEntry[] {
+  const byKey = new Map<string, TestStateEntry>();
+  for (const u of updates) {
+    const k = `${u.key.kind}|${canonicalizeKey(u.key.element)}`;
+    byKey.set(k, {
+      element: u.key.element,
+      test_kind: u.key.kind,
+      stability: u.after.stability,
+      difficulty: u.after.difficulty,
+      last_seen_secs: u.after.last_seen_secs,
+      last_base_secs: u.after.last_base_secs,
+      last_root_secs: u.after.last_root_secs,
+      pending_relearn: u.after.pending_relearn,
+    });
+  }
+  return Array.from(byKey.values());
+}
+
+/** Order-insensitive serialisation for use as a dedup key. Sorts object
+ *  fields recursively so `{a, b}` and `{b, a}` hash to the same string.
+ *  Arrays preserve order (positional semantics). Scalars passthrough.
+ *  Not for cryptographic use; not safe against cyclic structures (none
+ *  reach here — `ElementId` is an enum of finite-depth POD variants). */
+function canonicalizeKey(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalizeKey).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  const parts = Object.keys(obj)
+    .sort()
+    .map((k) => `${JSON.stringify(k)}:${canonicalizeKey(obj[k])}`);
+  return `{${parts.join(',')}}`;
+}
+
 /** Per-(user, material) target retention. Falls back to the
  *  `EngineStore` default when the user has no `user_year_settings`
  *  row yet (the pre-enrollment picker case). The settings endpoint

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -6,7 +6,11 @@ import { Hono } from 'hono';
 import type { DB } from '../db/client.js';
 import { graduatedCards, graduatedVerses } from '../db/schema.js';
 import { ApibibleCache, DEFAULT_NKJV_BIBLE_ID } from '../lib/apibible-cache.js';
-import { EngineStore, type TestStateEntry } from '../lib/engine.js';
+import {
+  EngineStore,
+  changedStatesFromUpdates,
+  type TestUpdateWire,
+} from '../lib/engine.js';
 import { bookCodeOf } from '../lib/book-codes.js';
 import { type ComposedRender, composeRender } from '../lib/render.js';
 import { type Grade, persistEngineState } from '../lib/review-log.js';
@@ -33,21 +37,6 @@ interface ReviewBody {
   materialId: string;
   cardId: number;
   grade: Grade;
-}
-
-interface TestUpdateWire {
-  key: { kind: string; element: unknown };
-  kind: 'Root' | 'Sub';
-  before: TestStateInner;
-  after: TestStateInner;
-}
-
-interface TestStateInner {
-  stability: number;
-  difficulty: number;
-  last_seen_secs: number;
-  last_base_secs: number;
-  last_root_secs: number;
 }
 
 interface CardRenderWire {
@@ -183,13 +172,10 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
         return c.json({ error: (err as Error).message }, 400);
       }
 
-      const touchedKeys = new Set(
-        updates.map((u) => `${u.key.kind}|${JSON.stringify(u.key.element)}`),
-      );
-      const allStates = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
-      const changed = allStates.filter((s) =>
-        touchedKeys.has(`${s.test_kind}|${JSON.stringify(s.element)}`),
-      );
+      // `replay_event`'s wire format already carries the post-update
+      // state for each touched test; no need to serialize + parse +
+      // filter the full catalog. See `changedStatesFromUpdates`.
+      const changed = changedStatesFromUpdates(updates);
 
       const eventId = randomUUID();
       deps.db.transaction((tx) => {

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -5,7 +5,9 @@ import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
 import {
   EngineStore,
+  changedStatesFromUpdates,
   type TestStateEntry,
+  type TestUpdateWire,
   getLatestSnapshot,
   readGraduatedCardIds,
   readGraduatedVerseIds,
@@ -65,11 +67,6 @@ interface UploadBody {
  *  a `needsConfirm` response so the user can choose Sync / Discard /
  *  Cancel before the merge actually runs. */
 const STALE_MERGE_THRESHOLD = 10;
-
-interface TestUpdateWire {
-  key: { kind: string; element: unknown };
-  kind: 'Root' | 'Sub';
-}
 
 function eventKind(e: SyncEventUpload): 'review' | 'graduate' | 'graduateCard' {
   return e.kind ?? 'review';
@@ -265,7 +262,7 @@ export function syncRoutes(deps: SyncRoutesDeps) {
     // lock callback resolves, not when the function returns the
     // pending promise.
     return await deps.engines.withLock(key, async () => {
-      const touchedKeys = new Set<string>();
+      const allUpdates: TestUpdateWire[] = [];
       const reviewEventInputs: ReviewEventInput[] = [];
       const graduations: { verseId: number; timestampSecs: number }[] = [];
       const cardGraduations: { cardId: number; timestampSecs: number }[] = [];
@@ -297,9 +294,7 @@ export function syncRoutes(deps: SyncRoutesDeps) {
             const updates = JSON.parse(
               loaded.engine.replay_event(re.cardId, re.grade, BigInt(re.timestampSecs)),
             ) as TestUpdateWire[];
-            for (const u of updates) {
-              touchedKeys.add(`${u.key.kind}|${JSON.stringify(u.key.element)}`);
-            }
+            allUpdates.push(...updates);
           }
           reviewEventInputs.push({
             userId: user.id,
@@ -313,16 +308,14 @@ export function syncRoutes(deps: SyncRoutesDeps) {
         }
       }
 
-      // Persist events first so rebuildFromEvents (if triggered) sees the
-      // new rows when it reads the log. On the in-order path the changed
-      // test states are filtered from the cached engine's export.
-      let changed: TestStateEntry[] = [];
-      if (!outOfOrder) {
-        const allStates = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
-        changed = allStates.filter((s) =>
-          touchedKeys.has(`${s.test_kind}|${JSON.stringify(s.element)}`),
-        );
-      }
+      // In-order path: `replay_event`'s wire format already carries the
+      // post-update state for each touched test, so we skip the full-
+      // catalog `export_test_states` + filter that the old code did
+      // here. `changedStatesFromUpdates` handles the "same test touched
+      // by multiple events in this batch" case via last-write-wins.
+      const changed: TestStateEntry[] = outOfOrder
+        ? []
+        : changedStatesFromUpdates(allUpdates);
 
       try {
         deps.db.transaction((tx) => {
@@ -374,6 +367,11 @@ export function syncRoutes(deps: SyncRoutesDeps) {
         using rebuilt = deps.engines.rebuildFromEvents(key);
         resultStates = JSON.parse(rebuilt.engine.export_test_states()) as TestStateEntry[];
       } else {
+        // The response carries the full catalog because thin clients
+        // wholesale-replace their cache. Eliminating this export
+        // requires a wire-shape change (response carries only the
+        // delta + the client merges) — out of scope here; the
+        // DB-write path's full export is already gone above.
         resultStates = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
       }
 


### PR DESCRIPTION
## Summary

Closes #15. `POST /api/cards/review` and the in-order branch of `POST /api/sync/:materialId/events` previously called `engine.export_test_states()` after each `replay_event`, parsed the full per-(user, material) catalog (~6000 entries on a real deck like `nkjv-cor`), then filtered to the ~5 rows actually touched — just to decide which rows to upsert.

Turns out the issue's "delta API on the WASM boundary" proposal isn't needed: `replay_event` already returns the post-update state for each touched test on the wire (`TestUpdateWire.after`, including `pending_relearn`). Read it directly.

### Changes

- **New `changedStatesFromUpdates(updates)` helper** in `lib/engine.ts` — maps `TestUpdateWire[]` straight to `TestStateEntry[]` for `writeTestStates`. Last-write-wins on duplicate test keys (matters in `sync.ts` where one batch can replay several events that hit the same test); chronological event sort ensures the latest update wins.
- **`canonicalizeKey()`** for the dedup map — sorts object fields recursively before serialising so two semantically-equal `ElementId`s with different field-insertion order collapse to one entry. Today's only producer is Rust serde (stable field order), but the helper is now a public export and a future TS caller could feed in field-by-field-built elements.
- **`cards.ts` POST `/review`** uses the helper. Local `TestUpdateWire` / `TestStateInner` deleted in favor of the shared ones now exported from `lib/engine.ts`.
- **`sync.ts` POST `/events`** (in-order path) accumulates `allUpdates` per replay and calls the helper once at the end. The response payload still calls `export_test_states()` once — thin clients wholesale-replace their cache, so eliminating that requires a wire-shape change (out of scope). Net: `sync.ts` goes from 2 full exports per in-order request to 1; `cards.ts` goes from 1 to 0.
- **Shared types**: `TestUpdateWire` and `TestUpdateState` (defined as `Pick<TestStateEntry, ...>` so a future core field can't drift) consolidated in `lib/engine.ts`.

The rebuild path in `sync.ts` and `engine.ts` still calls `export_test_states` — it's reconstructing state from the full event log, so a full export is correct there.

### Bundled algorithm contract

Unchanged — `verse-vault-core@0.5.0`, `verse-vault-wasm@0.5.0`. No wire-format break.

## Test plan

- [x] `pnpm --filter @verse-vault/api run type-check` — clean
- [x] 4 new vitest cases for `changedStatesFromUpdates`:
  - Maps each update to a `TestStateEntry` carrying the post-update state (with `pending_relearn`)
  - Collapses duplicate test keys to the last update (last-write-wins)
  - Returns empty array for an empty updates list
  - **Dedups elements regardless of object-field insertion order** (locks in canonicalisation)
- [x] Full suite passes (112/112)
- [ ] Manual smoke at deploy time: grade a few reviews, verify the response carries the expected `updates` and DB rows match

🤖 Generated with [Claude Code](https://claude.com/claude-code)