### PR TITLE
chore: release api 0.1.27 + web 0.2.0

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,21 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-06-12
+
+MINOR bump for the nav redesign (identity popover, mobile bottom tab bar, route renames). Also packs
+the pass-1 + pass-2 correctness sweeps from the same train: engine-store IDB write races,
+retention-slider plumb-through, discardStale resets to server view, the rate-limited vs offline
+distinction, and the OfflineBanner click that finally reaches the picker.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.1` — `ftv_words > 0` floor on FTV emission + retrievability-blend `elapsed`
+  floor that stops same-instant sub-updates from collapsing stability.
+* `verse-vault-wasm@0.5.1` — `memorize_session` gates all three loops (verse-anchor, HP/CCL,
+  conditional orphan) against the same `memorize_active_verses` HashSet, so Maintenance-tier verses
+  no longer leak into the queue via any path.
+
 ### Correctness sweep on engine-store + memorize input
 
 Four real bugs surfaced by an exhaustive review pass. Each was independently confirmed by tracing

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,30 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.27] — 2026-06-12
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.5.1` — adds the `ftv_words > 0` floor on FTV card emission (no zero-word
+  prompts) and floors `elapsed` consistently across `FsrsBridge::update`'s retrievability blend so
+  same-instant sub-updates no longer collapse stability to the ~365-day ceiling. PATCH-equivalent.
+* `verse-vault-wasm@0.5.1` — `memorize_session` precomputes a `memorize_active_verses` HashSet and
+  gates all three loops (verse-anchor, HP/CCL pseudo-card assignment, conditional orphan) against
+  it, so Maintenance-tier verses no longer leak into the memorize queue via any path. No wire-
+  format change.
+
+### Apply imported settings before resolving cardRefs
+
+* `applyAccountImport` (`lib/import.ts`) was building the cardRef index against the engine that
+  `engines.load` returned BEFORE the imported settings were applied — the engine reflected the
+  user's current `MaterialConfig`, while `applySettings` then wrote the imported settings inside the
+  same transaction. The cardId universe is config-dependent (`builder.rs` gates Ftv / HeadingPassage
+  / VerseInClub / etc. emission on `MaterialConfig` flags), so when the import flipped any of those
+  flags, cardRefs either dropped to `unresolved` (FSRS history lost) or silently misrouted onto the
+  wrong card. Split the transaction so settings + enrollment commit first, the engine cache
+  invalidates, then a fresh `engines.load` builds the index against post- import settings before
+  applying graduations + events.
+
 ### Reject out-of-range grades on `/api/import`
 
 * `applyReviewEvents` (in `lib/import.ts`) wrote every imported event's `grade` straight into

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

Paired release rolling up everything that landed on master since `api@0.1.26` / `web@0.1.20`. Both consumers pin `verse-vault-core@0.5.1` and `verse-vault-wasm@0.5.1`.

The merge of this PR onto master triggers two independent deploys:
- `deploy-api.yml` → rsync to VPS + atomic symlink flip + restart `verse-vault.service`
- `deploy-web.yml` → Cloudflare Pages

Each deploy's CI gate runs `tools/check-contract-versions.sh --ci <target>`, which verifies the consumer's `CHANGELOG.md` has a dated section for the version being deployed AND references the bundled `core` + `wasm` versions. Both consumers reference `0.5.1` consistently, so the gate should pass.

## `packages/api` 0.1.26 → 0.1.27 (PATCH)

Five bug fixes since `0.1.26`:

- **Apply imported settings before resolving cardRefs** — `applyAccountImport` was building the cardRef index against the engine reading the user's CURRENT `MaterialConfig`, then `applySettings` overwrote it inside the same transaction. The cardId universe is config-dependent, so imports flipping any of `ftv` / `headingPassageCard` / `clubCardScope` / etc. silently misrouted cardRefs onto the wrong cards. Split the transaction.
- **`/api/import` rejects out-of-range fields** — `grade`, `timestampSecs`, and `clientEventId` now all bound-checked. Pre-fix, an untrusted payload with e.g. `grade: 99` or `timestampSecs: NaN` committed the poisoned row inside the import transaction, then crashed `rebuildFromEvents` afterwards, **permanently wedging every subsequent sync / rebuild on the same `(user, material)`** until manual DB intervention.
- **Tier `/api/auth/get-session` + `list-device-sessions` onto the loose `authedTier`** — the credential-stuffing tier was tripping normal nav at single-digit refresh rates because those cheap reads fire on every app boot and route nav. Credential writes keep the tight tier.
- **CORS on 429 responses** — `cors()` reordered outermost so browsers see a real 429 + `Retry-After` instead of a generic `NetworkError`.
- **`ip:unknown` skips the rate-limit bucket in non-prod** — fixes the local dev wedge where every unauthenticated request collapsed into one shared bucket.

## `apps/web` 0.1.20 → 0.2.0 (MINOR)

MINOR-bump-worthy nav redesign drives the version. Substantive surface changes:

- **Nav redesign**: identity popover (`AppAvatar.vue`), mobile bottom tab bar (`MobileTabBar.vue`), top-bar grid layout, focus + keyboard polish.
- **Route renames**: `/material` → `/settings`, `/dashboard` → `/home` (both with redirects).
- **`SyncState` widened to four-state** with new `'rate-limited'` variant; OfflineBanner distinguishes "throttled, wait a moment" from "offline" and from "sign in".

Plus the pass-1 + pass-2 correctness sweeps from the same train (all detailed in the CHANGELOG):

- Engine-store IDB write races (`persistLocalGraduation`, 409 retry, post-rebuild graduations, profile switch).
- Retention slider plumbed into the local engine (was a no-op for the hot path).
- `discardStale` resets engine + snapshot to server view (was leaving divergent state forever).
- OfflineBanner click that finally reaches the picker (router guard needed `force: '1'`).
- `MemorizeView` rapid grade keys no longer skip drill cards.
- `/code-review` pass fixes: open-redirect, capture-phase grade-key leak, sign-out throw stranding, cold-boot grid collapse, env() fallback, etc.

## Test plan

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm type-check` (apps/web) clean
- [x] `pnpm test` (packages/api) — 161/161
- [x] `cargo test` + `cargo clippy --all-targets` clean
- [x] `tools/check-contract-versions.sh` clean locally
- [ ] CI runs `tools/check-contract-versions.sh --ci api` and `--ci web` on merge — should both pass since CHANGELOG entries reference `core@0.5.1` + `wasm@0.5.1` consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)