### PR TITLE
refactor(web): unify graduation persist helpers

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,19 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.19] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Internal refactor
+
+`persistLocalGraduation` and `persistLocalCardGraduation` in `lib/engine/engineStore.ts` were
+near-identical 5-line helpers differing only in the snapshot field they wrote to. Folded into one
+parameterised helper. No behaviour change.
+
 ## [0.1.18] — 2026-05-28
 
 ### Bundled algorithm contract

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -255,23 +255,27 @@ export async function submitGraduation(
   // Persist the graduation locally too so a page reload before the
   // event flushes (or after it flushes but before /state is re-fetched)
   // still resurrects the verse as Active.
-  void persistLocalGraduation(materialId, verseId).catch((e) => {
+  void persistLocalGraduation(materialId, 'graduatedVerseIds', verseId).catch((e) => {
     console.warn('engineStore.submitGraduation: snapshot update failed', e)
   })
 
   return count
 }
 
-async function persistLocalGraduation(materialId: string, verseId: number): Promise<void> {
-  // Caller (`submitGraduation`) already validated a live session via
-  // `requireSession`, and sessions imply a snapshot row in IDB —
-  // `getSnapshot` is treated as infallible here. A missing row
-  // signals genuine IDB corruption and propagates as a thrown error
-  // through the surrounding fire-and-forget `.catch`.
+// Caller (`submitGraduation` / `submitCardGraduation`) already validated
+// a live session via `requireSession`, and sessions imply a snapshot row
+// in IDB — `getSnapshot` is treated as infallible here. A missing row
+// signals genuine IDB corruption and propagates as a thrown error
+// through the surrounding fire-and-forget `.catch`.
+async function persistLocalGraduation(
+  materialId: string,
+  field: 'graduatedVerseIds' | 'graduatedCardIds',
+  id: number,
+): Promise<void> {
   const snapshot = (await idb.getSnapshot(materialId))!
-  const ids = snapshot.graduatedVerseIds ?? []
-  if (ids.includes(verseId)) return
-  await idb.putSnapshot({ ...snapshot, graduatedVerseIds: [...ids, verseId] })
+  const ids = snapshot[field] ?? []
+  if (ids.includes(id)) return
+  await idb.putSnapshot({ ...snapshot, [field]: [...ids, id] })
 }
 
 /** Apply a single-card graduation locally and queue the event for
@@ -298,18 +302,11 @@ export async function submitCardGraduation(
       console.warn('engineStore.submitCardGraduation: queue append failed', e)
     })
 
-  void persistLocalCardGraduation(materialId, cardId).catch((e) => {
+  void persistLocalGraduation(materialId, 'graduatedCardIds', cardId).catch((e) => {
     console.warn('engineStore.submitCardGraduation: snapshot update failed', e)
   })
 
   return flipped
-}
-
-async function persistLocalCardGraduation(materialId: string, cardId: number): Promise<void> {
-  const snapshot = (await idb.getSnapshot(materialId))!
-  const ids = snapshot.graduatedCardIds ?? []
-  if (ids.includes(cardId)) return
-  await idb.putSnapshot({ ...snapshot, graduatedCardIds: [...ids, cardId] })
 }
 
 /** Look up the next due review card. */


### PR DESCRIPTION
## Summary

\`persistLocalGraduation\` and \`persistLocalCardGraduation\` in \`apps/web/src/lib/engine/engineStore.ts\` were near-identical 5-line functions differing only in the snapshot field they wrote to (\`graduatedVerseIds\` vs \`graduatedCardIds\`). Parameterised by field name so \`submitGraduation\` and \`submitCardGraduation\` share one helper.

Net change: −3 lines. No observable behaviour change.

## Backstory

The refactor was authored alongside the original \`feat/detach-hp-ccl-memorize\` work (commit lands on \`8c17b96\` originally, now \`d37314e\` after rebase) but never merged — deferred at the time per the \"no single-commit PRs for substantive changes\" granularity rule, with the plan to fold into the next web-touching PR.

That PR never materialised: every PR since (#76–#84) has been api / deploy / docs only. Rather than let the branch keep bit-rotting indefinitely, shipping it as its own small refactor. Rebased clean — \`apps/web/src/lib/engine/engineStore.ts\` hasn't been touched on master since the original parent commit.

## Test plan

- [x] \`pnpm --filter @verse-vault/web run type-check\` — clean
- [x] No behaviour change → no test additions needed
- [ ] Manual smoke (deploy): grade a verse, graduate it (verse-bulk path); confirm IDB snapshot still tracks \`graduatedVerseIds\` correctly. Same for a card-only graduation on an HP/CCL item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)