### PR TITLE
fix(api): backfill desired_retention NULL storage (drill catch)

### DIFF
--- a/deploy/provision.sh
+++ b/deploy/provision.sh
@@ -68,8 +68,11 @@ echo "     System time: $(date -u +%FT%TZ)"
 
 echo "  -> apt update + base packages"
 apt-get update
+# `sqlite3` CLI is for operator scripts (deploy/restore-drill.sh,
+# litestream-health.sh); the API uses better-sqlite3 which statically
+# links its own SQLite and doesn't need the CLI.
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
-	curl ca-certificates git ufw unattended-upgrades jq
+	curl ca-certificates git ufw unattended-upgrades jq sqlite3
 
 echo "  -> Enabling unattended security upgrades"
 dpkg-reconfigure -f noninteractive unattended-upgrades

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,35 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.23] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Backfill `user_year_settings.desired_retention` storage
+
+Migration 0018 added `desired_retention REAL DEFAULT 0.9 NOT NULL` to `user_year_settings`. SQLite's
+`ALTER TABLE ADD COLUMN` doesn't physically write the DEFAULT into rows that pre-existed the
+migration — the default is applied at SELECT time. `PRAGMA integrity_check` flags those rows as NOT
+NULL violations even though every SELECT returns 0.9, and
+`UPDATE ... WHERE desired_retention IS NULL` matches nothing (the WHERE clause evaluates against the
+read-time value).
+
+Discovered by the freshly-added `deploy/restore-drill.sh` (PR #79) running `integrity_check` against
+a B2 restore. Live prod had four such rows. The restore chain itself was fine — the bug was in
+physical storage all along, and the drill surfaced it.
+
+* **Migration 0021** (`0021_backfill_desired_retention_storage`):
+  `UPDATE user_year_settings SET desired_retention = COALESCE(desired_retention, 0.9)`. The COALESCE
+  goes through the write path, rewriting storage with a literal 0.9 even though the read-side
+  already returned 0.9 from the DEFAULT.
+* No code change. The schema-side `NOT NULL DEFAULT 0.9` was already correct; the data just needed
+  to catch up.
+
+Bundled algorithm contract unchanged. No wire-format break.
+
 ## [0.1.22] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/packages/api/migrations/0021_backfill_desired_retention_storage.sql
+++ b/packages/api/migrations/0021_backfill_desired_retention_storage.sql
@@ -1,0 +1,17 @@
+-- Backfill physical storage for `user_year_settings.desired_retention`.
+--
+-- Migration 0018 added the column as `REAL DEFAULT 0.9 NOT NULL`. SQLite's
+-- ALTER TABLE ADD COLUMN doesn't physically write the DEFAULT into rows
+-- that pre-existed the migration — the default is applied at SELECT time.
+-- `PRAGMA integrity_check` (which inspects raw storage) flags these rows
+-- as NOT NULL violations even though every SELECT against them returns
+-- 0.9, and `UPDATE ... WHERE desired_retention IS NULL` matches nothing
+-- (the WHERE clause evaluates against the read-time value).
+--
+-- Discovered when `deploy/restore-drill.sh` (PR #79) ran integrity_check
+-- against a fresh restore from B2. Live prod had the same condition.
+--
+-- COALESCE through the write path is the documented fix: even though the
+-- read-side value is 0.9 (from the DEFAULT), the write rewrites the row
+-- with a literal 0.9 in storage.
+UPDATE `user_year_settings` SET `desired_retention` = COALESCE(`desired_retention`, 0.9);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1779386400000,
       "tag": "0020_drop_snapshot_material_data",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1779472800000,
+      "tag": "0021_backfill_desired_retention_storage",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

The new `deploy/restore-drill.sh` (PR #79) ran `PRAGMA integrity_check` against a fresh B2 restore on its first invocation and surfaced a real data bug that had been sitting silently in prod since migration 0018 shipped:

> NULL value in user_year_settings.desired_retention (×4)

**SQLite quirk:** `ALTER TABLE ADD COLUMN \`desired_retention\` REAL DEFAULT 0.9 NOT NULL` (migration 0018) doesn't physically write the DEFAULT into rows that pre-existed the migration. The default is applied **at SELECT time only** — so every SELECT returns 0.9, but raw storage stays NULL. `integrity_check` inspects raw storage and flags the violations. Worse: `UPDATE ... WHERE desired_retention IS NULL` matches **zero rows** because the WHERE evaluates against the read-time value.

The restore chain itself is fine — restored bytes match live exactly. The bug was in storage all along; the drill is the only thing that would have caught it.

### Fix

`packages/api/migrations/0021_backfill_desired_retention_storage.sql`:

```sql
UPDATE \`user_year_settings\` SET \`desired_retention\` = COALESCE(\`desired_retention\`, 0.9);
```

COALESCE goes through the write path, rewriting storage with a literal 0.9 even though the read-side already returned 0.9 from the DEFAULT. After this migration, `integrity_check` passes.

Also patches `deploy/provision.sh` phase 1 to include the `sqlite3` CLI in base packages — the drill scripts need it for `PRAGMA integrity_check` and row counts. better-sqlite3 (the Node binding) statically links its own SQLite so the API never needed the CLI, which is why it wasn't there.

### Commit sequence

- `fix(api): backfill desired_retention storage` — migration 0021 + journal
- `chore(deploy): add sqlite3 to provision packages` — provision.sh phase 1
- `chore: release @verse-vault/api 0.1.23` — version bump + CHANGELOG

### Bundled algorithm contract

Unchanged.

## Test plan

- [x] `pnpm --filter @verse-vault/api run type-check` — clean
- [x] Full vitest suite passes (115/115 — migration 0021 is a no-op on fresh test DBs, which is correct)
- [x] Live prod hot-fixed during incident triage: `UPDATE ... COALESCE(...)` ran via SSH; integrity_check returned `ok`
- [ ] Post-deploy: re-run `restore-drill.sh` against live, expect a clean run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)