### PR TITLE
feat(api): observability + rate-limit middleware

### DIFF
--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -392,6 +392,53 @@ Stability buckets (days): `weak < 1`, `learning [1, 7)`, `familiar [7, 30)`, `st
 | 404    | material id unknown, or caller not enrolled in the requested material, or card id unknown            |
 | 409    | sync batch uses a stale `snapshotVersion`, or already-enrolled on `/enroll`                          |
 | 413    | sync batch exceeds the 500-event cap                                                                 |
+| 429    | rate limit exceeded; `Retry-After` header carries integer seconds until next allowed request         |
 | 500    | engine threw on `replay_event` / `get_card_render` (unknown card id, malformed state) — caller's bug |
 
 All error bodies follow `{ "error": "..." }`.
+
+## Rate limiting
+
+The API runs an in-memory token-bucket per client IP. Defaults:
+
+| tier                 | limit       | applies to                                        |
+| -------------------- | ----------- | ------------------------------------------------- |
+| authed               | 120 req/min | every route except `/health` and the two below    |
+| unauthed (auth-flow) | 10 req/min  | `/api/auth/*` — defangs credential-stuffing loops |
+| exempt               | —           | `/health` (no bucket, no 429)                     |
+
+Bucket key is the client IP (`CF-Connecting-IP` in production behind the Cloudflare Tunnel,
+`X-Forwarded-For` first hop in dev, `unknown` if neither is present). Per-user keying is a follow-up
+if NAT'd users start tripping limits — siblings sharing a NAT currently share a bucket.
+
+Failed Better Auth attempts (e.g. 401 from `/api/auth/sign-in/email` with a bad password) still
+consume a token. That's intentional brute-force protection.
+
+Tuneable via env vars at boot:
+
+* `RATE_LIMIT_AUTHED_PER_MIN` — default 120.
+* `RATE_LIMIT_UNAUTHED_PER_MIN` — default 10.
+
+Garbage values (non-integer, non-positive) fall back to the defaults. Limits are per single API
+instance with no distributed coordination; a horizontal scale-out will need a shared store.
+
+## Request logging
+
+Every non-`OPTIONS` request emits one JSON-line log to stdout (captured into journald via the
+systemd unit). Shape:
+
+```json
+{
+  "requestId": "uuid-v4",
+  "userId": "user-id or null",
+  "ip": "1.2.3.4 or 'unknown'",
+  "method": "GET",
+  "path": "/api/cards/...",
+  "status": 200,
+  "durationMs": 47
+}
+```
+
+Additional fields when present: `rateLimited: true` on a 429, `error: "<message>"` when a handler
+threw. The `requestId` is also returned on every response in the `X-Request-Id` header so clients
+can quote it in support requests. `OPTIONS` preflights are intentionally not logged.

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,46 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.24] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Structured request logging + in-memory rate limits
+
+The API now ships an observability + rate-limit middleware. One unit handles both because they share
+the same per-request context (who, what route, status, duration). About 150 lines of focused
+middleware code instead of two separate ones.
+
+* **Structured per-request log**: replaces Hono's built-in `logger()`. Emits one JSON line per
+  non-OPTIONS request to stdout (captured into journald via the systemd unit). Shape:
+  `{requestId, userId, ip, method, path, status, durationMs}` plus `error` on handler throws and
+  `rateLimited: true` on 429s. See `docs/server-api.md` → "Request logging".
+* **`X-Request-Id` on every response**: clients can quote it in support requests; handlers can read
+  it from `c.get('requestId')` for cross-handler correlation.
+* **Token-bucket rate limit** with two tiers:
+  * Authed: 120 req/min for every route except the two below (env `RATE_LIMIT_AUTHED_PER_MIN`).
+  * Unauthed `/api/auth/*`: 10 req/min (env `RATE_LIMIT_UNAUTHED_PER_MIN`). Defangs
+    credential-stuffing loops without affecting normal review traffic.
+  * `/health` exempt entirely.
+  * Bucket key is the client IP (`CF-Connecting-IP` in production behind Cloudflare Tunnel).
+* **`429` responses** carry `Retry-After: <ceil(secs)>` and the standard
+  `{ "error": "Rate limit exceeded" }` body. The response flows back through `cors()` so browsers
+  see a real 429, not a network error. CORS `exposeHeaders` now lists `Retry-After` and
+  `X-Request-Id` so browser JS can read them.
+* **Failed `/api/auth/sign-in/email` attempts still consume a token** — intentional brute-force
+  protection.
+
+In-memory state lives in a new `TokenBucketStore` (`packages/api/src/lib/rate-limit.ts`) bounded at
+10 000 buckets with LRU eviction on insert. No periodic timer — sidesteps the `createApp`/test-leak
+trap the `EngineStore.start()` follow-up fixed. No new npm dependencies. Single-instance only;
+horizontal scale-out will need a shared store. NAT'd users currently share a bucket; per-user keying
+is a follow-up.
+
+Bundled algorithm contract unchanged. No wire-format break.
+
 ## [0.1.23] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,14 +1,23 @@
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
 import { cors } from 'hono/cors';
-import { logger } from 'hono/logger';
 
 import type { DB } from './db/client.js';
 import { ApibibleCache } from './lib/apibible-cache.js';
 import { TAURI_ORIGINS, type AuthEnv, createAuth } from './lib/auth.js';
 import { EngineStore } from './lib/engine.js';
 import { type Dialect } from './lib/spelling.js';
-import { type SessionVariables, getUser, requireAuth, sessionMiddleware } from './middleware/session.js';
+import {
+  type ObservabilityOptions,
+  observabilityMiddleware,
+  resolveObservabilityOptions,
+} from './middleware/observability.js';
+import {
+  type AppVariables,
+  getUser,
+  requireAuth,
+  sessionMiddleware,
+} from './middleware/session.js';
 import { cardsRoutes } from './routes/cards.js';
 import { materialsRoutes } from './routes/materials.js';
 import { activityRoutes } from './routes/activity.js';
@@ -32,6 +41,10 @@ export interface AppDeps {
    *  env var at boot; will move to a per-user setting later. */
   dialect?: Dialect;
   now?: () => number;
+  /** Override observability middleware defaults. Tests inject a low
+   *  cap + captured log callback; production uses the env-var-driven
+   *  shape from `src/index.ts`. */
+  observability?: Partial<ObservabilityOptions>;
 }
 
 export function createApp(deps: AppDeps) {
@@ -46,9 +59,17 @@ export function createApp(deps: AppDeps) {
   const apibibleCache = deps.bibleApiKey
     ? new ApibibleCache(deps.db, deps.bibleApiKey, deps.now)
     : undefined;
-  const app = new Hono<{ Variables: SessionVariables }>();
+  const app = new Hono<{ Variables: AppVariables }>();
 
-  app.use('*', logger());
+  // Observability + rate-limit middleware replaces Hono's default
+  // logger(). Mounts first so durationMs covers the full handler path
+  // and the 429 response flows back through cors() with the right
+  // headers. See middleware/observability.ts.
+  const observabilityOpts = resolveObservabilityOptions({
+    now: deps.now,
+    ...deps.observability,
+  });
+  app.use('*', observabilityMiddleware(observabilityOpts));
   // Drops the bulk renders payload for `nkjv-cor` from ~5 MB to ~1 MB.
   app.use('*', compress());
   const isProd = process.env.NODE_ENV === 'production';
@@ -79,6 +100,9 @@ export function createApp(deps: AppDeps) {
         return null;
       },
       credentials: true,
+      // Expose 429-related + correlation headers so browser JS can
+      // read them (defaults to a fixed safelist that omits these).
+      exposeHeaders: ['Retry-After', 'X-Request-Id'],
     }),
   );
 
@@ -87,9 +111,10 @@ export function createApp(deps: AppDeps) {
   // Session middleware runs on everything except Better Auth's own routes
   // (Better Auth does its own session handling internally) and /health
   // (no auth needed — skips a DB round-trip per healthcheck).
+  const session = sessionMiddleware<{ Variables: AppVariables }>(auth);
   app.use('/api/*', async (c, next) => {
     if (c.req.path.startsWith('/api/auth/')) return next();
-    return sessionMiddleware(auth)(c, next);
+    return session(c, next);
   });
 
   app.get('/health', (c) => c.json({ status: 'ok' }));

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -12,6 +12,14 @@ function requireEnv(name: string): string {
   return value;
 }
 
+/** Parse a per-minute rate-limit knob from an env var. Falls back to
+ *  the default if unset, non-numeric, or non-positive — bad input
+ *  should be safe, not crash boot. */
+function rateLimitPerMin(envVar: string, defaultPerMin: number): number {
+  const parsed = Number.parseInt(process.env[envVar] ?? '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultPerMin;
+}
+
 // Validate env before touching the filesystem — if secrets are missing we
 // don't want to have already opened a DB / run a migration.
 const authEnv = {
@@ -30,6 +38,12 @@ const authEnv = {
 const dbPath = process.env.DATABASE_PATH ?? resolve(import.meta.dirname, '../data/verse-vault.db');
 runMigrations(dbPath);
 
+// Rate-limit knobs read once each — derives both capacity and refillPerSec
+// from the same per-minute number so they can't drift apart on a future
+// edit.
+const authedPerMin = rateLimitPerMin('RATE_LIMIT_AUTHED_PER_MIN', 120);
+const unauthedPerMin = rateLimitPerMin('RATE_LIMIT_UNAUTHED_PER_MIN', 10);
+
 const { app, engines } = createApp({
   db: createDb(dbPath),
   authEnv,
@@ -44,6 +58,12 @@ const { app, engines } = createApp({
   dialect: ['american', 'british', 'canadian'].includes(process.env.RENDER_DIALECT ?? '')
     ? (process.env.RENDER_DIALECT as 'american' | 'british' | 'canadian')
     : 'canadian',
+  // Rate-limit tuneables. Defaults from middleware/observability.ts:
+  // 120 req/min for general traffic, 10 req/min for /api/auth/*.
+  observability: {
+    authedTier: { capacity: authedPerMin, refillPerSec: authedPerMin / 60 },
+    unauthedAuthTier: { capacity: unauthedPerMin, refillPerSec: unauthedPerMin / 60 },
+  },
 });
 
 // Start the EngineStore idle reaper here, not in createApp — tests

--- a/packages/api/src/lib/rate-limit.test.ts
+++ b/packages/api/src/lib/rate-limit.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import { type RateLimitTier, TokenBucketStore } from './rate-limit.js';
+
+// Tight tier so test assertions are simple — capacity 3, refill 1 token/sec.
+const TIER: RateLimitTier = { capacity: 3, refillPerSec: 1 };
+
+describe('TokenBucketStore', () => {
+  it('allows consumption up to capacity on first contact', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock });
+    for (let i = 0; i < TIER.capacity; i++) {
+      expect(s.consume('k', TIER).allowed).toBe(true);
+    }
+  });
+
+  it('denies past capacity and reports retryAfterSec via deficit math', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock });
+    for (let i = 0; i < TIER.capacity; i++) s.consume('k', TIER);
+    const denied = s.consume('k', TIER);
+    expect(denied.allowed).toBe(false);
+    // After draining, deficit is 1 token; refill 1/sec → retry in 1 sec.
+    expect(denied.retryAfterSec).toBeCloseTo(1, 6);
+  });
+
+  it('refills tokens proportionally to advanced clock', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock });
+    for (let i = 0; i < TIER.capacity; i++) s.consume('k', TIER);
+    clock = 2_000; // 2 seconds → 2 tokens refilled
+    expect(s.consume('k', TIER).allowed).toBe(true);
+    expect(s.consume('k', TIER).allowed).toBe(true);
+    expect(s.consume('k', TIER).allowed).toBe(false);
+  });
+
+  it('caps refill at capacity (no overflow on long idle)', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock });
+    s.consume('k', TIER); // 2 tokens left
+    clock = 10_000_000; // idle for ages — would refill way past capacity
+    for (let i = 0; i < TIER.capacity; i++) {
+      expect(s.consume('k', TIER).allowed).toBe(true);
+    }
+    // Capacity is the ceiling — the 4th request fails.
+    expect(s.consume('k', TIER).allowed).toBe(false);
+  });
+
+  it('keys are independent', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock });
+    for (let i = 0; i < TIER.capacity; i++) s.consume('a', TIER);
+    expect(s.consume('a', TIER).allowed).toBe(false);
+    // Different key starts fresh at full capacity.
+    expect(s.consume('b', TIER).allowed).toBe(true);
+  });
+
+  it('evicts the least-recently-used bucket when over maxBuckets', () => {
+    let clock = 0;
+    const s = new TokenBucketStore({ now: () => clock, maxBuckets: 2 });
+    clock = 100;
+    s.consume('a', TIER);
+    clock = 200;
+    s.consume('b', TIER);
+    clock = 300;
+    // Inserting c would push above the cap → a (lastUsed=100) gets evicted.
+    s.consume('c', TIER);
+    expect(s.size()).toBe(2);
+
+    // Drain a's deficit had it survived; instead it gets a fresh bucket.
+    for (let i = 0; i < TIER.capacity; i++) {
+      expect(s.consume('a', TIER).allowed).toBe(true);
+    }
+    expect(s.consume('a', TIER).allowed).toBe(false);
+  });
+
+  it('clamps clock-rewind so a backwards-stepping injected now() does not mint tokens', () => {
+    let clock = 1000;
+    const s = new TokenBucketStore({ now: () => clock });
+    for (let i = 0; i < TIER.capacity; i++) s.consume('k', TIER);
+    clock = 0; // rewind
+    // Without the Math.max(0, elapsed) clamp this would mint negative-elapsed
+    // tokens; with the clamp the bucket stays empty.
+    expect(s.consume('k', TIER).allowed).toBe(false);
+  });
+
+  it('clear() empties the store', () => {
+    const s = new TokenBucketStore();
+    s.consume('a', TIER);
+    s.consume('b', TIER);
+    expect(s.size()).toBe(2);
+    s.clear();
+    expect(s.size()).toBe(0);
+  });
+});

--- a/packages/api/src/lib/rate-limit.ts
+++ b/packages/api/src/lib/rate-limit.ts
@@ -1,0 +1,112 @@
+/**
+ * Token-bucket rate-limit store. Pure in-memory state, single-VPS scale.
+ *
+ * Each bucket tracks `(tokens, lastRefillMs)`. `consume(key, tier)` refills
+ * lazily based on elapsed time since `lastRefillMs`, decrements one token
+ * if allowed, otherwise reports how long until the next token is available.
+ *
+ * Bounded by `maxBuckets` with LRU eviction on insert — mirrors the
+ * `EngineStore.cache` pattern in `./engine.ts`. No periodic timer: buckets
+ * are pure state with no resource to dispose, and inline eviction at cap
+ * is enough. This deliberately sidesteps the `EngineStore.start()`
+ * test-leak trap (background `setInterval` per `createApp` accumulating
+ * across the suite).
+ *
+ * Construct once per process; tests can inject `now()` for deterministic
+ * advancement and a low `maxBuckets` to exercise eviction without
+ * scaling up the fixture.
+ */
+
+export interface RateLimitTier {
+  /** Maximum tokens a freshly-seen bucket starts with, and the cap
+   *  refills never exceed. */
+  capacity: number;
+  /** Tokens regenerated per second. Bucket size of 120 with
+   *  `refillPerSec: 2` = 120 req burst then steady 120/min. */
+  refillPerSec: number;
+}
+
+export interface ConsumeResult {
+  allowed: boolean;
+  /** Seconds (real, not rounded) until the bucket holds ≥ 1 token.
+   *  `0` when `allowed`. Callers should `Math.ceil` for `Retry-After`. */
+  retryAfterSec: number;
+}
+
+interface BucketState {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+const DEFAULT_MAX_BUCKETS = 10_000;
+
+export class TokenBucketStore {
+  private readonly buckets = new Map<string, BucketState>();
+  private readonly lastUsedAt = new Map<string, number>();
+  private readonly maxBuckets: number;
+  private readonly now: () => number;
+
+  constructor(opts: { maxBuckets?: number; now?: () => number } = {}) {
+    this.maxBuckets = opts.maxBuckets ?? DEFAULT_MAX_BUCKETS;
+    this.now = opts.now ?? Date.now;
+  }
+
+  consume(key: string, tier: RateLimitTier): ConsumeResult {
+    const nowMs = this.now();
+    let state = this.buckets.get(key);
+    if (!state) {
+      // First contact for this key — full burst available.
+      state = { tokens: tier.capacity, lastRefillMs: nowMs };
+      this.evictLruIfFull();
+      this.buckets.set(key, state);
+    } else {
+      const elapsedSec = (nowMs - state.lastRefillMs) / 1000;
+      // Refill caps at capacity; negative elapsed (clock rewind) is
+      // clamped to zero so a backwards-stepping injected clock doesn't
+      // mint tokens.
+      const refill = Math.max(0, elapsedSec) * tier.refillPerSec;
+      state.tokens = Math.min(tier.capacity, state.tokens + refill);
+      state.lastRefillMs = nowMs;
+    }
+    this.lastUsedAt.set(key, nowMs);
+
+    if (state.tokens >= 1) {
+      state.tokens -= 1;
+      return { allowed: true, retryAfterSec: 0 };
+    }
+    // Deficit math: tokens are < 1, fractional. Refill needs (1 - tokens)
+    // more tokens to allow a request.
+    const retryAfterSec = (1 - state.tokens) / tier.refillPerSec;
+    return { allowed: false, retryAfterSec };
+  }
+
+  size(): number {
+    return this.buckets.size;
+  }
+
+  clear(): void {
+    this.buckets.clear();
+    this.lastUsedAt.clear();
+  }
+
+  /** Drop the least-recently-used entry until under `maxBuckets`. Called
+   *  before inserting a new bucket. Iterates `buckets.keys()` so a stray
+   *  `lastUsedAt` entry without a matching bucket can't make this spin
+   *  (same defensive pattern as `EngineStore.evictLruIfFull`). */
+  private evictLruIfFull(): void {
+    while (this.buckets.size >= this.maxBuckets) {
+      let oldestKey: string | null = null;
+      let oldestTime = Infinity;
+      for (const k of this.buckets.keys()) {
+        const t = this.lastUsedAt.get(k) ?? -Infinity;
+        if (t < oldestTime) {
+          oldestTime = t;
+          oldestKey = k;
+        }
+      }
+      if (oldestKey === null) break;
+      this.buckets.delete(oldestKey);
+      this.lastUsedAt.delete(oldestKey);
+    }
+  }
+}

--- a/packages/api/src/middleware/observability.test.ts
+++ b/packages/api/src/middleware/observability.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import { TokenBucketStore } from '../lib/rate-limit.js';
+import { createTestApp } from '../test-utils.js';
+
+const TIGHT_AUTHED = { capacity: 2, refillPerSec: 0 };
+const TIGHT_UNAUTHED = { capacity: 3, refillPerSec: 0 };
+
+// Captures the JSON log lines for assertion.
+function makeLogger() {
+  const lines: string[] = [];
+  return {
+    lines,
+    log: (line: string) => lines.push(line),
+    parsed: () => lines.map((l) => JSON.parse(l) as Record<string, unknown>),
+  };
+}
+
+// Inject a stable clock so durationMs is deterministic. The middleware
+// reads now() twice (start + end); without per-test isolation the
+// elapsed delta is whatever the test runner happened to take.
+function fixedClock() {
+  let t = 1_000_000;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe('observability middleware', () => {
+  it('exempts /health from rate limiting but still logs each request', async () => {
+    const { log, lines, parsed } = makeLogger();
+    const { app, cleanup } = createTestApp({
+      observability: { authedTier: TIGHT_AUTHED, log },
+    });
+    try {
+      for (let i = 0; i < TIGHT_AUTHED.capacity + 5; i++) {
+        const res = await app.request('/health');
+        expect(res.status).toBe(200);
+      }
+      expect(lines.length).toBe(TIGHT_AUTHED.capacity + 5);
+      for (const entry of parsed()) {
+        expect(entry.path).toBe('/health');
+        expect(entry.status).toBe(200);
+      }
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('rate-limits past the authed tier capacity and returns 429 with Retry-After', async () => {
+    const { log, parsed } = makeLogger();
+    const clock = fixedClock();
+    const { app, cleanup } = createTestApp({
+      observability: {
+        authedTier: TIGHT_AUTHED,
+        log,
+        now: clock.now,
+      },
+    });
+    try {
+      // First two pass; third hits 429.
+      let res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).not.toBe(429);
+      res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).not.toBe(429);
+      res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).toBe(429);
+      const retryAfter = res.headers.get('Retry-After');
+      expect(retryAfter).toBeTruthy();
+      // refillPerSec is 0 → retryAfter would be Infinity. Middleware
+      // clamps via Math.ceil to a finite header but we mainly need
+      // SOME value present.
+      expect(Number.parseInt(retryAfter!, 10)).toBeGreaterThanOrEqual(1);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe('Rate limit exceeded');
+
+      // 429 emitted a log line with rateLimited true + bucketKey for
+      // operator debugging.
+      const rl = parsed().filter((e) => e.status === 429);
+      expect(rl).toHaveLength(1);
+      expect(rl[0].rateLimited).toBe(true);
+      expect(rl[0].bucketKey).toBe('ip:unknown');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('uses the tighter unauthedAuthTier for /api/auth/*', async () => {
+    const { log, parsed } = makeLogger();
+    const { app, cleanup } = createTestApp({
+      observability: {
+        authedTier: { capacity: 10_000, refillPerSec: 100 },
+        unauthedAuthTier: TIGHT_UNAUTHED,
+        log,
+      },
+    });
+    try {
+      let lastStatus = 0;
+      for (let i = 0; i < TIGHT_UNAUTHED.capacity + 1; i++) {
+        const res = await app.request('/api/auth/some-endpoint', {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        lastStatus = res.status;
+      }
+      expect(lastStatus).toBe(429);
+      // The 429 came from the unauthed-auth tier — the authed tier's
+      // 10k capacity wouldn't have tripped yet.
+      const rl = parsed().filter((e) => e.status === 429);
+      expect(rl).toHaveLength(1);
+      expect(rl[0].path).toMatch(/^\/api\/auth\//);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('skips OPTIONS preflights from both bucket and log', async () => {
+    const { log, lines } = makeLogger();
+    const { app, cleanup } = createTestApp({
+      observability: { authedTier: TIGHT_AUTHED, log },
+    });
+    try {
+      for (let i = 0; i < 50; i++) {
+        const res = await app.request('/api/sync/nkjv-cor/state', {
+          method: 'OPTIONS',
+          headers: { Origin: 'http://localhost:5173' },
+        });
+        // CORS middleware handles preflights — status is 204 (or
+        // similar non-error).
+        expect(res.status).not.toBe(429);
+      }
+      expect(lines.length).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('isolates buckets per CF-Connecting-IP', async () => {
+    const { log } = makeLogger();
+    const { app, cleanup } = createTestApp({
+      observability: { authedTier: TIGHT_AUTHED, log },
+    });
+    try {
+      // IP A drains its bucket.
+      for (let i = 0; i < TIGHT_AUTHED.capacity; i++) {
+        const res = await app.request('/api/sync/nkjv-cor/state', {
+          headers: { 'CF-Connecting-IP': '1.1.1.1' },
+        });
+        expect(res.status).not.toBe(429);
+      }
+      // IP B is fresh.
+      const resB = await app.request('/api/sync/nkjv-cor/state', {
+        headers: { 'CF-Connecting-IP': '2.2.2.2' },
+      });
+      expect(resB.status).not.toBe(429);
+      // IP A is over quota.
+      const resA = await app.request('/api/sync/nkjv-cor/state', {
+        headers: { 'CF-Connecting-IP': '1.1.1.1' },
+      });
+      expect(resA.status).toBe(429);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('refills tokens after the injected clock advances past the window', async () => {
+    const { log } = makeLogger();
+    const clock = fixedClock();
+    const tier = { capacity: 1, refillPerSec: 1 };
+    const { app, cleanup } = createTestApp({
+      observability: { authedTier: tier, log, now: clock.now },
+    });
+    try {
+      let res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).not.toBe(429);
+      res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).toBe(429);
+      clock.advance(2_000); // 2 sec → 2 tokens refilled, cap at 1
+      res = await app.request('/api/sync/nkjv-cor/state');
+      expect(res.status).not.toBe(429);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('caps the bucket store at maxBuckets and never leaks', async () => {
+    const { log } = makeLogger();
+    const buckets = new TokenBucketStore({ maxBuckets: 2 });
+    const { app, cleanup } = createTestApp({
+      observability: { authedTier: TIGHT_AUTHED, buckets, log },
+    });
+    try {
+      for (const ip of ['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4']) {
+        await app.request('/api/sync/nkjv-cor/state', {
+          headers: { 'CF-Connecting-IP': ip },
+        });
+      }
+      expect(buckets.size()).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('emits a JSON log line with the expected shape on every request', async () => {
+    const { log, parsed } = makeLogger();
+    const clock = fixedClock();
+    const { app, cleanup } = createTestApp({
+      observability: { log, now: clock.now },
+    });
+    try {
+      clock.advance(0);
+      const res = await app.request('/health');
+      expect(res.status).toBe(200);
+      expect(parsed()).toHaveLength(1);
+      const entry = parsed()[0];
+      expect(entry.requestId).toMatch(/^[0-9a-f-]{36}$/);
+      expect(entry.userId).toBeNull();
+      expect(entry.ip).toBe('unknown');
+      expect(entry.method).toBe('GET');
+      expect(entry.path).toBe('/health');
+      expect(entry.status).toBe(200);
+      expect(typeof entry.durationMs).toBe('number');
+      expect(Number.isFinite(entry.durationMs)).toBe(true);
+      // X-Request-Id header echoes the log's requestId.
+      expect(res.headers.get('X-Request-Id')).toBe(entry.requestId);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('logs status=500 and rethrows when a handler throws', async () => {
+    const { log, parsed } = makeLogger();
+    const { app, cleanup } = createTestApp({
+      observability: { log },
+    });
+    try {
+      // Mount a handler that throws on a known path.
+      app.get('/test/boom', () => {
+        throw new Error('intentional explosion');
+      });
+      // Hono's default error handler converts the throw to a 500.
+      const res = await app.request('/test/boom');
+      expect(res.status).toBe(500);
+      const entry = parsed().find((e) => e.path === '/test/boom');
+      expect(entry).toBeDefined();
+      expect(entry!.status).toBe(500);
+      expect(entry!.error).toBe('intentional explosion');
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/api/src/middleware/observability.ts
+++ b/packages/api/src/middleware/observability.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from 'node:crypto';
+
+import type { Context, MiddlewareHandler } from 'hono';
+
+import { type RateLimitTier, TokenBucketStore } from '../lib/rate-limit.js';
+
+import type { AppVariables } from './session.js';
+
+/**
+ * Joint observability + rate-limit middleware.
+ *
+ * Per request:
+ *  1. Generate a `requestId`, capture `startedAtMs`.
+ *  2. Decide whether to skip rate limiting (`OPTIONS` preflights and
+ *     `/health` are exempt).
+ *  3. Otherwise consume a token from the appropriate tier (unauthed-auth
+ *     for `/api/auth/*`, the generic authed tier for everything else).
+ *     Over-quota → return `429` with `Retry-After`.
+ *  4. Call `next()` in try/finally so the log line emits even if a
+ *     handler throws. Re-throw so Hono's default error handler still
+ *     runs.
+ *  5. Emit one JSON line to stdout with the request-scope fields. Lines
+ *     land in journald via the systemd unit on the VPS.
+ *
+ * The token is consumed BEFORE `next()` runs — a handler that throws on
+ * specific inputs doesn't double as a rate-limit bypass.
+ *
+ * v1 bucket key is IP-only (per the plan; see `docs/server-api.md` →
+ * Rate limiting). Switching the authed tier to per-user keying is a
+ * follow-up if NAT'd users start tripping limits.
+ */
+
+export interface ObservabilityOptions {
+  /** Token-bucket tier applied to every non-auth route. Defaults map
+   *  to 120 req/min sustained with a 120-token burst — covers
+   *  grade-sequence sessions comfortably (~2 req/sec). */
+  authedTier: RateLimitTier;
+  /** Tighter tier for `/api/auth/*` to defang credential-stuffing
+   *  loops. Defaults to 10 req/min (1 token / 6 sec, burst 10). */
+  unauthedAuthTier: RateLimitTier;
+  /** Inject your own store for tests; defaults to a fresh
+   *  `TokenBucketStore({ now })`. */
+  buckets?: TokenBucketStore;
+  /** Where the JSON-line log lands. Default is `console.log`, which
+   *  the systemd unit captures into journald. Tests pass a callback
+   *  that appends to an array. */
+  log?: (line: string) => void;
+  /** ms-epoch clock. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Request-id generator. Defaults to `crypto.randomUUID`. */
+  randomId?: () => string;
+}
+
+export interface ResolvedObservabilityOptions {
+  authedTier: RateLimitTier;
+  unauthedAuthTier: RateLimitTier;
+  buckets: TokenBucketStore;
+  log: (line: string) => void;
+  now: () => number;
+  randomId: () => string;
+}
+
+export const DEFAULT_AUTHED_TIER: RateLimitTier = { capacity: 120, refillPerSec: 2 };
+export const DEFAULT_UNAUTHED_AUTH_TIER: RateLimitTier = {
+  capacity: 10,
+  refillPerSec: 10 / 60,
+};
+
+export function resolveObservabilityOptions(
+  opts: Partial<ObservabilityOptions> = {},
+): ResolvedObservabilityOptions {
+  const now = opts.now ?? Date.now;
+  return {
+    authedTier: opts.authedTier ?? DEFAULT_AUTHED_TIER,
+    unauthedAuthTier: opts.unauthedAuthTier ?? DEFAULT_UNAUTHED_AUTH_TIER,
+    buckets: opts.buckets ?? new TokenBucketStore({ now }),
+    log: opts.log ?? ((line) => console.log(line)),
+    now,
+    randomId: opts.randomId ?? randomUUID,
+  };
+}
+
+/** IP source: Cloudflare Tunnel → standard proxy header → fallback.
+ *  In tests the harness doesn't synthesise a socket; injecting
+ *  `CF-Connecting-IP` per request keeps test buckets isolated. */
+function resolveIp(c: Context): string {
+  const cf = c.req.header('CF-Connecting-IP');
+  if (cf) return cf;
+  const xff = c.req.header('X-Forwarded-For');
+  if (xff) {
+    const first = xff.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return 'unknown';
+}
+
+export function observabilityMiddleware(
+  opts: ResolvedObservabilityOptions,
+): MiddlewareHandler<{ Variables: AppVariables }> {
+  return async (c, next) => {
+    const requestId = opts.randomId();
+    const startedAtMs = opts.now();
+    const ip = resolveIp(c);
+    const method = c.req.method;
+    const path = c.req.path;
+
+    c.set('requestId', requestId);
+    c.res.headers.set('X-Request-Id', requestId);
+
+    // OPTIONS preflights run downstream CORS — no bucket, no log line.
+    // Logging every preflight would multiply journal volume without
+    // observability benefit.
+    if (method === 'OPTIONS') {
+      return next();
+    }
+
+    // /health is exempt from rate limiting but still logged — uptime
+    // probes need to see the same correlation fields as real traffic.
+    const isHealth = path === '/health';
+    const isAuth = path.startsWith('/api/auth/');
+
+    if (!isHealth) {
+      const tier = isAuth ? opts.unauthedAuthTier : opts.authedTier;
+      const key = `ip:${ip}`;
+      const result = opts.buckets.consume(key, tier);
+      if (!result.allowed) {
+        // Clamp to a finite, sensible upper bound. A zero refill rate
+        // (test-only edge case) produces Infinity from the deficit math,
+        // which would render as the literal "Infinity" in the header
+        // and break clients parsing as int.
+        const raw = Number.isFinite(result.retryAfterSec)
+          ? Math.ceil(result.retryAfterSec)
+          : 3600;
+        const retryAfter = Math.max(1, Math.min(3600, raw));
+        c.res.headers.set('Retry-After', String(retryAfter));
+        const status = 429;
+        const durationMs = opts.now() - startedAtMs;
+        // `bucketKey` is logged separately from `ip` so future per-user
+        // keying (`user:<id>`) stays observable without changing the
+        // shape — operators debugging "why am I being limited?" can
+        // grep the same field regardless of tier.
+        opts.log(
+          JSON.stringify({
+            requestId,
+            userId: null,
+            ip,
+            method,
+            path,
+            status,
+            durationMs,
+            rateLimited: true,
+            bucketKey: key,
+          }),
+        );
+        return c.json({ error: 'Rate limit exceeded' }, status);
+      }
+    }
+
+    let caught: unknown = null;
+    try {
+      await next();
+    } catch (err) {
+      caught = err;
+    }
+    // Hono's app-level error handling can catch handler throws inside
+    // its dispatch loop before they propagate up through `next()`. In
+    // that case `c.error` carries the thrown value and `c.res.status`
+    // is already 500. Falling back to `c.error` lets us log the
+    // underlying error even when `await next()` resolved cleanly.
+    const error = caught ?? c.error;
+    const durationMs = opts.now() - startedAtMs;
+    const userId = c.get('user')?.id ?? null;
+    const status = c.res.status;
+    const record: Record<string, unknown> = {
+      requestId,
+      userId,
+      ip,
+      method,
+      path,
+      status,
+      durationMs,
+    };
+    if (error) {
+      record.error = error instanceof Error ? error.message : String(error);
+    }
+    opts.log(JSON.stringify(record));
+    if (caught) throw caught;
+  };
+}

--- a/packages/api/src/middleware/session.ts
+++ b/packages/api/src/middleware/session.ts
@@ -12,7 +12,20 @@ export interface SessionVariables {
   user: SessionUser | null;
 }
 
-export function sessionMiddleware(auth: Auth): MiddlewareHandler<{ Variables: SessionVariables }> {
+/** Superset of `SessionVariables` used by `app.ts` itself — the
+ *  observability middleware adds `requestId` for cross-handler
+ *  correlation. Route files keep using `SessionVariables` so the
+ *  observability addition stays a non-breaking type change. */
+export interface AppVariables extends SessionVariables {
+  requestId: string;
+}
+
+/** Generic over any Variables shape that contains `user`. Lets `app.ts`
+ *  use the wider `AppVariables` (adds `requestId`) without losing
+ *  assignability when passing the Context through. */
+export function sessionMiddleware<
+  E extends { Variables: SessionVariables },
+>(auth: Auth): MiddlewareHandler<E> {
   return async (c, next) => {
     const session = await auth.api.getSession({ headers: c.req.raw.headers });
     if (session?.user) {
@@ -28,7 +41,9 @@ export function sessionMiddleware(auth: Auth): MiddlewareHandler<{ Variables: Se
   };
 }
 
-export function requireAuth(): MiddlewareHandler<{ Variables: SessionVariables }> {
+export function requireAuth<
+  E extends { Variables: SessionVariables },
+>(): MiddlewareHandler<E> {
   return async (c, next) => {
     if (!c.get('user')) {
       return c.json({ error: 'Authentication required' }, 401);

--- a/packages/api/src/test-utils.ts
+++ b/packages/api/src/test-utils.ts
@@ -8,6 +8,7 @@ import { createApp } from './app.js';
 import { type DB, createDb } from './db/client.js';
 import { user } from './db/schema.js';
 import { runMigrations } from './db/migrate.js';
+import type { ObservabilityOptions } from './middleware/observability.js';
 
 export const TEST_AUTH_ENV = {
   baseUrl: 'http://localhost:3000',
@@ -37,12 +38,31 @@ export function createTestDb(): TestDb {
   };
 }
 
-export function createTestApp() {
+export interface CreateTestAppOptions {
+  /** Override observability middleware defaults. Useful for tests that
+   *  need tight rate-limit tiers or want to capture logged JSON lines. */
+  observability?: Partial<ObservabilityOptions>;
+}
+
+/** Permissive rate-limit defaults so existing route tests (which fire
+ *  many requests on the same `unknown` IP) don't accidentally hit
+ *  production-scale caps. Tests that specifically exercise rate
+ *  limiting pass `observability: { authedTier, ... }` to override. */
+const TEST_DEFAULT_OBSERVABILITY = {
+  authedTier: { capacity: 100_000, refillPerSec: 100_000 / 60 },
+  unauthedAuthTier: { capacity: 100_000, refillPerSec: 100_000 / 60 },
+};
+
+export function createTestApp(opts: CreateTestAppOptions = {}) {
   const test = createTestDb();
   // Pull `engines` so tests can clear() / inspect it if they want.
   // We deliberately don't call `engines.start()` here — tests run in
   // milliseconds and have no use for the 60 s idle reaper.
-  const { app, engines } = createApp({ db: test.db, authEnv: TEST_AUTH_ENV });
+  const { app, engines } = createApp({
+    db: test.db,
+    authEnv: TEST_AUTH_ENV,
+    observability: { ...TEST_DEFAULT_OBSERVABILITY, ...opts.observability },
+  });
   return { app, engines, ...test };
 }
 


### PR DESCRIPTION
## Summary

Lands a joint observability + rate-limit middleware on the API. Both concerns want the same per-request context (who, what route, status, duration) — one focused middleware (~150 lines) instead of two.

### What changed

- **Structured request log** replaces Hono's built-in `logger()`. One JSON line per non-OPTIONS request to stdout (captured into journald via the systemd unit):
  ```json
  { "requestId": "uuid", "userId": "...|null", "ip": "...", "method": "GET",
    "path": "/api/...", "status": 200, "durationMs": 47 }
  ```
  Plus `error` on handler throws, `rateLimited: true` on 429s.
- **`X-Request-Id` response header** echoes the same `requestId` so clients can quote it in support requests. Handlers can read it from `c.get('requestId')` for cross-handler correlation.
- **Token-bucket rate limit** with two tiers:
  - Authed: 120 req/min for every route except `/health` and `/api/auth/*` (env `RATE_LIMIT_AUTHED_PER_MIN`).
  - Unauthed `/api/auth/*`: 10 req/min (env `RATE_LIMIT_UNAUTHED_PER_MIN`).
  - `/health` exempt entirely.
  - Bucket key is the client IP from `CF-Connecting-IP` (production behind Cloudflare Tunnel), `X-Forwarded-For` (dev), or `unknown`.
- **`429` responses** carry `Retry-After: <ceil(secs)>` and the standard `{ "error": "Rate limit exceeded" }` body. Mounted before `cors()` so browsers see real 429s with CORS headers, not network errors. `exposeHeaders` now lists `Retry-After` and `X-Request-Id`.
- **Failed `/api/auth/sign-in/email` attempts still consume a token** — intentional brute-force protection.

### Architecture

- `packages/api/src/lib/rate-limit.ts` — `TokenBucketStore` class. Bounded at 10k entries with LRU eviction on insert, mirroring the `EngineStore.cache` idiom. No periodic timer — sidesteps the `EngineStore.start()` test-leak trap.
- `packages/api/src/middleware/observability.ts` — Hono middleware factory. Generates `requestId`, decides bucket key + tier from path, consumes a token, runs `next()` in try/catch that captures both rejected promises and Hono's swallowed handler throws (via `c.error`), emits the JSON line.
- `packages/api/src/middleware/session.ts` — new exported `AppVariables` type extending `SessionVariables` with `requestId`. Route files keep using `SessionVariables` so this is a non-breaking type addition. `sessionMiddleware` and `requireAuth` become generic over Variables to make assignment work.
- `packages/api/src/test-utils.ts` — `createTestApp({ observability })` accepts overrides. Defaults to a 100k-cap permissive tier so existing route tests (which fire many requests on the same `unknown` IP) don't accidentally trip rate limits.
- `packages/api/src/index.ts` — env-var read + thread to `createApp`. Garbage values fall back to defaults.

### Deliberate skips (out of scope for this PR)

- No Prometheus / OpenTelemetry / traces / spans. JSON-line in journald is enough at current scale.
- No Redis / shared store for distributed rate limiting. Single-VPS only; doc'd in `server-api.md`.
- No per-user tier beyond the two IP-based ones. NAT'd siblings share a bucket; per-user keying is a follow-up if it actually starts hurting.
- No new npm dependencies.

### Bundled algorithm contract

Unchanged — `verse-vault-core@0.5.0`, `verse-vault-wasm@0.5.0`. No wire-format break.

## Test plan

- [x] `pnpm --filter @verse-vault/api run type-check` — clean
- [x] 8 new vitest cases on `TokenBucketStore` (capacity, deficit math, refill, key isolation, LRU eviction, clock-rewind clamp, `clear()`)
- [x] 9 new vitest cases on the middleware (`/health` exempt, 429 + Retry-After, tighter unauthed tier on `/api/auth/*`, OPTIONS skipped, IP isolation, refill via injected clock, `maxBuckets` cap, log line shape + `X-Request-Id` correlation, handler-throws captured via `c.error`)
- [x] Full vitest suite passes (132/132 — 17 new + 115 existing)
- [ ] Local smoke: `curl -i http://localhost:3000/health` returns 200 + `X-Request-Id`; loop `/api/auth/sign-in/email` 15 times → ~10 normal then 429 + `Retry-After`
- [ ] Production smoke: `journalctl -u verse-vault.service -n 20 -o cat | jq .` shows JSON-line shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)