### PR TITLE
Web nav redesign: identity popover + mobile bottom tab bar + route renames

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,16 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Identity popover replaces email + switch-profile in the nav
+
+* New `AppAvatar.vue` renders a circular avatar button (display-name initials, or the profile image
+  when present) at the end of the nav. Clicking opens a popover with the display name + email,
+  **Switch profile**, and **Sign out**.
+* Sign-out is now reachable from the top nav for the first time: calls `useAuth().signOut()` against
+  the active profile, revokes its server session, and routes to `/profiles`.
+* Removes the always-visible email text and the **Switch profile** button-styled link from the nav
+  row, freeing horizontal space for the upcoming responsive layout work.
+
 ### `/dashboard` renamed to `/home`
 
 * The route, nav label, view file (`DashboardView.vue` → `HomeView.vue`), and post-sign-in default

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,15 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Keyboard + focus polish for the nav redesign
+
+* Escape closes the identity popover (window-level `keydown` listener, paired with the existing
+  click-outside dismissal).
+* `:focus-visible` rings on the avatar button, popover menu items, brand link, top-bar nav links,
+  and bottom tab bar tabs. Uses the existing 2 px `--color-accent` outline convention from
+  `ScopeLevelSelector` and `CardPrompt`. Active-route `aria-current="page"` comes for free from Vue
+  Router 4's `RouterLink`.
+
 ### Bottom tab bar at mobile widths
 
 * New `MobileTabBar.vue` renders a fixed-bottom 5-tab bar (**Home · Review · Memorize · Settings ·

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,13 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### `/dashboard` renamed to `/home`
+
+* The route, nav label, view file (`DashboardView.vue` → `HomeView.vue`), and post-sign-in default
+  redirect all rename to **Home**. The page is a landing-glance, not a widgets dashboard, and the
+  new name reads truer in the nav row.
+* `/dashboard` redirects to `/home`, mirroring the `/material` → `/settings` shim.
+
 ### `/material` renamed to `/settings`
 
 * The route, nav label, view file (`MaterialView.vue` → `SettingsView.vue`), and page heading all

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -18,6 +18,8 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
   the active profile, revokes its server session, and routes to `/profiles`.
 * Removes the always-visible email text and the **Switch profile** button-styled link from the nav
   row, freeing horizontal space for the upcoming responsive layout work.
+* Header now uses a `1fr auto 1fr` grid: brand pinned left, nav links centered, avatar pinned right.
+  Replaces the previous single-flex-row composition.
 
 ### `/dashboard` renamed to `/home`
 

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,16 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Bottom tab bar at mobile widths
+
+* New `MobileTabBar.vue` renders a fixed-bottom 5-tab bar (**Home · Review · Memorize · Settings ·
+  Stats**) at viewports ≤720 px, with inline Lucide-style SVG icons and the Memorize-new pill in its
+  existing spot. The inline top-bar nav hides at the same breakpoint.
+* Bar respects `env(safe-area-inset-bottom)` so it sits above the iOS home indicator and Android
+  gesture bar.
+* `.site` reserves `calc(3.75rem + env(safe-area-inset-bottom))` of padding at the mobile breakpoint
+  so the footer and any scroll content sit above the fixed bar rather than under it.
+
 ### Identity popover replaces email + switch-profile in the nav
 
 * New `AppAvatar.vue` renders a circular avatar button (display-name initials, or the profile image

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,36 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### `/code-review` pass on the nav redesign
+
+* **Open-redirect via `?redirect=`.** `router/index.ts`'s `beforeEach` guard and
+  `ProfilePickerView.vue`'s `redirectTarget()` were returning the raw `redirect` query parameter to
+  Vue Router. A signed-in user clicking `/profiles?redirect=https://evil.com` (or a sign-in link
+  with the same shape) would be navigated off-origin. New `safeRedirect()` helper rejects anything
+  not starting with a single `/`; both call sites route through it.
+* **Avatar popover swallows grade keys.** `ReviewView` and `MemorizeView` register their `keydown`
+  listeners with `{capture: true}` and treat 1–4 / Enter / Space as grade input. The avatar
+  popover's keydown listener was bubble-phase, so pressing "1" to dismiss the menu would also grade
+  the current card. AppAvatar's listener moves to the capture phase and `stopImmediatePropagation`s
+  the grade keys while the popover is open.
+* **`onSignOut` strands the user on throw.** If `useAuth().signOut()` rejected, the explicit
+  `router.push('/profiles')` never ran and the user was stuck on a half-signed-out workspace. The
+  push moves into a `finally` so the user always reaches the picker.
+* **Cold-boot grid collapse.** AppAvatar's outer `.avatar-wrap` was `v-if="activeProfile"`, so
+  during the pre-boot window the 3-column header grid lost its right anchor and the brand + nav
+  drifted right. The wrap renders unconditionally now; only the button + popover are gated.
+* **Phantom mobile padding on signed-out routes.** `.site` reserved `--mobile-tab-bar-h` of bottom
+  padding at ≤720 px unconditionally, even though `<MobileTabBar v-if="user">` only mounts when
+  signed in. The signed-out picker / sign-in page got a dead gap at the bottom on mobile. Gated via
+  a `has-user` class on `.site`.
+* **Missing `env(...)` fallback inside `calc(...)`.** Browsers without `safe-area-inset-bottom`
+  support drop the entire `calc()` value, collapsing the bottom padding to zero. Both call sites use
+  `env(safe-area-inset-bottom, 0px)` now.
+* **`profileInitials` blank fallback.** A profile with both `displayName` and `email` empty returned
+  `''`, rendering a visually-blank avatar circle. Falls back to `'?'`.
+* **Stale "rendered unconditionally" comment in `MobileTabBar.vue`** updated — the component is in
+  fact gated by `v-if="user"` in `App.vue`.
+
 ### Keyboard + focus polish for the nav redesign
 
 * Escape closes the identity popover (window-level `keydown` listener, paired with the existing

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,15 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### `/material` renamed to `/settings`
+
+* The route, nav label, view file (`MaterialView.vue` → `SettingsView.vue`), and page heading all
+  rename to **Settings**. The page still contains only per-year settings today; the new name leaves
+  obvious room to grow (Account, Appearance, Shortcuts) without restructuring nav.
+* `/material` redirects to `/settings` so existing bookmarks and deep links keep working.
+* In-app links from Dashboard's empty-CTA, MemorizeView's empty-state, and StatsView's empty-state
+  all point to `/settings`.
+
 ### Distinguish `rate-limited` from `offline` in the sync indicator
 
 * `SyncState` gains a `rate-limited` variant. The router's background `getSession()` handler now

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -52,8 +52,8 @@ watch(() => route.fullPath, refreshMemorizeCount)
         </RouterLink>
         <RouterLink to="/settings">Settings</RouterLink>
         <RouterLink to="/stats">Stats</RouterLink>
-        <AppAvatar />
       </nav>
+      <AppAvatar />
     </header>
     <OfflineBanner />
     <ConfirmDialog
@@ -102,9 +102,10 @@ watch(() => route.fullPath, refreshMemorizeCount)
 }
 
 .site-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
+  gap: 1rem;
   padding: 0.75rem 1.5rem;
   background: var(--color-bg-card);
   border-bottom: 1px solid var(--color-border);
@@ -115,12 +116,19 @@ watch(() => route.fullPath, refreshMemorizeCount)
   color: var(--color-text);
   text-decoration: none;
   font-size: 1.1rem;
+  justify-self: start;
 }
 
 .nav {
   display: flex;
   align-items: center;
   gap: 1rem;
+  justify-self: center;
+}
+
+/* AppAvatar's `.avatar-wrap` outer is the third grid track. Pin it right. */
+.site-header :deep(.avatar-wrap) {
+  justify-self: end;
 }
 
 .nav :deep(a) {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -145,6 +145,12 @@ watch(() => route.fullPath, refreshMemorizeCount)
   background: var(--color-accent-soft);
 }
 
+.nav :deep(a:focus-visible),
+.brand:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .memorize-link {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -128,6 +128,17 @@ watch(() => route.fullPath, refreshMemorizeCount)
   justify-self: center;
 }
 
+/* AppAvatar's `.avatar-wrap` is the third grid track. Pin both column
+   AND justify-self explicitly — at mobile widths `.nav` is `display:
+   none`, which removes it from grid auto-placement entirely; without
+   `grid-column: 3` the avatar would auto-flow into the middle (`auto`)
+   track and `justify-self: end` would only align it inside that
+   shrunken track instead of the header's right edge. */
+.site-header :deep(.avatar-wrap) {
+  grid-column: 3;
+  justify-self: end;
+}
+
 .nav :deep(a) {
   color: var(--color-muted);
   text-decoration: none;

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -5,6 +5,7 @@ import { RouterLink, RouterView, useRoute } from 'vue-router'
 import { api } from '@/api'
 import AppAvatar from '@/components/AppAvatar.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import MobileTabBar from '@/components/MobileTabBar.vue'
 import OfflineBanner from '@/components/OfflineBanner.vue'
 import { useAuth } from '@/composables/useAuth'
 
@@ -91,6 +92,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
         <a href="https://api.bible" target="_blank" rel="noopener">API.Bible</a>.
       </p>
     </footer>
+    <MobileTabBar v-if="user" :new-to-memorize="newToMemorize" />
   </div>
 </template>
 
@@ -190,5 +192,19 @@ watch(() => route.fullPath, refreshMemorizeCount)
 
 .site-footer a:hover {
   color: var(--color-text);
+}
+
+/* Hand the nav off to the fixed bottom tab bar at mobile widths.
+   Padding-bottom on `.site` reserves the bar's height so the footer
+   and any scroll content can sit above it instead of being overlapped
+   by the fixed bar. Breakpoint must match MobileTabBar.vue. */
+@media (max-width: 720px) {
+  .nav {
+    display: none;
+  }
+
+  .site {
+    padding-bottom: calc(3.75rem + env(safe-area-inset-bottom));
+  }
 }
 </style>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -41,7 +41,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
 </script>
 
 <template>
-  <div class="site">
+  <div class="site" :class="{ 'has-user': !!user }">
     <header class="site-header">
       <RouterLink to="/" class="brand">verse-vault</RouterLink>
       <nav v-if="user" class="nav">
@@ -207,16 +207,20 @@ watch(() => route.fullPath, refreshMemorizeCount)
 }
 
 /* Hand the nav off to the fixed bottom tab bar at mobile widths.
-   Padding-bottom on `.site` reserves the bar's height so the footer
-   and any scroll content can sit above it instead of being overlapped
-   by the fixed bar. Breakpoint must match MobileTabBar.vue. */
+   Padding-bottom on `.site.has-user` reserves the bar's height so the
+   footer and any scroll content can sit above it instead of being
+   overlapped by the fixed bar. The `.has-user` gate matches
+   `<MobileTabBar v-if="user">` in the template so signed-out routes
+   (/profiles, sign-in form) don't reserve a phantom gap where no bar
+   exists. The `env(...)` fallback covers browsers without
+   safe-area-inset support. Breakpoint must match MobileTabBar.vue. */
 @media (max-width: 720px) {
   .nav {
     display: none;
   }
 
-  .site {
-    padding-bottom: calc(var(--mobile-tab-bar-h) + env(safe-area-inset-bottom));
+  .site.has-user {
+    padding-bottom: calc(var(--mobile-tab-bar-h) + env(safe-area-inset-bottom, 0px));
   }
 }
 </style>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -128,11 +128,6 @@ watch(() => route.fullPath, refreshMemorizeCount)
   justify-self: center;
 }
 
-/* AppAvatar's `.avatar-wrap` outer is the third grid track. Pin it right. */
-.site-header :deep(.avatar-wrap) {
-  justify-self: end;
-}
-
 .nav :deep(a) {
   color: var(--color-muted);
   text-decoration: none;
@@ -210,7 +205,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
   }
 
   .site {
-    padding-bottom: calc(3.75rem + env(safe-area-inset-bottom));
+    padding-bottom: calc(var(--mobile-tab-bar-h) + env(safe-area-inset-bottom));
   }
 }
 </style>

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -43,7 +43,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
     <header class="site-header">
       <RouterLink to="/" class="brand">verse-vault</RouterLink>
       <nav v-if="user" class="nav">
-        <RouterLink to="/dashboard">Dashboard</RouterLink>
+        <RouterLink to="/home">Home</RouterLink>
         <RouterLink to="/review">Review</RouterLink>
         <RouterLink to="/memorize" class="memorize-link">
           Memorize

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from 'vue'
 import { RouterLink, RouterView, useRoute } from 'vue-router'
 
 import { api } from '@/api'
+import AppAvatar from '@/components/AppAvatar.vue'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import OfflineBanner from '@/components/OfflineBanner.vue'
 import { useAuth } from '@/composables/useAuth'
@@ -51,8 +52,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
         </RouterLink>
         <RouterLink to="/settings">Settings</RouterLink>
         <RouterLink to="/stats">Stats</RouterLink>
-        <span class="who">{{ user.email }}</span>
-        <RouterLink to="/profiles?force=1" class="switch-profile">Switch profile</RouterLink>
+        <AppAvatar />
       </nav>
     </header>
     <OfflineBanner />
@@ -149,25 +149,6 @@ watch(() => route.fullPath, refreshMemorizeCount)
   padding: 0.1rem 0.45rem;
   border-radius: 999px;
   line-height: 1.4;
-}
-
-.who {
-  color: var(--color-muted);
-  font-size: 0.85rem;
-}
-
-.switch-profile {
-  background: none;
-  border: 1px solid var(--color-border);
-  color: var(--color-muted);
-  padding: 0.25rem 0.75rem;
-  border-radius: 4px;
-  font-size: 0.85rem;
-  text-decoration: none;
-}
-
-.switch-profile:hover {
-  color: var(--color-text);
 }
 
 .site-main {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -49,7 +49,7 @@ watch(() => route.fullPath, refreshMemorizeCount)
           Memorize
           <span v-if="newToMemorize > 0" class="pill">{{ newToMemorize }}</span>
         </RouterLink>
-        <RouterLink to="/material">Material</RouterLink>
+        <RouterLink to="/settings">Settings</RouterLink>
         <RouterLink to="/stats">Stats</RouterLink>
         <span class="who">{{ user.email }}</span>
         <RouterLink to="/profiles?force=1" class="switch-profile">Switch profile</RouterLink>

--- a/apps/web/src/assets/colors.css
+++ b/apps/web/src/assets/colors.css
@@ -36,6 +36,10 @@
   --verse-c8: oklch(50% 0.18 263.47); /* dark blue */
   --verse-c9: oklch(58% 0.18 293.9); /* blue violet */
   --verse-c10: oklch(50% 0.19 333.28); /* dark magenta */
+
+  /* Layout dimensions. Kept here rather than in App.vue so multiple
+     components can reference the same source of truth. */
+  --mobile-tab-bar-h: 3.75rem;
 }
 
 /* Dark theme picks up automatically on OS preference. Background is a

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -38,8 +38,17 @@ function close() {
 function onWindowClick() {
   if (open.value) open.value = false
 }
-onMounted(() => window.addEventListener('click', onWindowClick))
-onBeforeUnmount(() => window.removeEventListener('click', onWindowClick))
+function onWindowKeydown(ev: KeyboardEvent) {
+  if (ev.key === 'Escape' && open.value) close()
+}
+onMounted(() => {
+  window.addEventListener('click', onWindowClick)
+  window.addEventListener('keydown', onWindowKeydown)
+})
+onBeforeUnmount(() => {
+  window.removeEventListener('click', onWindowClick)
+  window.removeEventListener('keydown', onWindowKeydown)
+})
 
 function goSwitchProfile() {
   close()
@@ -119,6 +128,11 @@ async function onSignOut() {
   color: var(--color-on-accent);
 }
 
+.avatar-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .avatar-btn img {
   width: 100%;
   height: 100%;
@@ -183,6 +197,12 @@ async function onSignOut() {
 }
 
 .menu-item:hover {
+  background: var(--color-bg);
+}
+
+.menu-item:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
   background: var(--color-bg);
 }
 </style>

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -3,25 +3,16 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
 import { useAuth } from '@/composables/useAuth'
+import { profileInitials } from '@/lib/profile'
 
 const { activeProfile, signOut } = useAuth()
 const router = useRouter()
 
 const open = ref(false)
 
-// Mirrors ProfileCard's derivation: two initials from a display name's
-// first + last word, or the first two characters when the source is a
-// single token (e.g. an email local-part).
-const initials = computed(() => {
-  const profile = activeProfile.value
-  if (!profile) return ''
-  const source = profile.displayName || profile.email
-  const parts = source.trim().split(/\s+/)
-  const letters = parts.length >= 2
-    ? parts[0]![0]! + parts[parts.length - 1]![0]!
-    : source.slice(0, 2)
-  return letters.toUpperCase()
-})
+const initials = computed(() =>
+  activeProfile.value ? profileInitials(activeProfile.value) : '',
+)
 
 function toggle(ev: Event) {
   ev.stopPropagation()
@@ -103,6 +94,10 @@ async function onSignOut() {
 .avatar-wrap {
   position: relative;
   flex: 0 0 auto;
+  /* The site header is a `1fr auto 1fr` grid; the wrap is the third
+     track. Pin it right so the avatar trails the nav rather than
+     centering in its track. */
+  justify-self: end;
 }
 
 .avatar-btn {

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -94,10 +94,6 @@ async function onSignOut() {
 .avatar-wrap {
   position: relative;
   flex: 0 0 auto;
-  /* The site header is a `1fr auto 1fr` grid; the wrap is the third
-     track. Pin it right so the avatar trails the nav rather than
-     centering in its track. */
-  justify-self: end;
 }
 
 .avatar-btn {

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+
+import { useAuth } from '@/composables/useAuth'
+
+const { activeProfile, signOut } = useAuth()
+const router = useRouter()
+
+const open = ref(false)
+
+// Mirrors ProfileCard's derivation: two initials from a display name's
+// first + last word, or the first two characters when the source is a
+// single token (e.g. an email local-part).
+const initials = computed(() => {
+  const profile = activeProfile.value
+  if (!profile) return ''
+  const source = profile.displayName || profile.email
+  const parts = source.trim().split(/\s+/)
+  const letters = parts.length >= 2
+    ? parts[0]![0]! + parts[parts.length - 1]![0]!
+    : source.slice(0, 2)
+  return letters.toUpperCase()
+})
+
+function toggle(ev: Event) {
+  ev.stopPropagation()
+  open.value = !open.value
+}
+
+function close() {
+  open.value = false
+}
+
+// Click-outside-to-close: same window-listener pattern as ProfileCard's
+// kebab — cheaper than a transparent overlay, doesn't intercept other
+// interactive elements.
+function onWindowClick() {
+  if (open.value) open.value = false
+}
+onMounted(() => window.addEventListener('click', onWindowClick))
+onBeforeUnmount(() => window.removeEventListener('click', onWindowClick))
+
+function goSwitchProfile() {
+  close()
+  void router.push('/profiles?force=1')
+}
+
+async function onSignOut() {
+  close()
+  // signOut() with no arg targets the active profile, revokes its
+  // server session, and clears in-memory state — the router guard
+  // then falls through to /profiles on the next navigation. We push
+  // explicitly so the user sees the picker immediately rather than
+  // staying on a now-signed-out view.
+  await signOut()
+  await router.push('/profiles')
+}
+</script>
+
+<template>
+  <div v-if="activeProfile" class="avatar-wrap" @click.stop>
+    <button
+      type="button"
+      class="avatar-btn"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      aria-label="Account menu"
+      @click="toggle"
+    >
+      <img
+        v-if="activeProfile.image"
+        :src="activeProfile.image"
+        :alt="activeProfile.displayName"
+      />
+      <span v-else class="initials">{{ initials }}</span>
+    </button>
+    <div v-if="open" class="menu" role="menu">
+      <div class="menu-header">
+        <p class="name">{{ activeProfile.displayName }}</p>
+        <p class="email">{{ activeProfile.email }}</p>
+      </div>
+      <button type="button" class="menu-item" role="menuitem" @click="goSwitchProfile">
+        Switch profile
+      </button>
+      <button type="button" class="menu-item" role="menuitem" @click="onSignOut">
+        Sign out
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.avatar-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.avatar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-weight: 600;
+  font-size: 0.75rem;
+  cursor: pointer;
+  overflow: hidden;
+}
+
+.avatar-btn:hover {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+.avatar-btn img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.initials {
+  letter-spacing: 0.05em;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  min-width: 12rem;
+  z-index: 10;
+  overflow: hidden;
+}
+
+.menu-header {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.menu-header p {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.name {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--color-text);
+}
+
+.email {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+}
+
+.menu-item {
+  background: none;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: var(--color-bg);
+}
+</style>

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -29,16 +29,34 @@ function close() {
 function onWindowClick() {
   if (open.value) open.value = false
 }
+// Keydown listener runs on the CAPTURE phase so it sees keys before the
+// active route's own capture-phase handlers do — ReviewView and
+// MemorizeView each register `keydown` with `{capture: true}` and treat
+// 1-4 / Enter / Space as grade input. While the popover is open, swallow
+// those keys before they reach the underlying view; otherwise a user
+// typing "1" to dismiss the menu would accidentally grade the current
+// card. Escape closes the menu and is also swallowed so it doesn't
+// trigger any escape-handlers in the underlying view.
+const GRADE_KEYS = new Set(['1', '2', '3', '4', 'Enter', ' '])
 function onWindowKeydown(ev: KeyboardEvent) {
-  if (ev.key === 'Escape' && open.value) close()
+  if (!open.value) return
+  if (ev.key === 'Escape') {
+    ev.stopImmediatePropagation()
+    close()
+    return
+  }
+  if (GRADE_KEYS.has(ev.key)) {
+    ev.stopImmediatePropagation()
+    ev.preventDefault()
+  }
 }
 onMounted(() => {
   window.addEventListener('click', onWindowClick)
-  window.addEventListener('keydown', onWindowKeydown)
+  window.addEventListener('keydown', onWindowKeydown, true)
 })
 onBeforeUnmount(() => {
   window.removeEventListener('click', onWindowClick)
-  window.removeEventListener('keydown', onWindowKeydown)
+  window.removeEventListener('keydown', onWindowKeydown, true)
 })
 
 function goSwitchProfile() {
@@ -53,40 +71,58 @@ async function onSignOut() {
   // then falls through to /profiles on the next navigation. We push
   // explicitly so the user sees the picker immediately rather than
   // staying on a now-signed-out view.
-  await signOut()
-  await router.push('/profiles')
+  //
+  // The push runs in a finally so an IDB or revoke failure inside
+  // signOut() still routes the user to the picker. Landing on the
+  // picker (where they can retry or see their profile listed) is
+  // always better than being stranded on a workspace view whose
+  // sign-out attempt half-succeeded.
+  try {
+    await signOut()
+  } finally {
+    void router.push('/profiles')
+  }
 }
 </script>
 
 <template>
-  <div v-if="activeProfile" class="avatar-wrap" @click.stop>
-    <button
-      type="button"
-      class="avatar-btn"
-      :aria-expanded="open"
-      aria-haspopup="menu"
-      aria-label="Account menu"
-      @click="toggle"
-    >
-      <img
-        v-if="activeProfile.image"
-        :src="activeProfile.image"
-        :alt="activeProfile.displayName"
-      />
-      <span v-else class="initials">{{ initials }}</span>
-    </button>
-    <div v-if="open" class="menu" role="menu">
-      <div class="menu-header">
-        <p class="name">{{ activeProfile.displayName }}</p>
-        <p class="email">{{ activeProfile.email }}</p>
+  <!-- The wrap renders unconditionally so the parent grid's third
+       column always has an anchor. Without it, a brief window during
+       cold boot (before activeProfile resolves from IDB) collapses the
+       1fr/auto/1fr header grid to 1fr/auto and the brand + nav drift
+       right. The avatar button + popover are still gated on
+       activeProfile so signed-out / pre-boot states render no visible
+       chrome here. -->
+  <div class="avatar-wrap" @click.stop>
+    <template v-if="activeProfile">
+      <button
+        type="button"
+        class="avatar-btn"
+        :aria-expanded="open"
+        aria-haspopup="menu"
+        aria-label="Account menu"
+        @click="toggle"
+      >
+        <img
+          v-if="activeProfile.image"
+          :src="activeProfile.image"
+          :alt="activeProfile.displayName"
+        />
+        <span v-else class="initials">{{ initials }}</span>
+      </button>
+      <div v-if="open" class="menu" role="menu">
+        <div class="menu-header">
+          <p class="name">{{ activeProfile.displayName }}</p>
+          <p class="email">{{ activeProfile.email }}</p>
+        </div>
+        <button type="button" class="menu-item" role="menuitem" @click="goSwitchProfile">
+          Switch profile
+        </button>
+        <button type="button" class="menu-item" role="menuitem" @click="onSignOut">
+          Sign out
+        </button>
       </div>
-      <button type="button" class="menu-item" role="menuitem" @click="goSwitchProfile">
-        Switch profile
-      </button>
-      <button type="button" class="menu-item" role="menuitem" @click="onSignOut">
-        Sign out
-      </button>
-    </div>
+    </template>
   </div>
 </template>
 

--- a/apps/web/src/components/MobileTabBar.vue
+++ b/apps/web/src/components/MobileTabBar.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router'
+
+defineProps<{
+  newToMemorize: number
+}>()
+</script>
+
+<template>
+  <nav class="mobile-tab-bar" aria-label="Primary">
+    <RouterLink to="/home" class="tab">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M3 11l9-8 9 8v10a2 2 0 0 1-2 2h-4v-7H9v7H5a2 2 0 0 1-2-2V11z" />
+      </svg>
+      <span class="label">Home</span>
+    </RouterLink>
+    <RouterLink to="/review" class="tab">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <polyline points="23 4 23 10 17 10" />
+        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+      </svg>
+      <span class="label">Review</span>
+    </RouterLink>
+    <RouterLink to="/memorize" class="tab">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+      </svg>
+      <span class="label">Memorize</span>
+      <span v-if="newToMemorize > 0" class="pill">{{ newToMemorize }}</span>
+    </RouterLink>
+    <RouterLink to="/settings" class="tab">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="3" />
+        <path
+          d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.04 1.56V21a2 2 0 0 1-4 0v-.1A1.7 1.7 0 0 0 9 19.4a1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.7 1.7 0 0 0 4.64 15a1.7 1.7 0 0 0-1.56-1.04H3a2 2 0 0 1 0-4h.1A1.7 1.7 0 0 0 4.64 9a1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.7 1.7 0 0 0 1.87.34H9a1.7 1.7 0 0 0 1.04-1.56V3a2 2 0 0 1 4 0v.1a1.7 1.7 0 0 0 1.04 1.56 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.7 1.7 0 0 0-.34 1.87V9a1.7 1.7 0 0 0 1.56 1.04H21a2 2 0 0 1 0 4h-.1A1.7 1.7 0 0 0 19.4 15z"
+        />
+      </svg>
+      <span class="label">Settings</span>
+    </RouterLink>
+    <RouterLink to="/stats" class="tab">
+      <svg
+        class="icon"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <line x1="12" y1="20" x2="12" y2="10" />
+        <line x1="18" y1="20" x2="18" y2="4" />
+        <line x1="6" y1="20" x2="6" y2="16" />
+      </svg>
+      <span class="label">Stats</span>
+    </RouterLink>
+  </nav>
+</template>
+
+<style scoped>
+/* Component is rendered unconditionally; the media query keeps it
+   hidden at desktop widths. Matches the spec's "no JS branch" stance
+   so SSR-like static analysis sees the same tree at every width. */
+.mobile-tab-bar {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  .mobile-tab-bar {
+    display: flex;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 5;
+    background: var(--color-bg-card);
+    border-top: 1px solid var(--color-border);
+    justify-content: space-around;
+    padding: 0.4rem 0.25rem calc(0.4rem + env(safe-area-inset-bottom));
+  }
+}
+
+.tab {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+  flex: 1 1 0;
+  min-width: 0;
+  padding: 0.25rem 0.3rem;
+  border-radius: 4px;
+  text-decoration: none;
+  color: var(--color-muted);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+.tab.router-link-active {
+  color: var(--color-accent);
+}
+
+.icon {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.label {
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.pill {
+  position: absolute;
+  top: 0;
+  right: 0.35rem;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.05rem 0.3rem;
+  border-radius: 999px;
+  line-height: 1.3;
+}
+</style>

--- a/apps/web/src/components/MobileTabBar.vue
+++ b/apps/web/src/components/MobileTabBar.vue
@@ -95,9 +95,10 @@ defineProps<{
 </template>
 
 <style scoped>
-/* Component is rendered unconditionally; the media query keeps it
-   hidden at desktop widths. Matches the spec's "no JS branch" stance
-   so SSR-like static analysis sees the same tree at every width. */
+/* Mounted only when a user is signed in (App.vue gates `<MobileTabBar
+   v-if="user">`); the media query then keeps it hidden at desktop
+   widths via a CSS-only branch. Same shape across viewports — no
+   JS-driven mount/unmount on resize. See docs/web-nav.md §Decisions. */
 .mobile-tab-bar {
   display: none;
 }
@@ -112,12 +113,15 @@ defineProps<{
     z-index: 5;
     /* The padded height of the bar drives the `.site` padding-bottom
        in App.vue — keep `--mobile-tab-bar-h` in sync with the natural
-       height the contents produce here. */
+       height the contents produce here. The `env(...)` fallback covers
+       browsers without safe-area-inset support; without it, an
+       unresolved env() would void the entire `calc()` and collapse
+       padding to zero. */
     min-height: var(--mobile-tab-bar-h);
     background: var(--color-bg-card);
     border-top: 1px solid var(--color-border);
     justify-content: space-around;
-    padding: 0.4rem 0.25rem calc(0.4rem + env(safe-area-inset-bottom));
+    padding: 0.4rem 0.25rem calc(0.4rem + env(safe-area-inset-bottom, 0px));
   }
 }
 

--- a/apps/web/src/components/MobileTabBar.vue
+++ b/apps/web/src/components/MobileTabBar.vue
@@ -110,6 +110,10 @@ defineProps<{
     right: 0;
     bottom: 0;
     z-index: 5;
+    /* The padded height of the bar drives the `.site` padding-bottom
+       in App.vue — keep `--mobile-tab-bar-h` in sync with the natural
+       height the contents produce here. */
+    min-height: var(--mobile-tab-bar-h);
     background: var(--color-bg-card);
     border-top: 1px solid var(--color-border);
     justify-content: space-around;

--- a/apps/web/src/components/MobileTabBar.vue
+++ b/apps/web/src/components/MobileTabBar.vue
@@ -138,6 +138,11 @@ defineProps<{
   color: var(--color-accent);
 }
 
+.tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
 .icon {
   width: 1.35rem;
   height: 1.35rem;

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 import StatusChip from '@/components/StatusChip.vue'
 import type { ProfileRow } from '@/lib/engine/registry'
+import { profileInitials } from '@/lib/profile'
 
 const props = defineProps<{
   profile: ProfileRow
@@ -44,14 +45,7 @@ function onWindowClick() {
 onMounted(() => window.addEventListener('click', onWindowClick))
 onBeforeUnmount(() => window.removeEventListener('click', onWindowClick))
 
-const initials = computed(() => {
-  const source = props.profile.displayName || props.profile.email
-  const parts = source.trim().split(/\s+/)
-  const letters = parts.length >= 2
-    ? parts[0]![0]! + parts[parts.length - 1]![0]!
-    : source.slice(0, 2)
-  return letters.toUpperCase()
-})
+const initials = computed(() => profileInitials(props.profile))
 
 const lastUsedLabel = computed(() => {
   const deltaSecs = Math.max(0, Math.floor(Date.now() / 1000) - props.profile.lastUsedAt)

--- a/apps/web/src/components/StatusChip.vue
+++ b/apps/web/src/components/StatusChip.vue
@@ -5,7 +5,7 @@ withDefaults(
      *  for in-progress/attention states, `muted` for inactive states. */
     variant: 'accent' | 'warning' | 'muted'
     /** Visual density. `sm` matches the per-deck status pill in
-     *  MaterialView; `xs` matches the tighter pill on ProfileCard. */
+     *  SettingsView; `xs` matches the tighter pill on ProfileCard. */
     size?: 'sm' | 'xs'
   }>(),
   { size: 'sm' },

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -23,7 +23,7 @@
  * envelope, the composable stores it on `staleSummary` with the
  * material id. The view shows the modal and calls `confirmMerge()` or
  * `discardStale()` based on the user's choice. (Modal UI lands with the
- * MaterialView attribution work; the composable surface is in place now
+ * SettingsView attribution work; the composable surface is in place now
  * so the wiring is clean.)
  */
 
@@ -149,7 +149,7 @@ export function useEngine() {
    *  Pass `config` to apply the user's year-settings (scope toggles,
    *  headings/ftv) when constructing the engine. Without it the engine
    *  uses `MaterialConfig::default()` — fine on a brand-new account,
-   *  but surfaces the wrong card set after /material is touched. */
+   *  but surfaces the wrong card set after /settings is touched. */
   async function init(id: string, config?: WireMaterialConfig) {
     try {
       await engineStore.loadEngine(id, nowSecs(), config)

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -1,0 +1,14 @@
+import type { ProfileRow } from '@/lib/engine/registry'
+
+/** Two uppercase letters that represent a profile in an avatar circle.
+ *  Uses the display-name's first + last word when there are two or more,
+ *  otherwise the first two characters of the source. Falls back to the
+ *  email when no display name is set. */
+export function profileInitials(profile: Pick<ProfileRow, 'displayName' | 'email'>): string {
+  const source = profile.displayName || profile.email
+  const parts = source.trim().split(/\s+/)
+  const letters = parts.length >= 2
+    ? parts[0]![0]! + parts[parts.length - 1]![0]!
+    : source.slice(0, 2)
+  return letters.toUpperCase()
+}

--- a/apps/web/src/lib/profile.ts
+++ b/apps/web/src/lib/profile.ts
@@ -3,10 +3,12 @@ import type { ProfileRow } from '@/lib/engine/registry'
 /** Two uppercase letters that represent a profile in an avatar circle.
  *  Uses the display-name's first + last word when there are two or more,
  *  otherwise the first two characters of the source. Falls back to the
- *  email when no display name is set. */
+ *  email when no display name is set, and to `?` when both are missing
+ *  so the circle never renders blank. */
 export function profileInitials(profile: Pick<ProfileRow, 'displayName' | 'email'>): string {
-  const source = profile.displayName || profile.email
-  const parts = source.trim().split(/\s+/)
+  const source = (profile.displayName || profile.email).trim()
+  if (!source) return '?'
+  const parts = source.split(/\s+/)
   const letters = parts.length >= 2
     ? parts[0]![0]! + parts[parts.length - 1]![0]!
     : source.slice(0, 2)

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -12,10 +12,11 @@ let reconcileFired = false
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-    { path: '/', redirect: '/dashboard' },
+    { path: '/', redirect: '/home' },
     { path: '/session', redirect: '/review' },
     { path: '/signin', redirect: '/profiles' },
     { path: '/material', redirect: '/settings' },
+    { path: '/dashboard', redirect: '/home' },
     {
       path: '/profiles',
       name: 'profiles',
@@ -23,9 +24,9 @@ const router = createRouter({
       meta: { public: true },
     },
     {
-      path: '/dashboard',
-      name: 'dashboard',
-      component: () => import('@/views/DashboardView.vue'),
+      path: '/home',
+      name: 'home',
+      component: () => import('@/views/HomeView.vue'),
     },
     {
       path: '/review',
@@ -96,7 +97,7 @@ router.beforeEach(async (to) => {
 
   if (to.meta.public) {
     if (signedIn && to.name === 'profiles' && to.query.force !== '1') {
-      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/dashboard'
+      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/home'
       return redirect
     }
     return true

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -9,6 +9,18 @@ import {
 
 let reconcileFired = false
 
+/** A `?redirect=` query parameter is attacker-controllable — guard against
+ *  external URLs and protocol-relative `//evil.com` paths. Only
+ *  same-origin SPA paths (starting with a single `/`) are honoured;
+ *  anything else falls back to the default landing route. */
+function safeRedirect(raw: unknown): string {
+  if (typeof raw !== 'string') return '/home'
+  if (!raw.startsWith('/') || raw.startsWith('//')) return '/home'
+  return raw
+}
+
+export { safeRedirect }
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
@@ -97,8 +109,7 @@ router.beforeEach(async (to) => {
 
   if (to.meta.public) {
     if (signedIn && to.name === 'profiles' && to.query.force !== '1') {
-      const redirect = typeof to.query.redirect === 'string' ? to.query.redirect : '/home'
-      return redirect
+      return safeRedirect(to.query.redirect)
     }
     return true
   }

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -15,6 +15,7 @@ const router = createRouter({
     { path: '/', redirect: '/dashboard' },
     { path: '/session', redirect: '/review' },
     { path: '/signin', redirect: '/profiles' },
+    { path: '/material', redirect: '/settings' },
     {
       path: '/profiles',
       name: 'profiles',
@@ -42,9 +43,9 @@ const router = createRouter({
       component: () => import('@/views/StatsView.vue'),
     },
     {
-      path: '/material',
-      name: 'material',
-      component: () => import('@/views/MaterialView.vue'),
+      path: '/settings',
+      name: 'settings',
+      component: () => import('@/views/SettingsView.vue'),
     },
   ],
 })

--- a/apps/web/src/views/DashboardView.vue
+++ b/apps/web/src/views/DashboardView.vue
@@ -134,7 +134,7 @@ onMounted(async () => {
     <template v-else-if="empty">
       <section class="empty">
         <p class="empty-line"><em>This codex is empty.</em></p>
-        <RouterLink to="/material" class="empty-cta">
+        <RouterLink to="/settings" class="empty-cta">
           Choose your first year
           <span aria-hidden="true">↗</span>
         </RouterLink>

--- a/apps/web/src/views/HomeView.vue
+++ b/apps/web/src/views/HomeView.vue
@@ -501,7 +501,7 @@ onMounted(async () => {
 }
 
 /* Idle (zero-count) tiles dim so the lit ones lead the eye.
-   Modifier is `stage-idle`, not `empty`, because the dashboard's
+   Modifier is `stage-idle`, not `empty`, because this view's
    no-enrollments `.empty` rule below would otherwise cascade onto
    these tiles by accident. */
 .codex.revealed .stage-idle {

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -411,7 +411,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown, true))
     <div v-else-if="empty" class="done">
       <h2>Nothing to memorize</h2>
       <p>
-        Activate a club in <RouterLink to="/material">/material</RouterLink> to introduce new
+        Activate a club in <RouterLink to="/settings">/settings</RouterLink> to introduce new
         verses.
       </p>
     </div>

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -10,6 +10,7 @@ import SignInForm from '@/components/SignInForm.vue'
 import TypeToConfirmDialog from '@/components/TypeToConfirmDialog.vue'
 import { useAuth } from '@/composables/useAuth'
 import { downloadJson, exportFilename, readJsonFile } from '@/lib/account-file'
+import { safeRedirect } from '@/router'
 import type { ProfileRow } from '@/lib/engine/registry'
 
 const {
@@ -66,7 +67,7 @@ watch(
 )
 
 function redirectTarget(): string {
-  return typeof route.query.redirect === 'string' ? route.query.redirect : '/home'
+  return safeRedirect(route.query.redirect)
 }
 
 async function onCardEnter(profile: ProfileRow) {

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -66,7 +66,7 @@ watch(
 )
 
 function redirectTarget(): string {
-  return typeof route.query.redirect === 'string' ? route.query.redirect : '/dashboard'
+  return typeof route.query.redirect === 'string' ? route.query.redirect : '/home'
 }
 
 async function onCardEnter(profile: ProfileRow) {

--- a/apps/web/src/views/SettingsView.vue
+++ b/apps/web/src/views/SettingsView.vue
@@ -279,8 +279,8 @@ onMounted(refresh)
 </script>
 
 <template>
-  <div class="material">
-    <h2>Material</h2>
+  <div class="settings">
+    <h2>Settings</h2>
     <div v-if="error" class="banner banner-error">{{ error }}</div>
     <div v-if="loading" class="status">Loading…</div>
     <div v-else-if="cards.length === 0" class="status">
@@ -490,7 +490,7 @@ onMounted(refresh)
 </template>
 
 <style scoped>
-.material {
+.settings {
   width: 100%;
   max-width: 720px;
   display: flex;

--- a/apps/web/src/views/StatsView.vue
+++ b/apps/web/src/views/StatsView.vue
@@ -72,7 +72,7 @@ onMounted(async () => {
     <div v-else-if="loading" class="status">Loading…</div>
     <div v-else-if="empty" class="status">
       No enrolled years yet. Pick one in
-      <RouterLink to="/material">/material</RouterLink> to start.
+      <RouterLink to="/settings">/settings</RouterLink> to start.
     </div>
     <div v-else class="content">
       <h2>Stats</h2>

--- a/docs/web-nav.md
+++ b/docs/web-nav.md
@@ -67,7 +67,7 @@ puts each in its own slot.
    * Desktop: same top bar as the action layer.
 
 3. **Identity layer** — who you are and how you administer this account.
-   * Members: signed-in email, **Switch profile**, future **Sign out**, future **Account →** link
+   * Members: signed-in email, **Switch profile**, **Sign out**, and a future **Account →** link
      (deep-link into the Account section of `/settings`).
    * Mobile and desktop: avatar/initials button top-right, opens a popover menu.
 
@@ -127,23 +127,22 @@ Single feature branch (`feat/web-nav-redesign`), one commit per logical step. Th
 Each step ships independently with no behaviour regression. Step 1 is mechanical; step 2 is the
 biggest visual change; step 3 is additive.
 
-## Open questions
+## Decisions
 
-* **Bottom-bar breakpoint.** 720 px is the existing `max-width: 720px` value `.settings` uses for
-  its centered column. Could also key off `pointer: coarse` to handle desktop windows narrowed to
-  phone width. Default: width-based; revisit if it misbehaves on landscape phones.
-* **Icon set.** No icons in the codebase today. Lightweight options: inline SVGs in
-  `components/icons/`, or pull a single icon font (Lucide, Tabler). Default: inline SVGs to avoid a
-  runtime dep.
+* **Bottom-bar breakpoint.** Width-based at 720 px, matching the existing `max-width: 720px` that
+  `.settings` uses for its centered column. Revisit if it misbehaves on landscape phones.
+* **Icon set.** Inline Lucide-style SVGs declared directly in `MobileTabBar.vue`. No runtime icon
+  dep; if a second consumer wants the same glyphs later, extract to `components/icons/` then.
 
 ## Backlog
 
 Tracked here so the spec stays the canonical record; promote to GitHub issues as work picks up.
 
-* **Account sub-page under `/settings`.** Migrate export / import / delete-all-progress out of
-  `ProfilePickerView`'s profile-card kebabs into a real `/settings` → Account section. The profile
-  switcher links into it; the kebabs go away. Lets `/profiles` go back to being purely sign-in +
-  multi-profile switching, which is its original job.
+* **Account sub-page under `/settings`**
+  ([#92](https://github.com/TommyAmberson/verse-vault/issues/92)). Migrate export / import /
+  delete-all-progress out of `ProfilePickerView`'s profile-card kebabs into a real `/settings` →
+  Account section. The profile switcher links into it; the kebabs go away. Lets `/profiles` go back
+  to being purely sign-in + multi-profile switching, which is its original job.
 * **Search route.** First reference-layer addition; no design exists yet.
 * **Theme / appearance.** Once a global preference exists, slot under `/settings` → Appearance.
 * **About / attribution surface.** Currently the API.Bible + NKJV copyright lines in the footer;

--- a/docs/web-nav.md
+++ b/docs/web-nav.md
@@ -1,0 +1,150 @@
+# Web nav
+
+Information architecture and layout for the web client's top-level navigation. Covers the route
+inventory, mobile vs. desktop chrome, and how identity/account chores fit in. Drives the redesign of
+the current single-row `<header>` in `apps/web/src/App.vue`, which overflows on phones and mixes
+navigation with identity.
+
+## Goals
+
+* **Thumb-friendly on mobile.** The daily-driver actions (start a review, memorize new verses) must
+  be reachable without reaching the top of the screen and without going through a menu.
+* **Same Vue bundle scales to desktop.** Tauri reuses this client (`docs/architecture.md`), so the
+  nav has to read well in a desktop window too — not just a phone.
+* **Identity is not navigation.** Email, switch-profile, sign-out, export/import/reset belong in a
+  corner menu, not in the row alongside Review and Memorize.
+* **Room to grow.** Future Search, Account sub-page, History, and a real preferences surface should
+  slot in without a redesign.
+
+## Current state
+
+`App.vue` renders a single `<header>` with a flex row containing: brand, five `<RouterLink>`s
+(Dashboard, Review, Memorize, Settings, Stats), the signed-in email as plain text, and a **Switch
+profile** link styled as a button. There is no responsive treatment — on a phone the row just
+overflows. Account-data management (export / import / delete-all-progress) is buried as kebab menu
+items inside `ProfilePickerView`'s profile cards, not surfaced anywhere in the nav.
+
+## Route inventory
+
+Source of truth: `apps/web/src/router/index.ts`.
+
+| Route       | View                | Purpose                                                                                      | Cadence      |
+| ----------- | ------------------- | -------------------------------------------------------------------------------------------- | ------------ |
+| `/home`     | `HomeView`          | At-a-glance landing: stability, recent activity, empty-state CTA                             | daily glance |
+| `/review`   | `ReviewView`        | Run a review session (single-grade pipeline)                                                 | daily action |
+| `/memorize` | `MemorizeView`      | Read → drill new-card walkthrough across enrolled years                                      | daily-ish    |
+| `/settings` | `SettingsView`      | Per-year scope sliders, headings/ftv toggles, offline-mode                                   | weekly+      |
+| `/stats`    | `StatsView`         | Activity heatmap and aggregate stats                                                         | weekly+      |
+| `/profiles` | `ProfilePickerView` | Sign-in form + multi-profile picker; **also** the secret home of account export/import/reset | rare         |
+
+Aliases (redirects): `/` → `/home`, `/session` → `/review`, `/signin` → `/profiles`, `/material` →
+`/settings`, `/dashboard` → `/home`.
+
+### Future surfaces to leave room for
+
+Not building these now — but the nav design must not preclude them:
+
+* **Search / browse** — look at a verse outside the review/memorize flow. Reference layer.
+* **Account sub-page under `/settings`** — relocate export / import / delete-all-progress out of
+  `ProfilePickerView`'s kebabs into a real Account section. Linked from the profile switcher. See
+  _Backlog_ below.
+* **History / audit log** — server already has the event log; no UI today. Reference layer.
+* **About / attribution / help** — currently in the footer; would slot into the identity menu.
+
+## IA: three layers
+
+The nav has three semantically distinct layers. Today they're crammed into one row; the redesign
+puts each in its own slot.
+
+1. **Action layer** — the verbs the user came to do.
+   * Members: **Review**, **Memorize**.
+   * Mobile: bottom tab bar (thumb-reach).
+   * Desktop: integrated into the top bar with the reference layer.
+
+2. **Reference layer** — landing pages and inspection surfaces.
+   * Members: **Home** (`/home`), **Settings**, **Stats**.
+   * Mobile: bottom tab bar alongside the action layer (5 tabs total).
+   * Desktop: same top bar as the action layer.
+
+3. **Identity layer** — who you are and how you administer this account.
+   * Members: signed-in email, **Switch profile**, future **Sign out**, future **Account →** link
+     (deep-link into the Account section of `/settings`).
+   * Mobile and desktop: avatar/initials button top-right, opens a popover menu.
+
+The action / reference split is conceptual, not visual. On screen, both layers live in the same
+component (the bottom tab bar on mobile, the top bar on desktop). The split governs _priority_: if
+we ever need to demote a destination to a "More" sheet, reference items go first.
+
+## Layout
+
+### Mobile (≤ 720 px viewport width)
+
+* **Top bar** (sticky): brand on the left, avatar button on the right. ~48 px tall. No nav links.
+* **Bottom tab bar** (sticky): five tabs in this left-to-right order: **Home · Review · Memorize ·
+  Settings · Stats**. Icon + short label per tab. The active tab uses the existing `--color-accent`
+  treatment.
+* **Memorize-new pill**: the existing "new to memorize" count badge follows the Memorize tab.
+* **Safe-area inset**: bottom bar respects `env(safe-area-inset-bottom)` so it sits above the iOS
+  home indicator and Android gesture bar.
+
+### Desktop (> 720 px viewport width)
+
+* **Single top bar** (sticky): brand on the left, five nav links in the middle (**Home · Review ·
+  Memorize · Settings · Stats**), avatar button on the right.
+* No bottom bar.
+
+### Identity popover
+
+Opened by tapping the avatar in either layout. Contents (top to bottom):
+
+1. Signed-in email (read-only header).
+2. **Switch profile** (existing `/profiles?force=1` link).
+3. **Sign out** (future — currently no sign-out affordance exists in the nav).
+4. **Account →** (backlog — deep-link to `/settings#account` once that section ships).
+
+Keep the popover light on chrome — small surface, plenty of padding, no nested submenus.
+
+## Implementation plan
+
+Single feature branch (`feat/web-nav-redesign`), one commit per logical step. The `/material` →
+`/settings` rename is already on this branch as commit 1.
+
+1. **Rename `/dashboard` → `/home`.** `DashboardView.vue` → `HomeView.vue`, route + name + nav label
+   updated, redirect `/dashboard` → `/home` for back-compat with bookmarks. Parallel to the
+   `/material` → `/settings` rename in shape and rationale.
+2. **Avatar component + identity popover.** New `AppAvatar.vue` + popover, wired to existing auth
+   state. Replaces the email-text + Switch-profile link in `App.vue`'s header. Desktop and mobile
+   both render this from day one.
+3. **Top bar layout.** Refactor `App.vue`'s `<header>` into a brand-left / nav-center / avatar-right
+   composition. Single-row at desktop widths.
+4. **Bottom tab bar.** New `MobileTabBar.vue`. Rendered at mobile widths only (CSS media query; no
+   JS branch). Adds a `padding-bottom` rule on `.site-main` equal to the bar height so content isn't
+   covered.
+5. **Polish + a11y.** Tab `aria-current="page"` on active routes, focus-visible rings,
+   reduced-motion handling for any transitions. Manual smoke on a phone-sized viewport (golden path:
+   review, memorize, switch via tab bar, open identity popover, switch profile).
+
+Each step ships independently with no behaviour regression. Step 1 is mechanical; step 2 is the
+biggest visual change; step 3 is additive.
+
+## Open questions
+
+* **Bottom-bar breakpoint.** 720 px is the existing `max-width: 720px` value `.settings` uses for
+  its centered column. Could also key off `pointer: coarse` to handle desktop windows narrowed to
+  phone width. Default: width-based; revisit if it misbehaves on landscape phones.
+* **Icon set.** No icons in the codebase today. Lightweight options: inline SVGs in
+  `components/icons/`, or pull a single icon font (Lucide, Tabler). Default: inline SVGs to avoid a
+  runtime dep.
+
+## Backlog
+
+Tracked here so the spec stays the canonical record; promote to GitHub issues as work picks up.
+
+* **Account sub-page under `/settings`.** Migrate export / import / delete-all-progress out of
+  `ProfilePickerView`'s profile-card kebabs into a real `/settings` → Account section. The profile
+  switcher links into it; the kebabs go away. Lets `/profiles` go back to being purely sign-in +
+  multi-profile switching, which is its original job.
+* **Search route.** First reference-layer addition; no design exists yet.
+* **Theme / appearance.** Once a global preference exists, slot under `/settings` → Appearance.
+* **About / attribution surface.** Currently the API.Bible + NKJV copyright lines in the footer;
+  could move to identity menu → About.

--- a/docs/web-nav.md
+++ b/docs/web-nav.md
@@ -97,9 +97,9 @@ we ever need to demote a destination to a "More" sheet, reference items go first
 
 Opened by tapping the avatar in either layout. Contents (top to bottom):
 
-1. Signed-in email (read-only header).
+1. Display name + signed-in email (read-only header).
 2. **Switch profile** (existing `/profiles?force=1` link).
-3. **Sign out** (future — currently no sign-out affordance exists in the nav).
+3. **Sign out** (calls `useAuth().signOut()` against the active profile, then pushes `/profiles`).
 4. **Account →** (backlog — deep-link to `/settings#account` once that section ships).
 
 Keep the popover light on chrome — small surface, plenty of padding, no nested submenus.


### PR DESCRIPTION
## Summary

Redesigns the web client's top-level nav, driven by `docs/web-nav.md` (added in `b63edfc`). The old single-flex-row `<header>` mixed brand, 5 nav links, the signed-in email, and a Switch-profile button — overflowing on phones and noisy on desktop.

### What changed

- **Route renames** (with redirects):
  - `/material` → `/settings` (`bc18748`) — the page is settings, not content
  - `/dashboard` → `/home` (`ce3da2a`) — landing-glance, not a widgets dashboard
- **Identity popover** (`758fae7`) — new `AppAvatar.vue` replaces the inline email + Switch-profile link. Avatar opens a popover with display name + email, Switch profile, and **Sign out** (first time the top nav has had a sign-out affordance).
- **Top bar grid layout** (`da4d19c`) — `1fr auto 1fr`: brand-left / nav-center / avatar-right.
- **Mobile bottom tab bar** (`0cd5005`) — `MobileTabBar.vue`, 5 tabs at ≤720 px with inline Lucide-style SVG icons + the Memorize-new pill. Inline top-bar nav hides at the same breakpoint.
- **Polish + a11y** (`ee1c99b`) — Escape closes the popover; `:focus-visible` rings on avatar, popover items, brand, nav links, and tab-bar tabs.
- **`/simplify` pass** (`034ab3c`) — extract `profileInitials()` helper (shared by `AppAvatar` and `ProfileCard`), `--mobile-tab-bar-h` CSS variable, layout cleanup.
- **Grid column 3 fix** (`58949d4`) — pin the avatar via `grid-column: 3 + justify-self: end` so it stays right-aligned when `.nav` is `display: none` at mobile widths.
- **`/code-review` pass** (`a6fcee4`) — fixes from an extra-high-effort review:
  - Open-redirect on `?redirect=` query parameter (security) — new `safeRedirect()` helper rejects anything not starting with a single `/`
  - Avatar popover swallowed grade keys — move keydown to capture phase, `stopImmediatePropagation` 1–4 / Enter / Space / Escape while open (`ReviewView` and `MemorizeView` register with `{capture: true}`)
  - `onSignOut` strands user on throw — push moves into `finally`
  - Cold-boot grid collapse — always-mount the avatar wrap so column 3 has an anchor
  - Phantom mobile padding on signed-out routes — gated via `.site.has-user`
  - Missing `env(...)` fallback inside `calc(...)` — both call sites
  - `profileInitials` blank fallback for empty `displayName` + `email`
  - Stale "rendered unconditionally" comment in `MobileTabBar.vue`

`/material` and `/dashboard` redirect to the new paths so existing bookmarks keep working. Account-data management (export / import / delete-progress) intentionally stays on `ProfilePickerView`'s profile-card kebabs for now — `docs/web-nav.md` backlog (and [#92](https://github.com/TommyAmberson/verse-vault/issues/92)) tracks the migration to a `/settings` → Account section.

Branch was rebased onto master after [#93](https://github.com/TommyAmberson/verse-vault/pull/93) landed; the original `fix(api): rate-limit + cors fixes for dev` commit was patch-id deduplicated automatically.

## Test plan

- [x] `pnpm type-check` clean throughout
- [ ] Manual smoke on desktop:
  - Nav at brand-left / nav-center / avatar-right
  - Avatar opens popover; Escape closes; click outside closes
  - Switch profile lands on `/profiles?force=1`
  - Sign out clears session and routes to `/profiles`
  - Bookmarked `/material` redirects to `/settings`; `/dashboard` to `/home`
  - Tab key cycles through nav with visible focus rings
- [ ] Manual smoke on a narrow (≤720 px) viewport:
  - Inline top-bar nav hides; bottom tab bar visible
  - Memorize tab shows count pill when `newToMemorize > 0`
  - Bar sits above the iOS home indicator (safe-area)
  - Active tab shows accent colour
- [ ] On `/memorize` or `/review`, open the avatar popover and press "1" — the popover should swallow it (NOT grade the current card)
- [ ] Try a crafted `/profiles?redirect=https://example.com` while signed in — should land on `/home`, not the external URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)