### PR TITLE
Existing-bug sweep: pass-2 expansion across core / wasm / api / web / tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,15 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Fix dead OfflineBanner click
+
+* `OfflineBanner.vue`'s click handler was pushing `{ name: 'signin', ... }`, but the `/signin` route
+  in `router/index.ts` is a bare `{ path, redirect }` shim with no `name:` field. Vue Router
+  silently returned a navigation failure, so a signed-out user clicking the "Sign in to sync."
+  banner stayed put — the banner did nothing. Push to `{ name: 'profiles', ... }` (which is a real
+  named route) so the click actually reaches the picker. Pre-existing bug surfaced by the
+  nav-redesign code review.
+
 ### `/code-review` pass on the nav redesign
 
 * **Open-redirect via `?redirect=`.** `router/index.ts`'s `beforeEach` guard and

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,41 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+### Correctness sweep on engine-store + memorize input
+
+Four real bugs surfaced by an exhaustive review pass. Each was independently confirmed by tracing
+the IDB write path or the keyboard-input path under the relevant trigger.
+
+* **Concurrent graduations dropped ids.** `persistLocalGraduation` was doing `await getSnapshot()` →
+  mutate → `await putSnapshot()` with no serialisation. `MemorizeView`'s
+  `Promise.all([submitGraduation(...), ...conditionalCardIds.map(submitCardGraduation)])` fired
+  multiple concurrent calls; every one read the same pre-mutation snapshot, each appended only its
+  own id, the last `putSnapshot` overwrote the others. The next page-load `loadEngine` then
+  graduated only the surviving id; every other graduation silently regressed to `New` and reappeared
+  in the memorize queue. Per-`materialId` `persistGraduationChains` map now serialises the reads +
+  writes.
+* **409 retry wedged on stale `snapshotVersion`.** Queued events bake the local `snapshotVersion` in
+  at queue time. On a 409 the catch arm refetched the live snapshot but didn't rewrite the queue, so
+  the next flush re-sent the same rows with the stale version and the server 409'd again. New
+  `idb.rewriteQueuedSnapshotVersion(materialId, ...)` runs after `refetchSyncState`, so the queued
+  events carry the upgraded version on the next attempt.
+* **Server-side rebuild dropped graduation state.** When `flush` got back `rebuilt: true`, the
+  client `.free()`'d the engine and rebuilt it from `snapshot.materialData + response.testStates`
+  but skipped `applyGraduations(...)`. Graduated verses leaked back into the New pool and next-card
+  selection ignored prior graduations until a full page reload re-entered `loadEngine`. `loadEngine`
+  and `refetchSyncState` both apply graduations after `createEngine`; this path now matches.
+* **Profile switch leaked cross-profile writes.** `clearAllSessions` was synchronous and just
+  cleared its maps. An in-flight `doFlush` for profile A kept running and its response handler ran
+  `await idb.replaceAllTestStates(...)` AFTER `enterProfile(B)` had swapped the active IDB — writing
+  profile A's testStates into profile B's IDB. `clearAllSessions` is now async and awaits every
+  in-flight flush + every per-`materialId` persistGraduation chain (settled, not resolved, so a
+  single rejection doesn't block cleanup). Every caller in `useAuth.ts` now awaits it.
+* **`MemorizeView` grade keys silently skipped drill cards.** `gradeAgain` / `gradeGood` checked
+  `if (submitting.value) return` but never set `submitting.value = true`. A user pressing "1" or "3"
+  twice in quick succession (key auto-repeat included) executed `drillQueue.value.shift()` twice
+  before the first `loadDrillCard` finished — the second card was popped off the queue without ever
+  being displayed or graded. Both handlers now set `submitting` in a `try/finally`.
+
 ### Fix dead OfflineBanner click
 
 * `OfflineBanner.vue`'s click handler was pushing `{ name: 'signin', ... }`, but the `/signin` route

--- a/apps/web/src/components/OfflineBanner.vue
+++ b/apps/web/src/components/OfflineBanner.vue
@@ -55,7 +55,23 @@ function onClick() {
   // the user to the picker. The banner stays as a passive indicator
   // until a future navigation flips syncState back to 'online'.
   if (syncState.value === 'rate-limited') return
-  void router.push({ name: 'signin', query: { redirect: route.fullPath } })
+  // Push to the `profiles` named route directly. Two corrections on
+  // top of the original `name: 'signin'` push (which targeted a route
+  // shim with no `name:` field and silently no-op'd):
+  //   1. Use the `profiles` named route, which actually exists.
+  //   2. Pass `force: '1'` so the router's `beforeEach` guard
+  //      doesn't immediately bounce us back. The guard treats a
+  //      registry-pinned activeProfile as `signedIn = true` and
+  //      redirects any /profiles navigation back to `redirect=` unless
+  //      `force` is set — but the OfflineBanner only renders when
+  //      `syncState !== 'online'`, which is exactly the
+  //      registry-pinned-but-server-says-no-session case the user
+  //      needs to escape via the picker. AppAvatar.vue:64 uses the
+  //      same `force=1` pattern for the same reason.
+  void router.push({
+    name: 'profiles',
+    query: { redirect: route.fullPath, force: '1' },
+  })
 }
 </script>
 

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -287,8 +287,12 @@ export async function signInComplete(
   }
 
   // Switch the persistence layer to the new profile's DB before any
-  // migration so the eager open creates all stores.
-  clearAllSessions()
+  // migration so the eager open creates all stores. clearAllSessions
+  // is awaited so any in-flight flush or persistLocalGraduation
+  // settles against the OLD profile's IDB before the swap — otherwise
+  // its response handler writes the old profile's testStates into
+  // the new profile's IDB after the swap.
+  await clearAllSessions()
   await setActiveProfile(user.id)
 
   if (isFirstEverProfile) {
@@ -330,7 +334,7 @@ export async function enterProfile(profileId: string): Promise<EnterResult> {
     // Offline — enter the cached profile anyway.
   }
 
-  clearAllSessions()
+  await clearAllSessions()
   await setActiveProfile(profileId)
 
   const touched: registry.ProfileRow = { ...row, lastUsedAt: nowSecs() }
@@ -360,7 +364,7 @@ export async function deleteProfile(profileId: string): Promise<void> {
   }
 
   if (wasActive) {
-    clearAllSessions()
+    await clearAllSessions()
     await setActiveProfile(null)
     await registry.setLastActiveProfileId(null)
     activeProfile.value = null
@@ -393,7 +397,7 @@ export async function deleteProfile(profileId: string): Promise<void> {
  *  (this only swaps the persistence-layer handle), so the caller stays
  *  on the same profile. */
 async function resetProfileLocalData(profileId: string): Promise<void> {
-  clearAllSessions()
+  await clearAllSessions()
   await setActiveProfile(null)
   await deleteIdb(profileDbName(profileId))
   await setActiveProfile(profileId)
@@ -423,7 +427,7 @@ export async function signOut(targetProfileId?: string): Promise<void> {
   if (activeProfile.value?.profileId === targetId) {
     await registry.setLastActiveProfileId(null)
     await setActiveProfile(null)
-    clearAllSessions()
+    await clearAllSessions()
     activeProfile.value = null
     // Reset the load-once flag so the next sign-in re-reads the
     // registry — keeps the "flag true ⟺ registry consulted this

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -149,10 +149,16 @@ export function useEngine() {
    *  Pass `config` to apply the user's year-settings (scope toggles,
    *  headings/ftv) when constructing the engine. Without it the engine
    *  uses `MaterialConfig::default()` — fine on a brand-new account,
-   *  but surfaces the wrong card set after /settings is touched. */
-  async function init(id: string, config?: WireMaterialConfig) {
+   *  but surfaces the wrong card set after /settings is touched.
+   *
+   *  Pass `desiredRetention` to honour the user's `/settings` target-
+   *  retention slider in the local-first hot path. Omitting it falls
+   *  back to the engine's default (0.9), which silently disagrees with
+   *  the server scheduler whenever the user has set a non-default
+   *  value. */
+  async function init(id: string, config?: WireMaterialConfig, desiredRetention?: number) {
     try {
-      await engineStore.loadEngine(id, nowSecs(), config)
+      await engineStore.loadEngine(id, nowSecs(), config, desiredRetention)
       active.add(id)
       await refreshCounts()
       ready.value = true
@@ -250,7 +256,27 @@ export function useEngine() {
   }
 
   /** Drop the queued events the server flagged stale on the affected
-   *  material. The user explicitly chose to throw them away. */
+   *  material. The user explicitly chose to throw them away.
+   *
+   *  This must also drop the cached engine + snapshot, NOT just the
+   *  event queue. Reasons:
+   *    1. The cached in-memory engine still has `replay_event` mutations
+   *       from every grade in the discarded batch, so its next-card
+   *       picker would keep showing the post-grade view even though
+   *       those grades are gone.
+   *    2. Worse, `submitGraduation` / `submitCardGraduation` write to
+   *       `snapshot.graduatedVerseIds` / `graduatedCardIds` via
+   *       `persistLocalGraduation` *separately* from queuing the
+   *       event. Discarding the queue rows leaves those lists with
+   *       entries the server never received — and on the next page
+   *       reload `loadEngine` re-applies them via `applyGraduations`,
+   *       diverging the local engine from the server permanently.
+   *
+   *  `invalidateSession` drops the cached engine + render cache;
+   *  `deleteSnapshot` drops the IDB snapshot so the next loadEngine
+   *  cold-paths through `GET /state` and rebuilds from the server's
+   *  authoritative view.
+   */
   async function discardStale() {
     const stale = staleSummary.value
     if (!stale) return
@@ -260,6 +286,8 @@ export function useEngine() {
     // response; without clearing it here, subsequent flushes would
     // continue to no-op even though there's nothing to confirm.
     engineStore.clearStaleGate(stale.materialId)
+    await engineStore.invalidateSession(stale.materialId)
+    await idb.deleteSnapshot(stale.materialId)
     staleSummary.value = null
     await refreshCounts()
     await engineStore.loadEngine(stale.materialId, nowSecs())

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -46,6 +46,13 @@ interface EngineSession {
   /** Cached so refetch + rebuild paths can re-pass it to `createEngine`
    *  without the caller having to reload year settings every time. */
   materialConfig: WireMaterialConfig | undefined
+  /** FSRS target retention the engine was constructed with. Same
+   *  motivation as `materialConfig`: refetch + rebuild paths re-pass
+   *  it, and the server-side scheduler uses the same per-user value
+   *  (packages/api/src/lib/enrollment.ts), so the local engine has to
+   *  honour the user's `/settings` slider rather than falling back to
+   *  the constant default. */
+  desiredRetention: number
 }
 
 function requireSession(materialId: string, caller: string): EngineSession {
@@ -114,6 +121,7 @@ export async function loadEngine(
   materialId: string,
   nowSecs: number,
   materialConfig?: WireMaterialConfig,
+  desiredRetention: number = DEFAULT_DESIRED_RETENTION,
 ): Promise<EngineSession> {
   const existing = sessions.get(materialId)
   if (existing) return existing
@@ -142,7 +150,7 @@ export async function loadEngine(
     materialData: snapshot.materialData,
     materialConfig: materialConfig ?? '',
     testStates,
-    desiredRetention: DEFAULT_DESIRED_RETENTION,
+    desiredRetention,
     nowSecs,
   })
   applyGraduations(engine, snapshot.graduatedVerseIds, snapshot.graduatedCardIds)
@@ -152,6 +160,7 @@ export async function loadEngine(
     engine,
     snapshotVersion: snapshot.version,
     materialConfig,
+    desiredRetention,
   }
   sessions.set(materialId, session)
   return session
@@ -186,7 +195,7 @@ async function refetchSyncState(session: EngineSession, nowSecs: number): Promis
     materialData: fetched.snapshot.materialData,
     materialConfig: session.materialConfig ?? '',
     testStates: fetched.testStates,
-    desiredRetention: DEFAULT_DESIRED_RETENTION,
+    desiredRetention: session.desiredRetention,
     nowSecs,
   })
   const previous = session.engine
@@ -541,7 +550,7 @@ async function doFlush(
         materialData: snapshot.materialData,
         materialConfig: session.materialConfig ?? '',
         testStates: response.testStates,
-        desiredRetention: DEFAULT_DESIRED_RETENTION,
+        desiredRetention: session.desiredRetention,
         nowSecs,
       })
       const previous = session.engine

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -56,6 +56,13 @@ function requireSession(materialId: string, caller: string): EngineSession {
 
 const sessions = new Map<string, EngineSession>()
 const inflightFlushes = new Map<string, Promise<FlushResult>>()
+/** Per-(materialId) serialisation chain for `persistLocalGraduation`. The
+ *  snapshot read-modify-write window in `persistLocalGraduation` runs as
+ *  two separate IDB operations, so concurrent fire-and-forget calls (e.g.
+ *  `MemorizeView`'s `Promise.all([submitGraduation, ...submitCardGraduation])`)
+ *  would each see the same pre-mutation snapshot and overwrite each
+ *  other's ids. Chaining onto the previous promise serialises them. */
+const persistGraduationChains = new Map<string, Promise<void>>()
 /** Materials the server has flagged with a stale-merge `needsConfirm`.
  *  Flush calls for these no-op until either `confirmMerge: true` is
  *  passed (which bypasses the gate and clears it on success) or
@@ -169,14 +176,22 @@ async function refetchSyncState(session: EngineSession, nowSecs: number): Promis
   if (fetched.snapshot.version !== session.snapshotVersion) {
     await idb.clearRenders(session.materialId)
   }
-  session.engine.free()
-  session.engine = createEngine({
+  // Build the replacement engine BEFORE freeing the old one — a
+  // free-then-create order leaves `session.engine` pointing at a
+  // dead Rust struct if `WasmEngine::new` throws (mismatched
+  // contract version, malformed materialData, etc.), and the next
+  // requireSession-driven call would trap dereferencing it. Build
+  // first → swap atomically → free the old engine only on success.
+  const replacement = createEngine({
     materialData: fetched.snapshot.materialData,
     materialConfig: session.materialConfig ?? '',
     testStates: fetched.testStates,
     desiredRetention: DEFAULT_DESIRED_RETENTION,
     nowSecs,
   })
+  const previous = session.engine
+  session.engine = replacement
+  previous.free()
   applyGraduations(session.engine, fetched.graduatedVerseIds, fetched.graduatedCardIds)
   session.snapshotVersion = fetched.snapshot.version
 }
@@ -267,15 +282,35 @@ export async function submitGraduation(
 // in IDB — `getSnapshot` is treated as infallible here. A missing row
 // signals genuine IDB corruption and propagates as a thrown error
 // through the surrounding fire-and-forget `.catch`.
+//
+// Concurrent calls are serialised via `persistGraduationChains` so the
+// read-modify-write of `graduatedVerseIds` / `graduatedCardIds` is
+// race-free. Without serialisation, MemorizeView's
+// `Promise.all([submitGraduation, ...conditionalCardIds.map(submitCardGraduation)])`
+// would have every call read the same pre-mutation snapshot and
+// overwrite each other's ids — silently dropping graduations that
+// then revert to `New` on the next page load.
 async function persistLocalGraduation(
   materialId: string,
   field: 'graduatedVerseIds' | 'graduatedCardIds',
   id: number,
 ): Promise<void> {
-  const snapshot = (await idb.getSnapshot(materialId))!
-  const ids = snapshot[field] ?? []
-  if (ids.includes(id)) return
-  await idb.putSnapshot({ ...snapshot, [field]: [...ids, id] })
+  const prev = persistGraduationChains.get(materialId) ?? Promise.resolve()
+  const next = prev.then(async () => {
+    const snapshot = (await idb.getSnapshot(materialId))!
+    const ids = snapshot[field] ?? []
+    if (ids.includes(id)) return
+    await idb.putSnapshot({ ...snapshot, [field]: [...ids, id] })
+  })
+  // Swallow the chained promise's rejection so a single failed write
+  // doesn't poison every subsequent write on the same material — the
+  // failure still surfaces through the returned `next` to the original
+  // caller's `.catch`.
+  persistGraduationChains.set(
+    materialId,
+    next.catch(() => {}),
+  )
+  return next
 }
 
 /** Apply a single-card graduation locally and queue the event for
@@ -463,12 +498,16 @@ async function doFlush(
     response = await api.postSyncEvents(materialId, { events, confirmMerge })
   } catch (err) {
     // 409 from snapshot mismatch is the one we can recover from
-    // without user input: refetch /state, rebuild the engine, and
-    // leave the events queued for the next flush to retry with the
-    // upgraded snapshotVersion. Any other error propagates.
+    // without user input: refetch /state, rebuild the engine, then
+    // re-stamp every queued event with the new snapshot version so
+    // the next flush passes the server's per-event check. Without
+    // the re-stamp the queued rows keep their original snapshot
+    // version, every retry 409s on the same rows, and the queue
+    // wedges forever. Any other error propagates.
     const status = (err as { status?: number }).status
     if (status === 409) {
       await refetchSyncState(session, nowSecs)
+      await idb.rewriteQueuedSnapshotVersion(materialId, session.snapshotVersion)
       return { accepted: 0, duplicates: 0, rebuilt: false }
     }
     throw err
@@ -494,14 +533,28 @@ async function doFlush(
   if (response.rebuilt) {
     const snapshot = await idb.getSnapshot(materialId)
     if (snapshot) {
-      session.engine.free()
-      session.engine = createEngine({
+      // Build → swap → free, same as refetchSyncState. createEngine
+      // throwing (e.g. mismatched contract version after a server-
+      // bumped snapshot) must not leave session.engine pointing at
+      // a freed Rust struct.
+      const replacement = createEngine({
         materialData: snapshot.materialData,
         materialConfig: session.materialConfig ?? '',
         testStates: response.testStates,
         desiredRetention: DEFAULT_DESIRED_RETENTION,
         nowSecs,
       })
+      const previous = session.engine
+      session.engine = replacement
+      previous.free()
+      // The fresh engine has no graduation history — without re-
+      // applying the locally-persisted graduated{Verse,Card}Ids,
+      // graduated verses leak back into the New pool, memorize_session
+      // re-introduces them, and next-card selection ignores prior
+      // graduations until a full page reload re-enters `loadEngine`.
+      // `loadEngine` and `refetchSyncState` both apply graduations
+      // after `createEngine`; this path was missing the same step.
+      applyGraduations(session.engine, snapshot.graduatedVerseIds, snapshot.graduatedCardIds)
     }
   }
 
@@ -528,15 +581,38 @@ export async function invalidateSession(materialId: string): Promise<void> {
 }
 
 /** Reset all per-profile in-memory state. Frees every cached WASM
- *  engine and drops the sessions / inflightFlushes / staleGate maps.
- *  Called on profile switch + sign-out (`useAuth.signInComplete` and
- *  `useAuth.signOut`) so the next profile starts fresh — without
- *  clearing `staleGate`, a stale-merge gate from profile A would
- *  silently no-op every flush in profile B (or the same user's next
- *  session). Does not touch IDB. */
-export function clearAllSessions(): void {
+ *  engine and drops the sessions / inflightFlushes / staleGate /
+ *  persistGraduationChains maps. Called on profile switch + sign-out
+ *  (`useAuth.signInComplete`, `useAuth.enterProfile`, `useAuth.signOut`)
+ *  so the next profile starts fresh — without clearing `staleGate`, a
+ *  stale-merge gate from profile A would silently no-op every flush
+ *  in profile B (or the same user's next session). Does not touch IDB.
+ *
+ *  **Asynchronous and must be awaited.** Any in-flight flush or
+ *  graduation persist runs `await idb.<op>(materialId, ...)` against
+ *  `openDb()`, which reads the global active profile id. If the
+ *  caller swaps the active profile (`setActiveProfile(B)`) before
+ *  awaiting these promises, the response handler resolves AFTER the
+ *  swap and writes profile A's testStates / graduations into profile
+ *  B's IDB — a concrete cross-profile data leak. The wait drains
+ *  outstanding writes against the still-current profile A's IDB
+ *  before clearing the maps. */
+export async function clearAllSessions(): Promise<void> {
+  // Snapshot the promises before clearing the maps so the awaited
+  // settle() doesn't race with new entries appearing in either map.
+  const pending: Promise<unknown>[] = [
+    ...inflightFlushes.values(),
+    ...persistGraduationChains.values(),
+  ]
+  // Drain — allSettled because a single failure shouldn't block the
+  // others or throw out of clearAllSessions. Callers expect this to
+  // succeed even when one of the in-flight ops rejects.
+  if (pending.length > 0) {
+    await Promise.allSettled(pending)
+  }
   for (const session of sessions.values()) session.engine.free()
   sessions.clear()
   inflightFlushes.clear()
   staleGate.clear()
+  persistGraduationChains.clear()
 }

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -273,6 +273,30 @@ export async function countAllQueuedEvents(): Promise<number> {
   )
 }
 
+/** Re-stamp every queued event for `materialId` with a new
+ *  `snapshotVersion`. Used after a 409 + `refetchSyncState`: the
+ *  events themselves are still valid (cardId / verseId mappings are
+ *  stable across snapshot bumps for the same material) but the
+ *  server's per-event snapshot-version check rejects anything
+ *  carrying the old value, so without rewriting the queue every
+ *  subsequent flush would 409 against the same stale rows forever. */
+export async function rewriteQueuedSnapshotVersion(
+  materialId: string,
+  snapshotVersion: number,
+): Promise<void> {
+  const db = await openDb()
+  const tx = db.transaction(STORE.EventQueue, 'readwrite')
+  const store = tx.objectStore(STORE.EventQueue)
+  const idx = store.index(BY_MATERIAL_ID_INDEX)
+  const rows = await promiseRequest<QueuedEvent[]>(idx.getAll(materialId))
+  for (const row of rows) {
+    if (row.snapshotVersion !== snapshotVersion) {
+      store.put({ ...row, snapshotVersion })
+    }
+  }
+  await transactionComplete(tx)
+}
+
 /** Delete acked events by clientEventId. Mid-flush additions to the
  *  queue survive because we delete by explicit key, not by clearing
  *  the whole store. */

--- a/apps/web/src/lib/engine/persistence.ts
+++ b/apps/web/src/lib/engine/persistence.ts
@@ -186,6 +186,18 @@ export async function putSnapshot(row: SnapshotRow): Promise<void> {
   )
 }
 
+/** Drop the cached snapshot row for `materialId`. Forces the next
+ *  `loadEngine` call to cold-path through `GET /api/sync/:id/state`
+ *  and rebuild from the server's authoritative view — used by
+ *  discard-stale where the local snapshot's `graduated{Verse,Card}Ids`
+ *  may have entries the server never received. */
+export async function deleteSnapshot(materialId: string): Promise<void> {
+  const db = await openDb()
+  await promiseRequest(
+    db.transaction(STORE.Snapshots, 'readwrite').objectStore(STORE.Snapshots).delete(materialId),
+  )
+}
+
 // --- Test-states store ---
 
 function testStateCompositeKey(entry: TestStateEntry): string {

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -98,7 +98,9 @@ async function buildSession() {
   // each year's session payload locally. Settings pass through so the
   // engine respects per-year scope toggles (e.g. chapter_list_scope).
   await Promise.all(
-    eligibleYears.map((y) => engine.init(y.materialId, buildMaterialConfig(y.settings))),
+    eligibleYears.map((y) =>
+      engine.init(y.materialId, buildMaterialConfig(y.settings), y.settings.desiredRetention),
+    ),
   )
   const sessions: {
     materialId: string

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -221,19 +221,34 @@ function revealDrill() {
 
 async function gradeAgain() {
   if (submitting.value) return
-  const entry = drillQueue.value.shift()
-  if (entry) drillQueue.value.push(entry)
-  await loadDrillCard()
+  // Set `submitting` BEFORE the queue mutation so a key-repeat or
+  // double-click on the Again button (or '1' key) can't fire twice
+  // before `loadDrillCard` finishes — the grade handlers were
+  // previously gated on `submitting` but never set it, so rapid
+  // input rotated the drill queue twice and silently skipped a card.
+  submitting.value = true
+  try {
+    const entry = drillQueue.value.shift()
+    if (entry) drillQueue.value.push(entry)
+    await loadDrillCard()
+  } finally {
+    submitting.value = false
+  }
 }
 
 async function gradeGood() {
   if (submitting.value) return
-  drillQueue.value.shift()
-  if (drillQueue.value.length === 0) {
-    enterReadingEnd()
-    return
+  submitting.value = true
+  try {
+    drillQueue.value.shift()
+    if (drillQueue.value.length === 0) {
+      enterReadingEnd()
+      return
+    }
+    await loadDrillCard()
+  } finally {
+    submitting.value = false
   }
-  await loadDrillCard()
 }
 
 /** Graduate one reading item and drop its drill entries. */

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -18,6 +18,7 @@ const engine = useEngine()
 
 const materialId = ref<string | null>(null)
 const materialConfig = shallowRef<ReturnType<typeof buildMaterialConfig> | null>(null)
+const desiredRetention = ref<number | null>(null)
 const card = ref<CardRender | null>(null)
 const revealed = ref(false)
 const done = ref(false)
@@ -34,6 +35,7 @@ async function resolveMaterial() {
   if (target) {
     materialId.value = target.materialId
     materialConfig.value = buildMaterialConfig(target.settings)
+    desiredRetention.value = target.settings.desiredRetention
     return true
   }
   return false
@@ -96,7 +98,11 @@ onMounted(async () => {
       done.value = true
       return
     }
-    await engine.init(materialId.value, materialConfig.value ?? undefined)
+    await engine.init(
+      materialId.value,
+      materialConfig.value ?? undefined,
+      desiredRetention.value ?? undefined,
+    )
     await loadNext()
   } catch (err) {
     error.value = formatError(err)

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,35 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-06-11
+
+Two correctness fixes surfaced by an exhaustive review pass. Both are pure implementation fixes with
+no event-replay semantic change for well-formed historical state: replaying a healthy event log
+under 0.5.1 produces the same `TestState` for every test that wasn't hitting the bug. Replay of a
+log that previously hit one of the bugs (same-instant sub-updates inflating stability, or a
+zero-word Ftv card emitted into the schedule) ends up in the corrected state, which is the intended
+direction. PATCH per this changelog's rubric.
+
+### Floor `elapsed` consistently across the retrievability-blend in `FsrsBridge::update`
+
+* The `weight<1` blend in `FsrsBridge::update` computed `r_now` and `r_direct` with raw `elapsed`
+  but inverted via `invert_r(elapsed.max(0.001), ...)`. A same-instant sub-update (`elapsed == 0`)
+  produced `r_now = r_direct = 1.0`, then `invert_r(1.0, 0.001, ...)` hit its `denom < 1e-9`
+  short-circuit and returned `S_MAX` — a single same-instant review collapsed stability to the
+  ~365-day ceiling regardless of prior state. The forward and inverse now share the same
+  `max(0.001)` floor on `elapsed`, so they agree numerically and the same-instant case correctly
+  resolves to the unchanged stability. 0.001 day (~86 s) is well below the resolution of any real
+  review timestamp, so human-scale intervals are unaffected.
+
+### Don't emit `Ftv` cards for verses with `ftvWordCount = 0`
+
+* `builder.rs`'s FTV eligibility check accepted `ftv_words == 0`: it required
+  `(ftv_words as usize) <= FTV_MAX_WORDS` and `ftv_words <= phrase_zero_word_count`, both of which
+  pass on zero. The doc on `Verse::ftv_word_count` says `None` means no FTV — `derive_structure` is
+  the gatekeeper — but shipped data (e.g. Ephesians 1:2, Philippians 1:2 in `data/1-gepc.json`)
+  carries an explicit `"ftvWordCount": 0`. The builder was emitting a zero-word FTV card for those
+  verses with no visible cue. Adds an `ftv_words > 0` floor to the eligibility check.
+
 ## [0.5.0] — 2026-05-28
 
 `graduate_verse` narrows to the unconditional verse-bound set. Conditional kinds (`Ftv`,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -415,15 +415,39 @@ pub fn build_with_config(
         push_card(CardKind::Recitation, &mut cards, &mut next_card_id);
         push_card(CardKind::Citation, &mut cards, &mut next_card_id);
 
-        // Composite: Ftv. Eligibility: verse has phrases, FTV is short
-        // enough, FTV doesn't exceed phrase 0 length. derive_structure
-        // verified the prefix invariant when emitting ftv_word_count,
-        // so we trust it here. The single FTV card always tests the
-        // citation triple on reveal — the no-citation variant was
-        // dropped because Recitation already covers the
-        // recall-without-ref case from the verse-text side.
+        // Composite: Ftv. Eligibility: verse has phrases, the FTV
+        // prompt is at least one word long, short enough overall, and
+        // doesn't exceed phrase 0 length. `derive_structure` verified
+        // the prefix invariant when emitting `ftv_word_count`, so we
+        // trust it here. The single FTV card always tests the citation
+        // triple on reveal — the no-citation variant was dropped
+        // because Recitation already covers the recall-without-ref
+        // case from the verse-text side.
+        //
+        // The two None-equivalent inputs:
+        //   - `verse.ftv_word_count == None` (the JSON had `null` or
+        //     omitted the key). The schema's "no Ftv card emitted"
+        //     sentinel, covering both "pending audit" (init_deck /
+        //     expand_deck just seeded the row; find_ftvs +
+        //     apply_audit haven't run yet) and "ambiguous"
+        //     (find_ftvs ran and found no unique opening prefix —
+        //     apply_audit deliberately leaves the row at `null`,
+        //     tools/apply_audit.py:154-156). The two states are
+        //     indistinguishable at rest in the JSON; both correctly
+        //     resolve to "no Ftv card" here.
+        //   - `ftv_words == 0`. Should be impossible given the
+        //     sentinel rule, but some shipped decks carry an explicit
+        //     `"ftvWordCount": 0` (data/1-gepc.json's Ephesians 1:2 /
+        //     Philippians 1:2 are the known offenders). Without the
+        //     `> 0` floor, the builder emits a zero-word FTV card
+        //     that schedules a prompt with no visible cue — same end
+        //     state as `null` semantically, but the scheduler treats
+        //     it as a real card. Reject. (The tools-side companion
+        //     fix on this PR stops new `0` rows from being seeded;
+        //     the existing offenders still need a data fix.)
         if config.ftv
             && let Some(ftv_words) = verse.ftv_word_count
+            && ftv_words > 0
             && phrase_count > 0
             && (ftv_words as usize) <= FTV_MAX_WORDS
             && ftv_words <= phrase_zero_word_count

--- a/crates/core/src/fsrs_bridge.rs
+++ b/crates/core/src/fsrs_bridge.rs
@@ -186,11 +186,21 @@ impl FsrsBridge {
                 pending_relearn: state.pending_relearn,
             };
         }
-        let elapsed = state.elapsed_days(now_secs).max(0.0);
+        // Floor elapsed BEFORE computing the forward retrievabilities so
+        // r_now / r_direct / invert_r all see the same value. Without
+        // the shared floor, a same-instant sub-update (elapsed = 0)
+        // produced r_now = r_direct = 1.0 → r_blend = 1.0, then
+        // invert_r(1.0, 0.001, ...) hit its denom<1e-9 branch and
+        // returned S_MAX — a single same-instant review collapsed
+        // stability to the ~365-day ceiling regardless of prior state.
+        // 0.001 day ≈ 86 s is below the resolution of any real review
+        // timestamp, so flooring the forward branch doesn't change
+        // observable behaviour at human-scale intervals.
+        let elapsed = state.elapsed_days(now_secs).max(0.001);
         let r_now = power_forgetting_curve(elapsed, state.stability, FSRS6_DEFAULT_DECAY);
         let r_direct = power_forgetting_curve(elapsed, direct.stability, FSRS6_DEFAULT_DECAY);
         let r_blend = (1.0 - w) * r_now + w * r_direct;
-        let s_blend = invert_r(r_blend, elapsed.max(0.001), FSRS6_DEFAULT_DECAY);
+        let s_blend = invert_r(r_blend, elapsed, FSRS6_DEFAULT_DECAY);
         let d_blend = (1.0 - w) * state.difficulty + w * direct.difficulty;
         let base_blend_f =
             (1.0 - w as f64) * state.last_base_secs as f64 + w as f64 * now_secs as f64;

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,25 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-06-11
+
+### Fix `memorize_session` ignoring tier-scope
+
+* `WasmEngine.memorize_session` was iterating the engine's card list and queuing any verse with at
+  least one `New` unconditional card, regardless of whether the verse's tier was in `new_scope`. A
+  verse in `Maintenance` status (its tier is in `review_scope` but not `new_scope` — e.g. Club 300
+  when the user set "Memorize new verses" to **150**) keeps its cards built so already-memorized
+  cards can still be reviewed, but its New cards must not enter the memorize queue. All three loops
+  in `memorize_session` now share a precomputed `memorize_active_verses` HashSet:
+  * The verse-anchor loop (originally surfacing John 1:6 in the reproduction).
+  * The HP / CCL pseudo-card assignment loop — a CCL pseudo whose tier is in `review_scope` but not
+    `new_scope` was leaking into `orphans` via the pending-pool overflow.
+  * The conditional-orphan loop — Ftv / VerseInHeading / VerseInClub cards on a Maintenance verse
+    (e.g. John 1:6's Ftv card) were the dominant residual leak even after the verse-anchor loop was
+    gated. Matches what `schedule::next_memorize_card` and `schedule::new_card_count` have been
+    doing per card all along.
+* No wire-format change. Patch bump.
+
 ## [0.5.0] — 2026-05-28
 
 Lockstep bump for `verse-vault-core@0.5.0` (per-card graduations). `WasmEngine.memorize_session`

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -469,6 +469,32 @@ impl WasmEngine {
         }
         let cards = &self.engine.cards;
 
+        // Tier-scope gate, computed once and reused across every loop
+        // below. A verse in `Maintenance` status (its tier is in
+        // `review_scope` but not in `new_scope`) keeps its cards built
+        // so already-memorized work can still be reviewed, but New
+        // cards on those verses must NOT enter the memorize queue —
+        // the user explicitly opted out of introducing new verses from
+        // that tier. `schedule::next_memorize_card` and
+        // `schedule::new_card_count` already apply this gate per-card
+        // for the next-card picker and the dashboard count; this path
+        // was independently picking the memorize batch and orphans and
+        // missed the same gate (the verse-anchor loop initially, and —
+        // discovered next — the HP/CCL assignment + conditional orphan
+        // loops). The HashSet collects verse_ids that have at least
+        // one `New` card AND pass `verse_active_for_memorize`, so
+        // every downstream loop can short-circuit with a single
+        // contains() check. Pseudo-verses (HP, CCL) carry their own
+        // `clubs` shape — HP has `Vec::new()` (no tier, gate passes),
+        // CCL has `vec![card_tier]` (gate fires on Maintenance, which
+        // is the correct exclusion).
+        let memorize_active_verses: HashSet<u32> = cards
+            .iter()
+            .filter(|c| matches!(c.state, CardState::New))
+            .filter(|c| self.engine.verse_active_for_memorize(c.verse_id))
+            .map(|c| c.verse_id)
+            .collect();
+
         // "Fresh" verses — those with at least one New unconditional
         // verse-bound card (the set `graduate_verse` flips). Orphan-only
         // verses (where every New card is a conditional kind on a verse
@@ -482,6 +508,9 @@ impl WasmEngine {
                 continue;
             }
             if !is_bulk_graduable(&card.kind) {
+                continue;
+            }
+            if !memorize_active_verses.contains(&card.verse_id) {
                 continue;
             }
             if seen_verses.insert(card.verse_id) {
@@ -535,6 +564,14 @@ impl WasmEngine {
 
         for card in cards.iter() {
             if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            // Same tier-scope gate as the verse-anchor loop. Excludes
+            // CCL pseudos whose tier is in Maintenance; HP pseudos
+            // pass through unconditionally because their `clubs` list
+            // is empty and `verse_active_for_memorize` returns true
+            // for None status.
+            if !memorize_active_verses.contains(&card.verse_id) {
                 continue;
             }
             let (is_hp, intent) = match card.kind {
@@ -717,6 +754,18 @@ impl WasmEngine {
         let mut seen_orphan_tiers: HashSet<ClubTier> = HashSet::new();
         for card in cards.iter() {
             if !matches!(card.state, CardState::New) {
+                continue;
+            }
+            // Same tier-scope gate. Without this, a verse in
+            // Maintenance status (its tier in `review_scope` but not
+            // `new_scope`) still leaks Ftv / VerseInHeading /
+            // VerseInClub orphans into the session even though the
+            // verse-anchor loop excluded it — concrete reported repro:
+            // John 1:6 (Club300, Maintenance under new=Up150 /
+            // review=Up300) has `ftvWordCount=5` so the builder emits a
+            // `Ftv` card in New state, which without this gate lands
+            // in `orphans[]`.
+            if !memorize_active_verses.contains(&card.verse_id) {
                 continue;
             }
             if session_verses.contains(&card.verse_id) {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,17 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### Reject out-of-range grades on `/api/import`
+
+* `applyReviewEvents` (in `lib/import.ts`) wrote every imported event's `grade` straight into
+  `reviewEvents` without bounds checking — `sync.ts`'s `validateUpload` and `cards.ts`'s review
+  handler both gate grades to `{1, 2, 3, 4}`, but the import path didn't. An untrusted payload with
+  e.g. `grade: 99` committed the poisoned row inside the import transaction, then crashed
+  `engines.rebuildFromEvents` (which calls `engine.replay_event`, which returns a `JsError` on
+  unknown grades). The import surfaced as a 500 and the bad row stayed in the database, wedging
+  every subsequent sync or rebuild on the same `(user, material)` until manual DB intervention
+  removed it. The import path now drops grades outside `1..=4` into `unresolved` instead.
+
 ### Tier cheap `/api/auth/*` reads onto the loose `authedTier`
 
 * `GET /api/auth/get-session` and `GET /api/auth/multi-session/list-device-sessions` now route

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -270,11 +270,43 @@ function applyReviewEvents(
 ): { inserted: number; skipped: number; unresolved: number } {
   // Resolve cardRefs to live cardIds, dropping any that don't exist in
   // the importing snapshot, and shape each into a ReviewEventInput.
+  //
+  // Every scalar field on the imported event is validated here. Sync's
+  // validateUpload (routes/sync.ts:439) gates the same fields and
+  // returns 400 on the same conditions; import drops bad rows into
+  // `unresolved` instead so a single malformed row doesn't reject an
+  // otherwise-good 50 MB import. The validators must match sync's
+  // shape exactly because the same poison-and-wedge class applies to
+  // every field that flows into `rebuildFromEvents`:
+  //   - `grade`: `engine.replay_event` (wasm/src/lib.rs) returns a
+  //     JsError on values outside 1..=4. Pre-fix, `grade: 99` committed
+  //     and then wedged every subsequent sync/rebuild on the same
+  //     (user, material).
+  //   - `timestampSecs`: `EngineStore.rebuildFromEvents` (lib/engine.ts)
+  //     calls `BigInt(row.timestampSecs)`, which throws synchronously
+  //     on NaN / Infinity / non-integer. Same wedge class: bad row
+  //     commits, every subsequent rebuild 500s.
+  //   - `clientEventId`: column is NOT NULL with a unique index on
+  //     (user, material, clientEventId). Empty string or null aborts
+  //     the whole tx on insert (500, no commit — so no wedge — but
+  //     still a sharp edge sync rejects with 400).
   const resolved: ReviewEventInput[] = [];
   let unresolved = 0;
   for (const e of material.reviewEvents) {
     const cardId = resolveCardRef(index, e.cardRef);
     if (cardId === undefined) {
+      unresolved += 1;
+      continue;
+    }
+    if (!Number.isInteger(e.grade) || e.grade < 1 || e.grade > 4) {
+      unresolved += 1;
+      continue;
+    }
+    if (!Number.isInteger(e.timestampSecs) || e.timestampSecs < 0) {
+      unresolved += 1;
+      continue;
+    }
+    if (typeof e.clientEventId !== 'string' || e.clientEventId.length === 0) {
       unresolved += 1;
       continue;
     }

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -104,13 +104,42 @@ export async function applyAccountImport(
     // race a concurrent review POST for the same (user, material).
     // Mirrors sync.ts, which wraps its own rebuild in withLock.
     await engines.withLock(key, async () => {
+      // STEP 1: apply enrollment + settings BEFORE building the card-
+      // ref index. The cardId universe is config-dependent (builder.rs
+      // gates Ftv / HeadingPassage / VerseInClub / etc. emission on
+      // MaterialConfig flags), and the imported settings may turn
+      // those flags on or off. Resolving cardRefs against the engine
+      // built with the user's OLD settings drops cardRefs that should
+      // be resolvable post-import (and silently misroutes ones whose
+      // cardId number happens to overlap between configs). Apply
+      // settings first, then invalidate the engine cache, then load
+      // a fresh engine that reads the new config.
+      //
+      // Tradeoff vs. the previous all-in-one transaction: if step 3
+      // (graduations + events) fails, the settings + enrollment from
+      // step 1 stay committed. For an import the user can re-run the
+      // operation — the import is idempotent on review events
+      // (clientEventId dedup) and on graduations (existing-row check
+      // in applyGraduations), so a second run picks up where the
+      // first left off without duplicates. Atomicity across all three
+      // would require a multi-stage compensating-write design we
+      // don't need for the import use case.
+      db.transaction((tx) => {
+        applyEnrollmentExtras(tx, key, material);
+        applySettings(tx, key, material);
+      });
+      engines.invalidate(key);
+
+      // STEP 2: load the engine with the just-applied settings and
+      // build the cardRef index. Subsequent applyGraduations /
+      // applyReviewEvents now resolve against the correct card
+      // universe.
       using loaded = await engines.load(key);
       const index = buildCardRefIndex(loaded.engine);
       const snapshotVersion = loaded.snapshotVersion;
 
+      // STEP 3: graduations + events in their own transaction.
       db.transaction((tx) => {
-        applyEnrollmentExtras(tx, key, material);
-        applySettings(tx, key, material);
         const gradResult = applyGraduations(tx, key, material, index);
         summary.graduationsApplied += gradResult.applied;
         summary.unresolvedCardRefs += gradResult.unresolved;

--- a/tools/expand_deck.py
+++ b/tools/expand_deck.py
@@ -287,7 +287,20 @@ def main() -> None:
             "verse": v,
             "phraseWordCounts": [len(tokens)],
             "annotations": [],
-            "ftvWordCount": 0,
+            # `null`, not 0. Newly seeded rows are always pre-audit —
+            # `null` is the schema's "no Ftv card emitted" sentinel,
+            # covering both "pending audit" (the state we're in
+            # immediately after this script writes) and "no unique
+            # prefix exists" (the state ambiguous verses land in after
+            # `find_ftvs.py --audit` + `apply_audit.py` run and the
+            # ambiguous-skip branch leaves the value alone). The Rust
+            # core's `builder.rs` short-circuits the Ftv card emission
+            # while the row is `null`, so the card never appears in
+            # /memorize until an integer is written. Zero would
+            # violate the deck invariant `evaluate_phrases.py:117`
+            # enforces (`ftv < 1` is BLOCK) and would make every
+            # seeded verse a blocker on the next audit pass.
+            "ftvWordCount": None,
             "clubs": clubs,
         }
         if clubs:

--- a/tools/init_deck.py
+++ b/tools/init_deck.py
@@ -204,7 +204,28 @@ def build_verses(
             "verse": v,
             "phraseWordCounts": [word_count] if word_count else [],
             "annotations": annotations,
-            "ftvWordCount": ftv_word_count(ftv_html) if ftv_html else 0,
+            # `None` (JSON `null`), not 0, when the Anki note has no
+            # FTV HTML. `null` is the schema's single "no Ftv card
+            # emitted" sentinel — it covers two distinct lifecycle
+            # states the JSON can't tell apart at rest:
+            #   (a) Pending: this verse hasn't been audited yet.
+            #       `find_ftvs.py --audit` will compute the shortest
+            #       unique prefix and `apply_audit.py` will rewrite
+            #       the row with an integer.
+            #   (b) Ambiguous: no unique opening prefix exists anywhere
+            #       in the material (find_ftvs reports the verse
+            #       under "Ambiguous — needs disambiguation").
+            #       `apply_audit.py` skips it (lines 154-156); the row
+            #       stays `null` permanently.
+            # In both states the Rust core's `Verse::ftv_word_count`
+            # deserialises to `None` and `builder.rs` short-circuits
+            # the Ftv card emission, so the card never appears in
+            # /memorize or /review until the row holds an integer.
+            # Zero would violate the deck invariant `evaluate_phrases
+            # .py:117` enforces (treats `ftv < 1` as BLOCK) and would
+            # make every uninitialised verse a blocker on the very
+            # next audit pass — that's the bug this fix closes.
+            "ftvWordCount": ftv_word_count(ftv_html) if ftv_html else None,
             "clubs": clubs,
         }
     return [seen[k] for k in sorted(seen)], warnings


### PR DESCRIPTION
## Summary

Pass-2 review expansion of #95. A second ultracode workflow (85 sub-agents, 4M tokens, 10 subsystem finders + 2 perspective-diverse verifiers per finding, plus per-fix adversarial verifiers) found:

- **2 of the 5 fixes shipped here in pass-1 were INCOMPLETE.** Both are now corrected via fixup.
- **30 confirmed new bugs** across less-audited subsystems (sim, api server entry, api engine-store internals, api account export/import, web render cache, other views, web engine-loader, web api client, tools/ Python pipeline). 7 were high-severity; the highest-impact subset is now fixed on this PR.

Branch is now 8 commits ahead of master.

## Commits

1. `f186aca fix(web): wire OfflineBanner click to /profiles` — original OfflineBanner fix + **fixup completing it with `force: '1'`** (the prior version pushed to the right named route but the router guard's signed-in branch immediately redirected back; AppAvatar.vue had been using `force=1` for the same reason).
2. `2195da4 fix(wasm): scope-filter memorize_session` — gates all three loops (verse-anchor, HP/CCL assignment, conditional orphans) against a shared `memorize_active_verses` HashSet.
3. `3745783 fix(core): tighten FSRS blend + FTV emission` — `invert_r` elapsed-floor mismatch + `ftvWordCount=0` Ftv card emission.
4. `5725c6d fix(api): validate grade range on /api/import` — grade validation + **fixup extending it to `timestampSecs` and `clientEventId`** (both were unbounded and could similarly wedge `rebuildFromEvents`).
5. `2934c83 fix(web): correctness sweep on web client` — five engine-state correctness bugs (persistLocalGraduation race, 409 retry stale snapshotVersion, post-rebuild missing applyGraduations, profile-switch cross-IDB leak, MemorizeView grade-keys race) + **fixup with build-swap-free pattern in refetchSyncState and rebuild** (a `WasmEngine::new` throw was leaving `session.engine` pointing at freed memory).
6. **`68296d4 fix(web): retention slider; discardStale resets`** *(new)* — Two correctness bugs in the engine-state layer:
   - The `/settings` retention slider was a no-op for the local hot path: `loadEngine` / `refetchSyncState` / post-rebuild all hardcoded 0.9 while the server scheduled to the per-user value. EngineSession now carries `desiredRetention`; ReviewView and MemorizeView thread it from year-settings.
   - `discardStale` deleted queued events but left the cached engine + snapshot's `graduated{Verse,Card}Ids` intact, so the discarded local-only graduations resurfaced on the next page load via `applyGraduations`. Now also invalidates the session and deletes the snapshot so the next `loadEngine` cold-paths through `/state` and rebuilds from the server's authoritative view.
7. **`2c025d1 fix(tools): emit ftvWordCount null, not 0`** *(new)* — `expand_deck.py` and `init_deck.py` were seeding `"ftvWordCount": 0` into fresh deck rows, violating the invariant `evaluate_phrases.py:117` enforces. Now emit `null` to match `init_side_deck.py`'s documented sentinel. Pairs with the core-side `ftv_words > 0` guard so Rust and Python agree that 0 is invalid.
8. **`13eec60 fix(api): apply settings before cardRef index`** *(new)* — `applyAccountImport` was building the cardRef index against an engine reading the user's CURRENT MaterialConfig, then `applySettings` wrote the IMPORTED settings inside the same transaction. The cardId universe is config-dependent (builder.rs gates Ftv / HP / VerseInClub emission on MaterialConfig flags) — when imported settings flipped any of those flags, cardRefs either dropped to `unresolved` (FSRS history lost) or silently misrouted onto the wrong card. Split the transaction: settings + enrollment commit first, engine cache invalidates, fresh load builds the index against post-import settings, then graduations + events.

## Test plan

- [x] Rust: `cargo test` (146 core + 18 wasm) clean
- [x] Rust: `cargo clippy --all-targets` clean
- [x] API: `pnpm test` (161/161) clean
- [x] Web: `pnpm type-check` clean
- [ ] Manual smoke on the John 1:6 reproduction (no longer leaks via orphans either)
- [ ] Manual smoke on the OfflineBanner click (now actually reaches the picker — previously the router guard bounced it back)
- [ ] Manual smoke on the retention slider (set to 70%, grade a card, confirm the next-due interval matches a 70% target not 90%)
- [ ] Manual smoke on discard-stale (graduate a verse, force a needsConfirm batch, discard, reload — verse should be back in the memorize queue, not silently re-graduated)
- [ ] Manual smoke on import-then-flag-toggle scenario for the cardRef ordering fix

## What's still on the table

Not fixed on this PR, but logged for follow-up issues:

- Cross-snapshot cardRef translation in `export.ts` (a snapshot bump between events being written and the export call mis-translates cardIds across snapshot versions).
- 19 confirmed-medium bugs across api engine-store (rebuildFromEvents engine leak on throw, snapshot-bump race vs withLock, reviewEvents id collision across users, settings unbounded updatedAt shadow), api server-entry (PORT env parsing, EADDRINUSE crash, no SIGTERM handler), web render-cache (staleGate sticky, single-op IDB writes resolving on onsuccess not commit, SettingsView toggle race), web views (ReviewView blank on init failure, SettingsView stuck spinner, loadEngine cached-session discards new materialConfig), web engine-loader (loadEngine persists before createEngine), Python tools (anki_to_export.py timestamp promotion, import_colpkg.py nondeterministic year filtering).
- 4 confirmed-low bugs (rate-limit forward-progress refill over-credit, EngineStore tails map unbounded growth, foreign_keys not ON during migration, submitGrade in-flight stamps stale snapshotVersion during 409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)