### PR TITLE
feat(api): account export/import + Anki converter

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -33,10 +33,10 @@ years of memorization history into verse-vault from their existing `.colpkg` bac
   into the wire format.
 * **`POST /api/import`** — accepts an `AccountExport`, returns an `ImportSummary` (events inserted /
   skipped via `clientEventId` dedup, graduations applied, unresolved cardRefs). Per-material
-  transaction: a bad cardRef in one material doesn't poison another's writes. After all DB writes
-  land, calls `EngineStore.rebuildFromEvents(key)` per material so `test_states` regenerates from
-  the now-augmented event log — no engine-state copying. Body capped at 50 MB via hono's
-  `body-limit`.
+  transaction: a bad cardRef in one material doesn't poison another's writes. After each material's
+  writes land, calls `EngineStore.rebuildFromEvents(key)` for that material (under the engine's
+  per-key lock) so `test_states` regenerates from the now-augmented event log — no engine-state
+  copying. Body capped at 50 MB via hono's `body-limit`.
 * **Settings merge policy**: per-row `max(updatedAt)` wins. Locally-tuned settings aren't blown away
   by an older imported row, and re-import of the same payload is a no-op. Imported settings run
   through the same bound/enum validation as the `PUT /api/years/:id/settings` route (extracted to

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,44 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.25] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Account export / import + Anki bootstrap
+
+Adds a versioned account portability format and an Anki bootstrap converter, so a new user can seed
+years of memorization history into verse-vault from their existing `.colpkg` backup.
+
+* **`AccountExport` v1** (`packages/api/src/lib/export-format.ts`) — single JSON payload covering
+  the user row, every enrolled material, per-year settings, graduations, and the full review-event
+  log. Cards key on `CardRef` (`kind` + verseId + params), not `cardId`, so an export from an older
+  snapshot version can be replayed against the current one as long as the referenced verses still
+  exist. HP / CCL use natural keys (`headingIdx`, `(book, chapter, tier)`) so external converters
+  don't need to know the builder's synthetic pseudo-verse ids.
+* **`GET /api/export`** — full account dump as `verse-vault-export-YYYY-MM-DD.json`. Walks every
+  enrolled material, loads the engine to build the cardId↔CardRef index, then translates DB rows
+  into the wire format.
+* **`POST /api/import`** — accepts an `AccountExport`, returns an `ImportSummary` (events inserted /
+  skipped via `clientEventId` dedup, graduations applied, unresolved cardRefs). Per-material
+  transaction: a bad cardRef in one material doesn't poison another's writes. After all DB writes
+  land, calls `EngineStore.rebuildFromEvents(key)` per material so `test_states` regenerates from
+  the now-augmented event log — no engine-state copying. Body capped at 50 MB via hono's
+  `body-limit`.
+* **Settings merge policy**: per-row `max(updatedAt)` wins. Locally-tuned settings aren't blown away
+  by an older imported row, and re-import of the same payload is a no-op.
+* **`tools/anki_to_export.py`** — reads a `.colpkg`, maps the 3 Verse template ords to Citation /
+  Recitation / Ftv, Heading notes to HeadingPassage, Key Verse List to ChapterClubList. Graduation
+  rule (per spec): any Verse note with ANY of its 3 cards in Anki queue ≥ 2 graduates the verse;
+  same rule for HP / CCL goes through `graduatedCards`. `clientEventId` is
+  `anki:<col-mod>:<revlog-id>` so re-running the converter is idempotent on import. Output uploads
+  directly to `/api/import`.
+
+Bundled algorithm contract unchanged. No wire-format break.
+
 ## [0.1.24] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -38,11 +38,15 @@ years of memorization history into verse-vault from their existing `.colpkg` bac
   the now-augmented event log — no engine-state copying. Body capped at 50 MB via hono's
   `body-limit`.
 * **Settings merge policy**: per-row `max(updatedAt)` wins. Locally-tuned settings aren't blown away
-  by an older imported row, and re-import of the same payload is a no-op.
+  by an older imported row, and re-import of the same payload is a no-op. Imported settings run
+  through the same bound/enum validation as the `PUT /api/years/:id/settings` route (extracted to
+  `lib/year-settings.ts`); an out-of-range value is rejected with a 400 rather than written
+  verbatim.
 * **`tools/anki_to_export.py`** — reads a `.colpkg`, maps the 3 Verse template ords to Citation /
   Recitation / Ftv, Heading notes to HeadingPassage, Key Verse List to ChapterClubList. Graduation
   rule (per spec): any Verse note with ANY of its 3 cards in Anki queue ≥ 2 graduates the verse;
-  same rule for HP / CCL goes through `graduatedCards`. `clientEventId` is
+  same rule for HP / CCL goes through `graduatedCards`, and the graduation timestamp is the earliest
+  _passing_ review (not the first time the card was seen). `clientEventId` is
   `anki:<col-mod>:<revlog-id>` so re-running the converter is idempotent on import. Output uploads
   directly to `/api/import`.
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -18,6 +18,7 @@ import {
   requireAuth,
   sessionMiddleware,
 } from './middleware/session.js';
+import { accountRoutes } from './routes/account.js';
 import { cardsRoutes } from './routes/cards.js';
 import { materialsRoutes } from './routes/materials.js';
 import { activityRoutes } from './routes/activity.js';
@@ -147,6 +148,7 @@ export function createApp(deps: AppDeps) {
   app.route('/api/years', yearsRoutes({ db: deps.db, engines, now: deps.now }));
   app.route('/api/stats', statsRoutes({ db: deps.db, engines, now: deps.now }));
   app.route('/api/activity', activityRoutes({ db: deps.db, now: deps.now }));
+  app.route('/api', accountRoutes({ db: deps.db, engines, now: deps.now }));
 
   return { app, engines };
 }

--- a/packages/api/src/lib/card-ref.test.ts
+++ b/packages/api/src/lib/card-ref.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WasmEngine } from 'verse-vault-wasm';
+
+import { afterEach } from 'vitest';
+import { EngineStore } from './engine.js';
+import { type CardRef, cardRefKey } from './export-format.js';
+import { buildCardRefIndex, resolveCardRef } from './card-ref.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb } from '../test-utils.js';
+
+/** Stubs the one engine method the indexer reads, so we can drive
+ *  every CardKindWire variant deterministically without standing up a
+ *  real engine. */
+function stubEngine(payload: unknown): WasmEngine {
+  return { all_card_renders: () => JSON.stringify(payload) } as unknown as WasmEngine;
+}
+
+describe('cardRefKey', () => {
+  it('produces stable strings per CardRef shape', () => {
+    const refs: CardRef[] = [
+      { kind: 'PhraseFill', verseId: 0, position: 1 },
+      { kind: 'Recitation', verseId: 0 },
+      { kind: 'VerseInClub', verseId: 0, tier: 'Club150' },
+      { kind: 'Ftv', verseId: 0, withCitation: true },
+      { kind: 'HeadingPassage', headingIdx: 3 },
+      { kind: 'ChapterClubList', book: 'John', chapter: 1, tier: 'Club300' },
+    ];
+    const keys = refs.map(cardRefKey);
+    // No collisions across distinct refs.
+    expect(new Set(keys).size).toBe(refs.length);
+    // Stable under repeat call.
+    expect(refs.map(cardRefKey)).toEqual(keys);
+  });
+
+  it('treats withCitation true vs false as distinct keys', () => {
+    expect(
+      cardRefKey({ kind: 'Ftv', verseId: 0, withCitation: true }),
+    ).not.toBe(cardRefKey({ kind: 'Ftv', verseId: 0, withCitation: false }));
+  });
+});
+
+describe('buildCardRefIndex', () => {
+  it('round-trips every CardKindWire variant', () => {
+    // Mirrors the flattened wire shape `all_card_renders` returns.
+    const renders = [
+      {
+        cardId: 1,
+        verseId: 0,
+        kind: 'PhraseFill',
+        position: 0,
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 2,
+        verseId: 0,
+        kind: 'VerseAtVerseRef',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 3,
+        verseId: 0,
+        kind: 'VerseInChapter',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 4,
+        verseId: 0,
+        kind: 'VerseInBook',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 5,
+        verseId: 0,
+        kind: 'Recitation',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 6,
+        verseId: 0,
+        kind: 'Citation',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 7,
+        verseId: 0,
+        kind: 'VerseInHeading',
+        headingIdx: 4,
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 8,
+        verseId: 0,
+        kind: 'VerseInClub',
+        tier: 'Club150',
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 9,
+        verseId: 0,
+        kind: 'Ftv',
+        withCitation: false,
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 10,
+        verseId: 9999,
+        kind: 'HeadingPassage',
+        headingIdx: 4,
+        verse: { book: 'John', chapter: 3, verse: 16 },
+      },
+      {
+        cardId: 11,
+        verseId: 9998,
+        kind: 'ChapterClubList',
+        tier: 'Club150',
+        verse: { book: 'John', chapter: 3, verse: 1 },
+      },
+    ];
+    const index = buildCardRefIndex(stubEngine(renders));
+    expect(index.byCardId.size).toBe(renders.length);
+    expect(index.byRef.size).toBe(renders.length);
+    // Round-trip: cardId → CardRef → cardId.
+    for (const r of renders) {
+      const ref = index.byCardId.get(r.cardId);
+      expect(ref).toBeDefined();
+      expect(resolveCardRef(index, ref!)).toBe(r.cardId);
+    }
+  });
+
+  it('omits verseId from HeadingPassage and ChapterClubList CardRefs', () => {
+    const renders = [
+      {
+        cardId: 1,
+        verseId: 9999,
+        kind: 'HeadingPassage',
+        headingIdx: 2,
+        verse: { book: 'John', chapter: 1, verse: 1 },
+      },
+      {
+        cardId: 2,
+        verseId: 9998,
+        kind: 'ChapterClubList',
+        tier: 'Club300',
+        verse: { book: 'John', chapter: 5, verse: 1 },
+      },
+    ];
+    const index = buildCardRefIndex(stubEngine(renders));
+    const hpRef = index.byCardId.get(1);
+    const cclRef = index.byCardId.get(2);
+    expect(hpRef).toEqual({ kind: 'HeadingPassage', headingIdx: 2 });
+    expect(cclRef).toEqual({
+      kind: 'ChapterClubList',
+      book: 'John',
+      chapter: 5,
+      tier: 'Club300',
+    });
+  });
+
+  it('skips unknown kinds rather than crashing', () => {
+    const index = buildCardRefIndex(
+      stubEngine([
+        {
+          cardId: 1,
+          verseId: 0,
+          kind: 'SomeUnknownKindFromTheFuture',
+          verse: { book: 'John', chapter: 1, verse: 1 },
+        },
+        {
+          cardId: 2,
+          verseId: 0,
+          kind: 'Recitation',
+          verse: { book: 'John', chapter: 1, verse: 1 },
+        },
+      ]),
+    );
+    expect(index.byCardId.size).toBe(1);
+    expect(index.byCardId.has(1)).toBe(false);
+    expect(index.byCardId.has(2)).toBe(true);
+  });
+
+  it('returns undefined for unresolved CardRefs', () => {
+    const index = buildCardRefIndex(stubEngine([]));
+    expect(resolveCardRef(index, { kind: 'Recitation', verseId: 0 })).toBeUndefined();
+  });
+});
+
+describe('buildCardRefIndex against a live engine', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('indexes every card the live engine emits', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: 'nkjv-cor' });
+
+    const store = new EngineStore(test.db);
+    try {
+      using loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
+      const index = buildCardRefIndex(loaded.engine);
+      // The fixture has at least one card.
+      expect(index.byCardId.size).toBeGreaterThan(0);
+      // Every cardId → CardRef → cardId round-trips.
+      for (const [cardId, ref] of index.byCardId) {
+        expect(resolveCardRef(index, ref)).toBe(cardId);
+      }
+    } finally {
+      store.clear();
+    }
+  });
+});

--- a/packages/api/src/lib/card-ref.ts
+++ b/packages/api/src/lib/card-ref.ts
@@ -1,0 +1,100 @@
+import type { WasmEngine } from 'verse-vault-wasm';
+
+import { type CardRef, cardRefKey } from './export-format.js';
+
+/**
+ * Bidirectional index between live `cardId`s and snapshot-stable
+ * `CardRef`s.
+ *
+ * Built once per (user, material) by walking `engine.all_card_renders()`
+ * — the same JSON the bulk-renders route returns. We re-translate the
+ * flattened `CardKindWire` JSON back into the `CardRef` shape: most
+ * fields pass through unchanged; HP/CCL discard the synthetic
+ * `verseId` in favour of natural keys (`headingIdx` for HP,
+ * `(book, chapter, tier)` for CCL) because those keys are stable
+ * across builder runs while pseudo-verse ids are not portable across
+ * materials.
+ *
+ * The `byRef` map uses `cardRefKey(ref)` (a canonical string) for
+ * O(1) resolution.
+ */
+export interface CardRefIndex {
+  byCardId: Map<number, CardRef>;
+  byRef: Map<string, number>;
+}
+
+/** Subset of `CardRenderWire` we actually need to build the index.
+ *  Decoded from `all_card_renders()` JSON; extra fields are ignored. */
+interface CardRenderWire {
+  cardId: number;
+  verseId: number;
+  kind: string;
+  // CardKindWire fields are flattened into the same object:
+  position?: number;
+  headingIdx?: number;
+  tier?: 'Club150' | 'Club300' | 'Full';
+  withCitation?: boolean;
+  verse: { book: string; chapter: number };
+}
+
+export function buildCardRefIndex(engine: WasmEngine): CardRefIndex {
+  const renders = JSON.parse(engine.all_card_renders()) as CardRenderWire[];
+  const byCardId = new Map<number, CardRef>();
+  const byRef = new Map<string, number>();
+  for (const c of renders) {
+    const ref = toCardRef(c);
+    if (!ref) continue;
+    byCardId.set(c.cardId, ref);
+    byRef.set(cardRefKey(ref), c.cardId);
+  }
+  return { byCardId, byRef };
+}
+
+/** Translate one `CardRenderWire` to a `CardRef`. Returns `undefined`
+ *  on an unrecognised kind so a future core-side addition doesn't
+ *  crash the resolver — the entry just won't appear in either map. */
+function toCardRef(c: CardRenderWire): CardRef | undefined {
+  switch (c.kind) {
+    case 'PhraseFill':
+      if (c.position === undefined) return undefined;
+      return { kind: 'PhraseFill', verseId: c.verseId, position: c.position };
+    case 'VerseAtVerseRef':
+    case 'VerseInChapter':
+    case 'VerseInBook':
+    case 'Recitation':
+    case 'Citation':
+    case 'Reading':
+      return { kind: c.kind, verseId: c.verseId };
+    case 'VerseInHeading':
+      if (c.headingIdx === undefined) return undefined;
+      return { kind: 'VerseInHeading', verseId: c.verseId, headingIdx: c.headingIdx };
+    case 'VerseInClub':
+      if (!c.tier) return undefined;
+      return { kind: 'VerseInClub', verseId: c.verseId, tier: c.tier };
+    case 'Ftv':
+      if (c.withCitation === undefined) return undefined;
+      return { kind: 'Ftv', verseId: c.verseId, withCitation: c.withCitation };
+    case 'HeadingPassage':
+      if (c.headingIdx === undefined) return undefined;
+      return { kind: 'HeadingPassage', headingIdx: c.headingIdx };
+    case 'ChapterClubList':
+      if (!c.tier) return undefined;
+      return {
+        kind: 'ChapterClubList',
+        book: c.verse.book,
+        chapter: c.verse.chapter,
+        tier: c.tier,
+      };
+    default:
+      return undefined;
+  }
+}
+
+/** Resolve a CardRef to a live cardId via the index. Returns
+ *  `undefined` when the importing snapshot doesn't have a matching
+ *  card (e.g. an `Ftv` ref when the importing user has `ftv: false`
+ *  so no FTV cards are emitted). The caller counts unresolved refs
+ *  in the import summary. */
+export function resolveCardRef(index: CardRefIndex, ref: CardRef): number | undefined {
+  return index.byRef.get(cardRefKey(ref));
+}

--- a/packages/api/src/lib/export-format.ts
+++ b/packages/api/src/lib/export-format.ts
@@ -1,0 +1,159 @@
+/**
+ * Account export/import payload — JSON shape transferred between
+ * `GET /api/export` and `POST /api/import`. Designed so a Python
+ * converter (e.g. `tools/anki_to_export.py`) can produce the same
+ * shape from a third-party source.
+ *
+ * Version contract: increment `exportVersion` (integer) on any
+ * non-additive shape change. Adding optional fields is backwards-
+ * compatible and does not require a bump. The importer rejects
+ * unknown major versions with a 400.
+ *
+ * Stability: review events and graduations key on `CardRef` —
+ * `(kind, verseId, params)` — not `cardId`. Card ids reshuffle when
+ * the deck JSON changes; `CardRef` is the canonical identity the
+ * engine materialises from at runtime via `engine.all_card_renders()`.
+ * That means an export from snapshot version 5 can be imported into
+ * snapshot version 7 as long as the referenced verses still exist.
+ */
+
+/** ClubTier wire form — matches `verse-vault-core::ClubTier` serde shape. */
+export type ClubTierName = 'Club150' | 'Club300' | 'Full';
+
+/** Identifies a card by its semantic position rather than its assigned
+ *  `cardId`. The `kind` discriminator lines up 1:1 with `CardKindWire`
+ *  in `crates/wasm/src/lib.rs`. Verse-bound kinds carry `verseId`;
+ *  pseudo-verse kinds (`HeadingPassage`, `ChapterClubList`) omit it
+ *  because their `verseId` is a synthetic builder-assigned value an
+ *  external converter has no way to compute. The natural key
+ *  (`headingIdx` for HP, `(book, chapter, tier)` for CCL) uniquely
+ *  identifies the card to the resolver. */
+export type CardRef =
+  | { kind: 'PhraseFill'; verseId: number; position: number }
+  | {
+      kind:
+        | 'VerseAtVerseRef'
+        | 'VerseInChapter'
+        | 'VerseInBook'
+        | 'Recitation'
+        | 'Citation'
+        | 'Reading';
+      verseId: number;
+    }
+  | { kind: 'VerseInHeading'; verseId: number; headingIdx: number }
+  | { kind: 'VerseInClub'; verseId: number; tier: ClubTierName }
+  | { kind: 'Ftv'; verseId: number; withCitation: boolean }
+  | { kind: 'HeadingPassage'; headingIdx: number }
+  | { kind: 'ChapterClubList'; book: string; chapter: number; tier: ClubTierName };
+
+/** Per-(user, material) settings. Mirrors `user_year_settings` columns
+ *  in camelCase so a new column added there propagates by re-running
+ *  the export with the wider type. */
+export interface YearSettingsExport {
+  headingCard: boolean;
+  headingPassageCard: boolean;
+  ftv: boolean;
+  newScope: string;
+  reviewScope: string;
+  clubCardScope: string;
+  chapterListScope: string;
+  lessonBatchSize: number;
+  desiredRetention: number;
+  updatedAt: number;
+}
+
+export interface EnrollmentExport {
+  clubTier: number | null;
+  offlineMode: boolean;
+  createdAt: number;
+}
+
+export interface MaterialSnapshotExport {
+  /** Informational. The importer does NOT enforce a match — cardRefs
+   *  resolve against the importing engine's current snapshot. */
+  version: number;
+  contentSha: string;
+}
+
+export interface ReviewEventExport {
+  /** Stable, deterministic per source row (e.g. `anki:<col-mod>:<revlog-id>`
+   *  for the Anki converter). The importer dedupes by this. */
+  clientEventId: string;
+  /** Unix seconds (not ms). */
+  timestampSecs: number;
+  cardRef: CardRef;
+  /** FSRS grade in `1..=4` (Again/Hard/Good/Easy). */
+  grade: 1 | 2 | 3 | 4;
+}
+
+export interface GraduatedVerseExport {
+  verseId: number;
+  graduatedAtSecs: number;
+}
+
+export interface GraduatedCardExport {
+  cardRef: CardRef;
+  graduatedAtSecs: number;
+}
+
+export interface MaterialExport {
+  materialId: string;
+  enrollment: EnrollmentExport;
+  /** `null` when no `user_year_settings` row exists (user enrolled but
+   *  never touched any setting). */
+  settings: YearSettingsExport | null;
+  snapshot: MaterialSnapshotExport;
+  graduatedVerses: GraduatedVerseExport[];
+  graduatedCards: GraduatedCardExport[];
+  reviewEvents: ReviewEventExport[];
+}
+
+export interface AccountExport {
+  exportVersion: 1;
+  /** Unix seconds at the moment the export was assembled. */
+  exportedAt: number;
+  user: { email: string; name: string };
+  materials: MaterialExport[];
+}
+
+export interface ImportSummary {
+  materialsApplied: number;
+  eventsInserted: number;
+  /** Events skipped because their `clientEventId` already existed for
+   *  this user × material — the dedup path is what makes re-import
+   *  idempotent. */
+  eventsSkipped: number;
+  graduationsApplied: number;
+  /** Count of CardRefs that didn't match any card in the importing
+   *  engine's current snapshot (e.g. `Ftv` in an export where the
+   *  importing user has `ftv: false`). Skipped, not rejected. */
+  unresolvedCardRefs: number;
+}
+
+/** Canonical key for the CardRef ↔ cardId index. Stable across
+ *  process restarts because it's built from the CardRef shape, not
+ *  from any in-memory pointer. Exported because both the export and
+ *  import paths use the same indexer. */
+export function cardRefKey(ref: CardRef): string {
+  switch (ref.kind) {
+    case 'PhraseFill':
+      return `PhraseFill|${ref.verseId}|${ref.position}`;
+    case 'VerseAtVerseRef':
+    case 'VerseInChapter':
+    case 'VerseInBook':
+    case 'Recitation':
+    case 'Citation':
+    case 'Reading':
+      return `${ref.kind}|${ref.verseId}`;
+    case 'VerseInHeading':
+      return `VerseInHeading|${ref.verseId}|${ref.headingIdx}`;
+    case 'VerseInClub':
+      return `VerseInClub|${ref.verseId}|${ref.tier}`;
+    case 'Ftv':
+      return `Ftv|${ref.verseId}|${ref.withCitation ? '1' : '0'}`;
+    case 'HeadingPassage':
+      return `HeadingPassage|${ref.headingIdx}`;
+    case 'ChapterClubList':
+      return `ChapterClubList|${ref.book}|${ref.chapter}|${ref.tier}`;
+  }
+}

--- a/packages/api/src/lib/export.test.ts
+++ b/packages/api/src/lib/export.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../db/schema.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb, createTestUser } from '../test-utils.js';
+
+import { buildCardRefIndex } from './card-ref.js';
+import { EngineStore } from './engine.js';
+import { buildAccountExport } from './export.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+const NOW = 1_700_000_000;
+
+describe('buildAccountExport', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('captures the user row, enrollment, settings, graduations, and review events', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+
+    // Need an engine handle to translate cardIds → cardRefs.
+    const engines = new EngineStore(test.db);
+    let firstCardId: number;
+    let firstVerseId: number;
+    try {
+      using loaded = await engines.load({ userId: 'u1', materialId: MATERIAL_ID });
+      const index = buildCardRefIndex(loaded.engine);
+      // Pick any cardId from the index — the indexer's round-trip
+      // guarantee (cardId → ref → cardId) means whichever we pick will
+      // appear in the export verbatim.
+      const [cardId, ref] = index.byCardId.entries().next().value!;
+      firstCardId = cardId;
+      // verseId is required by the verse-bound CardRef variants — use the
+      // ref's verseId if present, else any verseId from the catalogue.
+      firstVerseId = 'verseId' in ref ? ref.verseId : 0;
+    } finally {
+      engines.clear();
+    }
+
+    test.db
+      .insert(schema.userYearSettings)
+      .values({
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        headingCard: true,
+        headingPassageCard: false,
+        ftv: true,
+        newScope: 'up150',
+        reviewScope: 'all',
+        clubCardScope: 'off',
+        chapterListScope: 'up300',
+        lessonBatchSize: 7,
+        desiredRetention: 0.92,
+        updatedAt: NOW - 100,
+      })
+      .run();
+
+    test.db
+      .insert(schema.graduatedVerses)
+      .values({
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        verseId: firstVerseId,
+        graduatedAtSecs: NOW - 500,
+      })
+      .run();
+
+    test.db
+      .insert(schema.graduatedCards)
+      .values({
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        cardId: firstCardId,
+        graduatedAtSecs: NOW - 400,
+      })
+      .run();
+
+    test.db
+      .insert(schema.reviewEvents)
+      .values({
+        id: randomUUID(),
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW - 200,
+        cardId: firstCardId,
+        grade: 3,
+        clientEventId: 'seed-event-1',
+        createdAt: NOW - 200,
+      })
+      .run();
+
+    const engines2 = new EngineStore(test.db);
+    try {
+      const payload = await buildAccountExport(test.db, engines2, 'u1', NOW);
+
+      expect(payload.exportVersion).toBe(1);
+      expect(payload.exportedAt).toBe(NOW);
+      expect(payload.user.email).toBe('u1@example.com');
+      expect(payload.materials).toHaveLength(1);
+
+      const mat = payload.materials[0]!;
+      expect(mat.materialId).toBe(MATERIAL_ID);
+      expect(mat.enrollment.clubTier).toBeNull();
+      expect(mat.enrollment.offlineMode).toBe(false);
+      expect(mat.snapshot.version).toBe(1);
+      expect(mat.snapshot.contentSha).toMatch(/^[0-9a-f]{64}$/);
+
+      expect(mat.settings).not.toBeNull();
+      expect(mat.settings!.lessonBatchSize).toBe(7);
+      expect(mat.settings!.desiredRetention).toBeCloseTo(0.92, 5);
+      expect(mat.settings!.newScope).toBe('up150');
+      expect(mat.settings!.updatedAt).toBe(NOW - 100);
+
+      expect(mat.graduatedVerses).toEqual([
+        { verseId: firstVerseId, graduatedAtSecs: NOW - 500 },
+      ]);
+
+      expect(mat.graduatedCards).toHaveLength(1);
+      expect(mat.graduatedCards[0]!.graduatedAtSecs).toBe(NOW - 400);
+
+      expect(mat.reviewEvents).toHaveLength(1);
+      expect(mat.reviewEvents[0]!.clientEventId).toBe('seed-event-1');
+      expect(mat.reviewEvents[0]!.grade).toBe(3);
+      expect(mat.reviewEvents[0]!.timestampSecs).toBe(NOW - 200);
+      // CardRef shape varies by kind; we just verify it was translated
+      // (i.e. has a kind field) — the round-trip lives in import.test.
+      expect(mat.reviewEvents[0]!.cardRef.kind).toBeDefined();
+    } finally {
+      engines2.clear();
+    }
+  });
+
+  it('returns an empty materials array for a user with no enrollments', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'lonely');
+
+    const engines = new EngineStore(test.db);
+    try {
+      const payload = await buildAccountExport(test.db, engines, 'lonely', NOW);
+      expect(payload.materials).toEqual([]);
+      expect(payload.user.email).toBe('lonely@example.com');
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('orders reviewEvents by timestampSecs ascending', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+
+    const engines = new EngineStore(test.db);
+    let cardId: number;
+    try {
+      using loaded = await engines.load({ userId: 'u1', materialId: MATERIAL_ID });
+      const index = buildCardRefIndex(loaded.engine);
+      cardId = index.byCardId.keys().next().value!;
+    } finally {
+      engines.clear();
+    }
+
+    // Insert events out of order to make sure the readback re-sorts them.
+    for (const [ts, cid] of [[300, 'b'], [100, 'a'], [200, 'c']] as const) {
+      test.db
+        .insert(schema.reviewEvents)
+        .values({
+          id: randomUUID(),
+          userId: 'u1',
+          materialId: MATERIAL_ID,
+          snapshotVersion: 1,
+          timestampSecs: NOW - 1000 + ts,
+          cardId,
+          grade: 3,
+          clientEventId: `evt-${cid}`,
+          createdAt: NOW,
+        })
+        .run();
+    }
+
+    const engines2 = new EngineStore(test.db);
+    try {
+      const payload = await buildAccountExport(test.db, engines2, 'u1', NOW);
+      const order = payload.materials[0]!.reviewEvents.map((e) => e.clientEventId);
+      expect(order).toEqual(['evt-a', 'evt-c', 'evt-b']);
+    } finally {
+      engines2.clear();
+    }
+  });
+});

--- a/packages/api/src/lib/export.ts
+++ b/packages/api/src/lib/export.ts
@@ -5,6 +5,7 @@ import * as schema from '../db/schema.js';
 
 import { buildCardRefIndex, type CardRefIndex } from './card-ref.js';
 import { EngineStore } from './engine.js';
+import type { Grade } from './review-log.js';
 import type {
   AccountExport,
   EnrollmentExport,
@@ -213,7 +214,7 @@ function readReviewEventExport(
       clientEventId: row.clientEventId,
       timestampSecs: row.timestampSecs,
       cardRef: ref,
-      grade: row.grade as 1 | 2 | 3 | 4,
+      grade: row.grade as Grade,
     });
   }
   return out;

--- a/packages/api/src/lib/export.ts
+++ b/packages/api/src/lib/export.ts
@@ -1,0 +1,220 @@
+import { and, asc, eq } from 'drizzle-orm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+
+import { buildCardRefIndex, type CardRefIndex } from './card-ref.js';
+import { EngineStore } from './engine.js';
+import type {
+  AccountExport,
+  EnrollmentExport,
+  GraduatedCardExport,
+  GraduatedVerseExport,
+  MaterialExport,
+  MaterialSnapshotExport,
+  ReviewEventExport,
+  YearSettingsExport,
+} from './export-format.js';
+
+/** Assemble the export payload for one user. Walks every enrolled
+ *  material, loads the engine once per material to build the cardId↔
+ *  CardRef index, then reads graduations + reviews from the DB and
+ *  translates them. The engine handle is bound with `using` so the
+ *  refcount drops cleanly even on error. */
+export async function buildAccountExport(
+  db: DB,
+  engines: EngineStore,
+  userId: string,
+  nowSecs: number,
+): Promise<AccountExport> {
+  const userRow = db
+    .select({ email: schema.user.email, name: schema.user.name })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId))
+    .get();
+  if (!userRow) {
+    throw new Error(`buildAccountExport: no user row for ${userId}`);
+  }
+
+  const enrollments = db
+    .select()
+    .from(schema.userMaterials)
+    .where(eq(schema.userMaterials.userId, userId))
+    .all();
+
+  const materials: MaterialExport[] = [];
+  for (const enrollment of enrollments) {
+    const key = { userId, materialId: enrollment.materialId };
+    using loaded = await engines.load(key);
+    const index = buildCardRefIndex(loaded.engine);
+    materials.push(buildMaterialExport(db, key, enrollment, loaded.snapshotVersion, index));
+  }
+
+  return {
+    exportVersion: 1,
+    exportedAt: nowSecs,
+    user: { email: userRow.email, name: userRow.name },
+    materials,
+  };
+}
+
+function buildMaterialExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+  enrollmentRow: typeof schema.userMaterials.$inferSelect,
+  snapshotVersion: number,
+  index: CardRefIndex,
+): MaterialExport {
+  const enrollment: EnrollmentExport = {
+    clubTier: enrollmentRow.clubTier,
+    offlineMode: enrollmentRow.offlineMode,
+    createdAt: enrollmentRow.createdAt,
+  };
+
+  const settings = readSettingsExport(db, key);
+  const snapshot = readSnapshotExport(db, key, snapshotVersion);
+  const graduatedVerses = readGraduatedVerseExport(db, key);
+  const graduatedCards = readGraduatedCardExport(db, key, index);
+  const reviewEvents = readReviewEventExport(db, key, index);
+
+  return {
+    materialId: key.materialId,
+    enrollment,
+    settings,
+    snapshot,
+    graduatedVerses,
+    graduatedCards,
+    reviewEvents,
+  };
+}
+
+function readSettingsExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+): YearSettingsExport | null {
+  const row = db
+    .select()
+    .from(schema.userYearSettings)
+    .where(
+      and(
+        eq(schema.userYearSettings.userId, key.userId),
+        eq(schema.userYearSettings.materialId, key.materialId),
+      ),
+    )
+    .get();
+  if (!row) return null;
+  return {
+    headingCard: row.headingCard,
+    headingPassageCard: row.headingPassageCard,
+    ftv: row.ftv,
+    newScope: row.newScope,
+    reviewScope: row.reviewScope,
+    clubCardScope: row.clubCardScope,
+    chapterListScope: row.chapterListScope,
+    lessonBatchSize: row.lessonBatchSize,
+    desiredRetention: row.desiredRetention,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function readSnapshotExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+  version: number,
+): MaterialSnapshotExport {
+  // `engines.load(key)` already advanced the user to the latest version;
+  // we just read the row that matches it.
+  const row = db
+    .select({ contentSha: schema.graphSnapshots.contentSha })
+    .from(schema.graphSnapshots)
+    .where(
+      and(
+        eq(schema.graphSnapshots.userId, key.userId),
+        eq(schema.graphSnapshots.materialId, key.materialId),
+        eq(schema.graphSnapshots.version, version),
+      ),
+    )
+    .get();
+  return { version, contentSha: row?.contentSha ?? '' };
+}
+
+function readGraduatedVerseExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+): GraduatedVerseExport[] {
+  return db
+    .select({
+      verseId: schema.graduatedVerses.verseId,
+      graduatedAtSecs: schema.graduatedVerses.graduatedAtSecs,
+    })
+    .from(schema.graduatedVerses)
+    .where(
+      and(
+        eq(schema.graduatedVerses.userId, key.userId),
+        eq(schema.graduatedVerses.materialId, key.materialId),
+      ),
+    )
+    .all();
+}
+
+function readGraduatedCardExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+  index: CardRefIndex,
+): GraduatedCardExport[] {
+  const rows = db
+    .select({
+      cardId: schema.graduatedCards.cardId,
+      graduatedAtSecs: schema.graduatedCards.graduatedAtSecs,
+    })
+    .from(schema.graduatedCards)
+    .where(
+      and(
+        eq(schema.graduatedCards.userId, key.userId),
+        eq(schema.graduatedCards.materialId, key.materialId),
+      ),
+    )
+    .all();
+  const out: GraduatedCardExport[] = [];
+  for (const row of rows) {
+    const ref = index.byCardId.get(row.cardId);
+    if (!ref) continue; // card no longer in the catalog; drop silently
+    out.push({ cardRef: ref, graduatedAtSecs: row.graduatedAtSecs });
+  }
+  return out;
+}
+
+function readReviewEventExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+  index: CardRefIndex,
+): ReviewEventExport[] {
+  const rows = db
+    .select({
+      clientEventId: schema.reviewEvents.clientEventId,
+      timestampSecs: schema.reviewEvents.timestampSecs,
+      cardId: schema.reviewEvents.cardId,
+      grade: schema.reviewEvents.grade,
+    })
+    .from(schema.reviewEvents)
+    .where(
+      and(
+        eq(schema.reviewEvents.userId, key.userId),
+        eq(schema.reviewEvents.materialId, key.materialId),
+      ),
+    )
+    .orderBy(asc(schema.reviewEvents.timestampSecs), asc(schema.reviewEvents.clientEventId))
+    .all();
+  const out: ReviewEventExport[] = [];
+  for (const row of rows) {
+    const ref = index.byCardId.get(row.cardId);
+    if (!ref) continue;
+    out.push({
+      clientEventId: row.clientEventId,
+      timestampSecs: row.timestampSecs,
+      cardRef: ref,
+      grade: row.grade as 1 | 2 | 3 | 4,
+    });
+  }
+  return out;
+}

--- a/packages/api/src/lib/import.test.ts
+++ b/packages/api/src/lib/import.test.ts
@@ -1,0 +1,333 @@
+import { randomUUID } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../db/schema.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb, createTestUser } from '../test-utils.js';
+
+import { buildCardRefIndex } from './card-ref.js';
+import { EngineStore } from './engine.js';
+import type { AccountExport, CardRef } from './export-format.js';
+import { buildAccountExport } from './export.js';
+import { applyAccountImport, ImportValidationError } from './import.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+const NOW = 1_700_000_000;
+
+/** Pick any (cardId, CardRef) pair from the engine for use as fixture
+ *  data. Used by the round-trip tests to plant a review event with a
+ *  valid cardRef before the export/import pass. */
+async function pickAnyCard(
+  engines: EngineStore,
+  userId: string,
+): Promise<{ cardId: number; ref: CardRef; verseId: number }> {
+  using loaded = await engines.load({ userId, materialId: MATERIAL_ID });
+  const index = buildCardRefIndex(loaded.engine);
+  const [cardId, ref] = index.byCardId.entries().next().value!;
+  const verseId = 'verseId' in ref ? ref.verseId : 0;
+  return { cardId, ref, verseId };
+}
+
+describe('applyAccountImport', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('rejects unsupported exportVersion', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    const engines = new EngineStore(test.db);
+    try {
+      const payload = {
+        exportVersion: 99,
+        exportedAt: NOW,
+        user: { email: 'x@example.com', name: 'x' },
+        materials: [],
+      } as unknown as AccountExport;
+      await expect(applyAccountImport(test.db, engines, 'u1', payload, NOW)).rejects.toThrow(
+        ImportValidationError,
+      );
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('rejects unknown materialIds', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    const engines = new EngineStore(test.db);
+    try {
+      const payload: AccountExport = {
+        exportVersion: 1,
+        exportedAt: NOW,
+        user: { email: 'x@example.com', name: 'x' },
+        materials: [
+          {
+            materialId: 'no-such-material',
+            enrollment: { clubTier: null, offlineMode: false, createdAt: NOW },
+            settings: null,
+            snapshot: { version: 1, contentSha: '' },
+            graduatedVerses: [],
+            graduatedCards: [],
+            reviewEvents: [],
+          },
+        ],
+      };
+      await expect(applyAccountImport(test.db, engines, 'u1', payload, NOW)).rejects.toThrow(
+        ImportValidationError,
+      );
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('round-trips: export → import into fresh user → diff is empty', async () => {
+    const src = createTestDb();
+    cleanup = src.cleanup;
+    seedUserWithFixture({ db: src.db, userId: 'src', materialId: MATERIAL_ID });
+
+    const srcEngines = new EngineStore(src.db);
+    const { cardId, verseId } = await pickAnyCard(srcEngines, 'src');
+
+    src.db
+      .insert(schema.userYearSettings)
+      .values({
+        userId: 'src',
+        materialId: MATERIAL_ID,
+        headingCard: true,
+        headingPassageCard: true,
+        ftv: false,
+        newScope: 'up300',
+        reviewScope: 'all',
+        clubCardScope: 'up150',
+        chapterListScope: 'off',
+        lessonBatchSize: 5,
+        desiredRetention: 0.88,
+        updatedAt: NOW - 50,
+      })
+      .run();
+    src.db
+      .insert(schema.graduatedVerses)
+      .values({ userId: 'src', materialId: MATERIAL_ID, verseId, graduatedAtSecs: NOW - 100 })
+      .run();
+    src.db
+      .insert(schema.reviewEvents)
+      .values([
+        {
+          id: randomUUID(),
+          userId: 'src',
+          materialId: MATERIAL_ID,
+          snapshotVersion: 1,
+          timestampSecs: NOW - 300,
+          cardId,
+          grade: 3,
+          clientEventId: 'evt-1',
+          createdAt: NOW - 300,
+        },
+        {
+          id: randomUUID(),
+          userId: 'src',
+          materialId: MATERIAL_ID,
+          snapshotVersion: 1,
+          timestampSecs: NOW - 200,
+          cardId,
+          grade: 4,
+          clientEventId: 'evt-2',
+          createdAt: NOW - 200,
+        },
+      ])
+      .run();
+
+    const exportEngines = new EngineStore(src.db);
+    let payload: AccountExport;
+    try {
+      payload = await buildAccountExport(src.db, exportEngines, 'src', NOW);
+    } finally {
+      exportEngines.clear();
+      srcEngines.clear();
+    }
+
+    // Import into a fresh DB and a different userId. Enrollment doesn't
+    // exist yet — the importer creates it via enrollUser.
+    const dst = createTestDb();
+    const dstCleanup = dst.cleanup;
+    try {
+      createTestUser(dst.db, 'dst');
+      const dstEngines = new EngineStore(dst.db);
+      try {
+        const summary = await applyAccountImport(dst.db, dstEngines, 'dst', payload, NOW);
+        expect(summary.materialsApplied).toBe(1);
+        expect(summary.eventsInserted).toBe(2);
+        expect(summary.eventsSkipped).toBe(0);
+        expect(summary.unresolvedCardRefs).toBe(0);
+        expect(summary.graduationsApplied).toBe(1);
+
+        // Re-export from dst and confirm parity on the load-bearing
+        // fields. We don't compare exportedAt or user email (different
+        // user); we compare per-material payload shape.
+        const reexport = await buildAccountExport(dst.db, dstEngines, 'dst', NOW);
+        const srcMat = payload.materials[0]!;
+        const dstMat = reexport.materials[0]!;
+        expect(dstMat.materialId).toBe(srcMat.materialId);
+        expect(dstMat.enrollment.clubTier).toBe(srcMat.enrollment.clubTier);
+        expect(dstMat.settings).toEqual(srcMat.settings);
+        expect(dstMat.graduatedVerses).toEqual(srcMat.graduatedVerses);
+        expect(dstMat.reviewEvents.map((e) => e.clientEventId).sort()).toEqual(
+          srcMat.reviewEvents.map((e) => e.clientEventId).sort(),
+        );
+      } finally {
+        dstEngines.clear();
+      }
+    } finally {
+      dstCleanup();
+    }
+  });
+
+  it('is idempotent on re-import: second pass inserts nothing', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'src', materialId: MATERIAL_ID });
+
+    const engines = new EngineStore(test.db);
+    const { cardId } = await pickAnyCard(engines, 'src');
+
+    test.db
+      .insert(schema.reviewEvents)
+      .values({
+        id: randomUUID(),
+        userId: 'src',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW - 100,
+        cardId,
+        grade: 3,
+        clientEventId: 'idem-1',
+        createdAt: NOW - 100,
+      })
+      .run();
+
+    const payload = await buildAccountExport(test.db, engines, 'src', NOW);
+
+    // Import into the SAME user — re-application should hit dedup.
+    const summary = await applyAccountImport(test.db, engines, 'src', payload, NOW);
+    expect(summary.eventsInserted).toBe(0);
+    expect(summary.eventsSkipped).toBe(1);
+    engines.clear();
+  });
+
+  it('counts unresolved cardRefs without rejecting the import', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    createTestUser(test.db, 'u1');
+    const engines = new EngineStore(test.db);
+
+    const payload: AccountExport = {
+      exportVersion: 1,
+      exportedAt: NOW,
+      user: { email: 'u1@example.com', name: 'u1' },
+      materials: [
+        {
+          materialId: MATERIAL_ID,
+          enrollment: { clubTier: null, offlineMode: false, createdAt: NOW },
+          settings: null,
+          snapshot: { version: 1, contentSha: '' },
+          graduatedVerses: [],
+          graduatedCards: [
+            // A heading idx no live deck would emit — should fall into
+            // unresolved without aborting.
+            {
+              cardRef: { kind: 'HeadingPassage', headingIdx: 999_999 },
+              graduatedAtSecs: NOW - 100,
+            },
+          ],
+          reviewEvents: [
+            {
+              clientEventId: 'phantom-1',
+              timestampSecs: NOW - 200,
+              cardRef: { kind: 'HeadingPassage', headingIdx: 999_999 },
+              grade: 3,
+            },
+          ],
+        },
+      ],
+    };
+
+    try {
+      const summary = await applyAccountImport(test.db, engines, 'u1', payload, NOW);
+      expect(summary.materialsApplied).toBe(1);
+      expect(summary.eventsInserted).toBe(0);
+      expect(summary.unresolvedCardRefs).toBe(2);
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('preserves newer settings over an older imported settings row', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+
+    // User's current (newer) settings.
+    test.db
+      .insert(schema.userYearSettings)
+      .values({
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        headingCard: true,
+        headingPassageCard: true,
+        ftv: true,
+        newScope: 'all',
+        reviewScope: 'all',
+        clubCardScope: 'all',
+        // chapterListScope rejects 'all' — Full never emits a chapter list.
+        chapterListScope: 'up300',
+        lessonBatchSize: 10,
+        desiredRetention: 0.95,
+        updatedAt: NOW, // newer
+      })
+      .run();
+
+    const payload: AccountExport = {
+      exportVersion: 1,
+      exportedAt: NOW,
+      user: { email: 'u1@example.com', name: 'u1' },
+      materials: [
+        {
+          materialId: MATERIAL_ID,
+          enrollment: { clubTier: null, offlineMode: false, createdAt: NOW },
+          settings: {
+            headingCard: false,
+            headingPassageCard: false,
+            ftv: false,
+            newScope: 'off',
+            reviewScope: 'off',
+            clubCardScope: 'off',
+            chapterListScope: 'off',
+            lessonBatchSize: 1,
+            desiredRetention: 0.5,
+            updatedAt: NOW - 10_000, // older
+          },
+          snapshot: { version: 1, contentSha: '' },
+          graduatedVerses: [],
+          graduatedCards: [],
+          reviewEvents: [],
+        },
+      ],
+    };
+
+    const engines = new EngineStore(test.db);
+    try {
+      await applyAccountImport(test.db, engines, 'u1', payload, NOW);
+      const row = test.db.select().from(schema.userYearSettings).all()[0]!;
+      expect(row.lessonBatchSize).toBe(10);
+      expect(row.desiredRetention).toBeCloseTo(0.95, 5);
+    } finally {
+      engines.clear();
+    }
+  });
+});

--- a/packages/api/src/lib/import.test.ts
+++ b/packages/api/src/lib/import.test.ts
@@ -330,4 +330,51 @@ describe('applyAccountImport', () => {
       engines.clear();
     }
   });
+
+  it('rejects an import whose settings violate the year-settings bounds', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedUserWithFixture({ db: test.db, userId: 'u1', materialId: MATERIAL_ID });
+
+    const payload: AccountExport = {
+      exportVersion: 1,
+      exportedAt: NOW,
+      user: { email: 'u1@example.com', name: 'u1' },
+      materials: [
+        {
+          materialId: MATERIAL_ID,
+          enrollment: { clubTier: null, offlineMode: false, createdAt: NOW },
+          settings: {
+            headingCard: false,
+            headingPassageCard: false,
+            ftv: false,
+            newScope: 'off',
+            reviewScope: 'off',
+            clubCardScope: 'off',
+            chapterListScope: 'off',
+            lessonBatchSize: 1,
+            // Out of the FSRS-author bounds [0.7, 0.97] — must be rejected,
+            // not written verbatim.
+            desiredRetention: 5,
+            updatedAt: NOW,
+          },
+          snapshot: { version: 1, contentSha: '' },
+          graduatedVerses: [],
+          graduatedCards: [],
+          reviewEvents: [],
+        },
+      ],
+    };
+
+    const engines = new EngineStore(test.db);
+    try {
+      await expect(applyAccountImport(test.db, engines, 'u1', payload, NOW)).rejects.toThrow(
+        ImportValidationError,
+      );
+      // Nothing should have been written for the bad row.
+      expect(test.db.select().from(schema.userYearSettings).all()).toHaveLength(0);
+    } finally {
+      engines.clear();
+    }
+  });
 });

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -49,11 +49,12 @@ export class ImportValidationError extends Error {
  *  merge via per-row `max(updatedAt)`: an older imported settings row
  *  doesn't blow away the user's tuned current settings. Each material
  *  is wrapped in its own transaction so a bad cardRef in one doesn't
- *  poison the others. After all materials are written we call
- *  `engines.rebuildFromEvents(key)` per material; that regenerates
+ *  poison the others. After each material's writes land we call
+ *  `engines.rebuildFromEvents(key)` for that material; that regenerates
  *  `test_states` from the full event log (now including the imported
  *  events) and is the entire reason we don't need to write FSRS
- *  state directly. */
+ *  state directly. The whole per-material pass runs under the engine's
+ *  per-key lock so the rebuild can't race a concurrent review. */
 export async function applyAccountImport(
   db: DB,
   engines: EngineStore,
@@ -98,26 +99,34 @@ export async function applyAccountImport(
     }
 
     const key = { userId, materialId: material.materialId };
-    using loaded = await engines.load(key);
-    const index = buildCardRefIndex(loaded.engine);
-    const snapshotVersion = loaded.snapshotVersion;
+    // Hold the per-key lock across load + writes + rebuild: the
+    // `rebuildFromEvents` delete-then-insert of test_states must not
+    // race a concurrent review POST for the same (user, material).
+    // Mirrors sync.ts, which wraps its own rebuild in withLock.
+    await engines.withLock(key, async () => {
+      using loaded = await engines.load(key);
+      const index = buildCardRefIndex(loaded.engine);
+      const snapshotVersion = loaded.snapshotVersion;
 
-    db.transaction((tx) => {
-      applyEnrollmentExtras(tx, key, material);
-      applySettings(tx, key, material);
-      const gradResult = applyGraduations(tx, key, material, index);
-      summary.graduationsApplied += gradResult.applied;
-      summary.unresolvedCardRefs += gradResult.unresolved;
-      const eventResult = applyReviewEvents(tx, key, material, index, snapshotVersion);
-      summary.eventsInserted += eventResult.inserted;
-      summary.eventsSkipped += eventResult.skipped;
-      summary.unresolvedCardRefs += eventResult.unresolved;
+      db.transaction((tx) => {
+        applyEnrollmentExtras(tx, key, material);
+        applySettings(tx, key, material);
+        const gradResult = applyGraduations(tx, key, material, index);
+        summary.graduationsApplied += gradResult.applied;
+        summary.unresolvedCardRefs += gradResult.unresolved;
+        const eventResult = applyReviewEvents(tx, key, material, index, snapshotVersion);
+        summary.eventsInserted += eventResult.inserted;
+        summary.eventsSkipped += eventResult.skipped;
+        summary.unresolvedCardRefs += eventResult.unresolved;
+      });
+
+      // Replay the (now-augmented) event log into a fresh engine. This
+      // wipes test_states for the material and re-derives it from the
+      // committed reviewEvents — including everything we just inserted.
+      // Bind the returned handle with `using` so its refcount (bumped by
+      // rebuildFromEvents) is released at scope exit.
+      using _rebuilt = engines.rebuildFromEvents(key);
     });
-
-    // Replay the (now-augmented) event log into a fresh engine. This
-    // wipes test_states for the material and re-derives it from the
-    // committed reviewEvents — including everything we just inserted.
-    engines.rebuildFromEvents(key);
     summary.materialsApplied += 1;
   }
 
@@ -215,7 +224,8 @@ function applyGraduations(
   let unresolved = 0;
 
   for (const g of material.graduatedVerses) {
-    tx.insert(schema.graduatedVerses)
+    const res = tx
+      .insert(schema.graduatedVerses)
       .values({
         userId: key.userId,
         materialId: key.materialId,
@@ -224,7 +234,9 @@ function applyGraduations(
       })
       .onConflictDoNothing()
       .run();
-    applied += 1;
+    // Count only rows actually written, so a re-import (where every row
+    // hits onConflictDoNothing) honestly reports 0 graduations applied.
+    if (res.changes > 0) applied += 1;
   }
 
   for (const g of material.graduatedCards) {
@@ -233,7 +245,8 @@ function applyGraduations(
       unresolved += 1;
       continue;
     }
-    tx.insert(schema.graduatedCards)
+    const res = tx
+      .insert(schema.graduatedCards)
       .values({
         userId: key.userId,
         materialId: key.materialId,
@@ -242,7 +255,7 @@ function applyGraduations(
       })
       .onConflictDoNothing()
       .run();
-    applied += 1;
+    if (res.changes > 0) applied += 1;
   }
 
   return { applied, unresolved };

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -24,6 +24,11 @@ import {
   type ReviewEventInput,
   writeReviewEvents,
 } from './review-log.js';
+import {
+  ValidationError,
+  validateYearSettings,
+  type YearSettings,
+} from './year-settings.js';
 
 const SUPPORTED_EXPORT_VERSION = 1;
 
@@ -161,18 +166,23 @@ function applySettings(
   // user has tuned settings since the export was taken, leave them be.
   if (existing && existing.updatedAt >= material.settings.updatedAt) return;
 
+  // Validate the uploaded settings with the same rules the year-settings
+  // route enforces — an import payload is no more trusted than a request
+  // body. A bad enum/bound surfaces as a 400, not a corrupt row.
+  let validated: YearSettings;
+  try {
+    validated = validateYearSettings(material.settings);
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      throw new ImportValidationError(`settings for ${key.materialId}: ${err.message}`);
+    }
+    throw err;
+  }
+
   const row = {
     userId: key.userId,
     materialId: key.materialId,
-    headingCard: material.settings.headingCard,
-    headingPassageCard: material.settings.headingPassageCard,
-    ftv: material.settings.ftv,
-    newScope: material.settings.newScope,
-    reviewScope: material.settings.reviewScope,
-    clubCardScope: material.settings.clubCardScope,
-    chapterListScope: material.settings.chapterListScope,
-    lessonBatchSize: material.settings.lessonBatchSize,
-    desiredRetention: material.settings.desiredRetention,
+    ...validated,
     // Use the export-recorded `updatedAt` verbatim. It's the next-merge
     // anchor: a later re-import with the same anchor is a no-op, and
     // any local tweak after this row goes in stamps a newer ts via the

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -1,0 +1,321 @@
+import { randomUUID } from 'node:crypto';
+
+import { and, eq, inArray } from 'drizzle-orm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+
+import {
+  buildCardRefIndex,
+  type CardRefIndex,
+  resolveCardRef,
+} from './card-ref.js';
+import { EngineStore } from './engine.js';
+import {
+  AlreadyEnrolledError,
+  enrollUser,
+  UnknownMaterialError,
+} from './enrollment.js';
+import type {
+  AccountExport,
+  ImportSummary,
+  MaterialExport,
+} from './export-format.js';
+
+const SUPPORTED_EXPORT_VERSION = 1;
+const DEDUP_BATCH_SIZE = 500;
+
+/** drizzle's `db.transaction` callback receives this narrower type;
+ *  it shares the table-API surface (insert/update/select/delete) so
+ *  the per-material helper functions accept it transparently. */
+type Tx = Parameters<Parameters<DB['transaction']>[0]>[0];
+
+export class ImportValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ImportValidationError';
+  }
+}
+
+/** Apply an `AccountExport` payload to the calling user's account.
+ *  Idempotent on re-application via `clientEventId` dedup. Settings
+ *  merge via per-row `max(updatedAt)`: an older imported settings row
+ *  doesn't blow away the user's tuned current settings. Each material
+ *  is wrapped in its own transaction so a bad cardRef in one doesn't
+ *  poison the others. After all materials are written we call
+ *  `engines.rebuildFromEvents(key)` per material; that regenerates
+ *  `test_states` from the full event log (now including the imported
+ *  events) and is the entire reason we don't need to write FSRS
+ *  state directly. */
+export async function applyAccountImport(
+  db: DB,
+  engines: EngineStore,
+  userId: string,
+  payload: AccountExport,
+  nowSecs: number,
+): Promise<ImportSummary> {
+  if (payload.exportVersion !== SUPPORTED_EXPORT_VERSION) {
+    throw new ImportValidationError(
+      `unsupported exportVersion: got ${payload.exportVersion}, supported ${SUPPORTED_EXPORT_VERSION}`,
+    );
+  }
+
+  const summary: ImportSummary = {
+    materialsApplied: 0,
+    eventsInserted: 0,
+    eventsSkipped: 0,
+    graduationsApplied: 0,
+    unresolvedCardRefs: 0,
+  };
+
+  for (const material of payload.materials) {
+    // Ensure the user is enrolled; reuse existing enrollment if any.
+    try {
+      enrollUser({
+        db,
+        userId,
+        materialId: material.materialId,
+        clubTier: material.enrollment.clubTier ?? null,
+        now: () => nowSecs,
+      });
+    } catch (err) {
+      if (err instanceof AlreadyEnrolledError) {
+        // Existing enrollment is fine — we layer the import on top.
+      } else if (err instanceof UnknownMaterialError) {
+        throw new ImportValidationError(
+          `unknown materialId: ${material.materialId}`,
+        );
+      } else {
+        throw err;
+      }
+    }
+
+    const key = { userId, materialId: material.materialId };
+    using loaded = await engines.load(key);
+    const index = buildCardRefIndex(loaded.engine);
+    const snapshotVersion = loaded.snapshotVersion;
+
+    db.transaction((tx) => {
+      applyEnrollmentExtras(tx, key, material);
+      applySettings(tx, key, material);
+      const gradResult = applyGraduations(tx, key, material, index);
+      summary.graduationsApplied += gradResult.applied;
+      summary.unresolvedCardRefs += gradResult.unresolved;
+      const eventResult = applyReviewEvents(tx, key, material, index, snapshotVersion, nowSecs);
+      summary.eventsInserted += eventResult.inserted;
+      summary.eventsSkipped += eventResult.skipped;
+      summary.unresolvedCardRefs += eventResult.unresolved;
+    });
+
+    // Replay the (now-augmented) event log into a fresh engine. This
+    // wipes test_states for the material and re-derives it from the
+    // committed reviewEvents — including everything we just inserted.
+    engines.rebuildFromEvents(key);
+    summary.materialsApplied += 1;
+  }
+
+  return summary;
+}
+
+function applyEnrollmentExtras(
+  tx: Tx,
+  key: { userId: string; materialId: string },
+  material: MaterialExport,
+): void {
+  // enrollUser only ever sets clubTier; offlineMode comes via this
+  // patch when it differs from the default.
+  if (material.enrollment.offlineMode) {
+    tx.update(schema.userMaterials)
+      .set({ offlineMode: true })
+      .where(
+        and(
+          eq(schema.userMaterials.userId, key.userId),
+          eq(schema.userMaterials.materialId, key.materialId),
+        ),
+      )
+      .run();
+  }
+}
+
+function applySettings(
+  tx: Tx,
+  key: { userId: string; materialId: string },
+  material: MaterialExport,
+): void {
+  if (!material.settings) return;
+
+  const existing = tx
+    .select({ updatedAt: schema.userYearSettings.updatedAt })
+    .from(schema.userYearSettings)
+    .where(
+      and(
+        eq(schema.userYearSettings.userId, key.userId),
+        eq(schema.userYearSettings.materialId, key.materialId),
+      ),
+    )
+    .get();
+
+  // Per the plan's settings merge policy: newer updatedAt wins. If the
+  // user has tuned settings since the export was taken, leave them be.
+  if (existing && existing.updatedAt >= material.settings.updatedAt) return;
+
+  const row = {
+    userId: key.userId,
+    materialId: key.materialId,
+    headingCard: material.settings.headingCard,
+    headingPassageCard: material.settings.headingPassageCard,
+    ftv: material.settings.ftv,
+    newScope: material.settings.newScope,
+    reviewScope: material.settings.reviewScope,
+    clubCardScope: material.settings.clubCardScope,
+    chapterListScope: material.settings.chapterListScope,
+    lessonBatchSize: material.settings.lessonBatchSize,
+    desiredRetention: material.settings.desiredRetention,
+    // Use the export-recorded `updatedAt` verbatim. It's the next-merge
+    // anchor: a later re-import with the same anchor is a no-op, and
+    // any local tweak after this row goes in stamps a newer ts via the
+    // settings API and wins on the next merge.
+    updatedAt: material.settings.updatedAt,
+  };
+
+  if (existing) {
+    tx.update(schema.userYearSettings)
+      .set(row)
+      .where(
+        and(
+          eq(schema.userYearSettings.userId, key.userId),
+          eq(schema.userYearSettings.materialId, key.materialId),
+        ),
+      )
+      .run();
+  } else {
+    tx.insert(schema.userYearSettings).values(row).run();
+  }
+}
+
+function applyGraduations(
+  tx: Tx,
+  key: { userId: string; materialId: string },
+  material: MaterialExport,
+  index: CardRefIndex,
+): { applied: number; unresolved: number } {
+  let applied = 0;
+  let unresolved = 0;
+
+  for (const g of material.graduatedVerses) {
+    tx.insert(schema.graduatedVerses)
+      .values({
+        userId: key.userId,
+        materialId: key.materialId,
+        verseId: g.verseId,
+        graduatedAtSecs: g.graduatedAtSecs,
+      })
+      .onConflictDoNothing()
+      .run();
+    applied += 1;
+  }
+
+  for (const g of material.graduatedCards) {
+    const cardId = resolveCardRef(index, g.cardRef);
+    if (cardId === undefined) {
+      unresolved += 1;
+      continue;
+    }
+    tx.insert(schema.graduatedCards)
+      .values({
+        userId: key.userId,
+        materialId: key.materialId,
+        cardId,
+        graduatedAtSecs: g.graduatedAtSecs,
+      })
+      .onConflictDoNothing()
+      .run();
+    applied += 1;
+  }
+
+  return { applied, unresolved };
+}
+
+function applyReviewEvents(
+  tx: Tx,
+  key: { userId: string; materialId: string },
+  material: MaterialExport,
+  index: CardRefIndex,
+  snapshotVersion: number,
+  nowSecs: number,
+): { inserted: number; skipped: number; unresolved: number } {
+  // Resolve all cardRefs up front so we can chunk the dedup query by
+  // clientEventId without re-walking the input list.
+  type Resolved = {
+    clientEventId: string;
+    timestampSecs: number;
+    cardId: number;
+    grade: 1 | 2 | 3 | 4;
+  };
+  const resolved: Resolved[] = [];
+  let unresolved = 0;
+  for (const e of material.reviewEvents) {
+    const cardId = resolveCardRef(index, e.cardRef);
+    if (cardId === undefined) {
+      unresolved += 1;
+      continue;
+    }
+    resolved.push({
+      clientEventId: e.clientEventId,
+      timestampSecs: e.timestampSecs,
+      cardId,
+      grade: e.grade,
+    });
+  }
+
+  // Dedup pre-existing clientEventIds in chunks of `DEDUP_BATCH_SIZE`
+  // to stay under SQLite's 999-param limit (same pattern as sync.ts).
+  const seen = new Set<string>();
+  for (let i = 0; i < resolved.length; i += DEDUP_BATCH_SIZE) {
+    const chunk = resolved.slice(i, i + DEDUP_BATCH_SIZE);
+    const rows = tx
+      .select({ clientEventId: schema.reviewEvents.clientEventId })
+      .from(schema.reviewEvents)
+      .where(
+        and(
+          eq(schema.reviewEvents.userId, key.userId),
+          eq(schema.reviewEvents.materialId, key.materialId),
+          inArray(
+            schema.reviewEvents.clientEventId,
+            chunk.map((r) => r.clientEventId),
+          ),
+        ),
+      )
+      .all();
+    for (const r of rows) seen.add(r.clientEventId);
+  }
+
+  const fresh = resolved.filter((r) => !seen.has(r.clientEventId));
+  const skipped = resolved.length - fresh.length;
+
+  // Bulk insert. drizzle's .values([]) accepts arrays; better-sqlite3
+  // handles a few hundred rows per multi-VALUES insert comfortably.
+  if (fresh.length > 0) {
+    const INSERT_BATCH = 200;
+    for (let i = 0; i < fresh.length; i += INSERT_BATCH) {
+      const chunk = fresh.slice(i, i + INSERT_BATCH);
+      tx.insert(schema.reviewEvents)
+        .values(
+          chunk.map((r) => ({
+            id: randomUUID(),
+            userId: key.userId,
+            materialId: key.materialId,
+            snapshotVersion,
+            timestampSecs: r.timestampSecs,
+            cardId: r.cardId,
+            grade: r.grade,
+            clientEventId: r.clientEventId,
+            createdAt: nowSecs,
+          })),
+        )
+        .run();
+    }
+  }
+
+  return { inserted: fresh.length, skipped, unresolved };
+}

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -21,6 +21,7 @@ import type {
   ImportSummary,
   MaterialExport,
 } from './export-format.js';
+import type { Grade } from './review-log.js';
 
 const SUPPORTED_EXPORT_VERSION = 1;
 const DEDUP_BATCH_SIZE = 500;
@@ -250,7 +251,7 @@ function applyReviewEvents(
     clientEventId: string;
     timestampSecs: number;
     cardId: number;
-    grade: 1 | 2 | 3 | 4;
+    grade: Grade;
   };
   const resolved: Resolved[] = [];
   let unresolved = 0;

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -1,6 +1,4 @@
-import { randomUUID } from 'node:crypto';
-
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
@@ -21,10 +19,13 @@ import type {
   ImportSummary,
   MaterialExport,
 } from './export-format.js';
-import type { Grade } from './review-log.js';
+import {
+  existingEventIds,
+  type ReviewEventInput,
+  writeReviewEvents,
+} from './review-log.js';
 
 const SUPPORTED_EXPORT_VERSION = 1;
-const DEDUP_BATCH_SIZE = 500;
 
 /** drizzle's `db.transaction` callback receives this narrower type;
  *  it shares the table-API surface (insert/update/select/delete) so
@@ -102,7 +103,7 @@ export async function applyAccountImport(
       const gradResult = applyGraduations(tx, key, material, index);
       summary.graduationsApplied += gradResult.applied;
       summary.unresolvedCardRefs += gradResult.unresolved;
-      const eventResult = applyReviewEvents(tx, key, material, index, snapshotVersion, nowSecs);
+      const eventResult = applyReviewEvents(tx, key, material, index, snapshotVersion);
       summary.eventsInserted += eventResult.inserted;
       summary.eventsSkipped += eventResult.skipped;
       summary.unresolvedCardRefs += eventResult.unresolved;
@@ -243,17 +244,10 @@ function applyReviewEvents(
   material: MaterialExport,
   index: CardRefIndex,
   snapshotVersion: number,
-  nowSecs: number,
 ): { inserted: number; skipped: number; unresolved: number } {
-  // Resolve all cardRefs up front so we can chunk the dedup query by
-  // clientEventId without re-walking the input list.
-  type Resolved = {
-    clientEventId: string;
-    timestampSecs: number;
-    cardId: number;
-    grade: Grade;
-  };
-  const resolved: Resolved[] = [];
+  // Resolve cardRefs to live cardIds, dropping any that don't exist in
+  // the importing snapshot, and shape each into a ReviewEventInput.
+  const resolved: ReviewEventInput[] = [];
   let unresolved = 0;
   for (const e of material.reviewEvents) {
     const cardId = resolveCardRef(index, e.cardRef);
@@ -262,61 +256,25 @@ function applyReviewEvents(
       continue;
     }
     resolved.push({
-      clientEventId: e.clientEventId,
+      userId: key.userId,
+      materialId: key.materialId,
+      snapshotVersion,
       timestampSecs: e.timestampSecs,
       cardId,
       grade: e.grade,
+      clientEventId: e.clientEventId,
     });
   }
 
-  // Dedup pre-existing clientEventIds in chunks of `DEDUP_BATCH_SIZE`
-  // to stay under SQLite's 999-param limit (same pattern as sync.ts).
-  const seen = new Set<string>();
-  for (let i = 0; i < resolved.length; i += DEDUP_BATCH_SIZE) {
-    const chunk = resolved.slice(i, i + DEDUP_BATCH_SIZE);
-    const rows = tx
-      .select({ clientEventId: schema.reviewEvents.clientEventId })
-      .from(schema.reviewEvents)
-      .where(
-        and(
-          eq(schema.reviewEvents.userId, key.userId),
-          eq(schema.reviewEvents.materialId, key.materialId),
-          inArray(
-            schema.reviewEvents.clientEventId,
-            chunk.map((r) => r.clientEventId),
-          ),
-        ),
-      )
-      .all();
-    for (const r of rows) seen.add(r.clientEventId);
-  }
-
+  const seen = existingEventIds(
+    tx,
+    key.userId,
+    key.materialId,
+    resolved.map((r) => r.clientEventId),
+  );
   const fresh = resolved.filter((r) => !seen.has(r.clientEventId));
-  const skipped = resolved.length - fresh.length;
 
-  // Bulk insert. drizzle's .values([]) accepts arrays; better-sqlite3
-  // handles a few hundred rows per multi-VALUES insert comfortably.
-  if (fresh.length > 0) {
-    const INSERT_BATCH = 200;
-    for (let i = 0; i < fresh.length; i += INSERT_BATCH) {
-      const chunk = fresh.slice(i, i + INSERT_BATCH);
-      tx.insert(schema.reviewEvents)
-        .values(
-          chunk.map((r) => ({
-            id: randomUUID(),
-            userId: key.userId,
-            materialId: key.materialId,
-            snapshotVersion,
-            timestampSecs: r.timestampSecs,
-            cardId: r.cardId,
-            grade: r.grade,
-            clientEventId: r.clientEventId,
-            createdAt: nowSecs,
-          })),
-        )
-        .run();
-    }
-  }
+  writeReviewEvents(tx, fresh);
 
-  return { inserted: fresh.length, skipped, unresolved };
+  return { inserted: fresh.length, skipped: resolved.length - fresh.length, unresolved };
 }

--- a/packages/api/src/lib/review-log.ts
+++ b/packages/api/src/lib/review-log.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import type { DB } from '../db/client.js';
 import * as schema from '../db/schema.js';
@@ -36,9 +36,78 @@ export interface PersistArgs {
 
 type Tx = Parameters<Parameters<DB['transaction']>[0]>[0];
 
+/** A read/write executor: either the root `DB` or a transaction handle.
+ *  The dedup read runs pre-transaction in sync but inside the import
+ *  transaction, so the shared helper accepts both. */
+type Executor = DB | Tx;
+
 /** SQLite caps bind parameters at 999; test_states has 9 columns, so 100
  *  rows leaves headroom. Sync replays and seeding both can hit thousands. */
 const TEST_STATES_BATCH = 100;
+
+/** `review_events` has 9 columns, so 100 rows/insert stays under the 999
+ *  bind-parameter cap. An import can carry tens of thousands of events. */
+const REVIEW_EVENTS_BATCH = 100;
+
+/** clientEventIds are one bind parameter each; 500/query is well under the
+ *  cap and matches the sync upload ceiling. */
+const EVENT_ID_DEDUP_BATCH = 500;
+
+/** Of `clientEventIds`, return the subset already stored for this
+ *  (user, material) — the dedup hits. Chunked so a large import stays
+ *  under SQLite's bind-parameter cap; sync passes a bounded batch and
+ *  benefits from the same chunking for free. Both callers want the
+ *  "already seen" set to filter their fresh events. */
+export function existingEventIds(
+  exec: Executor,
+  userId: string,
+  materialId: string,
+  clientEventIds: string[],
+): Set<string> {
+  const seen = new Set<string>();
+  for (let i = 0; i < clientEventIds.length; i += EVENT_ID_DEDUP_BATCH) {
+    const chunk = clientEventIds.slice(i, i + EVENT_ID_DEDUP_BATCH);
+    const rows = exec
+      .select({ clientEventId: schema.reviewEvents.clientEventId })
+      .from(schema.reviewEvents)
+      .where(
+        and(
+          eq(schema.reviewEvents.userId, userId),
+          eq(schema.reviewEvents.materialId, materialId),
+          inArray(schema.reviewEvents.clientEventId, chunk),
+        ),
+      )
+      .all();
+    for (const r of rows) seen.add(r.clientEventId);
+  }
+  return seen;
+}
+
+/** Chunked append of `review_events`. The row `id` is the
+ *  `clientEventId` (stable + unique), and `createdAt` is the event's own
+ *  timestamp — same convention across the online, sync, and import write
+ *  paths. Callers are responsible for dedup (see `existingEventIds`). */
+export function writeReviewEvents(tx: Tx, events: ReviewEventInput[]): void {
+  for (let i = 0; i < events.length; i += REVIEW_EVENTS_BATCH) {
+    const slice = events.slice(i, i + REVIEW_EVENTS_BATCH);
+    if (slice.length === 0) continue;
+    tx.insert(schema.reviewEvents)
+      .values(
+        slice.map((e) => ({
+          id: e.clientEventId,
+          userId: e.userId,
+          materialId: e.materialId,
+          snapshotVersion: e.snapshotVersion,
+          timestampSecs: e.timestampSecs,
+          cardId: e.cardId,
+          grade: e.grade,
+          clientEventId: e.clientEventId,
+          createdAt: e.timestampSecs,
+        })),
+      )
+      .run();
+  }
+}
 
 interface UpsertOpts {
   /** When false, plain insert (used for fresh seeding where keys are unique). */
@@ -104,23 +173,6 @@ export function writeTestStates(
 export function persistEngineState(tx: Tx, args: PersistArgs): void {
   const { events, testStateUpdates, userId, materialId } = args;
 
-  if (events.length > 0) {
-    tx.insert(schema.reviewEvents)
-      .values(
-        events.map((e) => ({
-          id: e.clientEventId,
-          userId: e.userId,
-          materialId: e.materialId,
-          snapshotVersion: e.snapshotVersion,
-          timestampSecs: e.timestampSecs,
-          cardId: e.cardId,
-          grade: e.grade,
-          clientEventId: e.clientEventId,
-          createdAt: e.timestampSecs,
-        })),
-      )
-      .run();
-  }
-
+  writeReviewEvents(tx, events);
   writeTestStates(tx, userId, materialId, testStateUpdates, { onConflict: true });
 }

--- a/packages/api/src/lib/year-settings.ts
+++ b/packages/api/src/lib/year-settings.ts
@@ -1,0 +1,112 @@
+/**
+ * Per-(user, material) year settings: the domain types, bounds, and
+ * validation shared between the `PUT /api/years/:id/settings` route and
+ * the account importer. Both write to `user_year_settings`, so both must
+ * enforce the same field constraints — the importer can't trust an
+ * uploaded payload any more than the route trusts a request body.
+ */
+
+export type TierScope = 'off' | 'up150' | 'up300' | 'all';
+export type ChapterListScope = 'off' | 'up150' | 'up300';
+
+export const TIER_SCOPES: readonly TierScope[] = ['off', 'up150', 'up300', 'all'];
+// chapter_list_scope omits 'all' — Full never emits a chapter-list card.
+export const CHAPTER_LIST_SCOPES: readonly ChapterListScope[] = ['off', 'up150', 'up300'];
+
+export const DEFAULT_LESSON_BATCH_SIZE = 3;
+const MIN_LESSON_BATCH_SIZE = 1;
+const MAX_LESSON_BATCH_SIZE = 10;
+
+// FSRS-author recommended bounds: below 0.7 lets too much fade between
+// reviews; above 0.97 explodes review count for marginal recall gains.
+const MIN_DESIRED_RETENTION = 0.7;
+const MAX_DESIRED_RETENTION = 0.97;
+
+export interface YearSettings {
+  headingCard: boolean;
+  headingPassageCard: boolean;
+  ftv: boolean;
+  newScope: TierScope;
+  reviewScope: TierScope;
+  clubCardScope: TierScope;
+  chapterListScope: ChapterListScope;
+  lessonBatchSize: number;
+  desiredRetention: number;
+}
+
+export class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
+
+export function ensureBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new ValidationError(`${field} must be a boolean`);
+  }
+  return value;
+}
+
+export function ensureBatchSize(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new ValidationError('lessonBatchSize must be an integer');
+  }
+  if (value < MIN_LESSON_BATCH_SIZE || value > MAX_LESSON_BATCH_SIZE) {
+    throw new ValidationError(
+      `lessonBatchSize must be between ${MIN_LESSON_BATCH_SIZE} and ${MAX_LESSON_BATCH_SIZE}`,
+    );
+  }
+  return value;
+}
+
+export function ensureRetention(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ValidationError('desiredRetention must be a number');
+  }
+  if (value < MIN_DESIRED_RETENTION || value > MAX_DESIRED_RETENTION) {
+    throw new ValidationError(
+      `desiredRetention must be between ${MIN_DESIRED_RETENTION} and ${MAX_DESIRED_RETENTION}`,
+    );
+  }
+  return value;
+}
+
+export function ensureEnum<T extends string>(
+  value: unknown,
+  field: string,
+  allowed: readonly T[],
+): T {
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new ValidationError(`${field} must be one of: ${allowed.join(', ')}`);
+  }
+  return value as T;
+}
+
+/** Validate a full settings object (every field required), returning a
+ *  clean `YearSettings`. Throws `ValidationError` on the first bad
+ *  field. Used by the importer, where the whole row arrives at once;
+ *  the route's PATCH path validates field-by-field for partial bodies. */
+export function validateYearSettings(raw: {
+  headingCard: unknown;
+  headingPassageCard: unknown;
+  ftv: unknown;
+  newScope: unknown;
+  reviewScope: unknown;
+  clubCardScope: unknown;
+  chapterListScope: unknown;
+  lessonBatchSize: unknown;
+  desiredRetention: unknown;
+}): YearSettings {
+  return {
+    headingCard: ensureBoolean(raw.headingCard, 'headingCard'),
+    headingPassageCard: ensureBoolean(raw.headingPassageCard, 'headingPassageCard'),
+    ftv: ensureBoolean(raw.ftv, 'ftv'),
+    newScope: ensureEnum(raw.newScope, 'newScope', TIER_SCOPES),
+    reviewScope: ensureEnum(raw.reviewScope, 'reviewScope', TIER_SCOPES),
+    clubCardScope: ensureEnum(raw.clubCardScope, 'clubCardScope', TIER_SCOPES),
+    chapterListScope: ensureEnum(raw.chapterListScope, 'chapterListScope', CHAPTER_LIST_SCOPES),
+    lessonBatchSize: ensureBatchSize(raw.lessonBatchSize),
+    desiredRetention: ensureRetention(raw.desiredRetention),
+  };
+}

--- a/packages/api/src/routes/account.test.ts
+++ b/packages/api/src/routes/account.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AccountExport, ImportSummary } from '../lib/export-format.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestApp, signUpTestUser, type TestApp } from '../test-utils.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+
+async function enroll(test: TestApp, email: string): Promise<{ cookie: string; userId: string }> {
+  const { cookie, userId } = await signUpTestUser(test, email);
+  seedUserWithFixture({ db: test.db, userId, materialId: MATERIAL_ID, createUser: false });
+  return { cookie, userId };
+}
+
+describe('account routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('requires auth on both endpoints', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+
+    const exportRes = await test.app.request('/api/export');
+    expect(exportRes.status).toBe(401);
+
+    const importRes = await test.app.request('/api/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ exportVersion: 1, exportedAt: 0, user: { email: '', name: '' }, materials: [] }),
+    });
+    expect(importRes.status).toBe(401);
+  });
+
+  it('round-trips an account through GET /api/export → POST /api/import', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'src@example.com');
+
+    const exportRes = await test.app.request('/api/export', { headers: { cookie } });
+    expect(exportRes.status).toBe(200);
+    expect(exportRes.headers.get('content-disposition') ?? '').toMatch(
+      /verse-vault-export-\d{4}-\d{2}-\d{2}\.json/,
+    );
+    const payload = (await exportRes.json()) as AccountExport;
+    expect(payload.exportVersion).toBe(1);
+    expect(payload.materials).toHaveLength(1);
+    expect(payload.materials[0]!.materialId).toBe(MATERIAL_ID);
+
+    // Fresh user, fresh app — confirms the wire payload is self-contained.
+    const test2 = createTestApp();
+    const cleanup2 = test2.cleanup;
+    try {
+      const { cookie: cookie2 } = await signUpTestUser(test2, 'dst@example.com');
+      const importRes = await test2.app.request('/api/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', cookie: cookie2 },
+        body: JSON.stringify(payload),
+      });
+      expect(importRes.status).toBe(200);
+      const summary = (await importRes.json()) as ImportSummary;
+      expect(summary.materialsApplied).toBe(1);
+      expect(summary.unresolvedCardRefs).toBe(0);
+
+      // dst can now hit GET /api/export and see its own copy.
+      const verifyRes = await test2.app.request('/api/export', { headers: { cookie: cookie2 } });
+      expect(verifyRes.status).toBe(200);
+      const verifyPayload = (await verifyRes.json()) as AccountExport;
+      expect(verifyPayload.materials).toHaveLength(1);
+      expect(verifyPayload.materials[0]!.materialId).toBe(MATERIAL_ID);
+    } finally {
+      cleanup2();
+    }
+  });
+
+  it('rejects malformed JSON with 400', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'me@example.com');
+    const res = await test.app.request('/api/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: '{not valid json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects unsupported exportVersion with 400', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'me@example.com');
+    const res = await test.app.request('/api/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        exportVersion: 999,
+        exportedAt: 0,
+        user: { email: '', name: '' },
+        materials: [],
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects oversized payloads with 413', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'me@example.com');
+
+    // 50 MB cap; declare a Content-Length just past it so hono's body-limit
+    // rejects without us having to actually build a 50 MB string.
+    const res = await test.app.request('/api/import', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': String(50 * 1024 * 1024 + 1),
+        cookie,
+      },
+      body: '{}',
+    });
+    expect(res.status).toBe(413);
+  });
+});

--- a/packages/api/src/routes/account.ts
+++ b/packages/api/src/routes/account.ts
@@ -1,0 +1,67 @@
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+
+import type { DB } from '../db/client.js';
+import { EngineStore } from '../lib/engine.js';
+import type { AccountExport } from '../lib/export-format.js';
+import { buildAccountExport } from '../lib/export.js';
+import {
+  ImportValidationError,
+  applyAccountImport,
+} from '../lib/import.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface AccountRoutesDeps {
+  db: DB;
+  engines: EngineStore;
+  now?: () => number;
+}
+
+/** Cap on POST /api/import payload size. 52k revlog rows from the
+ *  test colpkg is ~10 MB of JSON; 50 MB leaves room for full deck
+ *  coverage at ~5x headroom. Beyond that, the user should split the
+ *  export anyway. */
+const IMPORT_MAX_BYTES = 50 * 1024 * 1024;
+
+export function accountRoutes(deps: AccountRoutesDeps) {
+  const app = new Hono<{ Variables: SessionVariables }>();
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
+
+  app.use('*', requireAuth());
+
+  app.get('/export', async (c) => {
+    const user = getUser(c);
+    const payload = await buildAccountExport(deps.db, deps.engines, user.id, now());
+    const dateStr = new Date(now() * 1000).toISOString().slice(0, 10);
+    c.header('Content-Disposition', `attachment; filename="verse-vault-export-${dateStr}.json"`);
+    return c.json(payload);
+  });
+
+  app.post(
+    '/import',
+    bodyLimit({
+      maxSize: IMPORT_MAX_BYTES,
+      onError: (c) => c.json({ error: 'payload too large' }, 413),
+    }),
+    async (c) => {
+      const user = getUser(c);
+      let payload: AccountExport;
+      try {
+        payload = await c.req.json<AccountExport>();
+      } catch {
+        return c.json({ error: 'invalid JSON body' }, 400);
+      }
+      try {
+        const summary = await applyAccountImport(deps.db, deps.engines, user.id, payload, now());
+        return c.json(summary);
+      } catch (err) {
+        if (err instanceof ImportValidationError) {
+          return c.json({ error: err.message }, 400);
+        }
+        throw err;
+      }
+    },
+  );
+
+  return app;
+}

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -14,7 +14,12 @@ import {
   readTestStateEntries,
 } from '../lib/engine.js';
 import { getMaterialJson } from '../lib/materials.js';
-import { type Grade, type ReviewEventInput, persistEngineState } from '../lib/review-log.js';
+import {
+  existingEventIds,
+  type Grade,
+  type ReviewEventInput,
+  persistEngineState,
+} from '../lib/review-log.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface SyncRoutesDeps {
@@ -23,7 +28,8 @@ export interface SyncRoutesDeps {
   now?: () => number;
 }
 
-/** Caps each upload so the `inArray` dedup stays under SQLite's 999-param limit. */
+/** Caps each upload to bound per-request work; the dedup query chunks
+ *  internally (see `existingEventIds`) so it isn't tied to this value. */
 const MAX_BATCH_SIZE = 500;
 
 /** Events with `timestampSecs` more than this far in the future are rejected.
@@ -158,21 +164,12 @@ export function syncRoutes(deps: SyncRoutesDeps) {
       }
     }
 
-    const existing = deps.db
-      .select({ clientEventId: schema.reviewEvents.clientEventId })
-      .from(schema.reviewEvents)
-      .where(
-        and(
-          eq(schema.reviewEvents.userId, user.id),
-          eq(schema.reviewEvents.materialId, materialId),
-          inArray(
-            schema.reviewEvents.clientEventId,
-            events.map((e) => e.clientEventId),
-          ),
-        ),
-      )
-      .all();
-    const seen = new Set(existing.map((r) => r.clientEventId));
+    const seen = existingEventIds(
+      deps.db,
+      user.id,
+      materialId,
+      events.map((e) => e.clientEventId),
+    );
 
     const fresh = events
       .filter((e) => !seen.has(e.clientEventId))

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -6,6 +6,19 @@ import * as schema from '../db/schema.js';
 import type { EngineStore } from '../lib/engine.js';
 import { AlreadyEnrolledError, enrollUser, isEnrolled } from '../lib/enrollment.js';
 import { MATERIALS } from '../lib/materials.js';
+import {
+  CHAPTER_LIST_SCOPES,
+  type ChapterListScope,
+  DEFAULT_LESSON_BATCH_SIZE,
+  ensureBatchSize,
+  ensureBoolean,
+  ensureEnum,
+  ensureRetention,
+  TIER_SCOPES,
+  type TierScope,
+  ValidationError,
+  type YearSettings,
+} from '../lib/year-settings.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface YearsRoutesDeps {
@@ -15,34 +28,9 @@ export interface YearsRoutesDeps {
 }
 
 export type ClubStatus = 'active' | 'maintenance' | 'paused';
-export type TierScope = 'off' | 'up150' | 'up300' | 'all';
-export type ChapterListScope = 'off' | 'up150' | 'up300';
 type ClubTier = '150' | '300' | 'full';
 
-const TIER_SCOPES: readonly TierScope[] = ['off', 'up150', 'up300', 'all'];
-const CHAPTER_LIST_SCOPES: readonly ChapterListScope[] = ['off', 'up150', 'up300'];
 const CLUB_TIERS: readonly ClubTier[] = ['150', '300', 'full'];
-
-const DEFAULT_LESSON_BATCH_SIZE = 3;
-const MIN_LESSON_BATCH_SIZE = 1;
-const MAX_LESSON_BATCH_SIZE = 10;
-
-// FSRS-author recommended bounds: below 0.7 lets too much fade between
-// reviews; above 0.97 explodes review count for marginal recall gains.
-const MIN_DESIRED_RETENTION = 0.7;
-const MAX_DESIRED_RETENTION = 0.97;
-
-interface YearSettings {
-  headingCard: boolean;
-  headingPassageCard: boolean;
-  ftv: boolean;
-  newScope: TierScope;
-  reviewScope: TierScope;
-  clubCardScope: TierScope;
-  chapterListScope: ChapterListScope;
-  lessonBatchSize: number;
-  desiredRetention: number;
-}
 
 interface ClubView {
   /** Effective per-tier status derived from active_scope and
@@ -89,55 +77,6 @@ interface ClubCounts {
   Club150?: number;
   Club300?: number;
   Full?: number;
-}
-
-class ValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'ValidationError';
-  }
-}
-
-function ensureBoolean(value: unknown, field: string): boolean {
-  if (typeof value !== 'boolean') {
-    throw new ValidationError(`${field} must be a boolean`);
-  }
-  return value;
-}
-
-function ensureBatchSize(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isInteger(value)) {
-    throw new ValidationError('lessonBatchSize must be an integer');
-  }
-  if (value < MIN_LESSON_BATCH_SIZE || value > MAX_LESSON_BATCH_SIZE) {
-    throw new ValidationError(
-      `lessonBatchSize must be between ${MIN_LESSON_BATCH_SIZE} and ${MAX_LESSON_BATCH_SIZE}`,
-    );
-  }
-  return value;
-}
-
-function ensureRetention(value: unknown): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new ValidationError('desiredRetention must be a number');
-  }
-  if (value < MIN_DESIRED_RETENTION || value > MAX_DESIRED_RETENTION) {
-    throw new ValidationError(
-      `desiredRetention must be between ${MIN_DESIRED_RETENTION} and ${MAX_DESIRED_RETENTION}`,
-    );
-  }
-  return value;
-}
-
-function ensureEnum<T extends string>(
-  value: unknown,
-  field: string,
-  allowed: readonly T[],
-): T {
-  if (typeof value !== 'string' || !allowed.includes(value as T)) {
-    throw new ValidationError(`${field} must be one of: ${allowed.join(', ')}`);
-  }
-  return value as T;
 }
 
 function tierScopeIncludes(scope: TierScope, tier: ClubTier): boolean {

--- a/tools/anki_to_export.py
+++ b/tools/anki_to_export.py
@@ -188,10 +188,10 @@ def parse_verse_fields(flds: str) -> Optional[Tuple[str, int, int]]:
 
 
 def tier_name(n: int) -> str:
-    """Map an Anki club number to the CardRef ``tier`` string. Full is
-    the unscoped "always-in" tier; everything else takes the literal
-    ``Club<N>`` form. Returns None for tier numbers the wire format
-    doesn't recognise; callers drop those events."""
+    """Map an Anki club number to the CardRef ``tier`` string
+    (``Club150`` / ``Club300``). Returns an empty string for club
+    numbers the wire format doesn't recognise; the caller treats that
+    as falsy and drops the event."""
     if n == 150:
         return "Club150"
     if n == 300:
@@ -318,9 +318,12 @@ def build_export(
     con = open_collection_db(db_path)
     col_mod = read_col_mod(con)
 
-    # nid → (materialId, CardRef) once resolved; cache so we don't
-    # re-resolve per revlog row.
-    note_resolution: Dict[int, Optional[Tuple[str, Dict[str, Any]]]] = {}
+    # cid → (materialId, CardRef) once resolved; cache so we don't
+    # re-resolve per revlog row. Keyed by *card* id, not note id: a
+    # Verse note fans out to three cards (ord 0/1/2 → Citation /
+    # Recitation / Ftv) that share one nid but resolve to distinct
+    # CardRefs, so caching per-nid would mislabel two of the three.
+    card_resolution: Dict[int, Optional[Tuple[str, Dict[str, Any]]]] = {}
     # (materialId, JSON-of-cardRef) → GradState. Folded per revlog row
     # via `fold_graduation_ts`: earliest passing (grade≥3) review wins,
     # else the latest row. Reduced to a bare ts in the promote step.
@@ -388,12 +391,12 @@ def build_export(
             counters["revlog_skipped_unmapped"] += 1
             continue
         nid = card["nid"]
-        if nid not in note_resolution:
+        if cid not in card_resolution:
             notetype, flds = nid_to_meta[nid]
-            note_resolution[nid] = resolve_note(
+            card_resolution[cid] = resolve_note(
                 notetype, card["ord"], flds, verse_indexes, heading_indexes
             )
-        resolved = note_resolution[nid]
+        resolved = card_resolution[cid]
         if resolved is None:
             counters["revlog_skipped_unmapped"] += 1
             continue

--- a/tools/anki_to_export.py
+++ b/tools/anki_to_export.py
@@ -38,7 +38,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from audit_colpkg import extract_collection, parse_clubs  # noqa: E402
+from audit_colpkg import ANKI_FIELD_SEP, extract_collection, parse_clubs  # noqa: E402
 from phrase_splitter.helpers import parse_reference  # noqa: E402
 
 EXPORT_VERSION = 1
@@ -119,8 +119,6 @@ def build_heading_index(
 
 
 # --- field parsers ------------------------------------------------------------
-
-ANKI_FIELD_SEP = "\x1f"
 
 # Heading-note Sort field looks like "2-01-001-018,001-025": that's
 # year-book-chapter-startVerse,endChapter-endVerse. We only need the
@@ -340,12 +338,7 @@ def build_export(
     nid_any_graduated: Dict[int, bool] = {}
     for nid, cid, queue, ord_, _mid, notetype, flds in cur:
         nid_to_meta[nid] = (notetype, flds)
-        cards_by_id[cid] = {
-            "nid": nid,
-            "queue": queue,
-            "ord": ord_,
-            "notetype": notetype,
-        }
+        cards_by_id[cid] = {"nid": nid, "ord": ord_}
         if queue in GRADUATED_QUEUES:
             nid_any_graduated[nid] = True
         else:

--- a/tools/anki_to_export.py
+++ b/tools/anki_to_export.py
@@ -38,7 +38,12 @@ from typing import Any, Dict, List, Optional, Tuple
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from audit_colpkg import ANKI_FIELD_SEP, extract_collection, parse_clubs  # noqa: E402
+from audit_colpkg import (  # noqa: E402
+    ANKI_FIELD_SEP,
+    extract_collection,
+    open_collection_db,
+    parse_clubs,
+)
 from phrase_splitter.helpers import parse_reference  # noqa: E402
 
 EXPORT_VERSION = 1
@@ -194,18 +199,33 @@ def tier_name(n: int) -> str:
     return ""
 
 
+# Running graduation-timestamp state for a single card: (ts, passed).
+# `ts` is the chosen graduation timestamp so far; `passed` records
+# whether it came from a passing (grade≥3) row, which locks it in.
+GradState = Tuple[Optional[int], bool]
+
+
+def fold_graduation_ts(state: GradState, ts: int, grade: int) -> GradState:
+    """Fold one revlog row into a card's graduation-timestamp state,
+    given rows arrive in ascending-time order.
+
+    Rule: the graduation moment is the *earliest passing* review
+    (grade≥3) — that's when the card left learning for review rotation.
+    Until a pass is seen, track the latest row so a card that reached
+    queue≥2 without any recorded pass still falls back to its most
+    recent activity rather than its first.
+    """
+    current, passed = state
+    if passed:
+        # Earliest pass already locked in; nothing later can improve it.
+        return current, True
+    if grade >= 3:
+        return ts, True
+    # No pass yet — keep advancing the fallback to the latest row.
+    return ts, False
+
+
 # --- main conversion ----------------------------------------------------------
-
-
-def open_collection(db_path: str) -> sqlite3.Connection:
-    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    # The Anki collation; even read-only queries need it registered
-    # because sqlite re-parses indexed columns lazily.
-    con.create_collation(
-        "unicase",
-        lambda a, b: (a.casefold() > b.casefold()) - (a.casefold() < b.casefold()),
-    )
-    return con
 
 
 def read_col_mod(con: sqlite3.Connection) -> int:
@@ -295,16 +315,16 @@ def build_export(
     verse_indexes = {mid: build_verse_index(d) for mid, d in decks.items()}
     heading_indexes = {mid: build_heading_index(d) for mid, d in decks.items()}
 
-    con = open_collection(db_path)
+    con = open_collection_db(db_path)
     col_mod = read_col_mod(con)
 
     # nid → (materialId, CardRef) once resolved; cache so we don't
     # re-resolve per revlog row.
     note_resolution: Dict[int, Optional[Tuple[str, Dict[str, Any]]]] = {}
-    # (materialId, JSON-of-cardRef) → graduatedAtSecs (earliest ts
-    # where ease ∈ {3,4} for any card under that note). Falls back to
-    # the latest revlog row when no Good/Easy row exists but queue≥2.
-    graduations_per_material: Dict[str, Dict[str, int]] = {mid: {} for mid in materials}
+    # (materialId, JSON-of-cardRef) → GradState. Folded per revlog row
+    # via `fold_graduation_ts`: earliest passing (grade≥3) review wins,
+    # else the latest row. Reduced to a bare ts in the promote step.
+    graduations_per_material: Dict[str, Dict[str, GradState]] = {mid: {} for mid in materials}
     # (materialId, verseId) → graduatedAtSecs
     verse_graduations: Dict[str, Dict[int, int]] = {mid: {} for mid in materials}
     # materialId → list of {clientEventId, timestampSecs, cardRef, grade}
@@ -390,24 +410,22 @@ def build_export(
         )
         counters["events_emitted"] += 1
 
-        # First Good/Easy (or sufficient queue) wins as graduation ts.
-        # The rule: if any card under this Anki note is in queue≥2, we
-        # graduate it; ts is the earliest revlog row with ease≥3, or
-        # the max revlog row if no ease≥3 exists.
+        # If any card under this Anki note reached queue≥2, the note
+        # graduated; fold this row into the card's running graduation-ts
+        # state (earliest pass wins — see `fold_graduation_ts`).
         if nid_any_graduated.get(nid):
             ref_key = json.dumps(card_ref, sort_keys=True)
-            existing = graduations_per_material[material_id].get(ref_key)
-            if grade >= 3 and (existing is None or timestamp_secs < existing):
-                graduations_per_material[material_id][ref_key] = timestamp_secs
-            elif existing is None:
-                graduations_per_material[material_id][ref_key] = timestamp_secs
+            by_ref = graduations_per_material[material_id]
+            by_ref[ref_key] = fold_graduation_ts(
+                by_ref.get(ref_key, (None, False)), timestamp_secs, grade
+            )
 
     # Promote verse-bound graduated cards to a single graduatedVerses
     # entry per (material, verseId), per the user's rule: graduate the
     # whole verse if ANY of Reference/Quote/FTV reached queue≥2 in Anki.
     graduated_cards_per_material: Dict[str, List[Dict[str, Any]]] = {mid: [] for mid in materials}
     for material_id, by_ref in graduations_per_material.items():
-        for ref_key, ts in by_ref.items():
+        for ref_key, (ts, _passed) in by_ref.items():
             card_ref = json.loads(ref_key)
             kind = card_ref["kind"]
             if kind in ("Citation", "Recitation", "Ftv"):

--- a/tools/anki_to_export.py
+++ b/tools/anki_to_export.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Convert an Anki ``.colpkg`` backup to the verse-vault account-export
+JSON format (``packages/api/src/lib/export-format.ts`` v1).
+
+The output is the same JSON shape ``GET /api/export`` produces, so it
+can be uploaded directly to ``POST /api/import`` to seed a new account
+from years of Anki review history.
+
+Reuses ``extract_collection`` and ``parse_clubs`` from
+``tools/audit_colpkg.py``, ``parse_reference`` from
+``tools/phrase_splitter/helpers.py``.
+
+Usage:
+
+    python3 tools/anki_to_export.py <colpkg> \\
+        --material nkjv-cor --deck data/3-corinthians.json \\
+        [--material nkjv-john --deck data/4-john.json ...] \\
+        --user-email you@example.com --user-name 'Your Name' \\
+        --out export.json
+
+Each ``--material`` pairs with the immediately preceding or following
+``--deck``; pairs may be given in either order. One pass produces ONE
+export.json covering every material whose deck was provided. Notes that
+don't resolve in any deck are skipped (counted at the end).
+
+Read-only against the colpkg. Does not need a running api server.
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+import tempfile
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from audit_colpkg import extract_collection, parse_clubs  # noqa: E402
+from phrase_splitter.helpers import parse_reference  # noqa: E402
+
+EXPORT_VERSION = 1
+
+# Verse-note template ords → CardRef kind (with FTV's withCitation default).
+# The Anki "Verse" notetype has three templates in this order:
+#   ord 0 "Reference" → Citation in verse-vault (just the citation card).
+#   ord 1 "Quote"     → Recitation (verse text on the back).
+#   ord 2 "FTV"       → Ftv (first three words / typing test).
+VERSE_ORD_TO_KIND = {0: "Citation", 1: "Recitation", 2: "Ftv"}
+
+# Anki revlog.ease → FSRS grade (1=Again, 2=Hard, 3=Good, 4=Easy).
+# Same numbering on both sides, so this is identity for valid grades.
+# ease=0 marks manual reschedule / cram and is filtered out upstream.
+EASE_TO_GRADE = {1: 1, 2: 2, 3: 3, 4: 4}
+
+# Anki revlog.type:
+#   0 = learn, 1 = review, 2 = relearn, 3 = cram, 4 = manual reset
+# verse-vault has no notion of "manual reset" so type=4 rows are
+# dropped. Cram/filtered grading (type=3) is also dropped since the
+# user wasn't grading against schedule; their FSRS state is in (0,1,2).
+REVLOG_TYPES_TO_KEEP = (0, 1, 2)
+
+# Anki cards.queue values:
+#   -3 user-buried, -2 sched-buried, -1 suspended,
+#    0 new, 1 learning, 2 review, 3 day-learn/relearn, 4 preview
+# Cards in queue >= 2 are "graduated" enough that the user has the verse
+# in long-term review rotation, which is the user's graduation criterion.
+GRADUATED_QUEUES = (2, 3)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("colpkg", help="path to the Anki .colpkg backup")
+    p.add_argument(
+        "--material",
+        action="append",
+        required=True,
+        dest="materials",
+        help="verse-vault materialId; pair with --deck",
+    )
+    p.add_argument(
+        "--deck",
+        action="append",
+        required=True,
+        dest="decks",
+        help="path to the corresponding data/<N>-<book>.json",
+    )
+    p.add_argument("--user-email", required=True)
+    p.add_argument("--user-name", required=True)
+    p.add_argument("--out", required=True, help="path to write export.json")
+    return p.parse_args()
+
+
+def load_deck(path: str) -> Dict[str, Any]:
+    with open(path) as f:
+        return json.load(f)
+
+
+def build_verse_index(deck: Dict[str, Any]) -> Dict[Tuple[str, int, int], int]:
+    """``(book, chapter, verse) → verseId``. The deck's ``verses`` array
+    index IS the verseId (confirmed against the Rust builder)."""
+    out: Dict[Tuple[str, int, int], int] = {}
+    for i, v in enumerate(deck["verses"]):
+        out[(v["book"], v["chapter"], v["verse"])] = i
+    return out
+
+
+def build_heading_index(
+    deck: Dict[str, Any],
+) -> Dict[Tuple[str, int, int], int]:
+    """``(book, startChapter, startVerse) → headingIdx``. The deck's
+    ``headings`` array index IS the headingIdx — see crates/core."""
+    out: Dict[Tuple[str, int, int], int] = {}
+    for i, h in enumerate(deck["headings"]):
+        out[(h["book"], h["startChapter"], h["startVerse"])] = i
+    return out
+
+
+# --- field parsers ------------------------------------------------------------
+
+ANKI_FIELD_SEP = "\x1f"
+
+# Heading-note Sort field looks like "2-01-001-018,001-025": that's
+# year-book-chapter-startVerse,endChapter-endVerse. We only need the
+# (chapter, startVerse) pair to key into the deck's headings array.
+_HEADING_SORT_RE = re.compile(r"^\d+-\d+-(\d+)-(\d+),")
+
+# Key-Verse-List Chapter field looks like "Luke 1 (150)". The tier in
+# parens is duplicated in the club field, but we read the chapter
+# number out of here and trust the club field for the tier.
+_KVL_CHAPTER_RE = re.compile(r"^(.+?)\s+(\d+)\s*\(\d+\)\s*$")
+
+
+def parse_heading_fields(flds: str) -> Optional[Tuple[str, int, int]]:
+    """Return ``(book, startChapter, startVerse)`` for a Heading note,
+    or None if the fields don't parse. Heading notes have:
+        [Sort, Front, Back, Add Reverse]
+    Front is the book name (trailing space in real data); Sort encodes
+    the verse range."""
+    parts = flds.split(ANKI_FIELD_SEP)
+    if len(parts) < 4:
+        return None
+    sort, front, _back, _rev = parts[:4]
+    m = _HEADING_SORT_RE.match(sort)
+    if not m:
+        return None
+    book = front.strip()
+    if not book:
+        return None
+    return book, int(m.group(1)), int(m.group(2))
+
+
+def parse_kvl_fields(flds: str) -> Optional[Tuple[str, int, int]]:
+    """Return ``(book, chapter, tier)`` for a Key-Verse-List note. KVL
+    notes have:
+        [Sort, Chapter, Verses, club]
+    Chapter encodes book + chapter + tier; club is the bare tier."""
+    parts = flds.split(ANKI_FIELD_SEP)
+    if len(parts) < 4:
+        return None
+    _sort, chapter_field, _verses, club_field = parts[:4]
+    m = _KVL_CHAPTER_RE.match(chapter_field)
+    if not m:
+        return None
+    book = m.group(1).strip()
+    chapter = int(m.group(2))
+    tiers = parse_clubs(club_field)
+    if not tiers:
+        return None
+    return book, chapter, tiers[0]
+
+
+def parse_verse_fields(flds: str) -> Optional[Tuple[str, int, int]]:
+    """Return ``(book, chapter, verse)`` for a Verse note. Verse notes
+    have ``[Sort, Ref, Text, FTV, club]`` — we only need ``Ref``."""
+    parts = flds.split(ANKI_FIELD_SEP)
+    if len(parts) < 2:
+        return None
+    try:
+        return parse_reference(parts[1])
+    except ValueError:
+        return None
+
+
+def tier_name(n: int) -> str:
+    """Map an Anki club number to the CardRef ``tier`` string. Full is
+    the unscoped "always-in" tier; everything else takes the literal
+    ``Club<N>`` form. Returns None for tier numbers the wire format
+    doesn't recognise; callers drop those events."""
+    if n == 150:
+        return "Club150"
+    if n == 300:
+        return "Club300"
+    return ""
+
+
+# --- main conversion ----------------------------------------------------------
+
+
+def open_collection(db_path: str) -> sqlite3.Connection:
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    # The Anki collation; even read-only queries need it registered
+    # because sqlite re-parses indexed columns lazily.
+    con.create_collation(
+        "unicase",
+        lambda a, b: (a.casefold() > b.casefold()) - (a.casefold() < b.casefold()),
+    )
+    return con
+
+
+def read_col_mod(con: sqlite3.Connection) -> int:
+    row = con.execute("SELECT mod FROM col").fetchone()
+    return int(row[0]) if row else 0
+
+
+def resolve_note(
+    notetype: str,
+    ord_: int,
+    flds: str,
+    verse_indexes: Dict[str, Dict[Tuple[str, int, int], int]],
+    heading_indexes: Dict[str, Dict[Tuple[str, int, int], int]],
+) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """Translate one Anki (notetype, ord, flds) tuple to
+    ``(materialId, CardRef)``. Returns None if the note doesn't map to
+    a verse-vault card in any of the provided decks."""
+    if notetype == "Verse":
+        ref = parse_verse_fields(flds)
+        if ref is None:
+            return None
+        for material_id, index in verse_indexes.items():
+            verse_id = index.get(ref)
+            if verse_id is None:
+                continue
+            kind = VERSE_ORD_TO_KIND.get(ord_)
+            if kind is None:
+                return None
+            card_ref: Dict[str, Any] = {"kind": kind, "verseId": verse_id}
+            if kind == "Ftv":
+                # The Anki FTV card has no citation showing; treat as
+                # withCitation=false. (verse-vault has both variants;
+                # the import resolver only matches the explicit one.)
+                card_ref["withCitation"] = False
+            return material_id, card_ref
+        return None
+
+    if notetype == "Heading":
+        parsed = parse_heading_fields(flds)
+        if parsed is None:
+            return None
+        for material_id, index in heading_indexes.items():
+            heading_idx = index.get(parsed)
+            if heading_idx is None:
+                continue
+            # Both Heading template ords (0 Card 1, 1 Card 2) collapse
+            # to the same HeadingPassage CardRef in verse-vault. The
+            # clientEventId per Anki revlog row stays unique, so the
+            # double-emit gets dedup'd naturally on the verse-vault
+            # side via the unique (user, material, clientEventId) idx.
+            return material_id, {"kind": "HeadingPassage", "headingIdx": heading_idx}
+        return None
+
+    if notetype == "Key Verse List":
+        parsed = parse_kvl_fields(flds)
+        if parsed is None:
+            return None
+        book, chapter, tier_num = parsed
+        tier = tier_name(tier_num)
+        if not tier:
+            return None
+        for material_id, index in verse_indexes.items():
+            # KVL doesn't have a verse to look up — we just confirm the
+            # book is present in this deck before claiming it.
+            if any(b == book for (b, _c, _v) in index):
+                return material_id, {
+                    "kind": "ChapterClubList",
+                    "book": book,
+                    "chapter": chapter,
+                    "tier": tier,
+                }
+        return None
+
+    return None
+
+
+def build_export(
+    db_path: str,
+    materials: Dict[str, str],
+    user_email: str,
+    user_name: str,
+) -> Tuple[Dict[str, Any], Dict[str, int]]:
+    """Read the colpkg DB and assemble the AccountExport JSON. Returns
+    ``(payload, counters)``. Counters cover skip / drop / accept rates
+    so the caller can print a summary."""
+    decks = {mid: load_deck(path) for mid, path in materials.items()}
+    verse_indexes = {mid: build_verse_index(d) for mid, d in decks.items()}
+    heading_indexes = {mid: build_heading_index(d) for mid, d in decks.items()}
+
+    con = open_collection(db_path)
+    col_mod = read_col_mod(con)
+
+    # nid → (materialId, CardRef) once resolved; cache so we don't
+    # re-resolve per revlog row.
+    note_resolution: Dict[int, Optional[Tuple[str, Dict[str, Any]]]] = {}
+    # (materialId, JSON-of-cardRef) → graduatedAtSecs (earliest ts
+    # where ease ∈ {3,4} for any card under that note). Falls back to
+    # the latest revlog row when no Good/Easy row exists but queue≥2.
+    graduations_per_material: Dict[str, Dict[str, int]] = {mid: {} for mid in materials}
+    # (materialId, verseId) → graduatedAtSecs
+    verse_graduations: Dict[str, Dict[int, int]] = {mid: {} for mid in materials}
+    # materialId → list of {clientEventId, timestampSecs, cardRef, grade}
+    events_per_material: Dict[str, List[Dict[str, Any]]] = {mid: [] for mid in materials}
+
+    counters = {
+        "revlog_total": 0,
+        "revlog_skipped_unmapped": 0,
+        "revlog_skipped_bad_grade": 0,
+        "revlog_skipped_type": 0,
+        "graduated_verses": 0,
+        "graduated_cards": 0,
+        "events_emitted": 0,
+    }
+
+    # Per-note "any-card-graduated?" preflight: gather the set of nids
+    # for which at least one card sits in queue>=2. Used for both the
+    # per-card graduation emission and the per-verse "graduate the
+    # whole verse if any of its 3 cards graduated" rule.
+    cur = con.execute(
+        """
+        SELECT c.nid, c.id, c.queue, c.ord, n.mid, m.name AS notetype, n.flds
+        FROM cards c
+        JOIN notes n ON n.id = c.nid
+        JOIN notetypes m ON m.id = n.mid
+        WHERE m.name IN ('Verse', 'Heading', 'Key Verse List')
+        """
+    )
+    nid_to_meta: Dict[int, Tuple[str, str]] = {}
+    cards_by_id: Dict[int, Dict[str, Any]] = {}
+    nid_any_graduated: Dict[int, bool] = {}
+    for nid, cid, queue, ord_, _mid, notetype, flds in cur:
+        nid_to_meta[nid] = (notetype, flds)
+        cards_by_id[cid] = {
+            "nid": nid,
+            "queue": queue,
+            "ord": ord_,
+            "notetype": notetype,
+        }
+        if queue in GRADUATED_QUEUES:
+            nid_any_graduated[nid] = True
+        else:
+            nid_any_graduated.setdefault(nid, False)
+
+    # Stream the revlog. Order by id ASC so the first Good/Easy row we
+    # see for a given (material, cardRef) is the earliest one — that's
+    # the graduation timestamp.
+    cur = con.execute(
+        """
+        SELECT id, cid, ease, type
+        FROM revlog
+        ORDER BY id ASC
+        """
+    )
+    for revlog_id, cid, ease, rtype in cur:
+        counters["revlog_total"] += 1
+        if rtype not in REVLOG_TYPES_TO_KEEP:
+            counters["revlog_skipped_type"] += 1
+            continue
+        grade = EASE_TO_GRADE.get(ease)
+        if grade is None:
+            counters["revlog_skipped_bad_grade"] += 1
+            continue
+        card = cards_by_id.get(cid)
+        if card is None:
+            counters["revlog_skipped_unmapped"] += 1
+            continue
+        nid = card["nid"]
+        if nid not in note_resolution:
+            notetype, flds = nid_to_meta[nid]
+            note_resolution[nid] = resolve_note(
+                notetype, card["ord"], flds, verse_indexes, heading_indexes
+            )
+        resolved = note_resolution[nid]
+        if resolved is None:
+            counters["revlog_skipped_unmapped"] += 1
+            continue
+        material_id, card_ref = resolved
+
+        timestamp_secs = revlog_id // 1000
+        events_per_material[material_id].append(
+            {
+                "clientEventId": f"anki:{col_mod}:{revlog_id}",
+                "timestampSecs": timestamp_secs,
+                "cardRef": card_ref,
+                "grade": grade,
+            }
+        )
+        counters["events_emitted"] += 1
+
+        # First Good/Easy (or sufficient queue) wins as graduation ts.
+        # The rule: if any card under this Anki note is in queue≥2, we
+        # graduate it; ts is the earliest revlog row with ease≥3, or
+        # the max revlog row if no ease≥3 exists.
+        if nid_any_graduated.get(nid):
+            ref_key = json.dumps(card_ref, sort_keys=True)
+            existing = graduations_per_material[material_id].get(ref_key)
+            if grade >= 3 and (existing is None or timestamp_secs < existing):
+                graduations_per_material[material_id][ref_key] = timestamp_secs
+            elif existing is None:
+                graduations_per_material[material_id][ref_key] = timestamp_secs
+
+    # Promote verse-bound graduated cards to a single graduatedVerses
+    # entry per (material, verseId), per the user's rule: graduate the
+    # whole verse if ANY of Reference/Quote/FTV reached queue≥2 in Anki.
+    graduated_cards_per_material: Dict[str, List[Dict[str, Any]]] = {mid: [] for mid in materials}
+    for material_id, by_ref in graduations_per_material.items():
+        for ref_key, ts in by_ref.items():
+            card_ref = json.loads(ref_key)
+            kind = card_ref["kind"]
+            if kind in ("Citation", "Recitation", "Ftv"):
+                vid = card_ref["verseId"]
+                existing = verse_graduations[material_id].get(vid)
+                if existing is None or ts < existing:
+                    verse_graduations[material_id][vid] = ts
+            else:
+                graduated_cards_per_material[material_id].append(
+                    {"cardRef": card_ref, "graduatedAtSecs": ts}
+                )
+                counters["graduated_cards"] += 1
+
+    counters["graduated_verses"] = sum(len(v) for v in verse_graduations.values())
+
+    now_secs = int(time.time())
+    payload: Dict[str, Any] = {
+        "exportVersion": EXPORT_VERSION,
+        "exportedAt": now_secs,
+        "user": {"email": user_email, "name": user_name},
+        "materials": [],
+    }
+    for material_id in materials:
+        payload["materials"].append(
+            {
+                "materialId": material_id,
+                "enrollment": {"clubTier": None, "offlineMode": False, "createdAt": now_secs},
+                "settings": None,
+                "snapshot": {"version": 1, "contentSha": ""},
+                "graduatedVerses": [
+                    {"verseId": vid, "graduatedAtSecs": ts}
+                    for vid, ts in sorted(verse_graduations[material_id].items())
+                ],
+                "graduatedCards": graduated_cards_per_material[material_id],
+                "reviewEvents": sorted(
+                    events_per_material[material_id],
+                    key=lambda e: (e["timestampSecs"], e["clientEventId"]),
+                ),
+            }
+        )
+    return payload, counters
+
+
+def main() -> int:
+    args = parse_args()
+    if len(args.materials) != len(args.decks):
+        sys.exit("--material and --deck must be passed the same number of times")
+    materials = dict(zip(args.materials, args.decks))
+
+    with tempfile.TemporaryDirectory(prefix="vv-anki-") as workdir:
+        db_path = extract_collection(args.colpkg, workdir)
+        payload, counters = build_export(
+            db_path, materials, args.user_email, args.user_name
+        )
+
+    with open(args.out, "w") as f:
+        json.dump(payload, f, indent=2)
+
+    skipped = (
+        counters["revlog_skipped_unmapped"]
+        + counters["revlog_skipped_bad_grade"]
+        + counters["revlog_skipped_type"]
+    )
+    print(
+        f"wrote {args.out}: "
+        f"{counters['events_emitted']} events, "
+        f"{counters['graduated_verses']} verse graduations, "
+        f"{counters['graduated_cards']} card graduations "
+        f"(skipped {skipped}/{counters['revlog_total']} revlog rows: "
+        f"{counters['revlog_skipped_type']} type, "
+        f"{counters['revlog_skipped_bad_grade']} bad grade, "
+        f"{counters['revlog_skipped_unmapped']} unmapped)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit_colpkg.py
+++ b/tools/audit_colpkg.py
@@ -120,6 +120,19 @@ def parse_clubs(club_str: str) -> List[int]:
     return sorted(set(out))
 
 
+def open_collection_db(db_path: str) -> sqlite3.Connection:
+    """Open an extracted Anki collection read-only with the ``unicase``
+    collation registered. Anki's indexes reference this collation, so
+    even read-only queries fail to prepare without it. Shared by every
+    tool that reads a colpkg's SQLite (audit, import, export)."""
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    con.create_collation(
+        "unicase",
+        lambda a, b: (a.casefold() > b.casefold()) - (a.casefold() < b.casefold()),
+    )
+    return con
+
+
 def query_verse_notes(
     db_path: str, year_prefix: str
 ) -> Iterable[Tuple[str, int, int, str, str, List[int]]]:
@@ -127,11 +140,7 @@ def query_verse_notes(
     Anki ``Verse`` note in decks whose name contains ``year_prefix``.
     Text and FTV are returned with markup intact so the auditor can
     parse keyword positions and FTV word boundaries."""
-    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-    con.create_collation(
-        "unicase",
-        lambda a, b: (a.casefold() > b.casefold()) - (a.casefold() < b.casefold()),
-    )
+    con = open_collection_db(db_path)
     try:
         cur = con.execute(
             """

--- a/tools/test_anki_to_export.py
+++ b/tools/test_anki_to_export.py
@@ -17,12 +17,22 @@ from anki_to_export import (  # noqa: E402
     VERSE_ORD_TO_KIND,
     build_heading_index,
     build_verse_index,
+    fold_graduation_ts,
     parse_heading_fields,
     parse_kvl_fields,
     parse_verse_fields,
     resolve_note,
     tier_name,
 )
+
+
+def fold_rows(rows):
+    """Fold a list of (ts, grade) rows (ascending) and return the chosen
+    graduation timestamp — mirrors how build_export reduces the state."""
+    state = (None, False)
+    for ts, grade in rows:
+        state = fold_graduation_ts(state, ts, grade)
+    return state[0]
 
 
 def f(*parts: str) -> str:
@@ -169,6 +179,25 @@ class ResolveNoteTests(unittest.TestCase):
             "Books", 0, "any\x1ffields", self.verse_indexes, self.heading_indexes
         )
         self.assertIsNone(out)
+
+
+class GraduationTimestampTests(unittest.TestCase):
+    def test_earliest_passing_review_wins(self):
+        # Learning failures first, then a Good — graduation ts is the
+        # first pass (300), not the first row (100).
+        self.assertEqual(fold_rows([(100, 1), (200, 2), (300, 3), (400, 3)]), 300)
+
+    def test_later_failures_do_not_override_earliest_pass(self):
+        # A lapse after graduating doesn't move the graduation moment.
+        self.assertEqual(fold_rows([(100, 3), (200, 1), (300, 3)]), 100)
+
+    def test_falls_back_to_latest_row_when_never_passed(self):
+        # queue≥2 but no recorded ease≥3 — fall back to the most recent
+        # activity, not the first.
+        self.assertEqual(fold_rows([(100, 1), (200, 2), (300, 1)]), 300)
+
+    def test_first_row_passing_is_kept(self):
+        self.assertEqual(fold_rows([(500, 4)]), 500)
 
 
 class ConstantTests(unittest.TestCase):

--- a/tools/test_anki_to_export.py
+++ b/tools/test_anki_to_export.py
@@ -1,0 +1,191 @@
+"""Unit tests for ``tools/anki_to_export.py`` - no fixture colpkg
+needed; we drive the field-parsing + kind-translation helpers directly
+against synthesised inputs. The real colpkg integration is exercised
+manually via ``python3 tools/anki_to_export.py ...``."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from anki_to_export import (  # noqa: E402
+    ANKI_FIELD_SEP,
+    EASE_TO_GRADE,
+    GRADUATED_QUEUES,
+    REVLOG_TYPES_TO_KEEP,
+    VERSE_ORD_TO_KIND,
+    build_heading_index,
+    build_verse_index,
+    parse_heading_fields,
+    parse_kvl_fields,
+    parse_verse_fields,
+    resolve_note,
+    tier_name,
+)
+
+
+def f(*parts: str) -> str:
+    return ANKI_FIELD_SEP.join(parts)
+
+
+class VerseFieldsTests(unittest.TestCase):
+    def test_parses_ref_field(self):
+        flds = f("8-01-001-003-", "Luke 1:3", "text", "ftv", "150")
+        self.assertEqual(parse_verse_fields(flds), ("Luke", 1, 3))
+
+    def test_returns_none_on_bad_ref(self):
+        flds = f("sort", "no colon here", "text", "ftv", "150")
+        self.assertIsNone(parse_verse_fields(flds))
+
+    def test_returns_none_on_short_fields(self):
+        self.assertIsNone(parse_verse_fields("only-one-field"))
+
+
+class HeadingFieldsTests(unittest.TestCase):
+    def test_parses_sort_and_front(self):
+        flds = f("2-01-001-018,001-025,", "Matthew ", "Christ Born of Mary", "")
+        self.assertEqual(parse_heading_fields(flds), ("Matthew", 1, 18))
+
+    def test_returns_none_when_sort_malformed(self):
+        flds = f("malformed-sort", "Matthew", "title", "")
+        self.assertIsNone(parse_heading_fields(flds))
+
+    def test_returns_none_when_front_empty(self):
+        flds = f("2-01-001-018,001-025,", "", "title", "")
+        self.assertIsNone(parse_heading_fields(flds))
+
+
+class KVLFieldsTests(unittest.TestCase):
+    def test_parses_chapter_and_tier(self):
+        flds = f("8-01-001_150_", "Luke 1 (150)", "3, 4, 13", "150")
+        self.assertEqual(parse_kvl_fields(flds), ("Luke", 1, 150))
+
+    def test_returns_none_on_missing_tier(self):
+        flds = f("sort", "Luke 1 (150)", "verses", "")
+        self.assertIsNone(parse_kvl_fields(flds))
+
+    def test_handles_two_word_book_names(self):
+        flds = f("sort", "1 Corinthians 12 (300)", "11", "300")
+        self.assertEqual(parse_kvl_fields(flds), ("1 Corinthians", 12, 300))
+
+
+class TierNameTests(unittest.TestCase):
+    def test_known_tiers(self):
+        self.assertEqual(tier_name(150), "Club150")
+        self.assertEqual(tier_name(300), "Club300")
+
+    def test_unknown_tier_is_empty(self):
+        # Empty string signals "drop the event" upstream.
+        self.assertEqual(tier_name(999), "")
+
+
+class IndexBuildingTests(unittest.TestCase):
+    def test_verse_index_uses_array_position(self):
+        deck = {
+            "verses": [
+                {"book": "John", "chapter": 1, "verse": 1},
+                {"book": "John", "chapter": 1, "verse": 2},
+                {"book": "John", "chapter": 1, "verse": 3},
+            ]
+        }
+        idx = build_verse_index(deck)
+        self.assertEqual(idx[("John", 1, 2)], 1)
+        self.assertEqual(idx[("John", 1, 3)], 2)
+
+    def test_heading_index_uses_array_position(self):
+        deck = {
+            "headings": [
+                {"book": "John", "startChapter": 1, "startVerse": 1, "endChapter": 1, "endVerse": 5},
+                {"book": "John", "startChapter": 1, "startVerse": 6, "endChapter": 1, "endVerse": 13},
+            ]
+        }
+        idx = build_heading_index(deck)
+        self.assertEqual(idx[("John", 1, 1)], 0)
+        self.assertEqual(idx[("John", 1, 6)], 1)
+
+
+class ResolveNoteTests(unittest.TestCase):
+    def setUp(self):
+        deck = {
+            "verses": [
+                {"book": "John", "chapter": 1, "verse": 1},
+                {"book": "John", "chapter": 1, "verse": 2},
+            ],
+            "headings": [
+                {"book": "John", "startChapter": 1, "startVerse": 1, "endChapter": 1, "endVerse": 5},
+            ],
+        }
+        self.verse_indexes = {"nkjv-john": build_verse_index(deck)}
+        self.heading_indexes = {"nkjv-john": build_heading_index(deck)}
+
+    def test_verse_reference_resolves_to_citation(self):
+        flds = f("sort", "John 1:1", "text", "ftv", "150")
+        out = resolve_note("Verse", 0, flds, self.verse_indexes, self.heading_indexes)
+        self.assertEqual(out, ("nkjv-john", {"kind": "Citation", "verseId": 0}))
+
+    def test_verse_quote_resolves_to_recitation(self):
+        flds = f("sort", "John 1:2", "text", "ftv", "150")
+        out = resolve_note("Verse", 1, flds, self.verse_indexes, self.heading_indexes)
+        self.assertEqual(out, ("nkjv-john", {"kind": "Recitation", "verseId": 1}))
+
+    def test_verse_ftv_default_no_citation(self):
+        flds = f("sort", "John 1:1", "text", "ftv", "150")
+        out = resolve_note("Verse", 2, flds, self.verse_indexes, self.heading_indexes)
+        self.assertEqual(
+            out, ("nkjv-john", {"kind": "Ftv", "verseId": 0, "withCitation": False})
+        )
+
+    def test_heading_both_ords_collapse_to_same_cardref(self):
+        # Verse-vault treats both Anki Heading template ords as the
+        # same HeadingPassage card; clientEventId dedup handles dupes.
+        flds = f("2-01-001-001,001-005,", "John ", "title", "")
+        a = resolve_note("Heading", 0, flds, self.verse_indexes, self.heading_indexes)
+        b = resolve_note("Heading", 1, flds, self.verse_indexes, self.heading_indexes)
+        self.assertEqual(a, ("nkjv-john", {"kind": "HeadingPassage", "headingIdx": 0}))
+        self.assertEqual(a, b)
+
+    def test_kvl_emits_chapter_club_list(self):
+        flds = f("sort", "John 1 (150)", "verses", "150")
+        out = resolve_note(
+            "Key Verse List", 0, flds, self.verse_indexes, self.heading_indexes
+        )
+        self.assertEqual(
+            out,
+            (
+                "nkjv-john",
+                {"kind": "ChapterClubList", "book": "John", "chapter": 1, "tier": "Club150"},
+            ),
+        )
+
+    def test_unresolved_verse_returns_none(self):
+        # No verse with this reference in the deck.
+        flds = f("sort", "John 99:99", "text", "ftv", "150")
+        out = resolve_note("Verse", 0, flds, self.verse_indexes, self.heading_indexes)
+        self.assertIsNone(out)
+
+    def test_unknown_notetype_returns_none(self):
+        out = resolve_note(
+            "Books", 0, "any\x1ffields", self.verse_indexes, self.heading_indexes
+        )
+        self.assertIsNone(out)
+
+
+class ConstantTests(unittest.TestCase):
+    def test_verse_ord_table(self):
+        self.assertEqual(VERSE_ORD_TO_KIND, {0: "Citation", 1: "Recitation", 2: "Ftv"})
+
+    def test_ease_to_grade_is_identity(self):
+        self.assertEqual(EASE_TO_GRADE, {1: 1, 2: 2, 3: 3, 4: 4})
+
+    def test_revlog_types_kept(self):
+        # learn / review / relearn — cram and manual reset dropped.
+        self.assertEqual(set(REVLOG_TYPES_TO_KEEP), {0, 1, 2})
+
+    def test_graduated_queues(self):
+        # Anki review (2) + day-learn/relearn (3) = "in long-term rotation".
+        self.assertEqual(set(GRADUATED_QUEUES), {2, 3})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a versioned account-portability format plus an Anki bootstrap converter, so a user can extract their full verse-vault data — and seed years of memorization history from an existing Anki `.colpkg`.

- **`AccountExport` v1** (`packages/api/src/lib/export-format.ts`) — one JSON payload covering the user row, every enrolled material, per-year settings, graduations, and the full review-event log. Cards key on `CardRef` (`kind` + verseId + params), **not** `cardId`, so an export stays valid across snapshot-version bumps as long as the referenced verses still exist. HP/CCL use natural keys (`headingIdx`, `(book, chapter, tier)`) so external converters don't need the builder's synthetic pseudo-verse ids.
- **`GET /api/export`** — full account dump as `verse-vault-export-YYYY-MM-DD.json`.
- **`POST /api/import`** — accepts an `AccountExport`, returns an `ImportSummary` (events inserted/skipped via `clientEventId` dedup, graduations applied, unresolved cardRefs). Per-material transaction so a bad cardRef in one material can't poison another; replays into a fresh engine via `EngineStore.rebuildFromEvents` so `test_states` regenerate from the augmented event log (no engine-state copying). Body capped at 50 MB.
- **Settings merge**: per-row `max(updatedAt)` wins — locally-tuned settings aren't clobbered by an older import, and re-import of the same payload is a no-op.
- **`tools/anki_to_export.py`** — reads a `.colpkg`, maps the 3 Verse template ords to Citation/Recitation/Ftv, Heading notes to HeadingPassage, Key Verse List to ChapterClubList. Graduation rule per spec: any Verse note with ANY of its 3 cards in Anki queue ≥ 2 graduates the verse. `clientEventId` is `anki:<col-mod>:<revlog-id>`, so re-running the converter is idempotent on import.

Bundled algorithm contract unchanged; no wire-format break. Ships as `@verse-vault/api` 0.1.25.

Commits:
1. `feat(api): account export format + cardRef`
2. `feat(api): /api/export + /api/import routes`
3. `feat(tools): anki colpkg → export converter`
4. `chore: release @verse-vault/api 0.1.25`

## Test plan

- [x] `pnpm --filter @verse-vault/api exec vitest run` — 153 passing (+21 new across `card-ref`, `export`, `import`, `routes/account`)
- [x] `python3 -m unittest tools.test_anki_to_export` — 24 passing
- [x] Ran the converter against the real `data/collection-2026-05-29@15-52-19.colpkg` across all 8 year decks: 41,937 events emitted, 364 verse + 267 card graduations
- [x] Imported the full export into a throwaway DB and inspected the replayed FSRS state — clean (0 non-finite states), well-distributed stability (touched p50 9.6d, p90 219d) with a proper maturity gradient; lockstep VerseRefPosition/Chapter/Book confirms composite propagation is intact
- [ ] Manual round-trip against a dev server (`curl /api/export` → wipe → `POST /api/import`, confirm `eventsInserted` matches and `unresolvedCardRefs === 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)