### PR TITLE
feat(web): account data management on profile card

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,27 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.1.20] — 2026-05-30
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Account data management on the profile card
+
+* The profile card kebab menu gains **Export my data**, **Import data**, and **Delete all progress**
+  (all gated on a signed-in card). Each switches the active session to that profile first
+  (`enterProfile`).
+* **Export** downloads the account as `verse-vault-export-<email>-<date>.json`.
+* **Import** picks a JSON file, confirms (neutral — import is additive and idempotent), and shows
+  the server's summary (events inserted/skipped, graduations, unresolved cards).
+* **Delete all progress** is gated behind a type-the-email confirmation and offers a one-click
+  backup download inside the dialog. It wipes review history and graduations across all decks but
+  keeps the decks + settings.
+* New: `lib/account-file.ts` (download/read helpers), `ImportResultDialog.vue`,
+  `TypeToConfirmDialog.vue`; `api.ts` gains `exportAccount` / `importAccount` / `deleteAllProgress`.
+
 ## [0.1.19] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -192,6 +192,26 @@ export interface YearsResponse {
   years: YearView[]
 }
 
+/** Full account export payload. Opaque to the web — it's downloaded and
+ *  re-uploaded verbatim; the server owns the shape + validation. */
+export type AccountExport = Record<string, unknown>
+
+/** Result of POST /api/import — mirrors the server's ImportSummary. */
+export interface ImportSummary {
+  materialsApplied: number
+  eventsInserted: number
+  eventsSkipped: number
+  graduationsApplied: number
+  unresolvedCardRefs: number
+}
+
+/** Result of DELETE /api/account/progress. */
+export interface ProgressDeletionSummary {
+  materialsReset: number
+  eventsDeleted: number
+  graduationsDeleted: number
+}
+
 export interface MemorizeSessionVerse {
   verseId: number
   /** Verse-bound cards drilled with this verse, in builder order.
@@ -257,13 +277,20 @@ export interface ApiClient {
   setOfflineMode(materialId: string, offlineMode: boolean): Promise<{ offlineMode: boolean }>
   /** Requires `offline_mode=true` on the server; returns 403 otherwise. */
   getMaterialRenders(materialId: string): Promise<{ renders: MaterialRender[] }>
+  /** Full account data dump for download (GET /api/export). */
+  exportAccount(): Promise<AccountExport>
+  /** Layer an export payload onto the account (POST /api/import). */
+  importAccount(payload: unknown): Promise<ImportSummary>
+  /** Wipe all review history / graduations across decks; keeps
+   *  enrollments + settings (DELETE /api/account/progress). */
+  deleteAllProgress(): Promise<ProgressDeletionSummary>
 }
 
 /** Build an API client targeting `apiUrl`. Sends `credentials: 'include'`
  *  so the Better Auth session cookie flows through on every call. */
 export function createApiClient(apiUrl: string): ApiClient {
   async function request<T>(
-    method: 'GET' | 'POST' | 'PATCH',
+    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
     path: string,
     body?: unknown,
   ): Promise<T> {
@@ -317,6 +344,9 @@ export function createApiClient(apiUrl: string): ApiClient {
       }),
     getMaterialRenders: (materialId) =>
       request('GET', `/api/materials/${encodeURIComponent(materialId)}/renders`),
+    exportAccount: () => request('GET', '/api/export'),
+    importAccount: (payload) => request('POST', '/api/import', payload),
+    deleteAllProgress: () => request('DELETE', '/api/account/progress'),
   }
 }
 

--- a/apps/web/src/components/BaseModal.vue
+++ b/apps/web/src/components/BaseModal.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { useId } from 'vue'
+
+defineProps<{
+  /** Heading text; also wired as the dialog's accessible name. */
+  title: string
+}>()
+
+const emit = defineEmits<{
+  /** Backdrop click — the host decides whether that means cancel/close. */
+  (e: 'dismiss'): void
+}>()
+
+const titleId = useId()
+</script>
+
+<template>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    @click.self="emit('dismiss')"
+  >
+    <div class="modal">
+      <h2 :id="titleId">{{ title }}</h2>
+      <div class="body">
+        <slot />
+      </div>
+      <div class="actions">
+        <slot name="actions" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  color: var(--color-muted);
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Shared styling for action buttons the host passes into #actions.
+ * `:slotted` is how a scoped child styles content provided by its parent. */
+:slotted(.btn) {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+:slotted(.btn:disabled) {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+:slotted(.btn.cancel) {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-muted);
+}
+
+:slotted(.btn.confirm) {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+:slotted(.btn.confirm.destructive) {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+</style>

--- a/apps/web/src/components/ConfirmDialog.vue
+++ b/apps/web/src/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useId } from 'vue'
+import BaseModal from '@/components/BaseModal.vue'
 
 withDefaults(
   defineProps<{
@@ -23,117 +23,24 @@ const emit = defineEmits<{
   (e: 'confirm'): void
   (e: 'cancel'): void
 }>()
-
-// Per-instance id so two ConfirmDialogs on the same page don't share
-// an aria-labelledby target.
-const titleId = useId()
 </script>
 
 <template>
-  <div
-    class="overlay"
-    role="dialog"
-    aria-modal="true"
-    :aria-labelledby="titleId"
-    @click.self="emit('cancel')"
-  >
-    <div class="modal">
-      <h2 :id="titleId">{{ title }}</h2>
-      <div class="body">
-        <slot />
-      </div>
-      <div class="actions">
-        <button
-          type="button"
-          class="btn cancel"
-          :disabled="busy"
-          @click="emit('cancel')"
-        >
-          {{ cancelLabel }}
-        </button>
-        <button
-          type="button"
-          class="btn confirm"
-          :class="{ destructive }"
-          :disabled="busy"
-          @click="emit('confirm')"
-        >
-          {{ confirmLabel }}
-        </button>
-      </div>
-    </div>
-  </div>
+  <BaseModal :title="title" @dismiss="emit('cancel')">
+    <slot />
+    <template #actions>
+      <button type="button" class="btn cancel" :disabled="busy" @click="emit('cancel')">
+        {{ cancelLabel }}
+      </button>
+      <button
+        type="button"
+        class="btn confirm"
+        :class="{ destructive }"
+        :disabled="busy"
+        @click="emit('confirm')"
+      >
+        {{ confirmLabel }}
+      </button>
+    </template>
+  </BaseModal>
 </template>
-
-<style scoped>
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  padding: 1rem;
-}
-
-.modal {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  max-width: 440px;
-  width: 100%;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.modal h2 {
-  font-size: 1.1rem;
-  margin: 0;
-}
-
-.body {
-  margin: 0;
-  color: var(--color-muted);
-  line-height: 1.5;
-}
-
-.actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  border: 1px solid transparent;
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.cancel {
-  background: transparent;
-  border-color: var(--color-border);
-  color: var(--color-muted);
-}
-
-.confirm {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-}
-
-.confirm.destructive {
-  background: var(--color-grade-again-bg);
-  color: var(--color-grade-again);
-}
-</style>

--- a/apps/web/src/components/ImportResultDialog.vue
+++ b/apps/web/src/components/ImportResultDialog.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { useId } from 'vue'
+
+import type { ImportSummary } from '@/api'
+
+defineProps<{
+  /** The import summary on success, or null when `error` is set. */
+  summary: ImportSummary | null
+  /** A human-readable error message when the import failed. */
+  error: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const titleId = useId()
+</script>
+
+<template>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    @click.self="emit('close')"
+  >
+    <div class="modal">
+      <h2 :id="titleId">{{ error ? 'Import failed' : 'Import complete' }}</h2>
+      <div class="body">
+        <p v-if="error" class="error">{{ error }}</p>
+        <ul v-else-if="summary" class="summary">
+          <li><span>Materials applied</span><strong>{{ summary.materialsApplied }}</strong></li>
+          <li><span>Events imported</span><strong>{{ summary.eventsInserted }}</strong></li>
+          <li><span>Events skipped (already present)</span><strong>{{ summary.eventsSkipped }}</strong></li>
+          <li><span>Graduations applied</span><strong>{{ summary.graduationsApplied }}</strong></li>
+          <li><span>Unresolved cards (dropped)</span><strong>{{ summary.unresolvedCardRefs }}</strong></li>
+        </ul>
+      </div>
+      <div class="actions">
+        <button type="button" class="btn confirm" @click="emit('close')">Done</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  color: var(--color-muted);
+  line-height: 1.5;
+}
+
+.error {
+  margin: 0;
+  color: var(--color-grade-again);
+}
+
+.summary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary strong {
+  color: var(--color-text);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.confirm {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+</style>

--- a/apps/web/src/components/ImportResultDialog.vue
+++ b/apps/web/src/components/ImportResultDialog.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { useId } from 'vue'
-
 import type { ImportSummary } from '@/api'
+import BaseModal from '@/components/BaseModal.vue'
 
 defineProps<{
   /** The import summary on success, or null when `error` is set. */
@@ -13,71 +12,25 @@ defineProps<{
 const emit = defineEmits<{
   (e: 'close'): void
 }>()
-
-const titleId = useId()
 </script>
 
 <template>
-  <div
-    class="overlay"
-    role="dialog"
-    aria-modal="true"
-    :aria-labelledby="titleId"
-    @click.self="emit('close')"
-  >
-    <div class="modal">
-      <h2 :id="titleId">{{ error ? 'Import failed' : 'Import complete' }}</h2>
-      <div class="body">
-        <p v-if="error" class="error">{{ error }}</p>
-        <ul v-else-if="summary" class="summary">
-          <li><span>Materials applied</span><strong>{{ summary.materialsApplied }}</strong></li>
-          <li><span>Events imported</span><strong>{{ summary.eventsInserted }}</strong></li>
-          <li><span>Events skipped (already present)</span><strong>{{ summary.eventsSkipped }}</strong></li>
-          <li><span>Graduations applied</span><strong>{{ summary.graduationsApplied }}</strong></li>
-          <li><span>Unresolved cards (dropped)</span><strong>{{ summary.unresolvedCardRefs }}</strong></li>
-        </ul>
-      </div>
-      <div class="actions">
-        <button type="button" class="btn confirm" @click="emit('close')">Done</button>
-      </div>
-    </div>
-  </div>
+  <BaseModal :title="error ? 'Import failed' : 'Import complete'" @dismiss="emit('close')">
+    <p v-if="error" class="error">{{ error }}</p>
+    <ul v-else-if="summary" class="summary">
+      <li><span>Materials applied</span><strong>{{ summary.materialsApplied }}</strong></li>
+      <li><span>Events imported</span><strong>{{ summary.eventsInserted }}</strong></li>
+      <li><span>Events skipped (already present)</span><strong>{{ summary.eventsSkipped }}</strong></li>
+      <li><span>Graduations applied</span><strong>{{ summary.graduationsApplied }}</strong></li>
+      <li><span>Unresolved cards (dropped)</span><strong>{{ summary.unresolvedCardRefs }}</strong></li>
+    </ul>
+    <template #actions>
+      <button type="button" class="btn confirm" @click="emit('close')">Done</button>
+    </template>
+  </BaseModal>
 </template>
 
 <style scoped>
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  padding: 1rem;
-}
-
-.modal {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  max-width: 440px;
-  width: 100%;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.modal h2 {
-  font-size: 1.1rem;
-  margin: 0;
-}
-
-.body {
-  color: var(--color-muted);
-  line-height: 1.5;
-}
-
 .error {
   margin: 0;
   color: var(--color-grade-again);
@@ -100,25 +53,5 @@ const titleId = useId()
 
 .summary strong {
   color: var(--color-text);
-}
-
-.actions {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  border: 1px solid transparent;
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.confirm {
-  background: var(--color-accent);
-  color: var(--color-on-accent);
 }
 </style>

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -15,14 +15,14 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   /** Clicked a signed-in card — swap workspace to this profile. */
-  (e: 'enter'): void
+  enter: []
   /** Clicked a signed-out card — re-auth required to use it. */
-  (e: 'reauth'): void
-  (e: 'sign-out'): void
-  (e: 'export'): void
-  (e: 'import'): void
-  (e: 'delete-progress'): void
-  (e: 'delete'): void
+  reauth: []
+  'sign-out': []
+  export: []
+  import: []
+  'delete-progress': []
+  delete: []
 }>()
 
 const menuOpen = ref(false)
@@ -66,34 +66,20 @@ const lastUsedLabel = computed(() => {
   })
 })
 
-function onSignOutClick(ev: Event) {
+// Every kebab item does the same three things — stop the card's click
+// handler firing, close the menu, then emit. One helper keeps the
+// handler list from growing 1:1 with the menu.
+function menuAction(
+  ev: Event,
+  action: 'export' | 'import' | 'sign-out' | 'delete-progress' | 'delete',
+) {
   ev.stopPropagation()
   closeMenu()
-  emit('sign-out')
-}
-
-function onExportClick(ev: Event) {
-  ev.stopPropagation()
-  closeMenu()
-  emit('export')
-}
-
-function onImportClick(ev: Event) {
-  ev.stopPropagation()
-  closeMenu()
-  emit('import')
-}
-
-function onDeleteProgressClick(ev: Event) {
-  ev.stopPropagation()
-  closeMenu()
-  emit('delete-progress')
-}
-
-function onDeleteClick(ev: Event) {
-  ev.stopPropagation()
-  closeMenu()
-  emit('delete')
+  // `defineEmits` types `emit` as an overload set — one signature per
+  // declared event — and TS can't match a union argument against
+  // overloads. `action` is always one of the declared events, so
+  // narrowing to a single name is sound.
+  emit(action as 'export')
 }
 
 // The card surface is a role="button" div rather than a native
@@ -152,7 +138,7 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item"
           role="menuitem"
-          @click="onExportClick"
+          @click="menuAction($event, 'export')"
         >
           Export my data
         </button>
@@ -161,7 +147,7 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item"
           role="menuitem"
-          @click="onImportClick"
+          @click="menuAction($event, 'import')"
         >
           Import data
         </button>
@@ -170,7 +156,7 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item"
           role="menuitem"
-          @click="onSignOutClick"
+          @click="menuAction($event, 'sign-out')"
         >
           Sign out
         </button>
@@ -179,7 +165,7 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item destructive"
           role="menuitem"
-          @click="onDeleteProgressClick"
+          @click="menuAction($event, 'delete-progress')"
         >
           Delete all progress
         </button>
@@ -187,7 +173,7 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item destructive"
           role="menuitem"
-          @click="onDeleteClick"
+          @click="menuAction($event, 'delete')"
         >
           Delete profile
         </button>

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -19,6 +19,9 @@ const emit = defineEmits<{
   /** Clicked a signed-out card — re-auth required to use it. */
   (e: 'reauth'): void
   (e: 'sign-out'): void
+  (e: 'export'): void
+  (e: 'import'): void
+  (e: 'delete-progress'): void
   (e: 'delete'): void
 }>()
 
@@ -67,6 +70,24 @@ function onSignOutClick(ev: Event) {
   ev.stopPropagation()
   closeMenu()
   emit('sign-out')
+}
+
+function onExportClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('export')
+}
+
+function onImportClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('import')
+}
+
+function onDeleteProgressClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('delete-progress')
 }
 
 function onDeleteClick(ev: Event) {
@@ -131,9 +152,36 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item"
           role="menuitem"
+          @click="onExportClick"
+        >
+          Export my data
+        </button>
+        <button
+          v-if="signedIn"
+          type="button"
+          class="menu-item"
+          role="menuitem"
+          @click="onImportClick"
+        >
+          Import data
+        </button>
+        <button
+          v-if="signedIn"
+          type="button"
+          class="menu-item"
+          role="menuitem"
           @click="onSignOutClick"
         >
           Sign out
+        </button>
+        <button
+          v-if="signedIn"
+          type="button"
+          class="menu-item destructive"
+          role="menuitem"
+          @click="onDeleteProgressClick"
+        >
+          Delete all progress
         </button>
         <button
           type="button"

--- a/apps/web/src/components/TypeToConfirmDialog.vue
+++ b/apps/web/src/components/TypeToConfirmDialog.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ref, useId } from 'vue'
+import { computed, ref, useId } from 'vue'
+
+import BaseModal from '@/components/BaseModal.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -23,86 +25,46 @@ const emit = defineEmits<{
 }>()
 
 const typed = ref('')
-const titleId = useId()
 const inputId = useId()
 
-const matched = () => typed.value.trim() === props.matchText
+const matched = computed(() => typed.value.trim() === props.matchText)
 </script>
 
 <template>
-  <div
-    class="overlay"
-    role="dialog"
-    aria-modal="true"
-    :aria-labelledby="titleId"
-    @click.self="emit('cancel')"
-  >
-    <div class="modal">
-      <h2 :id="titleId">{{ title }}</h2>
-      <div class="body">
-        <slot />
-        <label :for="inputId" class="match-label">
-          Type <code>{{ matchText }}</code> to confirm
-        </label>
-        <input
-          :id="inputId"
-          v-model="typed"
-          type="text"
-          autocomplete="off"
-          autocapitalize="off"
-          spellcheck="false"
-          class="match-input"
-        />
-      </div>
-      <div class="actions">
-        <button type="button" class="btn cancel" :disabled="busy" @click="emit('cancel')">
-          {{ cancelLabel }}
-        </button>
-        <button
-          type="button"
-          class="btn confirm destructive"
-          :disabled="busy || !matched()"
-          @click="emit('confirm')"
-        >
-          {{ confirmLabel }}
-        </button>
-      </div>
+  <BaseModal :title="title" @dismiss="emit('cancel')">
+    <div class="ttc-body">
+      <slot />
+      <label :for="inputId" class="match-label">
+        Type <code>{{ matchText }}</code> to confirm
+      </label>
+      <input
+        :id="inputId"
+        v-model="typed"
+        type="text"
+        autocomplete="off"
+        autocapitalize="off"
+        spellcheck="false"
+        class="match-input"
+      />
     </div>
-  </div>
+    <template #actions>
+      <button type="button" class="btn cancel" :disabled="busy" @click="emit('cancel')">
+        {{ cancelLabel }}
+      </button>
+      <button
+        type="button"
+        class="btn confirm destructive"
+        :disabled="busy || !matched"
+        @click="emit('confirm')"
+      >
+        {{ confirmLabel }}
+      </button>
+    </template>
+  </BaseModal>
 </template>
 
 <style scoped>
-.overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 100;
-  padding: 1rem;
-}
-
-.modal {
-  background: var(--color-bg-card);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  max-width: 440px;
-  width: 100%;
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.modal h2 {
-  font-size: 1.1rem;
-  margin: 0;
-}
-
-.body {
-  color: var(--color-muted);
-  line-height: 1.5;
+.ttc-body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -126,37 +88,5 @@ const matched = () => typed.value.trim() === props.matchText
   color: var(--color-text);
   font-family: inherit;
   font-size: 0.9rem;
-}
-
-.actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.95rem;
-  border: 1px solid transparent;
-  font-family: inherit;
-  cursor: pointer;
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.cancel {
-  background: transparent;
-  border-color: var(--color-border);
-  color: var(--color-muted);
-}
-
-.confirm.destructive {
-  background: var(--color-grade-again-bg);
-  color: var(--color-grade-again);
 }
 </style>

--- a/apps/web/src/components/TypeToConfirmDialog.vue
+++ b/apps/web/src/components/TypeToConfirmDialog.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import { ref, useId } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    confirmLabel?: string
+    cancelLabel?: string
+    /** The exact string the user must type to enable confirm. */
+    matchText: string
+    busy?: boolean
+  }>(),
+  {
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    busy: false,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'confirm'): void
+  (e: 'cancel'): void
+}>()
+
+const typed = ref('')
+const titleId = useId()
+const inputId = useId()
+
+const matched = () => typed.value.trim() === props.matchText
+</script>
+
+<template>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    @click.self="emit('cancel')"
+  >
+    <div class="modal">
+      <h2 :id="titleId">{{ title }}</h2>
+      <div class="body">
+        <slot />
+        <label :for="inputId" class="match-label">
+          Type <code>{{ matchText }}</code> to confirm
+        </label>
+        <input
+          :id="inputId"
+          v-model="typed"
+          type="text"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          class="match-input"
+        />
+      </div>
+      <div class="actions">
+        <button type="button" class="btn cancel" :disabled="busy" @click="emit('cancel')">
+          {{ cancelLabel }}
+        </button>
+        <button
+          type="button"
+          class="btn confirm destructive"
+          :disabled="busy || !matched()"
+          @click="emit('confirm')"
+        >
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  color: var(--color-muted);
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-label {
+  font-size: 0.85rem;
+}
+
+.match-label code {
+  color: var(--color-text);
+  font-family: monospace;
+}
+
+.match-input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cancel {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-muted);
+}
+
+.confirm.destructive {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+</style>

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -370,6 +370,28 @@ export async function deleteProfile(profileId: string): Promise<void> {
   await refreshProfilesList()
 }
 
+/** Drop a profile's locally cached study data — in-memory wasm engines
+ *  plus the IDB snapshot / test-states / event queue / renders — without
+ *  signing out or removing the registry row. Call after a server-side
+ *  mutation the fat client can't detect via a snapshot-version bump
+ *  (account import / delete-all-progress): the next deck open then
+ *  cold-loads fresh `/state` from the server instead of warm-starting a
+ *  stale cached engine — or re-flushing queued events that no longer
+ *  exist server-side.
+ *
+ *  Wiping IDB needs the profile's DB handle closed first, so we toggle
+ *  the active profile off and back on around `deleteIdb` — the same
+ *  close-then-delete dance `deleteProfile` uses, minus the revoke +
+ *  registry removal. The reactive `activeProfile` ref is untouched
+ *  (this only swaps the persistence-layer handle), so the caller stays
+ *  on the same profile. */
+async function resetProfileLocalData(profileId: string): Promise<void> {
+  clearAllSessions()
+  await setActiveProfile(null)
+  await deleteIdb(profileDbName(profileId))
+  await setActiveProfile(profileId)
+}
+
 /** Sign out a profile by revoking its server-side session and clearing
  *  its stored token. Defaults to the active profile when no id is
  *  given. Profile + IDB stay intact — sign-out is the "I'll be back"
@@ -495,6 +517,7 @@ export function useAuth() {
     signInComplete,
     enterProfile,
     deleteProfile,
+    resetProfileLocalData,
     markSyncState,
     clearConflict,
     acceptPendingSignIn,

--- a/apps/web/src/lib/account-file.ts
+++ b/apps/web/src/lib/account-file.ts
@@ -1,0 +1,31 @@
+/**
+ * Browser file-I/O for account export/import. Kept framework-free so
+ * it's testable in isolation if a web test harness is added later.
+ */
+
+/** Trigger a download of `data` as a pretty-printed JSON file. */
+export function downloadJson(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+/** Read a user-picked file as JSON. Rejects on malformed JSON — the
+ *  caller surfaces the error before any network call. */
+export async function readJsonFile(file: File): Promise<unknown> {
+  const text = await file.text()
+  return JSON.parse(text)
+}
+
+/** `verse-vault-export-<email>-<YYYY-MM-DD>.json`, with the email
+ *  sanitised to filename-safe characters. */
+export function exportFilename(email: string, isoDate: string): string {
+  const safeEmail = email.replace(/[^a-zA-Z0-9._-]/g, '_')
+  return `verse-vault-export-${safeEmail}-${isoDate}.json`
+}

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -34,9 +34,16 @@ const deleteBusy = ref(false)
 const banner = ref<string | null>(null)
 
 const fileInput = ref<HTMLInputElement | null>(null)
-const pendingImport = ref<{ profile: ProfileRow; payload: unknown } | null>(null)
+// The parsed payload awaiting the import confirm. `switchTo` has already
+// made the target the active profile by the time this is set, so the
+// confirm dialog reads the account from `activeProfile`, not from here.
+const pendingImportPayload = ref<unknown | null>(null)
 const importBusy = ref(false)
-const importResult = ref<{ summary: ImportSummary | null; error: string | null } | null>(null)
+// Mutually exclusive: a summary on success, a message on failure. Both
+// null while no result dialog is showing.
+const importSummary = ref<ImportSummary | null>(null)
+const importError = ref<string | null>(null)
+const showImportResult = ref(false)
 
 const pendingDeleteProgress = ref<ProfileRow | null>(null)
 const deleteProgressBusy = ref(false)
@@ -106,6 +113,15 @@ async function switchTo(profile: ProfileRow): Promise<boolean> {
   return false
 }
 
+/** Clear the banner, switch to `profile`, then run `fn` against the
+ *  now-active account. Skips `fn` if the switch needed reauth. The
+ *  shared preamble for every per-card account action. */
+async function withActiveProfile(profile: ProfileRow, fn: () => Promise<void>) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  await fn()
+}
+
 /** Download the active account's full export. Shared by the kebab
  *  Export item and the backup button inside the delete dialog. */
 async function exportActiveAccount() {
@@ -115,14 +131,14 @@ async function exportActiveAccount() {
   downloadJson(exportFilename(email, isoDate), data)
 }
 
-async function onCardExport(profile: ProfileRow) {
-  banner.value = null
-  if (!(await switchTo(profile))) return
-  try {
-    await exportActiveAccount()
-  } catch (err) {
-    banner.value = err instanceof ApiError ? err.message : 'Export failed.'
-  }
+function onCardExport(profile: ProfileRow) {
+  return withActiveProfile(profile, async () => {
+    try {
+      await exportActiveAccount()
+    } catch (err) {
+      banner.value = err instanceof ApiError ? err.message : 'Export failed.'
+    }
+  })
 }
 
 async function onBackupClick() {
@@ -134,65 +150,61 @@ async function onBackupClick() {
   }
 }
 
-async function onCardImport(profile: ProfileRow) {
-  banner.value = null
-  if (!(await switchTo(profile))) return
-  // Stash the target so the file-input change handler knows which
-  // account it's importing into, then open the OS file picker.
-  pendingImport.value = { profile, payload: null }
-  fileInput.value?.click()
+function onCardImport(profile: ProfileRow) {
+  return withActiveProfile(profile, async () => {
+    // The active profile is now the import target; open the OS file
+    // picker and let `onFilePicked` carry on from the change event.
+    fileInput.value?.click()
+  })
 }
 
 async function onFilePicked(ev: Event) {
   const input = ev.target as HTMLInputElement
   const file = input.files?.[0]
   input.value = '' // allow re-picking the same file later
-  if (!file || !pendingImport.value) return
+  if (!file) return
   try {
-    const payload = await readJsonFile(file)
-    pendingImport.value = { ...pendingImport.value, payload }
+    pendingImportPayload.value = await readJsonFile(file)
   } catch {
-    pendingImport.value = null
-    importResult.value = { summary: null, error: 'That file isn’t valid JSON.' }
+    pendingImportPayload.value = null
+    importSummary.value = null
+    importError.value = 'That file isn’t valid JSON.'
+    showImportResult.value = true
   }
 }
 
 function cancelImport() {
-  pendingImport.value = null
+  pendingImportPayload.value = null
 }
 
 async function confirmImport() {
-  const target = pendingImport.value
-  if (!target || target.payload === null) return
+  if (pendingImportPayload.value === null) return
   importBusy.value = true
   try {
-    const summary = await api.importAccount(target.payload)
-    importResult.value = { summary, error: null }
+    importSummary.value = await api.importAccount(pendingImportPayload.value)
+    importError.value = null
   } catch (err) {
-    const message = err instanceof ApiError ? err.message : 'Import failed.'
-    importResult.value = { summary: null, error: message }
+    importSummary.value = null
+    importError.value = err instanceof ApiError ? err.message : 'Import failed.'
   } finally {
     importBusy.value = false
-    pendingImport.value = null
+    pendingImportPayload.value = null
+    showImportResult.value = true
   }
 }
 
 function closeImportResult() {
-  importResult.value = null
-}
-
-function requestDeleteProgress(profile: ProfileRow) {
-  pendingDeleteProgress.value = profile
+  showImportResult.value = false
 }
 
 function cancelDeleteProgress() {
   pendingDeleteProgress.value = null
 }
 
-async function onCardDeleteProgress(profile: ProfileRow) {
-  banner.value = null
-  if (!(await switchTo(profile))) return
-  requestDeleteProgress(profile)
+function onCardDeleteProgress(profile: ProfileRow) {
+  return withActiveProfile(profile, async () => {
+    pendingDeleteProgress.value = profile
+  })
 }
 
 async function confirmDeleteProgress() {
@@ -313,7 +325,7 @@ async function onSignInSuccess() {
     />
 
     <ConfirmDialog
-      v-if="pendingImport && pendingImport.payload !== null"
+      v-if="pendingImportPayload !== null"
       title="Import data?"
       confirm-label="Import"
       :busy="importBusy"
@@ -321,16 +333,16 @@ async function onSignInSuccess() {
       @cancel="cancelImport"
     >
       <p>
-        Import data into <strong>{{ pendingImport.profile.email }}</strong>?
+        Import data into <strong>{{ activeProfile?.email }}</strong>?
         This adds review history and graduations from the file. Existing
         data is kept, and re-importing the same file is safe.
       </p>
     </ConfirmDialog>
 
     <ImportResultDialog
-      v-if="importResult"
-      :summary="importResult.summary"
-      :error="importResult.error"
+      v-if="showImportResult"
+      :summary="importSummary"
+      :error="importError"
       @close="closeImportResult"
     />
 

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -2,10 +2,14 @@
 import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
+import { api, ApiError, type ImportSummary } from '@/api'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import ImportResultDialog from '@/components/ImportResultDialog.vue'
 import ProfileCard from '@/components/ProfileCard.vue'
 import SignInForm from '@/components/SignInForm.vue'
+import TypeToConfirmDialog from '@/components/TypeToConfirmDialog.vue'
 import { useAuth } from '@/composables/useAuth'
+import { downloadJson, exportFilename, readJsonFile } from '@/lib/account-file'
 import type { ProfileRow } from '@/lib/engine/registry'
 
 const {
@@ -26,6 +30,16 @@ const mode = ref<'empty' | 'cards' | 'add'>(profiles.value.length === 0 ? 'empty
 const prefillEmail = ref<string | undefined>(undefined)
 const pendingDelete = ref<ProfileRow | null>(null)
 const deleteBusy = ref(false)
+
+const banner = ref<string | null>(null)
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const pendingImport = ref<{ profile: ProfileRow; payload: unknown } | null>(null)
+const importBusy = ref(false)
+const importResult = ref<{ summary: ImportSummary | null; error: string | null } | null>(null)
+
+const pendingDeleteProgress = ref<ProfileRow | null>(null)
+const deleteProgressBusy = ref(false)
 
 // Keep mode in sync with the shared profiles list (reconcile, sign-in
 // from another flow, etc.). Skip when the user is mid-add — don't
@@ -72,6 +86,121 @@ async function onCardSignOut(profile: ProfileRow) {
   await signOut(profile.profileId)
 }
 
+/** Make `profile`'s session active (no-op if it already is). Returns
+ *  false and routes to the reauth form when the token is dead. */
+async function switchTo(profile: ProfileRow): Promise<boolean> {
+  if (activeProfile.value?.profileId === profile.profileId) return true
+  const result = await enterProfile(profile.profileId)
+  if (result.ok) return true
+  prefillEmail.value = profile.email
+  mode.value = 'add'
+  return false
+}
+
+/** Download the active account's full export. Shared by the kebab
+ *  Export item and the backup button inside the delete dialog. */
+async function exportActiveAccount() {
+  const email = activeProfile.value?.email ?? 'account'
+  const data = await api.exportAccount()
+  const isoDate = new Date().toISOString().slice(0, 10)
+  downloadJson(exportFilename(email, isoDate), data)
+}
+
+async function onCardExport(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  try {
+    await exportActiveAccount()
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Export failed.'
+  }
+}
+
+async function onBackupClick() {
+  banner.value = null
+  try {
+    await exportActiveAccount()
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Backup download failed.'
+  }
+}
+
+async function onCardImport(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  // Stash the target so the file-input change handler knows which
+  // account it's importing into, then open the OS file picker.
+  pendingImport.value = { profile, payload: null }
+  fileInput.value?.click()
+}
+
+async function onFilePicked(ev: Event) {
+  const input = ev.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = '' // allow re-picking the same file later
+  if (!file || !pendingImport.value) return
+  try {
+    const payload = await readJsonFile(file)
+    pendingImport.value = { ...pendingImport.value, payload }
+  } catch {
+    pendingImport.value = null
+    importResult.value = { summary: null, error: 'That file isn’t valid JSON.' }
+  }
+}
+
+function cancelImport() {
+  pendingImport.value = null
+}
+
+async function confirmImport() {
+  const target = pendingImport.value
+  if (!target || target.payload === null) return
+  importBusy.value = true
+  try {
+    const summary = await api.importAccount(target.payload)
+    importResult.value = { summary, error: null }
+  } catch (err) {
+    const message = err instanceof ApiError ? err.message : 'Import failed.'
+    importResult.value = { summary: null, error: message }
+  } finally {
+    importBusy.value = false
+    pendingImport.value = null
+  }
+}
+
+function closeImportResult() {
+  importResult.value = null
+}
+
+function requestDeleteProgress(profile: ProfileRow) {
+  pendingDeleteProgress.value = profile
+}
+
+function cancelDeleteProgress() {
+  pendingDeleteProgress.value = null
+}
+
+async function onCardDeleteProgress(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  requestDeleteProgress(profile)
+}
+
+async function confirmDeleteProgress() {
+  const target = pendingDeleteProgress.value
+  if (!target) return
+  deleteProgressBusy.value = true
+  try {
+    const summary = await api.deleteAllProgress()
+    banner.value = `Reset ${summary.materialsReset} deck(s): removed ${summary.eventsDeleted} reviews and ${summary.graduationsDeleted} graduations.`
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Delete failed.'
+  } finally {
+    deleteProgressBusy.value = false
+    pendingDeleteProgress.value = null
+  }
+}
+
 function requestDelete(profile: ProfileRow) {
   pendingDelete.value = profile
 }
@@ -113,6 +242,8 @@ async function onSignInSuccess() {
     <h2 v-else-if="mode === 'add'">Add a profile</h2>
     <h2 v-else>Sign in</h2>
 
+    <p v-if="banner" class="banner">{{ banner }}</p>
+
     <template v-if="mode === 'cards'">
       <div class="cards">
         <ProfileCard
@@ -125,6 +256,9 @@ async function onSignInSuccess() {
           @reauth="onCardReauth(p)"
           @sign-out="onCardSignOut(p)"
           @delete="requestDelete(p)"
+          @export="onCardExport(p)"
+          @import="onCardImport(p)"
+          @delete-progress="onCardDeleteProgress(p)"
         />
       </div>
       <button type="button" class="add-btn" @click="startAdd">
@@ -160,6 +294,55 @@ async function onSignInSuccess() {
         can sign in again later to start fresh.
       </p>
     </ConfirmDialog>
+
+    <input
+      ref="fileInput"
+      type="file"
+      accept="application/json"
+      class="hidden-file"
+      @change="onFilePicked"
+    />
+
+    <ConfirmDialog
+      v-if="pendingImport && pendingImport.payload !== null"
+      title="Import data?"
+      confirm-label="Import"
+      :busy="importBusy"
+      @confirm="confirmImport"
+      @cancel="cancelImport"
+    >
+      <p>
+        Import data into <strong>{{ pendingImport.profile.email }}</strong>?
+        This adds review history and graduations from the file. Existing
+        data is kept, and re-importing the same file is safe.
+      </p>
+    </ConfirmDialog>
+
+    <ImportResultDialog
+      v-if="importResult"
+      :summary="importResult.summary"
+      :error="importResult.error"
+      @close="closeImportResult"
+    />
+
+    <TypeToConfirmDialog
+      v-if="pendingDeleteProgress"
+      title="Delete all progress?"
+      confirm-label="Delete all progress"
+      :match-text="pendingDeleteProgress.email"
+      :busy="deleteProgressBusy"
+      @confirm="confirmDeleteProgress"
+      @cancel="cancelDeleteProgress"
+    >
+      <p>
+        This permanently deletes <strong>all review history, graduations,
+        and progress</strong> for <strong>{{ pendingDeleteProgress.email }}</strong>
+        across every deck. Your decks and settings stay. This cannot be undone.
+      </p>
+      <button type="button" class="backup-btn" @click="onBackupClick">
+        ⬇ Download a backup (.json)
+      </button>
+    </TypeToConfirmDialog>
   </div>
 </template>
 
@@ -215,5 +398,35 @@ h2 {
 
 .back-btn:hover {
   color: var(--color-text);
+}
+
+.banner {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.hidden-file {
+  display: none;
+}
+
+.backup-btn {
+  align-self: flex-start;
+  padding: 0.45rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.backup-btn:hover {
+  border-color: var(--color-accent);
 }
 </style>

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -90,7 +90,16 @@ async function onCardSignOut(profile: ProfileRow) {
  *  false and routes to the reauth form when the token is dead. */
 async function switchTo(profile: ProfileRow): Promise<boolean> {
   if (activeProfile.value?.profileId === profile.profileId) return true
-  const result = await enterProfile(profile.profileId)
+  let result: { ok: boolean }
+  try {
+    result = await enterProfile(profile.profileId)
+  } catch {
+    // enterProfile normally resolves { ok: false } for a dead token, but
+    // a network error during the multiSession switch can reject — surface
+    // it as a banner rather than an unhandled rejection.
+    banner.value = 'Could not switch to that profile. Please try again.'
+    return false
+  }
   if (result.ok) return true
   prefillEmail.value = profile.email
   mode.value = 'add'

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -21,6 +21,7 @@ const {
   signOut,
   enterProfile,
   deleteProfile,
+  resetProfileLocalData,
 } = useAuth()
 
 const router = useRouter()
@@ -183,6 +184,10 @@ async function confirmImport() {
   try {
     importSummary.value = await api.importAccount(pendingImportPayload.value)
     importError.value = null
+    // The import mutated this account server-side but didn't bump the
+    // snapshot version, so the local fat-client cache won't notice. Drop
+    // it so the next deck open cold-loads the imported state.
+    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
   } catch (err) {
     importSummary.value = null
     importError.value = err instanceof ApiError ? err.message : 'Import failed.'
@@ -214,6 +219,10 @@ async function confirmDeleteProgress() {
   try {
     const summary = await api.deleteAllProgress()
     banner.value = `Reset ${summary.materialsReset} deck(s): removed ${summary.eventsDeleted} reviews and ${summary.graduationsDeleted} graduations.`
+    // The wipe didn't bump the snapshot version; without dropping the
+    // local cache the engine would keep serving (and could re-sync) the
+    // now-deleted progress.
+    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
   } catch (err) {
     banner.value = err instanceof ApiError ? err.message : 'Delete failed.'
   } finally {

--- a/docs/server-api.md
+++ b/docs/server-api.md
@@ -383,6 +383,40 @@ over `test_states`:
 Stability buckets (days): `weak < 1`, `learning [1, 7)`, `familiar [7, 30)`, `strong [30, 90)`,
 `mastered >= 90`.
 
+## Account data — `/api/export`, `/api/import`, `/api/account/progress`
+
+Account-level data portability + reset. All require the session cookie.
+
+### `GET /api/export`
+
+Full account dump — every enrolled material with its settings, graduations, and review events — as a
+downloadable `AccountExport` JSON
+(`Content-Disposition: attachment; filename="verse-vault-export-YYYY-MM-DD.json"`). Cards key on
+`CardRef` (`kind` + verseId + params), not `cardId`, so the payload survives snapshot bumps.
+
+### `POST /api/import`
+
+Apply an `AccountExport` to the caller's account. Additive and idempotent: review events dedup on
+`clientEventId`, graduations `onConflictDoNothing`, settings merge by `max(updatedAt)`. Returns an
+`ImportSummary`:
+
+```json
+{ "materialsApplied": 8, "eventsInserted": 41608, "eventsSkipped": 0, "graduationsApplied": 631, "unresolvedCardRefs": 329 }
+```
+
+400 on an unsupported `exportVersion`, unknown `materialId`, or out-of-bounds settings; 413 if the
+body exceeds the 50 MB cap.
+
+### `DELETE /api/account/progress`
+
+Wipe the caller's review events, graduations, and derived `test_states` across every enrolled
+material (each under `engines.withLock`). Keeps enrollments, per-year settings, and the content
+snapshot — decks stay, reset to all-new. Idempotent. Returns:
+
+```json
+{ "materialsReset": 8, "eventsDeleted": 41608, "graduationsDeleted": 631 }
+```
+
 ## Status codes
 
 | status | when                                                                                                 |

--- a/docs/superpowers/plans/2026-05-29-account-data-management.md
+++ b/docs/superpowers/plans/2026-05-29-account-data-management.md
@@ -1,0 +1,1456 @@
+# Account Data Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Export / Import / Delete-all-progress to the profile card kebab menu, backed by the
+existing export-import endpoints plus one new progress-reset endpoint.
+
+**Architecture:** Server gains `DELETE /api/account/progress` (a thin route over a new
+`lib/reset.ts` helper that wipes review/graduation/test-state rows per enrolled material under the
+engine's per-key lock, keeping enrollment + settings). The web app adds three kebab actions that
+switch to the target profile's session first (`enterProfile`), then call the endpoints; import uses
+a neutral confirm + result modal, delete uses a type-the-email destructive modal with an in-dialog
+backup download.
+
+**Tech Stack:** Hono + Drizzle (better-sqlite3) on the server with Vitest; Vue 3 `<script setup>`
+SFCs with scoped CSS on the web (no test harness — web changes are type-checked + manually
+verified).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-account-data-management-design.md`
+
+---
+
+## File structure
+
+**Server (`packages/api`)**
+
+* Create `src/lib/reset.ts` — `deleteAccountProgress(db, engines, userId)` +
+  `ProgressDeletionSummary`. One responsibility: wipe learning state.
+* Create `src/lib/reset.test.ts` — unit tests for the helper.
+* Modify `src/routes/account.ts` — add the `DELETE /account/progress` route.
+* Modify `src/routes/account.test.ts` — route-level tests.
+
+**Web (`apps/web`)**
+
+* Modify `src/api.ts` — `'DELETE'` method, three new client methods + types.
+* Create `src/lib/account-file.ts` — pure download/read/filename helpers.
+* Create `src/components/ImportResultDialog.vue` — neutral import-summary/error modal.
+* Create `src/components/TypeToConfirmDialog.vue` — destructive type-to-match modal.
+* Modify `src/components/ProfileCard.vue` — three kebab items + emits.
+* Modify `src/views/ProfilePickerView.vue` — orchestration of all three flows.
+
+**Release / docs**
+
+* Modify `docs/server-api.md`, `packages/api/CHANGELOG.md` + `package.json`,
+  `apps/web/CHANGELOG.md` + `package.json`.
+
+**Conventions to know**
+
+* Run all commands from the repo root `/home/amberson/Code/verse-vault`.
+* Server tests: `pnpm --filter @verse-vault/api exec vitest run <path>`.
+* Server type-check: `pnpm --filter @verse-vault/api run type-check`.
+* Web type-check: `pnpm --filter @verse-vault/web run type-check`. If it errors about missing
+  `verse-vault-wasm` types, the bundler wasm build is stale — run
+  `pnpm --filter @verse-vault/web run build:wasm:dev` once first (see the `pkg-web/` gotcha in
+  `CLAUDE.md`).
+* Commit subjects: Conventional Commits, **≤ 50 chars** including the `type(scope):` prefix
+  (commitlint blocks longer). No `Co-Authored-By`.
+* Pre-commit hooks run `lint-staged` (dprint on md/toml), `cargo fmt`, `typos`. Use `--no-verify`
+  only for behaviour-neutral commits if a hook misfires; these tasks shouldn't need it.
+
+---
+
+## Task 1: Server — `deleteAccountProgress` helper (TDD)
+
+**Files:**
+
+* Create: `packages/api/src/lib/reset.ts`
+* Test: `packages/api/src/lib/reset.test.ts`
+
+* [ ] **Step 1: Write the failing test**
+
+Create `packages/api/src/lib/reset.test.ts`:
+
+```ts
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../db/schema.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb } from '../test-utils.js';
+
+import { EngineStore } from './engine.js';
+import { deleteAccountProgress } from './reset.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+const NOW = 1_700_000_000;
+
+function seedProgress(db: ReturnType<typeof createTestDb>['db']) {
+  // Enrolls u1 (seeds user_materials, graph_snapshot, test_states) and
+  // gives us settings + events + graduations to wipe.
+  seedUserWithFixture({ db, userId: 'u1', materialId: MATERIAL_ID });
+  db.insert(schema.userYearSettings)
+    .values({
+      userId: 'u1',
+      materialId: MATERIAL_ID,
+      headingCard: true,
+      headingPassageCard: true,
+      ftv: true,
+      newScope: 'all',
+      reviewScope: 'all',
+      clubCardScope: 'off',
+      chapterListScope: 'up150',
+      lessonBatchSize: 3,
+      desiredRetention: 0.9,
+      updatedAt: NOW,
+    })
+    .run();
+  db.insert(schema.reviewEvents)
+    .values([
+      {
+        id: 'e1',
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW,
+        cardId: 0,
+        grade: 3,
+        clientEventId: 'e1',
+        createdAt: NOW,
+      },
+      {
+        id: 'e2',
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW + 1,
+        cardId: 0,
+        grade: 4,
+        clientEventId: 'e2',
+        createdAt: NOW + 1,
+      },
+    ])
+    .run();
+  db.insert(schema.graduatedVerses)
+    .values({ userId: 'u1', materialId: MATERIAL_ID, verseId: 0, graduatedAtSecs: NOW })
+    .run();
+  db.insert(schema.graduatedCards)
+    .values({ userId: 'u1', materialId: MATERIAL_ID, cardId: 0, graduatedAtSecs: NOW })
+    .run();
+}
+
+describe('deleteAccountProgress', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('wipes learning state but keeps enrollment + settings', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedProgress(test.db);
+
+    const engines = new EngineStore(test.db);
+    try {
+      const summary = await deleteAccountProgress(test.db, engines, 'u1');
+
+      expect(summary.materialsReset).toBe(1);
+      expect(summary.eventsDeleted).toBe(2);
+      expect(summary.graduationsDeleted).toBe(2);
+
+      expect(test.db.select().from(schema.reviewEvents).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.graduatedVerses).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.graduatedCards).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.testStates).all()).toHaveLength(0);
+
+      // Enrollment + settings survive — decks stay, just reset to new.
+      expect(test.db.select().from(schema.userMaterials).all()).toHaveLength(1);
+      expect(test.db.select().from(schema.userYearSettings).all()).toHaveLength(1);
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('is idempotent: a second call returns zeros', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedProgress(test.db);
+
+    const engines = new EngineStore(test.db);
+    try {
+      await deleteAccountProgress(test.db, engines, 'u1');
+      const second = await deleteAccountProgress(test.db, engines, 'u1');
+      expect(second).toEqual({ materialsReset: 0, eventsDeleted: 0, graduationsDeleted: 0 });
+    } finally {
+      engines.clear();
+    }
+  });
+});
+```
+
+* [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run src/lib/reset.test.ts` Expected: FAIL —
+`Cannot find module './reset.js'` (the helper doesn't exist yet).
+
+* [ ] **Step 3: Write the helper**
+
+Create `packages/api/src/lib/reset.ts`:
+
+```ts
+import { and, eq } from 'drizzle-orm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+
+import { EngineStore } from './engine.js';
+
+export interface ProgressDeletionSummary {
+  /** Enrolled materials that actually had rows removed. */
+  materialsReset: number;
+  /** Total `review_events` rows removed across all materials. */
+  eventsDeleted: number;
+  /** `graduated_verses` + `graduated_cards` rows removed. */
+  graduationsDeleted: number;
+}
+
+/**
+ * Wipe a user's learning state — review events, graduations, and the
+ * derived test_states — across every material they're enrolled in.
+ * Enrollment (`user_materials`), per-year settings, and the content
+ * snapshot are deliberately kept: decks stay in the user's list, reset
+ * to all-new. Each material is cleared under the engine's per-key lock
+ * (mirroring import / rebuildFromEvents) so the delete can't race a
+ * concurrent review POST, then the cached engine is invalidated so the
+ * next load rebuilds from the now-empty event log.
+ *
+ * Idempotent: a second call finds nothing to delete and returns zeros.
+ */
+export async function deleteAccountProgress(
+  db: DB,
+  engines: EngineStore,
+  userId: string,
+): Promise<ProgressDeletionSummary> {
+  const materials = db
+    .select({ materialId: schema.userMaterials.materialId })
+    .from(schema.userMaterials)
+    .where(eq(schema.userMaterials.userId, userId))
+    .all();
+
+  let materialsReset = 0;
+  let eventsDeleted = 0;
+  let graduationsDeleted = 0;
+
+  for (const { materialId } of materials) {
+    const key = { userId, materialId };
+    await engines.withLock(key, async () => {
+      let materialChanges = 0;
+      db.transaction((tx) => {
+        const ev = tx
+          .delete(schema.reviewEvents)
+          .where(
+            and(
+              eq(schema.reviewEvents.userId, userId),
+              eq(schema.reviewEvents.materialId, materialId),
+            ),
+          )
+          .run();
+        const gv = tx
+          .delete(schema.graduatedVerses)
+          .where(
+            and(
+              eq(schema.graduatedVerses.userId, userId),
+              eq(schema.graduatedVerses.materialId, materialId),
+            ),
+          )
+          .run();
+        const gc = tx
+          .delete(schema.graduatedCards)
+          .where(
+            and(
+              eq(schema.graduatedCards.userId, userId),
+              eq(schema.graduatedCards.materialId, materialId),
+            ),
+          )
+          .run();
+        const ts = tx
+          .delete(schema.testStates)
+          .where(
+            and(
+              eq(schema.testStates.userId, userId),
+              eq(schema.testStates.materialId, materialId),
+            ),
+          )
+          .run();
+        eventsDeleted += ev.changes;
+        graduationsDeleted += gv.changes + gc.changes;
+        materialChanges = ev.changes + gv.changes + gc.changes + ts.changes;
+      });
+      // Only count + invalidate when something was actually removed, so a
+      // re-run is a clean all-zeros no-op and we don't evict engines for
+      // nothing.
+      if (materialChanges > 0) {
+        materialsReset += 1;
+        engines.invalidate(key);
+      }
+    });
+  }
+
+  return { materialsReset, eventsDeleted, graduationsDeleted };
+}
+```
+
+* [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run src/lib/reset.test.ts` Expected: PASS (2
+tests).
+
+* [ ] **Step 5: Type-check**
+
+Run: `pnpm --filter @verse-vault/api run type-check` Expected: no output, exit 0.
+
+* [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/lib/reset.ts packages/api/src/lib/reset.test.ts
+git commit -m "feat(api): deleteAccountProgress helper"
+```
+
+---
+
+## Task 2: Server — `DELETE /api/account/progress` route
+
+**Files:**
+
+* Modify: `packages/api/src/routes/account.ts`
+* Test: `packages/api/src/routes/account.test.ts`
+
+* [ ] **Step 1: Write the failing route tests**
+
+Append these to the existing `describe('account routes', ...)` block in
+`packages/api/src/routes/account.test.ts` (before its closing `});`). They reuse the file's existing
+`enroll` helper (sign up + `seedUserWithFixture`) and imports (`createTestApp`, `signUpTestUser`).
+No new imports are needed — the two tests below don't reference `schema` directly:
+
+```ts
+  it('DELETE /api/account/progress requires auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const res = await test.app.request('/api/account/progress', { method: 'DELETE' });
+    expect(res.status).toBe(401);
+  });
+
+  it('wipes progress but keeps the enrolled material', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'reset@example.com');
+
+    const res = await test.app.request('/api/account/progress', {
+      method: 'DELETE',
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    const summary = (await res.json()) as {
+      materialsReset: number;
+      eventsDeleted: number;
+      graduationsDeleted: number;
+    };
+    expect(summary.materialsReset).toBeGreaterThanOrEqual(0);
+
+    // The deck is still enrolled after a reset.
+    const exportRes = await test.app.request('/api/export', { headers: { cookie } });
+    const payload = (await exportRes.json()) as {
+      materials: { materialId: string; reviewEvents: unknown[] }[];
+    };
+    expect(payload.materials).toHaveLength(1);
+    expect(payload.materials[0]!.reviewEvents).toHaveLength(0);
+  });
+```
+
+* [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run src/routes/account.test.ts` Expected: FAIL —
+the DELETE returns 404 (route not mounted), so the 200/401 assertions fail.
+
+* [ ] **Step 3: Add the route**
+
+In `packages/api/src/routes/account.ts`, add the import alongside the existing `../lib/*` imports:
+
+```ts
+import { deleteAccountProgress } from '../lib/reset.js';
+```
+
+Then inside `accountRoutes`, after the `app.post('/import', ...)` block and before `return app;`,
+add:
+
+```ts
+app.delete('/account/progress', async (c) => {
+  const user = getUser(c);
+  const summary = await deleteAccountProgress(deps.db, deps.engines, user.id);
+  return c.json(summary);
+});
+```
+
+(`requireAuth()` already applies via the `app.use('*', requireAuth())` at the top of
+`accountRoutes`. The app is mounted at `/api` in `app.ts`, so this route resolves to
+`/api/account/progress`. `getUser` is already imported in this file.)
+
+* [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run src/routes/account.test.ts` Expected: PASS
+(existing tests + the 2 new ones).
+
+* [ ] **Step 5: Full server suite + type-check**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run` Expected: all pass. Run:
+`pnpm --filter @verse-vault/api run type-check` Expected: exit 0.
+
+* [ ] **Step 6: Commit**
+
+```bash
+git add packages/api/src/routes/account.ts packages/api/src/routes/account.test.ts
+git commit -m "feat(api): DELETE /api/account/progress route"
+```
+
+---
+
+## Task 3: Web — api client methods + types
+
+**Files:**
+
+* Modify: `apps/web/src/api.ts`
+
+* [ ] **Step 1: Add the wire types**
+
+In `apps/web/src/api.ts`, after the existing `YearsResponse` interface (anywhere in the type section
+is fine), add:
+
+```ts
+/** Full account export payload. Opaque to the web — it's downloaded and
+ *  re-uploaded verbatim; the server owns the shape + validation. */
+export type AccountExport = Record<string, unknown>;
+
+/** Result of POST /api/import — mirrors the server's ImportSummary. */
+export interface ImportSummary {
+  materialsApplied: number
+  eventsInserted: number
+  eventsSkipped: number
+  graduationsApplied: number
+  unresolvedCardRefs: number
+}
+
+/** Result of DELETE /api/account/progress. */
+export interface ProgressDeletionSummary {
+  materialsReset: number
+  eventsDeleted: number
+  graduationsDeleted: number
+}
+```
+
+* [ ] **Step 2: Widen the request method union + add interface methods**
+
+In the private `request` signature inside `createApiClient`, change:
+
+```ts
+method: 'GET' | 'POST' | 'PATCH',
+```
+
+to:
+
+```ts
+method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+```
+
+In the `ApiClient` interface, add these three members (e.g. after `getMaterialRenders`):
+
+```ts
+/** Full account data dump for download (GET /api/export). */
+exportAccount(): Promise<AccountExport>
+/** Layer an export payload onto the account (POST /api/import). */
+importAccount(payload: unknown): Promise<ImportSummary>
+/** Wipe all review history / graduations across decks; keeps
+ *  enrollments + settings (DELETE /api/account/progress). */
+deleteAllProgress(): Promise<ProgressDeletionSummary>
+```
+
+* [ ] **Step 3: Implement the methods in the factory return**
+
+In the object returned by `createApiClient`, after `getMaterialRenders: ...,` add:
+
+```ts
+exportAccount: () => request('GET', '/api/export'),
+importAccount: (payload) => request('POST', '/api/import', payload),
+deleteAllProgress: () => request('DELETE', '/api/account/progress'),
+```
+
+* [ ] **Step 4: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0. (If it complains about
+`verse-vault-wasm` types, run `pnpm --filter @verse-vault/web run build:wasm:dev` once, then
+re-run.)
+
+* [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/api.ts
+git commit -m "feat(web): account export/import/reset api methods"
+```
+
+---
+
+## Task 4: Web — file-I/O helpers
+
+**Files:**
+
+* Create: `apps/web/src/lib/account-file.ts`
+
+* [ ] **Step 1: Write the helpers**
+
+Create `apps/web/src/lib/account-file.ts`:
+
+```ts
+/**
+ * Browser file-I/O for account export/import. Kept framework-free so
+ * it's testable in isolation if a web test harness is added later.
+ */
+
+/** Trigger a download of `data` as a pretty-printed JSON file. */
+export function downloadJson(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+/** Read a user-picked file as JSON. Rejects on malformed JSON — the
+ *  caller surfaces the error before any network call. */
+export async function readJsonFile(file: File): Promise<unknown> {
+  const text = await file.text()
+  return JSON.parse(text)
+}
+
+/** `verse-vault-export-<email>-<YYYY-MM-DD>.json`, with the email
+ *  sanitised to filename-safe characters. */
+export function exportFilename(email: string, isoDate: string): string {
+  const safeEmail = email.replace(/[^a-zA-Z0-9._-]/g, '_')
+  return `verse-vault-export-${safeEmail}-${isoDate}.json`
+}
+```
+
+* [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0.
+
+* [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/account-file.ts
+git commit -m "feat(web): account-file download/read helpers"
+```
+
+---
+
+## Task 5: Web — import result dialog
+
+**Files:**
+
+* Create: `apps/web/src/components/ImportResultDialog.vue`
+
+* [ ] **Step 1: Write the component**
+
+Create `apps/web/src/components/ImportResultDialog.vue` (modeled on `ConfirmDialog.vue`'s
+overlay/aria/style conventions; single "Done" action; renders either a summary or an error):
+
+```vue
+<script setup lang="ts">
+import { useId } from 'vue'
+
+import type { ImportSummary } from '@/api'
+
+defineProps<{
+  /** The import summary on success, or null when `error` is set. */
+  summary: ImportSummary | null
+  /** A human-readable error message when the import failed. */
+  error: string | null
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const titleId = useId()
+</script>
+
+<template>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    @click.self="emit('close')"
+  >
+    <div class="modal">
+      <h2 :id="titleId">{{ error ? 'Import failed' : 'Import complete' }}</h2>
+      <div class="body">
+        <p v-if="error" class="error">{{ error }}</p>
+        <ul v-else-if="summary" class="summary">
+          <li><span>Materials applied</span><strong>{{ summary.materialsApplied }}</strong></li>
+          <li><span>Events imported</span><strong>{{ summary.eventsInserted }}</strong></li>
+          <li><span>Events skipped (already present)</span><strong>{{ summary.eventsSkipped }}</strong></li>
+          <li><span>Graduations applied</span><strong>{{ summary.graduationsApplied }}</strong></li>
+          <li><span>Unresolved cards (dropped)</span><strong>{{ summary.unresolvedCardRefs }}</strong></li>
+        </ul>
+      </div>
+      <div class="actions">
+        <button type="button" class="btn confirm" @click="emit('close')">Done</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  color: var(--color-muted);
+  line-height: 1.5;
+}
+
+.error {
+  margin: 0;
+  color: var(--color-grade-again);
+}
+
+.summary {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.summary li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary strong {
+  color: var(--color-text);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.confirm {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+</style>
+```
+
+* [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0.
+
+* [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/ImportResultDialog.vue
+git commit -m "feat(web): import result dialog"
+```
+
+---
+
+## Task 6: Web — type-to-confirm dialog
+
+**Files:**
+
+* Create: `apps/web/src/components/TypeToConfirmDialog.vue`
+
+* [ ] **Step 1: Write the component**
+
+Create `apps/web/src/components/TypeToConfirmDialog.vue` — generalises `ConfirmDialog` with a text
+input the user must match before the destructive confirm enables. The warning body (and any extra
+controls like a backup button) come from the default slot:
+
+```vue
+<script setup lang="ts">
+import { ref, useId } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    title: string
+    confirmLabel?: string
+    cancelLabel?: string
+    /** The exact string the user must type to enable confirm. */
+    matchText: string
+    busy?: boolean
+  }>(),
+  {
+    confirmLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    busy: false,
+  },
+)
+
+const emit = defineEmits<{
+  (e: 'confirm'): void
+  (e: 'cancel'): void
+}>()
+
+const typed = ref('')
+const titleId = useId()
+const inputId = useId()
+
+const matched = () => typed.value.trim() === props.matchText
+</script>
+
+<template>
+  <div
+    class="overlay"
+    role="dialog"
+    aria-modal="true"
+    :aria-labelledby="titleId"
+    @click.self="emit('cancel')"
+  >
+    <div class="modal">
+      <h2 :id="titleId">{{ title }}</h2>
+      <div class="body">
+        <slot />
+        <label :for="inputId" class="match-label">
+          Type <code>{{ matchText }}</code> to confirm
+        </label>
+        <input
+          :id="inputId"
+          v-model="typed"
+          type="text"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          class="match-input"
+        />
+      </div>
+      <div class="actions">
+        <button type="button" class="btn cancel" :disabled="busy" @click="emit('cancel')">
+          {{ cancelLabel }}
+        </button>
+        <button
+          type="button"
+          class="btn confirm destructive"
+          :disabled="busy || !matched()"
+          @click="emit('confirm')"
+        >
+          {{ confirmLabel }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1rem;
+}
+
+.modal {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  max-width: 440px;
+  width: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.body {
+  color: var(--color-muted);
+  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.match-label {
+  font-size: 0.85rem;
+}
+
+.match-label code {
+  color: var(--color-text);
+  font-family: monospace;
+}
+
+.match-input {
+  width: 100%;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  border: 1px solid transparent;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cancel {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-muted);
+}
+
+.confirm.destructive {
+  background: var(--color-grade-again-bg);
+  color: var(--color-grade-again);
+}
+</style>
+```
+
+* [ ] **Step 2: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0.
+
+* [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/TypeToConfirmDialog.vue
+git commit -m "feat(web): type-to-confirm dialog"
+```
+
+---
+
+## Task 7: Web — profile card kebab items
+
+**Files:**
+
+* Modify: `apps/web/src/components/ProfileCard.vue`
+
+* [ ] **Step 1: Add the emits**
+
+In `apps/web/src/components/ProfileCard.vue`, extend `defineEmits` (currently `enter` / `reauth` /
+`sign-out` / `delete`) to add three members:
+
+```ts
+const emit = defineEmits<{
+  /** Clicked a signed-in card — swap workspace to this profile. */
+  (e: 'enter'): void
+  /** Clicked a signed-out card — re-auth required to use it. */
+  (e: 'reauth'): void
+  (e: 'sign-out'): void
+  (e: 'export'): void
+  (e: 'import'): void
+  (e: 'delete-progress'): void
+  (e: 'delete'): void
+}>()
+```
+
+* [ ] **Step 2: Add the click handlers**
+
+After the existing `onSignOutClick` function, add three handlers following the same
+`stopPropagation` + `closeMenu` + `emit` pattern:
+
+```ts
+function onExportClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('export')
+}
+
+function onImportClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('import')
+}
+
+function onDeleteProgressClick(ev: Event) {
+  ev.stopPropagation()
+  closeMenu()
+  emit('delete-progress')
+}
+```
+
+* [ ] **Step 3: Add the menu items**
+
+In the template's `<div v-if="menuOpen" class="menu" role="menu">`, the order is Export, Import,
+Sign out, Delete all progress, Delete profile. Replace the menu's inner buttons with:
+
+```vue
+<button
+  v-if="signedIn"
+  type="button"
+  class="menu-item"
+  role="menuitem"
+  @click="onExportClick"
+>
+  Export my data
+</button>
+<button
+  v-if="signedIn"
+  type="button"
+  class="menu-item"
+  role="menuitem"
+  @click="onImportClick"
+>
+  Import data
+</button>
+<button
+  v-if="signedIn"
+  type="button"
+  class="menu-item"
+  role="menuitem"
+  @click="onSignOutClick"
+>
+  Sign out
+</button>
+<button
+  v-if="signedIn"
+  type="button"
+  class="menu-item destructive"
+  role="menuitem"
+  @click="onDeleteProgressClick"
+>
+  Delete all progress
+</button>
+<button
+  type="button"
+  class="menu-item destructive"
+  role="menuitem"
+  @click="onDeleteClick"
+>
+  Delete profile
+</button>
+```
+
+(No CSS change — `.menu-item` / `.menu-item.destructive` already exist.)
+
+* [ ] **Step 4: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0.
+
+* [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ProfileCard.vue
+git commit -m "feat(web): export/import/reset kebab items"
+```
+
+---
+
+## Task 8: Web — picker orchestration
+
+**Files:**
+
+* Modify: `apps/web/src/views/ProfilePickerView.vue`
+
+* [ ] **Step 1: Extend the script imports + state**
+
+In `apps/web/src/views/ProfilePickerView.vue`, update the imports at the top of `<script setup>`:
+
+```ts
+import { ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { api, ApiError, type ImportSummary } from '@/api'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import ImportResultDialog from '@/components/ImportResultDialog.vue'
+import ProfileCard from '@/components/ProfileCard.vue'
+import SignInForm from '@/components/SignInForm.vue'
+import TypeToConfirmDialog from '@/components/TypeToConfirmDialog.vue'
+import { useAuth } from '@/composables/useAuth'
+import { downloadJson, exportFilename, readJsonFile } from '@/lib/account-file'
+import type { ProfileRow } from '@/lib/engine/registry'
+```
+
+After the existing `pendingDelete` / `deleteBusy` refs, add the new state:
+
+```ts
+const banner = ref<string | null>(null)
+
+const fileInput = ref<HTMLInputElement | null>(null)
+const pendingImport = ref<{ profile: ProfileRow; payload: unknown } | null>(null)
+const importBusy = ref(false)
+const importResult = ref<{ summary: ImportSummary | null; error: string | null } | null>(null)
+
+const pendingDeleteProgress = ref<ProfileRow | null>(null)
+const deleteProgressBusy = ref(false)
+```
+
+* [ ] **Step 2: Add the switch-first + export helpers**
+
+After `onCardSignOut`, add the shared helpers + export flow:
+
+```ts
+/** Make `profile`'s session active (no-op if it already is). Returns
+ *  false and routes to the reauth form when the token is dead. */
+async function switchTo(profile: ProfileRow): Promise<boolean> {
+  if (activeProfile.value?.profileId === profile.profileId) return true
+  const result = await enterProfile(profile.profileId)
+  if (result.ok) return true
+  prefillEmail.value = profile.email
+  mode.value = 'add'
+  return false
+}
+
+/** Download the active account's full export. Shared by the kebab
+ *  Export item and the backup button inside the delete dialog. */
+async function exportActiveAccount() {
+  const email = activeProfile.value?.email ?? 'account'
+  const data = await api.exportAccount()
+  const isoDate = new Date().toISOString().slice(0, 10)
+  downloadJson(exportFilename(email, isoDate), data)
+}
+
+async function onCardExport(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  try {
+    await exportActiveAccount()
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Export failed.'
+  }
+}
+
+async function onBackupClick() {
+  banner.value = null
+  try {
+    await exportActiveAccount()
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Backup download failed.'
+  }
+}
+```
+
+* [ ] **Step 3: Add the import flow**
+
+After the export helpers, add:
+
+```ts
+async function onCardImport(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  // Stash the target so the file-input change handler knows which
+  // account it's importing into, then open the OS file picker.
+  pendingImport.value = { profile, payload: null }
+  fileInput.value?.click()
+}
+
+async function onFilePicked(ev: Event) {
+  const input = ev.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = '' // allow re-picking the same file later
+  if (!file || !pendingImport.value) return
+  try {
+    const payload = await readJsonFile(file)
+    pendingImport.value = { ...pendingImport.value, payload }
+  } catch {
+    pendingImport.value = null
+    importResult.value = { summary: null, error: 'That file isn’t valid JSON.' }
+  }
+}
+
+function cancelImport() {
+  pendingImport.value = null
+}
+
+async function confirmImport() {
+  const target = pendingImport.value
+  if (!target || target.payload === null) return
+  importBusy.value = true
+  try {
+    const summary = await api.importAccount(target.payload)
+    importResult.value = { summary, error: null }
+  } catch (err) {
+    const message = err instanceof ApiError ? err.message : 'Import failed.'
+    importResult.value = { summary: null, error: message }
+  } finally {
+    importBusy.value = false
+    pendingImport.value = null
+  }
+}
+
+function closeImportResult() {
+  importResult.value = null
+}
+```
+
+* [ ] **Step 4: Add the delete-progress flow**
+
+After the import flow, add:
+
+```ts
+function requestDeleteProgress(profile: ProfileRow) {
+  pendingDeleteProgress.value = profile
+}
+
+function cancelDeleteProgress() {
+  pendingDeleteProgress.value = null
+}
+
+async function onCardDeleteProgress(profile: ProfileRow) {
+  banner.value = null
+  if (!(await switchTo(profile))) return
+  requestDeleteProgress(profile)
+}
+
+async function confirmDeleteProgress() {
+  const target = pendingDeleteProgress.value
+  if (!target) return
+  deleteProgressBusy.value = true
+  try {
+    const summary = await api.deleteAllProgress()
+    banner.value = `Reset ${summary.materialsReset} deck(s): removed ${summary.eventsDeleted} reviews and ${summary.graduationsDeleted} graduations.`
+  } catch (err) {
+    banner.value = err instanceof ApiError ? err.message : 'Delete failed.'
+  } finally {
+    deleteProgressBusy.value = false
+    pendingDeleteProgress.value = null
+  }
+}
+```
+
+* [ ] **Step 5: Wire the template**
+
+On the `<ProfileCard>` element, add the three new event bindings alongside the existing ones:
+
+```vue
+@export="onCardExport(p)"
+@import="onCardImport(p)"
+@delete-progress="onCardDeleteProgress(p)"
+```
+
+Add a status banner just under the `<h2>`s (inside `.picker`, before the `mode === 'cards'`
+template):
+
+```vue
+<p v-if="banner" class="banner">{{ banner }}</p>
+```
+
+Add the hidden file input, the import confirm dialog, the import result dialog, and the
+delete-progress dialog before the closing `</div>` of `.picker` (the existing delete-profile
+`<ConfirmDialog>` stays):
+
+```vue
+    <input
+      ref="fileInput"
+      type="file"
+      accept="application/json"
+      class="hidden-file"
+      @change="onFilePicked"
+    />
+
+    <ConfirmDialog
+      v-if="pendingImport && pendingImport.payload !== null"
+      title="Import data?"
+      confirm-label="Import"
+      :busy="importBusy"
+      @confirm="confirmImport"
+      @cancel="cancelImport"
+    >
+      <p>
+        Import data into <strong>{{ pendingImport.profile.email }}</strong>?
+        This adds review history and graduations from the file. Existing
+        data is kept, and re-importing the same file is safe.
+      </p>
+    </ConfirmDialog>
+
+    <ImportResultDialog
+      v-if="importResult"
+      :summary="importResult.summary"
+      :error="importResult.error"
+      @close="closeImportResult"
+    />
+
+    <TypeToConfirmDialog
+      v-if="pendingDeleteProgress"
+      title="Delete all progress?"
+      confirm-label="Delete all progress"
+      :match-text="pendingDeleteProgress.email"
+      :busy="deleteProgressBusy"
+      @confirm="confirmDeleteProgress"
+      @cancel="cancelDeleteProgress"
+    >
+      <p>
+        This permanently deletes <strong>all review history, graduations,
+        and progress</strong> for <strong>{{ pendingDeleteProgress.email }}</strong>
+        across every deck. Your decks and settings stay. This cannot be undone.
+      </p>
+      <button type="button" class="backup-btn" @click="onBackupClick">
+        ⬇ Download a backup (.json)
+      </button>
+    </TypeToConfirmDialog>
+```
+
+Add the styles to the component's `<style scoped>` block:
+
+```css
+.banner {
+  margin: 0;
+  padding: 0.6rem 0.75rem;
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.hidden-file {
+  display: none;
+}
+
+.backup-btn {
+  align-self: flex-start;
+  padding: 0.45rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.backup-btn:hover {
+  border-color: var(--color-accent);
+}
+```
+
+* [ ] **Step 6: Type-check**
+
+Run: `pnpm --filter @verse-vault/web run type-check` Expected: exit 0.
+
+* [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/views/ProfilePickerView.vue
+git commit -m "feat(web): wire export/import/reset on picker"
+```
+
+---
+
+## Task 9: Docs + version bumps + changelogs
+
+**Files:**
+
+* Modify: `docs/server-api.md`
+* Modify: `packages/api/package.json`, `packages/api/CHANGELOG.md`
+* Modify: `apps/web/package.json`, `apps/web/CHANGELOG.md`
+
+* [ ] **Step 1: Document the endpoint**
+
+In `docs/server-api.md`, find the section listing account routes (the `GET /api/export` /
+`POST /api/import` entries added in the prior PR — if they're missing, add them too). Add an entry:
+
+```markdown
+### `DELETE /api/account/progress`
+
+Auth required. Wipes the caller's learning state — review events, graduations, and derived test
+states — across every enrolled material. Keeps enrollments, per-year settings, and the content
+snapshot (decks stay, reset to all-new). Idempotent. Returns
+`{ materialsReset, eventsDeleted, graduationsDeleted }`.
+```
+
+* [ ] **Step 2: Bump the API version + changelog**
+
+In `packages/api/package.json`, change `"version": "0.1.25"` to `"version": "0.1.26"`.
+
+In `packages/api/CHANGELOG.md`, under `## [Unreleased]`, add a new dated section (today is
+2026-05-29):
+
+```markdown
+## [0.1.26] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Account progress reset endpoint
+
+* **`DELETE /api/account/progress`** — wipes the caller's review events, graduations, and derived
+  test states across every enrolled material, under the engine's per-key lock; keeps enrollments +
+  per-year settings + the content snapshot. Idempotent; returns
+  `{ materialsReset, eventsDeleted, graduationsDeleted }`. Backs the web "Delete all progress"
+  action. Logic in `lib/reset.ts`, route in `routes/account.ts`.
+
+Bundled algorithm contract unchanged. No wire-format break.
+```
+
+* [ ] **Step 3: Bump the web version + changelog**
+
+In `apps/web/package.json`, change `"version": "0.1.19"` to `"version": "0.1.20"`.
+
+In `apps/web/CHANGELOG.md`, under `## [Unreleased]`, add a new dated section. Mirror the existing
+entries' shape — keep the `### Bundled algorithm contract` subsection carrying
+`verse-vault-core@0.5.0` / `verse-vault-wasm@0.5.0` forward unchanged:
+
+```markdown
+## [0.1.20] — 2026-05-29
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Account data management on the profile card
+
+* The profile card kebab menu gains **Export my data**, **Import data**, and **Delete all progress**
+  (all gated on a signed-in card). Each switches the active session to that profile first
+  (`enterProfile`).
+* **Export** downloads the account as `verse-vault-export-<email>-<date>.json`.
+* **Import** picks a JSON file, confirms (neutral — import is additive and idempotent), and shows
+  the server's summary (events inserted/skipped, graduations, unresolved cards).
+* **Delete all progress** is gated behind a type-the-email confirmation and offers a one-click
+  backup download inside the dialog. It wipes review history and graduations across all decks but
+  keeps the decks + settings.
+* New: `lib/account-file.ts` (download/read helpers), `ImportResultDialog.vue`,
+  `TypeToConfirmDialog.vue`; `api.ts` gains `exportAccount` / `importAccount` / `deleteAllProgress`.
+```
+
+* [ ] **Step 4: Verify the contract-version check passes**
+
+Run: `tools/check-contract-versions.sh` Expected: no output, exit 0 (both bumped packages now have
+matching dated changelog sections).
+
+* [ ] **Step 5: Commit**
+
+```bash
+git add docs/server-api.md packages/api/package.json packages/api/CHANGELOG.md apps/web/package.json apps/web/CHANGELOG.md
+git commit -m "chore: release api 0.1.26 + web 0.1.20"
+```
+
+---
+
+## Task 10: Final verification
+
+**Files:** none (verification only)
+
+* [ ] **Step 1: Full server suite**
+
+Run: `pnpm --filter @verse-vault/api exec vitest run` Expected: all pass (includes the new
+`reset.test.ts` + `account.test.ts` cases).
+
+* [ ] **Step 2: Both type-checks**
+
+Run: `pnpm --filter @verse-vault/api run type-check` Run:
+`pnpm --filter @verse-vault/web run type-check` Expected: both exit 0.
+
+* [ ] **Step 3: Manual smoke (dev server)**
+
+Start the API + web dev servers, sign in with a profile that has review history, then on
+`/profiles`:
+
+* Kebab → **Export my data**: a `verse-vault-export-<email>-<date>.json` file downloads; open it and
+  confirm it has `materials[].reviewEvents`.
+* Kebab → **Import data**: pick that file → confirm → the result dialog shows a summary (on a fresh
+  re-import, `eventsSkipped` equals the event count and `eventsInserted` is 0 — idempotent).
+* Kebab → **Delete all progress**: the confirm button stays disabled until the email is typed
+  exactly; click **Download a backup** and confirm it downloads; confirm the delete → banner reports
+  the reset counts; re-enter the profile and confirm decks are still listed but progress is reset.
+* On a non-active signed-in card, confirm the action switches to that profile first (its card
+  becomes the active one).
+
+* [ ] **Step 4: Done**
+
+All tasks complete. Open the PR per the repo's PR conventions (feature branch
+`feat/account-data-management`, one PR, conventional-commit merge subject).
+
+---
+
+## Notes for the implementer
+
+* **TDD applies to the server only.** The web app has no test harness (repo convention); web tasks
+  are type-checked and manually verified. Don't scaffold a web test framework — out of scope.
+* **`enterProfile` is the switch primitive** (`useAuth.ts`): it calls `multiSession.setActive`,
+  returns `{ ok: false }` only when reauth is needed. The kebab items are gated on `signedIn`, so
+  `switchTo` returning false is the rare token-died-mid-session case — it routes to the sign-in form
+  and aborts.
+* **The import payload is opaque to the web.** Don't validate its shape client-side; the server
+  returns 400 (bad version / unknown material / invalid settings) or 413 (>50 MB), surfaced via
+  `ApiError.message` in the result dialog.
+* **Delete keeps decks + settings** by design — only `review_events`, `graduated_verses`,
+  `graduated_cards`, `test_states` are removed. Don't touch `user_materials`, `user_year_settings`,
+  or `graph_snapshots`.
+* **`matched()` is called as a function** in `TypeToConfirmDialog`'s `:disabled` binding
+  (re-evaluates on `typed` change via the reactive `v-model`); keep it that way rather than a
+  `computed` only if you mirror this exactly — a
+  `computed(() => typed.value.trim() === props.matchText)` is equally fine and slightly cleaner if
+  you prefer.

--- a/docs/superpowers/specs/2026-05-29-account-data-management-design.md
+++ b/docs/superpowers/specs/2026-05-29-account-data-management-design.md
@@ -1,0 +1,268 @@
+# Account data management (export / import / reset) — design
+
+**Status:** approved design, pre-implementation **Date:** 2026-05-29 **Scope:** `apps/web` (UI) +
+`packages/api` (one new endpoint). One feature PR.
+
+## Goal
+
+Give a signed-in user three account-data actions from the profile card's kebab menu:
+
+1. **Export my data** — download the account's full data as a JSON file.
+2. **Import data** — upload a previously-exported (or Anki-converted) JSON file, layering it onto
+   the account.
+3. **Delete all progress** — wipe the account's learning state (review history, graduations, derived
+   FSRS state) across every deck, behind a GitHub-style type-the-email confirmation, with a
+   one-click backup download inside the confirm dialog.
+
+Export and import wire into the already-shipped `GET /api/export` / `POST /api/import` endpoints
+(api 0.1.25). Delete-all-progress needs a **new** server endpoint.
+
+## Background / current state
+
+* **No settings page.** Account-level actions live on `ProfileCard.vue`'s kebab (`⋮`) menu — today
+  just **Sign out** (gated on `signedIn`) and **Delete profile**. The cards live in
+  `ProfilePickerView.vue` (route `/profiles`), which owns the delete-confirm flow via the reusable
+  `ConfirmDialog.vue`.
+* **Multi-profile / multi-session.** `useAuth.ts` tracks `activeProfile` (stable `profileId` =
+  server `userId`) and a `profiles` list. The api client (`api.ts`) carries no profile id — it
+  relies purely on the Better Auth session cookie (`credentials: 'include'`). "The account the API
+  talks to" ≡ the last `multiSession.setActive` target ≡ `activeProfile`.
+* **Switching is silent + password-less** when a profile's stored `sessionToken` is live:
+  `enterProfile(profileId)` calls `multiSession.setActive`, swaps the per-profile IDB database, and
+  returns `{ ok: false }` only when the token is dead (→ reauth via the sign-in form). `ProfileCard`
+  already binds `:signed-in="p.sessionToken !== null"` and
+  `:active="activeProfile?.profileId === p.profileId"`.
+* **No file-I/O precedent** in the web app (no Blob download, no `<input type=file>`). This feature
+  establishes that pattern.
+* **No web test harness** (repo convention). Server has `routes/account.test.ts` round-tripping
+  export→import.
+* **API client** (`apps/web/src/api.ts`) is a typed `ApiClient` interface + `createApiClient`
+  factory with a private `request(method, path, body?)` that `res.json()`-parses every response.
+  `GET /api/export` returns JSON via `c.json(...)`, so it fits `request('GET', ...)` directly — the
+  client builds the download Blob from the returned object. The request method union is
+  `'GET' | 'POST' | 'PATCH'` and must gain `'DELETE'`.
+* **Import is additive + idempotent**, not a wipe: review events dedup on the unique
+  `(userId, materialId, clientEventId)` index, graduations insert `onConflictDoNothing`, settings
+  merge by `max(updatedAt)` with a `>=` guard. Re-importing the same file is a safe no-op. This
+  justifies _neutral_ (not destructive) framing for the import confirm.
+
+## Decisions (locked via brainstorming)
+
+| Decision       | Choice                                                                 |
+| -------------- | ---------------------------------------------------------------------- |
+| Placement      | ProfileCard kebab menu (with Sign out / Delete profile)                |
+| Card scope     | Every card — switch to that profile first via `enterProfile`           |
+| Import gating  | Confirm dialog → result summary modal                                  |
+| Import framing | **Neutral** (additive + idempotent, not destructive)                   |
+| Delete scope   | **Learning state only** — keep enrollments + year settings             |
+| Delete confirm | Type the **account email** exactly to enable the button                |
+| Delete dialog  | Includes a **"Download a backup (.json)"** button (same export action) |
+| PR split       | **One** feature PR                                                     |
+
+## Server: `DELETE /api/account/progress`
+
+### Route (`packages/api/src/routes/account.ts`)
+
+Add to the existing `accountRoutes`:
+
+```
+app.delete('/account/progress', async (c) => {
+  const user = getUser(c)
+  const summary = await deleteAccountProgress(deps.db, deps.engines, user.id)
+  return c.json(summary)   // ProgressDeletionSummary
+})
+```
+
+(`requireAuth()` already applies via `app.use('*', requireAuth())`. Mounted under `/api`, so the
+full path is `/api/account/progress`.)
+
+### Logic (`packages/api/src/lib/reset.ts`, new)
+
+```
+deleteAccountProgress(db, engines, userId): ProgressDeletionSummary
+```
+
+For every material the user is enrolled in (`user_materials` rows for `userId`), hold
+`engines.withLock(key, async () => { ... })` and inside one transaction delete the user's rows from,
+in this order:
+
+* `review_events`
+* `graduated_verses`
+* `graduated_cards`
+* `test_states`
+
+Then `engines.invalidate(key)` so the cached engine is dropped; the next load rebuilds from empty
+events → empty `test_states`, no graduations → all cards `New`. **No explicit `rebuildFromEvents`
+needed** — invalidate-then-lazy-rebuild is sufficient and cheaper.
+
+**Kept untouched:** `user_materials` (enrollment), `user_year_settings` (scopes/retention),
+`graph_snapshots` (content version). So the decks remain in the user's list with their tuned
+settings, just reset to all-new.
+
+`withLock` per material mirrors the import path and the documented `rebuildFromEvents`/cache
+contract — the delete must not race a concurrent review POST for the same `(user, material)`.
+
+Return:
+
+```ts
+interface ProgressDeletionSummary {
+  materialsReset: number      // count of enrolled materials touched
+  eventsDeleted: number       // total review_events rows removed
+  graduationsDeleted: number  // graduated_verses + graduated_cards rows removed
+}
+```
+
+Idempotent: a second call deletes nothing more and returns zeros.
+
+### Server tests
+
+* `packages/api/src/lib/reset.test.ts`: seed a user with events + graduations + test_states +
+  settings across ≥1 material → `deleteAccountProgress` → assert `review_events` / `graduated_*` /
+  `test_states` empty for the user, while `user_materials` and `user_year_settings` rows survive;
+  assert the returned counts; assert a second call returns zeros (idempotent).
+* `packages/api/src/routes/account.test.ts`: `DELETE /api/account/progress` returns 401
+  unauthenticated; authenticated round-trip wipes a seeded account and returns the summary; after
+  delete, `GET /api/export` shows empty `materials[].reviewEvents` / `graduatedVerses` but the
+  material still present.
+
+## Web: profile-card actions
+
+### `apps/web/src/api.ts`
+
+* Extend the `request` method union to `'GET' | 'POST' | 'PATCH' | 'DELETE'`.
+* Add types: an opaque `AccountExport` (`Record<string, unknown>` — the web only downloads +
+  re-uploads it), `ImportSummary`, `ProgressDeletionSummary`.
+* Add to the `ApiClient` interface + factory:
+  * `exportAccount(): Promise<AccountExport>` → `request('GET', '/api/export')`
+  * `importAccount(payload: unknown): Promise<ImportSummary>` →
+    `request('POST', '/api/import', payload)`
+  * `deleteAllProgress(): Promise<ProgressDeletionSummary>` →
+    `request('DELETE', '/api/account/progress')`
+
+```ts
+interface ImportSummary {
+  materialsApplied: number
+  eventsInserted: number
+  eventsSkipped: number
+  graduationsApplied: number
+  unresolvedCardRefs: number
+}
+```
+
+### `apps/web/src/lib/account-file.ts` (new)
+
+Pure file-I/O helpers, kept framework-free so they're trivially testable if a harness lands later:
+
+* `downloadJson(filename: string, data: unknown): void` — `JSON.stringify` → `Blob` →
+  `URL.createObjectURL` → temporary `<a download>` click → revoke.
+* `readJsonFile(file: File): Promise<unknown>` — `await file.text()` → `JSON.parse` (throws on
+  malformed JSON; caller surfaces the error).
+* `exportFilename(email: string, isoDate: string): string` →
+  `verse-vault-export-<email>-<YYYY-MM-DD>.json` (sanitise the email for a safe filename).
+
+### `apps/web/src/components/ProfileCard.vue`
+
+* Add emits `(e: 'export')`, `(e: 'import')`, `(e: 'delete-progress')`.
+* Add three `menu-item` buttons gated on `signedIn` (same pattern as the existing `onSignOutClick`:
+  `ev.stopPropagation()`, `closeMenu()`, `emit(...)`): **Export my data**, **Import data**, then a
+  separated destructive **Delete all progress** (uses the `--color-grade-again` red, like a future
+  destructive item). Order: Export, Import, Sign out, Delete all progress, Delete profile.
+
+### `apps/web/src/components/ImportResultDialog.vue` (new)
+
+Neutral modal (same overlay/aria conventions as `ConfirmDialog`) showing an `ImportSummary` as a
+readable list (materials applied, events inserted, events skipped, graduations applied, unresolved
+card refs) with a single **Done** button. Also renders an error state (string message) for failed
+imports so one component covers both outcomes.
+
+### `apps/web/src/components/TypeToConfirmDialog.vue` (new, reusable)
+
+Destructive modal generalising `ConfirmDialog`:
+
+* Props: `title`, `confirmLabel`, `matchText` (the string the user must type), `busy`, plus a
+  default slot for the warning body (so the picker can slot in the **Download a backup** button +
+  copy).
+* A text `<input>`; the confirm button is `disabled` until `input.trim() === matchText`. Destructive
+  styling.
+* Emits `confirm` / `cancel`; overlay-click + Esc cancel.
+
+The **Download a backup** button lives in the slotted body (provided by the picker), wired to the
+same `exportActiveAccount()` handler — it's a safety net, non-blocking, and doesn't gate the
+confirm.
+
+### `apps/web/src/views/ProfilePickerView.vue` (orchestration)
+
+Owns the new state + handlers, mirroring how it already owns `pendingDelete` + `ConfirmDialog`:
+
+* A hidden `<input type="file" accept="application/json">` ref for import.
+* State: `pendingImport` (the chosen profile + parsed payload), `importResult` (`ImportSummary` |
+  error), `pendingDeleteProgress` (chosen profile), per-action `busy` and `error` refs.
+* A shared `switchTo(profile)` helper: if `profile.profileId !== activeProfile`,
+  `await enterProfile(profile.profileId)`; on `{ ok: false }`, fall through to the existing reauth
+  path (`prefillEmail` + `mode = 'add'`) and abort. (Menu items are gated on `signedIn`, so this is
+  the rare token-died-mid-session case.)
+* A shared `exportActiveAccount()` helper:
+  `const data = await api.exportAccount(); downloadJson(exportFilename(activeProfile.email, today), data)`.
+  Used by both the kebab **Export** item (after `switchTo`) and the **Download a backup** button
+  inside the delete dialog.
+* `onCardExport(p)` → `await switchTo(p)` → `exportActiveAccount()`.
+* `onCardImport(p)` → `await switchTo(p)` → open the file picker → on file: `readJsonFile` → set
+  `pendingImport` → neutral `ConfirmDialog` (import is additive). On confirm:
+  `api.importAccount(payload)` → set `importResult` → show `ImportResultDialog`. JSON-parse failure
+  or `ApiError` (400/413) → `ImportResultDialog` error state.
+* `onCardDeleteProgress(p)` → `await switchTo(p)` → set `pendingDeleteProgress` →
+  `TypeToConfirmDialog` (`matchText = p.email`, backup button slotted) → on confirm:
+  `api.deleteAllProgress()` → success banner with the deletion counts; `ApiError` → error banner.
+
+### Confirm copy
+
+* **Import** (`ConfirmDialog`, neutral): "Import data into **&lt;email&gt;**? This adds review
+  history and graduations from the file. Existing data is kept, and re-importing the same file is
+  safe."
+* **Delete all progress** (`TypeToConfirmDialog`, destructive): "This permanently deletes **all
+  review history, graduations, and progress** for **&lt;email&gt;** across every deck. Your decks
+  and settings stay. This cannot be undone." + a **Download a backup (.json)** button + "Type
+  **&lt;email&gt;** to confirm:" input.
+
+## Error handling
+
+* **Export**: `ApiError` (e.g. 401 stale session, network) → inline error banner on the picker.
+* **Import**: malformed JSON (`readJsonFile`/`JSON.parse` throws, before any network call) → error
+  in `ImportResultDialog`; `400` (unsupported/unknown `exportVersion`, unknown `materialId`, invalid
+  settings bounds) and `413` (>50 MB) → surface `ApiError.message` in the dialog's error state;
+  offline → error.
+* **Delete**: `ApiError` → error banner; the type-to-confirm guard prevents accidental triggers.
+* **Switch**: `enterProfile` `{ ok: false }` → reauth fallback, action aborted.
+
+## Release
+
+* `packages/api`: 0.1.25 → **0.1.26** (new `DELETE /api/account/progress`); promote `[Unreleased]` →
+  dated `[0.1.26]` in `packages/api/CHANGELOG.md`, carrying `verse-vault-core@0.5.0` /
+  `verse-vault-wasm@0.5.0` forward.
+* `apps/web`: 0.1.19 → **0.1.20**; matching `apps/web/CHANGELOG.md` entry, same contract versions
+  carried forward.
+* `docs/server-api.md`: document `DELETE /api/account/progress` (and confirm `GET /api/export` /
+  `POST /api/import` are documented from the prior PR; add if missing).
+* No `crates/{core,wasm}` change — no contract-crate bump.
+
+## Out of scope
+
+* Per-material / per-year progress reset (this wipes **all** materials at once).
+* Full account deletion (already exists as "Delete profile").
+* A general settings page (the kebab is the chosen surface).
+* A web unit-test harness (none exists; helpers kept pure for later).
+* The double-engine-construction perf follow-up (issue #89) — unrelated.
+
+## Build order (for the implementation plan)
+
+1. Server: `lib/reset.ts` + `reset.test.ts` (TDD), then the route + route tests.
+2. Web api client: types + three methods + `'DELETE'`.
+3. Web: `account-file.ts` helpers.
+4. Web: `ImportResultDialog.vue`, `TypeToConfirmDialog.vue`.
+5. Web: `ProfileCard.vue` menu items + emits.
+6. Web: `ProfilePickerView.vue` orchestration (switch-first, export, import, delete-progress,
+   backup-in-dialog).
+7. Docs + version bumps + CHANGELOG entries.
+8. Manual verification: export downloads a valid file; re-import shows a correct (idempotent)
+   summary; delete-all-progress wipes learning state, keeps decks + settings, and the in-dialog
+   backup downloads.

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,23 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.26] — 2026-05-30
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.0` — unchanged.
+* `verse-vault-wasm@0.5.0` — unchanged.
+
+### Account progress reset endpoint
+
+* **`DELETE /api/account/progress`** — wipes the caller's review events, graduations, and derived
+  test states across every enrolled material, under the engine's per-key lock; keeps enrollments +
+  per-year settings + the content snapshot. Idempotent; returns
+  `{ materialsReset, eventsDeleted, graduationsDeleted }`. Backs the web "Delete all progress"
+  action. Logic in `lib/reset.ts`, route in `routes/account.ts`.
+
+Bundled algorithm contract unchanged. No wire-format break.
+
 ## [0.1.25] — 2026-05-29
 
 ### Bundled algorithm contract

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/lib/reset.test.ts
+++ b/packages/api/src/lib/reset.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import * as schema from '../db/schema.js';
+import { seedUserWithFixture } from '../test-fixtures.js';
+import { createTestDb } from '../test-utils.js';
+
+import { EngineStore } from './engine.js';
+import { deleteAccountProgress } from './reset.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+const NOW = 1_700_000_000;
+
+function seedProgress(db: ReturnType<typeof createTestDb>['db']) {
+  // Enrolls u1 (seeds user_materials, graph_snapshot, test_states) and
+  // gives us settings + events + graduations to wipe.
+  seedUserWithFixture({ db, userId: 'u1', materialId: MATERIAL_ID });
+  db.insert(schema.userYearSettings)
+    .values({
+      userId: 'u1',
+      materialId: MATERIAL_ID,
+      headingCard: true,
+      headingPassageCard: true,
+      ftv: true,
+      newScope: 'all',
+      reviewScope: 'all',
+      clubCardScope: 'off',
+      chapterListScope: 'up150',
+      lessonBatchSize: 3,
+      desiredRetention: 0.9,
+      updatedAt: NOW,
+    })
+    .run();
+  db.insert(schema.reviewEvents)
+    .values([
+      {
+        id: 'e1',
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW,
+        cardId: 0,
+        grade: 3,
+        clientEventId: 'e1',
+        createdAt: NOW,
+      },
+      {
+        id: 'e2',
+        userId: 'u1',
+        materialId: MATERIAL_ID,
+        snapshotVersion: 1,
+        timestampSecs: NOW + 1,
+        cardId: 0,
+        grade: 4,
+        clientEventId: 'e2',
+        createdAt: NOW + 1,
+      },
+    ])
+    .run();
+  db.insert(schema.graduatedVerses)
+    .values({ userId: 'u1', materialId: MATERIAL_ID, verseId: 0, graduatedAtSecs: NOW })
+    .run();
+  db.insert(schema.graduatedCards)
+    .values({ userId: 'u1', materialId: MATERIAL_ID, cardId: 0, graduatedAtSecs: NOW })
+    .run();
+}
+
+describe('deleteAccountProgress', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('wipes learning state but keeps enrollment + settings', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedProgress(test.db);
+
+    const engines = new EngineStore(test.db);
+    try {
+      const summary = await deleteAccountProgress(test.db, engines, 'u1');
+
+      expect(summary.materialsReset).toBe(1);
+      expect(summary.eventsDeleted).toBe(2);
+      expect(summary.graduationsDeleted).toBe(2);
+
+      expect(test.db.select().from(schema.reviewEvents).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.graduatedVerses).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.graduatedCards).all()).toHaveLength(0);
+      expect(test.db.select().from(schema.testStates).all()).toHaveLength(0);
+
+      // Enrollment + settings survive — decks stay, just reset to new.
+      expect(test.db.select().from(schema.userMaterials).all()).toHaveLength(1);
+      expect(test.db.select().from(schema.userYearSettings).all()).toHaveLength(1);
+    } finally {
+      engines.clear();
+    }
+  });
+
+  it('is idempotent: a second call returns zeros', async () => {
+    const test = createTestDb();
+    cleanup = test.cleanup;
+    seedProgress(test.db);
+
+    const engines = new EngineStore(test.db);
+    try {
+      await deleteAccountProgress(test.db, engines, 'u1');
+      const second = await deleteAccountProgress(test.db, engines, 'u1');
+      expect(second).toEqual({ materialsReset: 0, eventsDeleted: 0, graduationsDeleted: 0 });
+    } finally {
+      engines.clear();
+    }
+  });
+});

--- a/packages/api/src/lib/reset.ts
+++ b/packages/api/src/lib/reset.ts
@@ -1,0 +1,97 @@
+import { and, eq } from 'drizzle-orm';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+
+import { EngineStore } from './engine.js';
+
+export interface ProgressDeletionSummary {
+  /** Enrolled materials that actually had rows removed. */
+  materialsReset: number;
+  /** Total `review_events` rows removed across all materials. */
+  eventsDeleted: number;
+  /** `graduated_verses` + `graduated_cards` rows removed. */
+  graduationsDeleted: number;
+}
+
+/**
+ * Wipe a user's learning state — review events, graduations, and the
+ * derived test_states — across every material they're enrolled in.
+ * Enrollment (`user_materials`), per-year settings, and the content
+ * snapshot are deliberately kept: decks stay in the user's list, reset
+ * to all-new. Each material is cleared under the engine's per-key lock
+ * (mirroring import / rebuildFromEvents) so the delete can't race a
+ * concurrent review POST, then the cached engine is invalidated so the
+ * next load rebuilds from the now-empty event log.
+ *
+ * Idempotent: a second call finds nothing to delete and returns zeros.
+ */
+export async function deleteAccountProgress(
+  db: DB,
+  engines: EngineStore,
+  userId: string,
+): Promise<ProgressDeletionSummary> {
+  const materials = db
+    .select({ materialId: schema.userMaterials.materialId })
+    .from(schema.userMaterials)
+    .where(eq(schema.userMaterials.userId, userId))
+    .all();
+
+  let materialsReset = 0;
+  let eventsDeleted = 0;
+  let graduationsDeleted = 0;
+
+  for (const { materialId } of materials) {
+    const key = { userId, materialId };
+    await engines.withLock(key, async () => {
+      let materialChanges = 0;
+      db.transaction((tx) => {
+        const ev = tx
+          .delete(schema.reviewEvents)
+          .where(
+            and(
+              eq(schema.reviewEvents.userId, userId),
+              eq(schema.reviewEvents.materialId, materialId),
+            ),
+          )
+          .run();
+        const gv = tx
+          .delete(schema.graduatedVerses)
+          .where(
+            and(
+              eq(schema.graduatedVerses.userId, userId),
+              eq(schema.graduatedVerses.materialId, materialId),
+            ),
+          )
+          .run();
+        const gc = tx
+          .delete(schema.graduatedCards)
+          .where(
+            and(
+              eq(schema.graduatedCards.userId, userId),
+              eq(schema.graduatedCards.materialId, materialId),
+            ),
+          )
+          .run();
+        const ts = tx
+          .delete(schema.testStates)
+          .where(
+            and(
+              eq(schema.testStates.userId, userId),
+              eq(schema.testStates.materialId, materialId),
+            ),
+          )
+          .run();
+        eventsDeleted += ev.changes;
+        graduationsDeleted += gv.changes + gc.changes;
+        materialChanges = ev.changes + gv.changes + gc.changes + ts.changes;
+      });
+      if (materialChanges > 0) {
+        materialsReset += 1;
+        engines.invalidate(key);
+      }
+    });
+  }
+
+  return { materialsReset, eventsDeleted, graduationsDeleted };
+}

--- a/packages/api/src/routes/account.test.ts
+++ b/packages/api/src/routes/account.test.ts
@@ -122,4 +122,37 @@ describe('account routes', () => {
     });
     expect(res.status).toBe(413);
   });
+
+  it('DELETE /api/account/progress requires auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const res = await test.app.request('/api/account/progress', { method: 'DELETE' });
+    expect(res.status).toBe(401);
+  });
+
+  it('wipes progress but keeps the enrolled material', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await enroll(test, 'reset@example.com');
+
+    const res = await test.app.request('/api/account/progress', {
+      method: 'DELETE',
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    const summary = (await res.json()) as {
+      materialsReset: number;
+      eventsDeleted: number;
+      graduationsDeleted: number;
+    };
+    expect(summary.materialsReset).toBeGreaterThanOrEqual(0);
+
+    // The deck is still enrolled after a reset.
+    const exportRes = await test.app.request('/api/export', { headers: { cookie } });
+    const payload = (await exportRes.json()) as {
+      materials: { materialId: string; reviewEvents: unknown[] }[];
+    };
+    expect(payload.materials).toHaveLength(1);
+    expect(payload.materials[0]!.reviewEvents).toHaveLength(0);
+  });
 });

--- a/packages/api/src/routes/account.ts
+++ b/packages/api/src/routes/account.ts
@@ -9,6 +9,7 @@ import {
   ImportValidationError,
   applyAccountImport,
 } from '../lib/import.js';
+import { deleteAccountProgress } from '../lib/reset.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
 
 export interface AccountRoutesDeps {
@@ -62,6 +63,12 @@ export function accountRoutes(deps: AccountRoutesDeps) {
       }
     },
   );
+
+  app.delete('/account/progress', async (c) => {
+    const user = getUser(c);
+    const summary = await deleteAccountProgress(deps.db, deps.engines, user.id);
+    return c.json(summary);
+  });
 
   return app;
 }


### PR DESCRIPTION
## Summary

Adds account data management to the Vue web app's profile-card kebab menu, plus a new server reset endpoint.

Three actions, each gated on a signed-in card and switching the active session to that profile first (`enterProfile`):

- **Export my data** — downloads the account as `verse-vault-export-<email>-<date>.json` (via the existing `GET /api/export`).
- **Import data** — pick a JSON file → neutral confirm (import is additive + idempotent) → result summary modal (`POST /api/import`).
- **Delete all progress** — wipes review history + graduations + derived FSRS state across all decks, gated behind a GitHub-style type-the-email confirm, with a one-click backup download inside the dialog. Keeps enrollments + per-year settings + content snapshot.

### Server
- **`DELETE /api/account/progress`** (`lib/reset.ts` + `routes/account.ts`) — deletes `review_events` / `graduated_verses` / `graduated_cards` / `test_states` per enrolled material under `engines.withLock`, then invalidates the cached engine. userId+materialId-scoped, idempotent, returns `{ materialsReset, eventsDeleted, graduationsDeleted }`.

### Web
- `api.ts`: `exportAccount` / `importAccount` / `deleteAllProgress` + `'DELETE'` method + mirrored wire types.
- `lib/account-file.ts`: `downloadJson` / `readJsonFile` / `exportFilename` (first file-I/O in the app).
- New `ImportResultDialog.vue`, `TypeToConfirmDialog.vue`; extracted a shared `BaseModal.vue` and rebuilt `ConfirmDialog` on it (net −123 lines across the dialog set).
- After a successful import/delete, `resetProfileLocalData` drops the local fat-client engine + IDB cache so the next deck open cold-loads fresh `/state` (the ops don't bump the snapshot version, so the staleness check wouldn't otherwise fire).

Ships `@verse-vault/api` 0.1.26 + `@verse-vault/web` 0.1.20; contract crates unchanged. Spec + plan committed under `docs/superpowers/`.

## Test plan
- [x] `pnpm --filter @verse-vault/api exec vitest run` — 158 pass (incl. new `reset.test.ts` + `account.test.ts` cases: wipe-keeps-enrollment, idempotency, 401, post-delete export)
- [x] `pnpm --filter @verse-vault/api run type-check` + `pnpm --filter @verse-vault/web run type-check` — both clean
- [x] `tools/check-contract-versions.sh` — passes
- [ ] Manual smoke (no web test harness): export downloads valid file; re-import shows idempotent summary; delete gated on email, in-dialog backup downloads, decks survive reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)