### PR TITLE
feat: schedules + per-club settings (Phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ __pycache__/
 
 # Local git worktrees
 /.worktrees/
+
+# Visual companion (brainstorming) scratch
+/.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,13 @@ __pycache__/
 # counts, user annotations, and verse refs. The other gitignored data/*
 # files (Anki backups, raw NKJV text, the api.bible cache) stay ignored.
 !/data/[0-9]-*.json
+# Bundled memorize schedules for the Phase 1 schedules + per-club work
+# (see `docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md`).
+# Same whitelist pattern as the deck files — the loader at
+# `packages/api/src/lib/schedules.ts` picks them up from disk per
+# materialId.
+!/data/schedules/
+!/data/schedules/*.json
 
 # wasm-pack build output
 /crates/wasm/pkg/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "verse-vault-wasm"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,7 +213,7 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "verse-vault-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -22,6 +22,75 @@ Bumps follow semver semantics:
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-14
+
+MAJOR bump for the schedules + per-club settings rework (Phase 1). The state shape of
+`MaterialConfig` changes: the flat `(new_scope, review_scope, desired_retention)` triple is replaced
+by per-club `memorize`, `review`, and a per-pair `move_to_next` gate. Event replay of pre-0.6.0
+settings JSON still works via serde aliases that materialise the per-club shape on read — but a
+0.6.0 engine constructed from a 0.5.1 settings string sees a different `MaterialConfig` than a 0.5.1
+engine would, so this is a MAJOR by the changelog's "different state under replay" rubric.
+
+### New: per-club memorize + review config
+
+* `MaterialConfig.memorize: ClubMemorizeMap` — per-club
+  `{ enabled, catch_up: Sequential | CalendarCascade }`. Replaces `new_scope` and
+  `desired_retention`'s memorize half.
+* `MaterialConfig.review: ClubReviewMap` — per-club `{ enabled, desired_retention }`. Retention is
+  now per-club (range `[0.5, 0.9]`, default `0.8`); the old flat `desired_retention` migrates by
+  applying the (clamped) value across every enabled review club.
+* `MaterialConfig.move_to_next: MoveToNextConfig` — per adjacent pair (`p150_to_300`,
+  `p300_to_full`), with five gates: `FullyMemorized`, `AfterMajorCheckpoint`,
+  `AfterMinorCheckpoint`, `CaughtUp`, `Always`. Default `CaughtUp` so enabling a lower club surfaces
+  its verses as soon as the user is on-pace for the higher.
+* `MaterialConfig.lesson_batch_size: u8` (default `1`) — moved into the config so per-session size
+  travels with the rest of the per-material preferences.
+* `MaterialConfig::default()` is now the spec's new-user shape (Club 150 enabled at retention 0.8,
+  others off). The historical "everything active at 0.9" is now
+  `MaterialConfig::all_clubs_enabled(0.9)`; `builder::build()` uses the latter so existing test
+  fixtures continue to emit cards for every tier.
+
+Legacy JSON (`{ new_scope, review_scope, desired_retention, ... }`) still parses through
+`MaterialConfigRaw`'s `from` adapter. The retention is clamped to the new `[0.5, 0.9]` range; values
+stored above 0.9 (a common pre-0.6.0 preference) cap to 0.9 on first load.
+
+### New: `Schedule` data model
+
+* `crates/core/src/schedule_data.rs` introduces
+  `Schedule { weeks, meets, meeting_day_of_week, ... }` and
+  `Meet { id, name, start_date, end_date, location }`. Bundled per material at
+  `data/schedules/<deck>-<season>.json`; the API ships a customised copy per user in a
+  `material_schedules` row.
+* Date helpers (`current_week_index`, `most_recent_past_meet`) and verse-ref helpers
+  (`week_verse_refs`, `cumulative_verse_refs_through_week`, `cumulative_count_*`) anchor the
+  cross-club gate evaluators and the memorize-tab badge math downstream. Full-tier refs are derived
+  as `passage` range minus `club150 ∪ club300`.
+
+### Per-verse retention threading
+
+* `ReviewEngine::target_r_for_verse(verse_id) -> f32` reads the verse's most-specific tier and looks
+  up `MaterialConfig::target_r_for(tier)`. Falls back to `schedule_params.target_retention` for
+  pseudo-verses with no tier.
+* `next_card`, `due_review_count`, `due_verse_count`, and `next_relearn_card` all switch to the
+  per-verse path. `ScheduleParams.target_retention` stays as the fallback only; the scheduler no
+  longer uses it directly for the threshold check.
+* `target_r_for` clamps to `[0.5, 0.9]` on read — out-of-range stored values can't reach FSRS math
+  (would produce NaN or infinite due times).
+
+### New: two-phase canonical memorize fill
+
+* `next_memorize_batch(engine, schedule, now_secs, batch_size) -> Vec<CardId>` in `schedule.rs`
+  implements the spec's algorithm. Phase 1 picks `CalendarCascade` clubs' this-week primary verses
+  in canonical order (soft cap overflow allowed). Phase 2 picks everything else eligible in
+  canonical order until the batch fills. Cross-club gates only control eligibility; once eligible,
+  ordering is purely canonical.
+* `next_memorize_card(engine, now_secs)` is now a thin `.first()` wrapper around
+  `next_memorize_batch(engine, None, now_secs, 1)`. Passing `schedule: None` collapses the algorithm
+  to Phase 2 only (i.e. pure-Sequential), which matches the legacy single-card surface.
+* `anchor_card_for_verse(engine, verse_id)` extracted as a shared helper — picks `Recitation` when
+  New, else the first `New` bulk-graduable card. Commit on `crates/wasm@0.6.0` reuses this in
+  `memorize_session_v2` so the wasm verse-anchor pick stays consistent with the new batch surface.
+
 ## [0.5.1] — 2026-06-11
 
 Two correctness fixes surfaced by an exhaustive review pass. Both are pure implementation fixes with

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-core"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/builder.rs
+++ b/crates/core/src/builder.rs
@@ -309,11 +309,18 @@ fn build_heading_lookup(headings: &[HeadingData]) -> HashMap<(String, u16, u16),
     lookup
 }
 
-/// Build cards and seeded test states from material data, with the default
-/// (everything-on) `MaterialConfig`. Convenience wrapper around
-/// [`build_with_config`] for callers (sim, tests) that don't filter.
+/// Build cards and seeded test states from material data with the
+/// "everything-on" config — every club enabled for both memorize and
+/// review at 0.9 retention. Convenience wrapper around
+/// [`build_with_config`] for callers (sim, tests, the WASM smoke harness)
+/// that want a fully-open engine without specifying per-club shape.
+///
+/// Note: `MaterialConfig::default()` is the *new-user* default
+/// (Club 150 only, retention 0.8). This wrapper specifically opens
+/// every tier so test fixtures using `clubs: []` (which `parse_tiers`
+/// resolves to `Full`) aren't silently paused.
 pub fn build(data: &MaterialData, now_secs: i64) -> BuildResult {
-    build_with_config(data, &MaterialConfig::default(), now_secs)
+    build_with_config(data, &MaterialConfig::all_clubs_enabled(0.9), now_secs)
 }
 
 /// Build cards and seeded test states from material data.
@@ -984,11 +991,7 @@ mod tests {
             ClubTier::Club300 => crate::material_config::TierScope::Up150,
             ClubTier::Full => crate::material_config::TierScope::Up300,
         };
-        MaterialConfig {
-            new_scope: scope,
-            review_scope: scope,
-            ..MaterialConfig::default()
-        }
+        MaterialConfig::from_scopes(scope, scope)
     }
 
     #[test]
@@ -1075,9 +1078,11 @@ mod tests {
         let m: MaterialData = serde_json::from_str(json).unwrap();
         // chapter_list_scope defaults to Up150 (per ChapterListScope::default),
         // so the Club300 chapter card needs an explicit Up300 to surface.
+        // Use the test-friendly all-clubs-enabled config so the Club300
+        // verse isn't filtered out by the new "Club 150 only" default.
         let cfg = MaterialConfig {
             chapter_list_scope: ChapterListScope::Up300,
-            ..MaterialConfig::default()
+            ..MaterialConfig::all_clubs_enabled(0.9)
         };
         let r = build_with_config(&m, &cfg, 0);
         let chapter_cards: Vec<&Card> = r

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -126,6 +126,24 @@ impl ReviewEngine {
         !matches!(self.verse_status(verse_id), Some(ClubStatus::Maintenance))
     }
 
+    /// Per-verse target retention used by the scheduler — reads the
+    /// most-specific tier from `verse_index` and looks it up via
+    /// `MaterialConfig::target_r_for`. Falls back to the engine's
+    /// fallback `schedule_params.target_retention` when the verse has
+    /// no tier (pseudos, fixtures with empty `clubs`).
+    ///
+    /// All due-time math (`next_card`, relearn lane, `due_*_count`)
+    /// reads through this helper so per-club retention preferences
+    /// kick in without re-threading parameters through every scheduler
+    /// entry point.
+    pub fn target_r_for_verse(&self, verse_id: u32) -> f32 {
+        self.verse_index
+            .elements_of(verse_id)
+            .and_then(|e| e.clubs.first().copied())
+            .map(|tier| self.material_config.target_r_for(tier))
+            .unwrap_or(self.schedule_params.target_retention)
+    }
+
     /// Borrow the per-verse render data for a verse, or `None` if the verse
     /// isn't in the catalog.
     pub fn verse_render(&self, verse_id: u32) -> Option<&VerseRender> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fsrs_bridge;
 pub mod material_config;
 pub mod render;
 pub mod schedule;
+pub mod schedule_data;
 pub mod session;
 pub mod test_kind;
 pub mod test_state;

--- a/crates/core/src/material_config.rs
+++ b/crates/core/src/material_config.rs
@@ -162,27 +162,18 @@ pub enum MoveToNextGate {
 }
 
 /// Per-adjacent-pair cross-club gates.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MoveToNextConfig {
     pub p150_to_300: MoveToNextGate,
     pub p300_to_full: MoveToNextGate,
 }
 
-impl Default for MoveToNextConfig {
-    fn default() -> Self {
-        Self {
-            p150_to_300: MoveToNextGate::default(),
-            p300_to_full: MoveToNextGate::default(),
-        }
-    }
-}
-
 /// Three named slots indexed by `ClubTier`. JSON wire form is
 /// `{"club150": …, "club300": …, "full": …}` — chosen over a HashMap
 /// keyed by the tier enum for explicit field shapes and zero-cost
 /// indexing.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClubMemorizeMap {
     #[serde(default)]
@@ -191,16 +182,6 @@ pub struct ClubMemorizeMap {
     pub club300: ClubMemorizeConfig,
     #[serde(default)]
     pub full: ClubMemorizeConfig,
-}
-
-impl Default for ClubMemorizeMap {
-    fn default() -> Self {
-        Self {
-            club150: ClubMemorizeConfig::default(),
-            club300: ClubMemorizeConfig::default(),
-            full: ClubMemorizeConfig::default(),
-        }
-    }
 }
 
 impl ClubMemorizeMap {
@@ -213,7 +194,7 @@ impl ClubMemorizeMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClubReviewMap {
     #[serde(default)]
@@ -222,16 +203,6 @@ pub struct ClubReviewMap {
     pub club300: ClubReviewConfig,
     #[serde(default)]
     pub full: ClubReviewConfig,
-}
-
-impl Default for ClubReviewMap {
-    fn default() -> Self {
-        Self {
-            club150: ClubReviewConfig::default(),
-            club300: ClubReviewConfig::default(),
-            full: ClubReviewConfig::default(),
-        }
-    }
 }
 
 impl ClubReviewMap {

--- a/crates/core/src/material_config.rs
+++ b/crates/core/src/material_config.rs
@@ -16,8 +16,12 @@ pub enum ClubStatus {
 
 /// How far up the tier ladder a "scope" reaches. `Up150` includes only
 /// `Club150` verses; `Up300` includes both `Club150` and `Club300`;
-/// `All` includes every verse. Used for the per-verse club card, the
-/// per-(year) Active scope, and the per-(year) Maintenance scope.
+/// `All` includes every verse.
+///
+/// Retained post-Phase-1 for `club_card_scope` (which still ladders
+/// across tiers — its spec rework is deferred) and for the legacy
+/// `(new_scope, review_scope)` deserialization path that maps old
+/// configs into the per-club shape on read.
 ///
 /// Wire form is camelCase (`off` / `up150` / `up300` / `all`) so the
 /// API can ship the same lowercase strings it stores in the DB straight
@@ -65,91 +69,439 @@ impl ChapterListScope {
     }
 }
 
-/// Per-user, per-year material configuration consumed by the builder.
+/// How a club's pool is ordered when the user is behind the calendar.
 ///
-/// The four scopes are independent levers on the "up to which tier" axis:
+/// `Sequential` ignores the calendar entirely — the pool is "next
+/// un-memorized verse in canonical (deck/passage) order." Catches up
+/// automatically when behind, rolls ahead naturally when caught up.
 ///
-/// - `new_scope`: tiers that introduce new verses via /memorize.
-/// - `review_scope`: tiers whose verses surface in /review.
-/// - `club_card_scope`: which tiers get the per-verse "which club?" card.
-/// - `chapter_list_scope`: which tiers get the chapter-list card.
+/// `CalendarCascade` prefers this week's calendar row first (Phase 1
+/// of the memorize fill), then falls through to backlog and lookahead
+/// via Phase 2. Users on a strict league schedule pick this; one-verse-
+/// a-day users typically don't.
 ///
-/// `new` and `review` are orthogonal — a tier covered by both is the
-/// usual "Active" state; review-only is "Maintenance"; covered by
-/// neither is "Paused". (New-only is the rare edge case where the user
-/// is introducing verses without re-surfacing them; still valid, just
-/// unusual.)
-///
-/// `heading_card`, `heading_passage_card`, and `ftv` are independent
-/// bool toggles. `heading_card` controls the per-verse
-/// `VerseInHeading` ("which heading is *this* verse in?") card;
-/// `heading_passage_card` controls the per-heading `HeadingPassage`
-/// ("what heading is this whole passage under?") card. Both grade the
-/// same `VerseHeadingBinding` test set, so the two cards share FSRS
-/// state on each member's binding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MaterialConfig {
-    /// Per-verse "which heading?" card. Defaults off: the passage-cued
-    /// version (`heading_passage_card`) is the primary heading test;
-    /// asking the same question per-verse is high-volume and low-signal
-    /// for most learners. Old JSON with the legacy `headings` key is
-    /// accepted via the serde alias.
-    #[serde(default, alias = "headings")]
-    pub heading_card: bool,
-    #[serde(default = "default_true")]
-    pub heading_passage_card: bool,
-    pub ftv: bool,
-    #[serde(default)]
-    pub new_scope: TierScope,
-    #[serde(default)]
-    pub review_scope: TierScope,
-    #[serde(default = "default_club_card_scope")]
-    pub club_card_scope: TierScope,
-    #[serde(default)]
-    pub chapter_list_scope: ChapterListScope,
+/// JSON form is camelCase (`sequential` / `calendarCascade`) — matches
+/// the per-club shape the API uses for the new fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum CatchUp {
+    #[default]
+    Sequential,
+    CalendarCascade,
 }
 
-/// "Which club is this verse in?" prompts default off: they're high
-/// effort for low signal until the user has memorised enough verses
-/// to actually distinguish clubs. The picker exposes the toggle.
-fn default_club_card_scope() -> TierScope {
-    TierScope::Off
+/// Per-club memorize configuration: is the club introducing new verses,
+/// and if so, how is its pool ordered when the user is behind?
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClubMemorizeConfig {
+    pub enabled: bool,
+    #[serde(default)]
+    pub catch_up: CatchUp,
+}
+
+impl Default for ClubMemorizeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            catch_up: CatchUp::Sequential,
+        }
+    }
+}
+
+/// Per-club review configuration: is the club's verses surfacing in
+/// /review, and what target retention does the scheduler aim at for
+/// those cards?
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClubReviewConfig {
+    pub enabled: bool,
+    /// Valid range `[0.5, 0.9]`. Stored as the user-set value; the
+    /// scheduler reads it through `MaterialConfig::target_r_for` which
+    /// applies the clamp on read for defence-in-depth.
+    pub desired_retention: f32,
+}
+
+impl Default for ClubReviewConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            desired_retention: DEFAULT_REVIEW_RETENTION,
+        }
+    }
+}
+
+/// When does the lower club's pool become eligible to contribute to a
+/// memorize session? Applied per adjacent pair (`p150_to_300` between
+/// Club 150 and Club 300, `p300_to_full` between Club 300 and Full).
+///
+/// Each variant describes a condition on the higher club's progress
+/// against the schedule; gate-open means the lower club enters the
+/// eligible set for Phase 2's canonical-order fill. Eligibility is
+/// independent of fill priority — once eligible, both clubs interleave
+/// by deck position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum MoveToNextGate {
+    /// Lower club waits until the higher is fully memorized
+    /// (strict drain).
+    FullyMemorized,
+    /// Lower club enters after the higher's verses through the most
+    /// recent past meet are all memorized. Never open before the
+    /// season's first meet.
+    AfterMajorCheckpoint,
+    /// Lower club enters once the higher's this-week row is done.
+    AfterMinorCheckpoint,
+    /// Lower club is eligible whenever the higher's user position is
+    /// at or past the previous week's checkpoint. Open by default at
+    /// season start (no previous checkpoint yet).
+    #[default]
+    CaughtUp,
+    /// No gate — lower always eligible.
+    Always,
+}
+
+/// Per-adjacent-pair cross-club gates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MoveToNextConfig {
+    pub p150_to_300: MoveToNextGate,
+    pub p300_to_full: MoveToNextGate,
+}
+
+impl Default for MoveToNextConfig {
+    fn default() -> Self {
+        Self {
+            p150_to_300: MoveToNextGate::default(),
+            p300_to_full: MoveToNextGate::default(),
+        }
+    }
+}
+
+/// Three named slots indexed by `ClubTier`. JSON wire form is
+/// `{"club150": …, "club300": …, "full": …}` — chosen over a HashMap
+/// keyed by the tier enum for explicit field shapes and zero-cost
+/// indexing.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClubMemorizeMap {
+    #[serde(default)]
+    pub club150: ClubMemorizeConfig,
+    #[serde(default)]
+    pub club300: ClubMemorizeConfig,
+    #[serde(default)]
+    pub full: ClubMemorizeConfig,
+}
+
+impl Default for ClubMemorizeMap {
+    fn default() -> Self {
+        Self {
+            club150: ClubMemorizeConfig::default(),
+            club300: ClubMemorizeConfig::default(),
+            full: ClubMemorizeConfig::default(),
+        }
+    }
+}
+
+impl ClubMemorizeMap {
+    pub fn get(&self, tier: ClubTier) -> ClubMemorizeConfig {
+        match tier {
+            ClubTier::Club150 => self.club150,
+            ClubTier::Club300 => self.club300,
+            ClubTier::Full => self.full,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClubReviewMap {
+    #[serde(default)]
+    pub club150: ClubReviewConfig,
+    #[serde(default)]
+    pub club300: ClubReviewConfig,
+    #[serde(default)]
+    pub full: ClubReviewConfig,
+}
+
+impl Default for ClubReviewMap {
+    fn default() -> Self {
+        Self {
+            club150: ClubReviewConfig::default(),
+            club300: ClubReviewConfig::default(),
+            full: ClubReviewConfig::default(),
+        }
+    }
+}
+
+impl ClubReviewMap {
+    pub fn get(&self, tier: ClubTier) -> ClubReviewConfig {
+        match tier {
+            ClubTier::Club150 => self.club150,
+            ClubTier::Club300 => self.club300,
+            ClubTier::Full => self.full,
+        }
+    }
+}
+
+pub const DEFAULT_REVIEW_RETENTION: f32 = 0.8;
+pub const MIN_REVIEW_RETENTION: f32 = 0.5;
+pub const MAX_REVIEW_RETENTION: f32 = 0.9;
+pub const DEFAULT_LESSON_BATCH_SIZE: u8 = 1;
+
+/// Per-user, per-material configuration consumed by the builder and the
+/// scheduler.
+///
+/// The per-club shape replaces the prior flat `(new_scope, review_scope,
+/// desired_retention)` triple — `memorize.{tier}.enabled` controls whether
+/// a club introduces new verses via /memorize; `review.{tier}.enabled`
+/// controls whether its verses surface in /review; `review.{tier}.desired_retention`
+/// is the per-club FSRS target. Card-kind toggles (`heading_card`,
+/// `heading_passage_card`, `ftv`, `club_card_scope`, `chapter_list_scope`)
+/// are unchanged.
+///
+/// `Active`/`Maintenance`/`Paused` per tier is derived from the orthogonal
+/// memorize+review pair:
+/// `(memorize ✓, review *)` → `Active`, `(memorize ✗, review ✓)` →
+/// `Maintenance`, `(memorize ✗, review ✗)` → `Paused`.
+///
+/// JSON wire form keeps the legacy fields' snake_case names
+/// (`new_scope`, `review_scope`, `heading_card`, `club_card_scope`,
+/// `chapter_list_scope`, `desired_retention`) because that's what the
+/// existing API → wasm path emits. The new per-club fields (`memorize`,
+/// `move_to_next`, `review`, `lesson_batch_size`) and the new nested
+/// shapes use camelCase since they're new contract surface. Legacy
+/// scope JSON parses via `MaterialConfigRaw`'s `from` adapter into the
+/// per-club shape on read.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(from = "MaterialConfigRaw")]
+pub struct MaterialConfig {
+    /// Per-verse "which heading?" card. Defaults off: the passage-cued
+    /// version (`heading_passage_card`) is the primary heading test; the
+    /// per-verse version is high-volume, low-signal for most learners.
+    pub heading_card: bool,
+    /// `HeadingPassage` ("what heading is this whole passage under?")
+    /// card. Defaults on.
+    pub heading_passage_card: bool,
+    /// FTV (finish-the-verse) prompts. Defaults on.
+    pub ftv: bool,
+    /// Which clubs get the per-verse `VerseInClub` ("which club is this
+    /// verse in?") card. Still a `TierScope` ladder; reshape to per-club
+    /// booleans deferred to Phase 2 (UI rework) per the spec's open
+    /// questions.
+    pub club_card_scope: TierScope,
+    /// Which clubs get the chapter-list card. Same `ChapterListScope`
+    /// ladder as today.
+    pub chapter_list_scope: ChapterListScope,
+    /// Per-club memorize config. `enabled` is the source of truth for
+    /// "is this club introducing new verses?"; `catch_up` picks the
+    /// pool ordering when behind.
+    pub memorize: ClubMemorizeMap,
+    /// Per-adjacent-pair cross-club gates.
+    pub move_to_next: MoveToNextConfig,
+    /// Per-club review config — `enabled` + `desired_retention`.
+    pub review: ClubReviewMap,
+    /// Target verses per memorize session. Default `1`. The actual
+    /// session size passed to the wasm `memorize_session_v2` call still
+    /// rides as an explicit parameter; this field stores the per-material
+    /// preference the client uses to populate it.
+    pub lesson_batch_size: u8,
+}
+
+/// Deserialization adapter accepting both the legacy flat shape
+/// (`new_scope`, `review_scope`, `desired_retention`) and the per-club
+/// shape. Missing fields fall back to defaults; legacy fields, when the
+/// per-club fields aren't present, derive the per-club values per the
+/// spec's migration table. Field names use snake_case to match the
+/// existing API → wasm wire contract; the new per-club fields accept
+/// camelCase aliases on top so the API can transition to the cleaner
+/// form without a hard cutover.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct MaterialConfigRaw {
+    #[serde(alias = "headings", alias = "headingCard")]
+    heading_card: bool,
+    #[serde(default = "default_true", alias = "headingPassageCard")]
+    heading_passage_card: bool,
+    #[serde(default = "default_true")]
+    ftv: bool,
+    #[serde(alias = "clubCardScope")]
+    club_card_scope: Option<TierScope>,
+    #[serde(alias = "chapterListScope")]
+    chapter_list_scope: Option<ChapterListScope>,
+    memorize: Option<ClubMemorizeMap>,
+    #[serde(alias = "moveToNext")]
+    move_to_next: Option<MoveToNextConfig>,
+    review: Option<ClubReviewMap>,
+    #[serde(alias = "lessonBatchSize")]
+    lesson_batch_size: Option<u8>,
+    // Legacy shape — only consulted when the per-club fields are absent.
+    #[serde(alias = "newScope")]
+    new_scope: Option<TierScope>,
+    #[serde(alias = "reviewScope")]
+    review_scope: Option<TierScope>,
+    #[serde(alias = "desiredRetention")]
+    desired_retention: Option<f32>,
 }
 
 fn default_true() -> bool {
     true
 }
 
+impl From<MaterialConfigRaw> for MaterialConfig {
+    fn from(raw: MaterialConfigRaw) -> Self {
+        let defaults = MaterialConfig::default();
+        // Per-club fields explicit? use them. Else legacy fields present?
+        // migrate per the spec's table. Else fall back to the new-user
+        // default (Club 150 only). Distinguishing "empty JSON" from
+        // "explicit new_scope: all" is critical — the former matches
+        // Default::default() while the latter enables every club.
+        let memorize = raw.memorize.unwrap_or_else(|| match raw.new_scope {
+            Some(scope) => memorize_from_scope(scope),
+            None => defaults.memorize,
+        });
+        let review = raw.review.unwrap_or_else(|| match raw.review_scope {
+            Some(scope) => {
+                let r = raw
+                    .desired_retention
+                    .unwrap_or(DEFAULT_REVIEW_RETENTION)
+                    .clamp(MIN_REVIEW_RETENTION, MAX_REVIEW_RETENTION);
+                review_from_scope(scope, r)
+            }
+            None => defaults.review,
+        });
+        Self {
+            heading_card: raw.heading_card,
+            heading_passage_card: raw.heading_passage_card,
+            ftv: raw.ftv,
+            club_card_scope: raw.club_card_scope.unwrap_or(defaults.club_card_scope),
+            chapter_list_scope: raw
+                .chapter_list_scope
+                .unwrap_or(defaults.chapter_list_scope),
+            memorize,
+            move_to_next: raw.move_to_next.unwrap_or(defaults.move_to_next),
+            review,
+            lesson_batch_size: raw.lesson_batch_size.unwrap_or(defaults.lesson_batch_size),
+        }
+    }
+}
+
+fn memorize_from_scope(scope: TierScope) -> ClubMemorizeMap {
+    ClubMemorizeMap {
+        club150: ClubMemorizeConfig {
+            enabled: scope.includes(ClubTier::Club150),
+            catch_up: CatchUp::Sequential,
+        },
+        club300: ClubMemorizeConfig {
+            enabled: scope.includes(ClubTier::Club300),
+            catch_up: CatchUp::Sequential,
+        },
+        full: ClubMemorizeConfig {
+            enabled: scope.includes(ClubTier::Full),
+            catch_up: CatchUp::Sequential,
+        },
+    }
+}
+
+fn review_from_scope(scope: TierScope, desired_retention: f32) -> ClubReviewMap {
+    ClubReviewMap {
+        club150: ClubReviewConfig {
+            enabled: scope.includes(ClubTier::Club150),
+            desired_retention,
+        },
+        club300: ClubReviewConfig {
+            enabled: scope.includes(ClubTier::Club300),
+            desired_retention,
+        },
+        full: ClubReviewConfig {
+            enabled: scope.includes(ClubTier::Full),
+            desired_retention,
+        },
+    }
+}
+
 impl Default for MaterialConfig {
+    /// New-user default per the spec: Club 150 enabled (memorize + review),
+    /// others off, one verse a day, retention 0.8 across the board.
     fn default() -> Self {
         Self {
             heading_card: false,
             heading_passage_card: true,
             ftv: true,
-            new_scope: TierScope::All,
-            review_scope: TierScope::All,
             club_card_scope: TierScope::Off,
             chapter_list_scope: ChapterListScope::Up150,
+            memorize: ClubMemorizeMap {
+                club150: ClubMemorizeConfig {
+                    enabled: true,
+                    catch_up: CatchUp::Sequential,
+                },
+                club300: ClubMemorizeConfig::default(),
+                full: ClubMemorizeConfig::default(),
+            },
+            move_to_next: MoveToNextConfig::default(),
+            review: ClubReviewMap {
+                club150: ClubReviewConfig {
+                    enabled: true,
+                    desired_retention: DEFAULT_REVIEW_RETENTION,
+                },
+                club300: ClubReviewConfig::default(),
+                full: ClubReviewConfig::default(),
+            },
+            lesson_batch_size: DEFAULT_LESSON_BATCH_SIZE,
         }
     }
 }
 
 impl MaterialConfig {
-    /// Effective per-tier status, derived from the two scopes.
+    /// Construct a config equivalent to the legacy
+    /// `(new_scope, review_scope)` shape with default
+    /// `DEFAULT_REVIEW_RETENTION` for every enabled review club. Useful
+    /// for tests that previously expressed eligibility through scopes and
+    /// for the migration helper that synthesises the per-club shape from
+    /// legacy DB rows.
+    pub fn from_scopes(new_scope: TierScope, review_scope: TierScope) -> Self {
+        Self::from_scopes_with_retention(new_scope, review_scope, DEFAULT_REVIEW_RETENTION)
+    }
+
+    /// Same as `from_scopes` but with explicit retention. Clamps the
+    /// retention to `[MIN_REVIEW_RETENTION, MAX_REVIEW_RETENTION]`.
+    pub fn from_scopes_with_retention(
+        new_scope: TierScope,
+        review_scope: TierScope,
+        desired_retention: f32,
+    ) -> Self {
+        let clamped = desired_retention.clamp(MIN_REVIEW_RETENTION, MAX_REVIEW_RETENTION);
+        Self {
+            memorize: memorize_from_scope(new_scope),
+            review: review_from_scope(review_scope, clamped),
+            ..Self::default()
+        }
+    }
+
+    /// Test helper: every club enabled (memorize + review) at the supplied
+    /// retention. Replaces the old "default = all-active" pattern that
+    /// tests relied on before the spec flipped the new-user default to
+    /// Club 150-only.
+    pub fn all_clubs_enabled(desired_retention: f32) -> Self {
+        Self::from_scopes_with_retention(TierScope::All, TierScope::All, desired_retention)
+    }
+
+    /// Effective per-tier status, derived from the orthogonal memorize +
+    /// review pair. Preserves the prior table:
     ///
-    /// | new | review | status        |
-    /// |-----|--------|---------------|
-    /// |  ✓  |   ✓    | `Active`      |
-    /// |  ✗  |   ✓    | `Maintenance` |
-    /// |  ✓  |   ✗    | `Active`*     |
-    /// |  ✗  |   ✗    | `Paused`      |
+    /// | memorize | review | status        |
+    /// |----------|--------|---------------|
+    /// |    ✓     |   ✓    | `Active`      |
+    /// |    ✗     |   ✓    | `Maintenance` |
+    /// |    ✓     |   ✗    | `Active`*     |
+    /// |    ✗     |   ✗    | `Paused`      |
     ///
-    /// *new-only is mapped to `Active` since it's most-similar to the
-    /// "user is actively studying this tier" intent, even though they've
-    /// switched off review for it.
+    /// *memorize-only is mapped to `Active` since it's most-similar to
+    /// "user is actively studying this tier" even though they've turned
+    /// review off for it.
     pub fn effective_status(&self, tier: ClubTier) -> ClubStatus {
-        let n = self.new_scope.includes(tier);
-        let r = self.review_scope.includes(tier);
+        let n = self.memorize.get(tier).enabled;
+        let r = self.review.get(tier).enabled;
         match (n, r) {
             (false, false) => ClubStatus::Paused,
             (false, true) => ClubStatus::Maintenance,
@@ -158,13 +510,48 @@ impl MaterialConfig {
     }
 
     /// True iff this verse's most-specific tier is paused — neither
-    /// scope covers it. `parse_tiers` guarantees every verse has at
-    /// least one tier (Full when no narrower tag), so the empty branch
-    /// is defensive only.
+    /// memorize nor review covers it. `parse_tiers` guarantees every
+    /// verse has at least one tier (Full when no narrower tag), so the
+    /// empty branch is defensive only.
     pub fn verse_is_paused(&self, verse_clubs: &[ClubTier]) -> bool {
         match verse_clubs.first() {
             Some(t) => self.effective_status(*t) == ClubStatus::Paused,
             None => false,
+        }
+    }
+
+    /// Whether memorize introduces new verses for this club.
+    pub fn memorize_enabled_for(&self, tier: ClubTier) -> bool {
+        self.memorize.get(tier).enabled
+    }
+
+    /// Per-club catch-up behaviour.
+    pub fn catch_up_for(&self, tier: ClubTier) -> CatchUp {
+        self.memorize.get(tier).catch_up
+    }
+
+    /// Whether /review surfaces verses for this club.
+    pub fn review_enabled_for(&self, tier: ClubTier) -> bool {
+        self.review.get(tier).enabled
+    }
+
+    /// Per-club target retention, clamped to the valid range on read so
+    /// out-of-range stored values never reach FSRS math.
+    pub fn target_r_for(&self, tier: ClubTier) -> f32 {
+        self.review
+            .get(tier)
+            .desired_retention
+            .clamp(MIN_REVIEW_RETENTION, MAX_REVIEW_RETENTION)
+    }
+
+    /// Gate from the previous (higher-priority) enabled club to `tier`,
+    /// where `tier` is treated as the candidate "next" club. `None` for
+    /// `Club150` (it has no higher club above it).
+    pub fn gate_to(&self, tier: ClubTier) -> Option<MoveToNextGate> {
+        match tier {
+            ClubTier::Club150 => None,
+            ClubTier::Club300 => Some(self.move_to_next.p150_to_300),
+            ClubTier::Full => Some(self.move_to_next.p300_to_full),
         }
     }
 }
@@ -174,33 +561,176 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_is_everything_active() {
+    fn default_is_club150_only_at_default_retention() {
         let c = MaterialConfig::default();
-        // VerseInHeading defaults off; HeadingPassage defaults on. The
-        // passage-cued card is the primary heading test; the per-verse
-        // version is opt-in.
+        // Card-kind toggles unchanged from pre-Phase-1 defaults.
         assert!(!c.heading_card);
         assert!(c.heading_passage_card);
         assert!(c.ftv);
-        assert_eq!(c.new_scope, TierScope::All);
-        assert_eq!(c.review_scope, TierScope::All);
-        // Club-card prompts default off; chapter-list defaults to Up150.
         assert_eq!(c.club_card_scope, TierScope::Off);
         assert_eq!(c.chapter_list_scope, ChapterListScope::Up150);
+        // Per-spec new-user shape: Club 150 enabled (memorize + review),
+        // others off.
+        assert!(c.memorize_enabled_for(ClubTier::Club150));
+        assert!(!c.memorize_enabled_for(ClubTier::Club300));
+        assert!(!c.memorize_enabled_for(ClubTier::Full));
+        assert!(c.review_enabled_for(ClubTier::Club150));
+        assert!(!c.review_enabled_for(ClubTier::Club300));
+        assert!(!c.review_enabled_for(ClubTier::Full));
+        // Default retention 0.8, batch 1.
+        assert_eq!(c.target_r_for(ClubTier::Club150), DEFAULT_REVIEW_RETENTION);
+        assert_eq!(c.lesson_batch_size, DEFAULT_LESSON_BATCH_SIZE);
+        // Gates default to CaughtUp.
+        assert_eq!(c.gate_to(ClubTier::Club150), None);
+        assert_eq!(c.gate_to(ClubTier::Club300), Some(MoveToNextGate::CaughtUp));
+        assert_eq!(c.gate_to(ClubTier::Full), Some(MoveToNextGate::CaughtUp));
+        // Effective status reflects the new shape: 150 Active, others Paused.
+        assert_eq!(c.effective_status(ClubTier::Club150), ClubStatus::Active);
+        assert_eq!(c.effective_status(ClubTier::Club300), ClubStatus::Paused);
+        assert_eq!(c.effective_status(ClubTier::Full), ClubStatus::Paused);
+    }
+
+    #[test]
+    fn legacy_headings_alias_still_parses() {
+        // Pre-Phase-1 JSON with the older `headings` key (in turn pre-
+        // VerseInHeading split) reads as `heading_card: true`.
+        let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
+        assert!(c.heading_card);
+        assert!(c.heading_passage_card);
+        assert!(c.ftv);
+    }
+
+    #[test]
+    fn legacy_scopes_migrate_to_per_club() {
+        // Legacy flat shape with `new_scope`/`review_scope`/
+        // `desired_retention` — no per-club fields — materialises into
+        // the per-club shape per the spec's migration table.
+        let raw = r#"{
+            "headingCard": false,
+            "headingPassageCard": true,
+            "ftv": true,
+            "newScope": "up150",
+            "reviewScope": "up300",
+            "clubCardScope": "off",
+            "chapterListScope": "up150",
+            "desiredRetention": 0.85
+        }"#;
+        let c: MaterialConfig = serde_json::from_str(raw).unwrap();
+        // memorize.{club}.enabled mirrors `new_scope`.
+        assert!(c.memorize_enabled_for(ClubTier::Club150));
+        assert!(!c.memorize_enabled_for(ClubTier::Club300));
+        assert!(!c.memorize_enabled_for(ClubTier::Full));
+        // review.{club}.enabled mirrors `review_scope`.
+        assert!(c.review_enabled_for(ClubTier::Club150));
+        assert!(c.review_enabled_for(ClubTier::Club300));
+        assert!(!c.review_enabled_for(ClubTier::Full));
+        // Retention applies to every enabled review club, clamped.
+        assert_eq!(c.target_r_for(ClubTier::Club150), 0.85);
+        assert_eq!(c.target_r_for(ClubTier::Club300), 0.85);
+    }
+
+    #[test]
+    fn legacy_retention_above_max_clamps_to_0_9() {
+        // 0.95 was a popular value pre-Phase-1; the new range tops out at
+        // 0.9 and the migrator clamps to fit.
+        let raw = r#"{
+            "newScope": "all",
+            "reviewScope": "all",
+            "desiredRetention": 0.95
+        }"#;
+        let c: MaterialConfig = serde_json::from_str(raw).unwrap();
         for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
-            assert_eq!(c.effective_status(tier), ClubStatus::Active);
+            assert_eq!(c.target_r_for(tier), MAX_REVIEW_RETENTION);
         }
     }
 
     #[test]
-    fn legacy_headings_key_aliases_to_heading_card() {
-        // Pre-split JSON had `headings: bool`. The serde alias keeps
-        // those rows readable so existing users don't lose their
-        // VerseInHeading preference on the bump.
-        let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
-        assert!(c.heading_card);
-        // Missing field falls back to the new default (on).
-        assert!(c.heading_passage_card);
+    fn from_scopes_helper_matches_legacy_deserialize() {
+        let raw = r#"{
+            "newScope": "up300",
+            "reviewScope": "all",
+            "desiredRetention": 0.8
+        }"#;
+        let from_json: MaterialConfig = serde_json::from_str(raw).unwrap();
+        let from_helper =
+            MaterialConfig::from_scopes_with_retention(TierScope::Up300, TierScope::All, 0.8);
+        // Direct equality fails on f32 in general but our retention values
+        // are clean; compare field-by-field for the bits that matter.
+        for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
+            assert_eq!(
+                from_json.memorize_enabled_for(tier),
+                from_helper.memorize_enabled_for(tier),
+                "memorize differs on {tier:?}"
+            );
+            assert_eq!(
+                from_json.review_enabled_for(tier),
+                from_helper.review_enabled_for(tier),
+                "review differs on {tier:?}"
+            );
+            assert_eq!(
+                from_json.target_r_for(tier),
+                from_helper.target_r_for(tier),
+                "retention differs on {tier:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn per_club_explicit_shape_round_trips() {
+        let raw = r#"{
+            "headingCard": false,
+            "headingPassageCard": true,
+            "ftv": true,
+            "clubCardScope": "off",
+            "chapterListScope": "up150",
+            "memorize": {
+                "club150": { "enabled": true, "catchUp": "calendarCascade" },
+                "club300": { "enabled": true, "catchUp": "sequential" },
+                "full": { "enabled": false, "catchUp": "sequential" }
+            },
+            "moveToNext": {
+                "p150To300": "fullyMemorized",
+                "p300ToFull": "always"
+            },
+            "review": {
+                "club150": { "enabled": true, "desiredRetention": 0.9 },
+                "club300": { "enabled": true, "desiredRetention": 0.75 },
+                "full": { "enabled": false, "desiredRetention": 0.8 }
+            },
+            "lessonBatchSize": 3
+        }"#;
+        let c: MaterialConfig = serde_json::from_str(raw).unwrap();
+        assert_eq!(c.catch_up_for(ClubTier::Club150), CatchUp::CalendarCascade);
+        assert_eq!(c.catch_up_for(ClubTier::Club300), CatchUp::Sequential);
+        assert_eq!(
+            c.gate_to(ClubTier::Club300),
+            Some(MoveToNextGate::FullyMemorized)
+        );
+        assert_eq!(c.gate_to(ClubTier::Full), Some(MoveToNextGate::Always));
+        assert_eq!(c.target_r_for(ClubTier::Club300), 0.75);
+        assert_eq!(c.lesson_batch_size, 3);
+        // Round-trip the serialised form back through the deserializer.
+        let j = serde_json::to_string(&c).unwrap();
+        let back: MaterialConfig = serde_json::from_str(&j).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn empty_object_uses_defaults() {
+        // Empty JSON object → MaterialConfig::default()-equivalent shape.
+        let c: MaterialConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(c, MaterialConfig::default());
+    }
+
+    #[test]
+    fn missing_fields_fall_back_through_legacy_or_default() {
+        // Just `ftv: false` set — everything else defaults. Note the
+        // legacy migration path doesn't fire (no `new_scope`/etc.), so
+        // memorize/review come from `MaterialConfig::default()`.
+        let c: MaterialConfig = serde_json::from_str(r#"{"ftv":false}"#).unwrap();
+        assert!(!c.ftv);
+        assert!(c.memorize_enabled_for(ClubTier::Club150));
+        assert!(!c.memorize_enabled_for(ClubTier::Club300));
     }
 
     #[test]
@@ -238,15 +768,11 @@ mod tests {
 
     #[test]
     fn effective_status_combines_two_scopes() {
-        // new=Up150, review=Up300:
-        //   Club 150 → Active   (both cover it)
+        // memorize=Up150, review=Up300:
+        //   Club 150 → Active (both cover it)
         //   Club 300 → Maintenance (only review covers)
-        //   Full     → Paused   (neither covers)
-        let c = MaterialConfig {
-            new_scope: TierScope::Up150,
-            review_scope: TierScope::Up300,
-            ..MaterialConfig::default()
-        };
+        //   Full     → Paused (neither covers)
+        let c = MaterialConfig::from_scopes(TierScope::Up150, TierScope::Up300);
         assert_eq!(c.effective_status(ClubTier::Club150), ClubStatus::Active);
         assert_eq!(
             c.effective_status(ClubTier::Club300),
@@ -257,11 +783,7 @@ mod tests {
 
     #[test]
     fn effective_status_review_only() {
-        let c = MaterialConfig {
-            new_scope: TierScope::Off,
-            review_scope: TierScope::All,
-            ..MaterialConfig::default()
-        };
+        let c = MaterialConfig::from_scopes(TierScope::Off, TierScope::All);
         for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
             assert_eq!(c.effective_status(tier), ClubStatus::Maintenance);
         }
@@ -269,33 +791,20 @@ mod tests {
 
     #[test]
     fn effective_status_all_paused_when_both_scopes_off() {
-        let c = MaterialConfig {
-            new_scope: TierScope::Off,
-            review_scope: TierScope::Off,
-            ..MaterialConfig::default()
-        };
+        let c = MaterialConfig::from_scopes(TierScope::Off, TierScope::Off);
         for tier in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
             assert_eq!(c.effective_status(tier), ClubStatus::Paused);
         }
     }
 
     #[test]
-    fn round_trips_through_json() {
-        let c = MaterialConfig::default();
-        let j = serde_json::to_string(&c).unwrap();
-        let back: MaterialConfig = serde_json::from_str(&j).unwrap();
-        assert_eq!(c, back);
-    }
-
-    #[test]
-    fn missing_scopes_match_default_impl() {
-        // Older JSON may omit scopes. Each defaults to the same value that
-        // `MaterialConfig::default()` uses: new/review at All, club-card
-        // at Off (rarely useful out of the box), chapter-list at Up150.
-        let c: MaterialConfig = serde_json::from_str(r#"{"headings":true,"ftv":true}"#).unwrap();
-        assert_eq!(c.new_scope, TierScope::All);
-        assert_eq!(c.review_scope, TierScope::All);
-        assert_eq!(c.club_card_scope, TierScope::Off);
-        assert_eq!(c.chapter_list_scope, ChapterListScope::Up150);
+    fn verse_is_paused_uses_first_tier() {
+        let c = MaterialConfig::from_scopes(TierScope::Up150, TierScope::Up150);
+        // Full not covered → paused.
+        assert!(c.verse_is_paused(&[ClubTier::Full]));
+        // Club 150 covered → not paused.
+        assert!(!c.verse_is_paused(&[ClubTier::Club150]));
+        // Empty list → defensive false.
+        assert!(!c.verse_is_paused(&[]));
     }
 }

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet};
 use serde::{Deserialize, Serialize};
 
 use crate::card::{Card, CardKind, CardState};
-use crate::engine::ReviewEngine;
+use crate::element::ClubTier;
+use crate::engine::{ReviewEngine, is_bulk_graduable};
+use crate::material_config::{CatchUp, MoveToNextGate};
+use crate::schedule_data::{Schedule, VerseRef};
 use crate::types::CardId;
 
 /// Whether a card tests the **content of one verse** — its text,
@@ -272,12 +275,293 @@ pub fn due_review_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
 /// reviewed. Ties broken by `CardId` (insertion order), which means the
 /// memorize queue surfaces cards in the same order the builder emitted
 /// them (early verses first).
-pub fn next_memorize_card(engine: &ReviewEngine, _now_secs: i64) -> Option<CardId> {
+pub fn next_memorize_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
+    // Thin wrapper around the two-phase batch; the existing single-card
+    // surface is preserved for callers (the wasm `next_memorize_card`
+    // binding, schedule tests) that don't have or need a schedule.
+    next_memorize_batch(engine, None, now_secs, 1)
+        .first()
+        .copied()
+}
+
+/// Build the next `batch_size` memorize cards, in spec-defined order:
+///
+/// 1. **Phase 1** — across enabled clubs whose `catch_up` is
+///    `CalendarCascade` AND whose cross-club gate is open, take all
+///    un-memorized verses in *this week's* calendar row, sorted by
+///    canonical (deck/verse_id) order. Phase 1 ignores `batch_size`
+///    (soft cap overflow allowed per the spec).
+/// 2. **Phase 2** — across all eligible clubs (Sequential pools + the
+///    backlog/lookahead of CalendarCascade pools), take un-memorized
+///    verses in canonical order until the batch is filled.
+///
+/// Returns one anchor `CardId` per chosen verse — `Recitation` if the
+/// verse emits one, otherwise the first un-graduated bulk-graduable
+/// card for that verse (typically `PhraseFill { 0 }`).
+///
+/// Passing `schedule = None` is equivalent to all-`Sequential`: Phase 1
+/// contributes nothing, Phase 2 collects every eligible un-memorized
+/// verse in canonical order.
+pub fn next_memorize_batch(
+    engine: &ReviewEngine,
+    schedule: Option<&Schedule>,
+    now_secs: i64,
+    batch_size: u8,
+) -> Vec<CardId> {
+    let eligible = compute_eligible_clubs(engine, schedule, now_secs);
+    if eligible.is_empty() {
+        return Vec::new();
+    }
+
+    let lookup = build_verse_lookup(engine);
+    let unmemorized = unmemorized_verses_by_tier(engine, &eligible);
+    let mut picked: Vec<u32> = Vec::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+
+    // Phase 1: CalendarCascade clubs' this-week primary.
+    if let Some(sched) = schedule
+        && let Some(week_idx) = sched.current_week_index(now_secs)
+    {
+        let mut phase1: Vec<u32> = Vec::new();
+        for &club in &eligible {
+            if engine.material_config.catch_up_for(club) != CatchUp::CalendarCascade {
+                continue;
+            }
+            let unmem_for_club = unmemorized.get(&club).map(Vec::as_slice).unwrap_or(&[]);
+            for vref in sched.week_verse_refs(week_idx, club) {
+                let Some(&vid) = lookup.get(&vref) else {
+                    continue;
+                };
+                if unmem_for_club.binary_search(&vid).is_ok() && seen.insert(vid) {
+                    phase1.push(vid);
+                }
+            }
+        }
+        phase1.sort_unstable();
+        picked.extend(phase1);
+    }
+
+    // Phase 2: everything else eligible, in canonical (verse_id) order,
+    // capped at remaining batch_size.
+    let remaining = (batch_size as usize).saturating_sub(picked.len());
+    if remaining > 0 {
+        let mut phase2: Vec<u32> = Vec::new();
+        for &club in &eligible {
+            let Some(verses) = unmemorized.get(&club) else {
+                continue;
+            };
+            for &vid in verses {
+                if seen.insert(vid) {
+                    phase2.push(vid);
+                }
+            }
+        }
+        phase2.sort_unstable();
+        picked.extend(phase2.into_iter().take(remaining));
+    }
+
+    picked
+        .into_iter()
+        .filter_map(|vid| anchor_card_for_verse(engine, vid))
+        .collect()
+}
+
+/// Anchor card for a verse: Recitation if the deck emitted one, else the
+/// first un-graduated bulk-graduable card (typically `PhraseFill { 0 }`).
+/// Returns `None` when the verse has no un-graduated content cards at
+/// all — caller should treat that as "verse is fully memorized."
+///
+/// Shared helper so `next_memorize_batch` and the wasm `memorize_session`
+/// verse-anchor pick converge.
+pub fn anchor_card_for_verse(engine: &ReviewEngine, verse_id: u32) -> Option<CardId> {
+    let recitation = engine
+        .cards
+        .iter()
+        .find(|c| c.verse_id == verse_id && matches!(c.kind, CardKind::Recitation));
+    if let Some(card) = recitation
+        && matches!(card.state, CardState::New)
+    {
+        return Some(card.id);
+    }
     engine
         .cards
         .iter()
-        .find(|c| matches!(c.state, CardState::New) && engine.verse_active_for_memorize(c.verse_id))
+        .find(|c| {
+            c.verse_id == verse_id
+                && matches!(c.state, CardState::New)
+                && is_bulk_graduable(&c.kind)
+        })
         .map(|c| c.id)
+}
+
+/// Apply the per-pair cross-club gates and return the enabled clubs in
+/// priority order [Club150, Club300, Full] that actually contribute to
+/// the memorize fill at `now_secs`.
+///
+/// The highest-priority *enabled* club is always eligible (no gate above
+/// it). For subsequent enabled clubs, look up the gate from the most-
+/// recent enabled higher club and evaluate it. A skip-club layout
+/// (e.g. Club 150 enabled, Club 300 disabled, Full enabled) uses
+/// `move_to_next.p300_to_full` against Club 150's position — adjacent-
+/// pair gates don't compose across skips, by design.
+fn compute_eligible_clubs(
+    engine: &ReviewEngine,
+    schedule: Option<&Schedule>,
+    now_secs: i64,
+) -> Vec<ClubTier> {
+    let config = &engine.material_config;
+    let mut result: Vec<ClubTier> = Vec::new();
+    let mut prev_eligible: Option<ClubTier> = None;
+    for club in [ClubTier::Club150, ClubTier::Club300, ClubTier::Full] {
+        if !config.memorize_enabled_for(club) {
+            continue;
+        }
+        let gate_open = match prev_eligible {
+            None => true,
+            Some(higher) => {
+                let gate = config.gate_to(club).unwrap_or(MoveToNextGate::Always);
+                gate_is_open(engine, schedule, higher, gate, now_secs)
+            }
+        };
+        if gate_open {
+            result.push(club);
+            prev_eligible = Some(club);
+        }
+    }
+    result
+}
+
+/// Is the cross-club gate `gate` open, given that `higher` is the most-
+/// recent enabled club above the candidate?
+fn gate_is_open(
+    engine: &ReviewEngine,
+    schedule: Option<&Schedule>,
+    higher: ClubTier,
+    gate: MoveToNextGate,
+    now_secs: i64,
+) -> bool {
+    match gate {
+        MoveToNextGate::Always => true,
+        MoveToNextGate::FullyMemorized => {
+            let (memorized, total) = tier_memorize_progress(engine, higher);
+            total > 0 && memorized == total
+        }
+        MoveToNextGate::AfterMajorCheckpoint => {
+            let Some(sched) = schedule else {
+                return false;
+            };
+            let needed = sched.cumulative_count_through_last_meet(higher, now_secs);
+            if needed == 0 {
+                // No meet has passed yet.
+                return false;
+            }
+            tier_memorize_progress(engine, higher).0 >= needed
+        }
+        MoveToNextGate::AfterMinorCheckpoint => {
+            let Some(sched) = schedule else {
+                return false;
+            };
+            let needed = sched.cumulative_count_through_current_week(higher, now_secs);
+            if needed == 0 {
+                return false;
+            }
+            tier_memorize_progress(engine, higher).0 >= needed
+        }
+        MoveToNextGate::CaughtUp => {
+            let Some(sched) = schedule else {
+                // No schedule = no calendar position to compare against;
+                // treat as "always caught up" so the next club isn't
+                // permanently gated out.
+                return true;
+            };
+            let needed = sched.cumulative_count_through_previous_week(higher, now_secs);
+            tier_memorize_progress(engine, higher).0 >= needed
+        }
+    }
+}
+
+/// Map of (book, chapter, verse) → verse_id, sourced from the engine's
+/// per-verse render data. Built once per `next_memorize_batch` call.
+fn build_verse_lookup(engine: &ReviewEngine) -> HashMap<VerseRef, u32> {
+    let mut map: HashMap<VerseRef, u32> = HashMap::new();
+    for (&vid, render) in engine.verse_render_data.iter() {
+        map.insert((render.book.clone(), render.chapter, render.verse), vid);
+    }
+    map
+}
+
+/// For each `tier` in `eligible`, the sorted-ascending list of verse_ids
+/// with that tier whose bulk-graduable cards include at least one `New`
+/// — i.e. verses the user hasn't yet graduated.
+fn unmemorized_verses_by_tier(
+    engine: &ReviewEngine,
+    eligible: &[ClubTier],
+) -> HashMap<ClubTier, Vec<u32>> {
+    let tier_set: HashSet<ClubTier> = eligible.iter().copied().collect();
+    let mut grouped: HashMap<ClubTier, Vec<u32>> = HashMap::new();
+    let mut seen: HashSet<u32> = HashSet::new();
+    for card in &engine.cards {
+        if !matches!(card.state, CardState::New) || !is_bulk_graduable(&card.kind) {
+            continue;
+        }
+        if !seen.insert(card.verse_id) {
+            continue;
+        }
+        let Some(elements) = engine.verse_index.elements_of(card.verse_id) else {
+            continue;
+        };
+        let Some(&tier) = elements.clubs.first() else {
+            continue;
+        };
+        if !tier_set.contains(&tier) {
+            continue;
+        }
+        grouped.entry(tier).or_default().push(card.verse_id);
+    }
+    // verse_ids are assigned in deck order, so the per-tier vectors are
+    // already ascending — but the card scan can reach them out-of-order
+    // (e.g. Recitation cards land after their PhraseFills, both sharing
+    // the same verse_id). Sort for canonical-order safety.
+    for v in grouped.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+    grouped
+}
+
+/// `(memorized, total)` count of verses with `tier` as their most-specific
+/// tier in this engine. `memorized` = verses with no `New` bulk-graduable
+/// cards left.
+fn tier_memorize_progress(engine: &ReviewEngine, tier: ClubTier) -> (usize, usize) {
+    let mut memorized = 0;
+    let mut total = 0;
+    let mut counted: HashSet<u32> = HashSet::new();
+    let mut has_new: HashMap<u32, bool> = HashMap::new();
+    for card in &engine.cards {
+        if !is_bulk_graduable(&card.kind) {
+            continue;
+        }
+        let entry = has_new.entry(card.verse_id).or_insert(false);
+        if matches!(card.state, CardState::New) {
+            *entry = true;
+        }
+    }
+    for (&vid, &any_new) in &has_new {
+        if !counted.insert(vid) {
+            continue;
+        }
+        let Some(elements) = engine.verse_index.elements_of(vid) else {
+            continue;
+        };
+        if elements.clubs.first().copied() != Some(tier) {
+            continue;
+        }
+        total += 1;
+        if !any_new {
+            memorized += 1;
+        }
+    }
+    (memorized, total)
 }
 
 /// Count of `New` cards eligible for the memorize queue — every
@@ -934,5 +1218,285 @@ mod tests {
         let engine = ReviewEngine::new(r, 0.9);
         let now = 86400 * 365;
         assert_eq!(due_review_count(&engine, now), 0);
+    }
+
+    // ===== next_memorize_batch (two-phase canonical fill) =====
+
+    use crate::material_config::{
+        CatchUp, ClubMemorizeConfig, MaterialConfig, MoveToNextConfig, MoveToNextGate, TierScope,
+    };
+    use crate::schedule_data::{ClubVerseLists, Passage, Schedule, ScheduleWeek};
+
+    fn make_two_club_schedule() -> Schedule {
+        // Single passage covering both fixture verses: John 3:16 (Club150)
+        // and John 3:17 (Club300). week_verse_refs(0, Club150) → [(John,3,16)];
+        // week_verse_refs(0, Club300) → [(John,3,17)].
+        Schedule {
+            version: 1,
+            material_id: "test".into(),
+            season: "2025-26".into(),
+            title: "test".into(),
+            meeting_day_of_week: "Mon".into(),
+            weeks: vec![ScheduleWeek {
+                date: "2025-09-08".into(),
+                passage: Some(Passage {
+                    book: "John".into(),
+                    chapter: 3,
+                    start_verse: 16,
+                    end_verse: 17,
+                }),
+                verses: Some(ClubVerseLists {
+                    club150: vec![16],
+                    club300: vec![17],
+                }),
+                is_review: false,
+            }],
+            meets: vec![],
+        }
+    }
+
+    /// Helper: unwrap the verse_id of the first chosen anchor card.
+    fn batch_verse_ids(engine: &ReviewEngine, batch: Vec<CardId>) -> Vec<u32> {
+        batch
+            .into_iter()
+            .map(|id| engine.card(id).unwrap().verse_id)
+            .collect()
+    }
+
+    #[test]
+    fn batch_no_schedule_sequential_matches_legacy_next_memorize_card() {
+        // Default config = Club 150 only, Sequential. Without a schedule,
+        // Phase 1 contributes nothing → Phase 2 picks the first Club 150
+        // verse in canonical order. The single-card wrapper must agree.
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        let batch = next_memorize_batch(&engine, None, 0, 1);
+        assert_eq!(batch.len(), 1);
+        // Anchor must match the legacy single-card surface verbatim.
+        assert_eq!(Some(batch[0]), next_memorize_card(&engine, 0));
+    }
+
+    #[test]
+    fn batch_two_sequential_clubs_canonical_order() {
+        // 150 + 300 enabled, gate Always → both pools eligible. Canonical
+        // (verse_id) order means verse 16 (Club150, id 0) comes before
+        // verse 17 (Club300, id 1).
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.material_config.move_to_next = MoveToNextConfig {
+            p150_to_300: MoveToNextGate::Always,
+            p300_to_full: MoveToNextGate::Always,
+        };
+        let batch = next_memorize_batch(&engine, None, 0, 2);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        assert_eq!(verse_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn batch_strict_drain_keeps_lower_club_off() {
+        // Gate FullyMemorized on 150 → 300: Club 300 stays ineligible
+        // until every Club 150 verse is memorized. With batch_size=2
+        // we still get only verse 16 (Club 150) since 17 is Club 300.
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.material_config.move_to_next = MoveToNextConfig {
+            p150_to_300: MoveToNextGate::FullyMemorized,
+            p300_to_full: MoveToNextGate::Always,
+        };
+        let batch = next_memorize_batch(&engine, None, 0, 2);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        assert_eq!(verse_ids, vec![0]);
+        // After Club 150 is fully graduated, gate opens.
+        engine.graduate_verse(0);
+        let batch_after = next_memorize_batch(&engine, None, 0, 2);
+        let verse_ids_after = batch_verse_ids(&engine, batch_after);
+        assert_eq!(verse_ids_after, vec![1]);
+    }
+
+    #[test]
+    fn batch_calendar_cascade_picks_this_week_first() {
+        // Two-verse deck with one Club150 (verse 16) and one Club300
+        // (verse 17). Schedule's week 0 covers John 3:16-17, lists 16 as
+        // Club150 and 17 as Club300. With Club 150 in CalendarCascade
+        // and gate Always → Phase 1 takes verse 16, Phase 2 takes
+        // verse 17 (eligible via Always). With batch_size=1, only
+        // verse 16 appears.
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.material_config.memorize = crate::material_config::ClubMemorizeMap {
+            club150: ClubMemorizeConfig {
+                enabled: true,
+                catch_up: CatchUp::CalendarCascade,
+            },
+            club300: ClubMemorizeConfig {
+                enabled: true,
+                catch_up: CatchUp::Sequential,
+            },
+            full: ClubMemorizeConfig::default(),
+        };
+        engine.material_config.move_to_next = MoveToNextConfig {
+            p150_to_300: MoveToNextGate::Always,
+            p300_to_full: MoveToNextGate::Always,
+        };
+        let sched = make_two_club_schedule();
+        // ts=2025-09-08 (week 0's date) — converted to unix secs.
+        let now = crate::schedule_data::parse_iso_date("2025-09-08").unwrap() * 86400;
+        let batch = next_memorize_batch(&engine, Some(&sched), now, 1);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        // Phase 1 contributes verse 16 (Club150 this-week). Soft cap on
+        // primary keeps it, even though batch_size=1.
+        assert_eq!(verse_ids, vec![0]);
+    }
+
+    #[test]
+    fn batch_calendar_cascade_soft_cap_overflows_phase1() {
+        // Both verses are Club150 this week, CalendarCascade. batch_size=1
+        // but Phase 1's primary pool has 2 verses → soft cap pulls both in.
+        let m = sample_material_two_verses(); // both verses → Full (clubs:[])
+        let mut config = MaterialConfig::all_clubs_enabled(0.9);
+        // Force everything to Full club to match the fixture verses.
+        config.memorize.full = ClubMemorizeConfig {
+            enabled: true,
+            catch_up: CatchUp::CalendarCascade,
+        };
+        config.memorize.club150 = ClubMemorizeConfig::default();
+        config.memorize.club300 = ClubMemorizeConfig::default();
+        let r = crate::builder::build_with_config(&m, &config, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+
+        // Schedule: week 0 covers John 3:16-17, no explicit 150/300 lists
+        // (both empty) → Full derives both verses.
+        let sched = Schedule {
+            version: 1,
+            material_id: "t".into(),
+            season: "x".into(),
+            title: "t".into(),
+            meeting_day_of_week: "Mon".into(),
+            weeks: vec![ScheduleWeek {
+                date: "2025-09-08".into(),
+                passage: Some(Passage {
+                    book: "John".into(),
+                    chapter: 3,
+                    start_verse: 16,
+                    end_verse: 17,
+                }),
+                verses: Some(ClubVerseLists {
+                    club150: vec![],
+                    club300: vec![],
+                }),
+                is_review: false,
+            }],
+            meets: vec![],
+        };
+
+        let now = crate::schedule_data::parse_iso_date("2025-09-08").unwrap() * 86400;
+        let batch = next_memorize_batch(&engine, Some(&sched), now, 1);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        // Soft cap on Phase 1: both Full verses surface even though
+        // batch_size=1.
+        assert_eq!(verse_ids.len(), 2);
+        assert_eq!(verse_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn batch_cascade_falls_through_to_lookahead_in_phase2() {
+        // Schedule has two weeks; we're at week 0. CalendarCascade picks
+        // week 0's verse for Phase 1 (verse 16); Phase 2 has room for
+        // verse 17 (week 1's Club150 lookahead).
+        let m = sample_material_two_verses();
+        let mut config = MaterialConfig::all_clubs_enabled(0.9);
+        // Force Full so both verses are eligible.
+        config.memorize.full = ClubMemorizeConfig {
+            enabled: true,
+            catch_up: CatchUp::CalendarCascade,
+        };
+        config.memorize.club150 = ClubMemorizeConfig::default();
+        config.memorize.club300 = ClubMemorizeConfig::default();
+        let r = crate::builder::build_with_config(&m, &config, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+
+        let mk_week = |date: &str, start: u16, end: u16| ScheduleWeek {
+            date: date.into(),
+            passage: Some(Passage {
+                book: "John".into(),
+                chapter: 3,
+                start_verse: start,
+                end_verse: end,
+            }),
+            verses: Some(ClubVerseLists {
+                club150: vec![],
+                club300: vec![],
+            }),
+            is_review: false,
+        };
+        let sched = Schedule {
+            version: 1,
+            material_id: "t".into(),
+            season: "x".into(),
+            title: "t".into(),
+            meeting_day_of_week: "Mon".into(),
+            weeks: vec![mk_week("2025-09-08", 16, 16), mk_week("2025-09-15", 17, 17)],
+            meets: vec![],
+        };
+        let now = crate::schedule_data::parse_iso_date("2025-09-08").unwrap() * 86400;
+        let batch = next_memorize_batch(&engine, Some(&sched), now, 5);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        // Phase 1 takes verse 16 (this week's Full); Phase 2 picks up
+        // verse 17 (next week's lookahead, in canonical order).
+        assert_eq!(verse_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn caught_up_gate_opens_at_season_start_without_schedule() {
+        // Gate = CaughtUp + no schedule → next club is eligible. Avoids
+        // the degenerate case where a configured gate permanently
+        // suppresses the lower club for users with no schedule.
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.material_config.move_to_next = MoveToNextConfig {
+            p150_to_300: MoveToNextGate::CaughtUp,
+            p300_to_full: MoveToNextGate::CaughtUp,
+        };
+        let batch = next_memorize_batch(&engine, None, 0, 2);
+        let verse_ids = batch_verse_ids(&engine, batch);
+        assert_eq!(verse_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn batch_empty_when_nothing_eligible() {
+        // All clubs disabled → batch is empty (matches Phase 2's
+        // empty-eligible early return).
+        let m = sample_material_mixed_tiers();
+        let r = crate::builder::build_with_config(&m, &MaterialConfig::all_clubs_enabled(0.9), 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        engine.material_config = MaterialConfig::from_scopes(TierScope::Off, TierScope::Off);
+        let batch = next_memorize_batch(&engine, None, 0, 5);
+        assert!(batch.is_empty());
+    }
+
+    #[test]
+    fn anchor_card_prefers_recitation_over_phrase_fill() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let engine = ReviewEngine::new(r, 0.9);
+        let anchor = anchor_card_for_verse(&engine, 0).expect("anchor for verse 0");
+        let card = engine.card(anchor).unwrap();
+        assert!(matches!(card.kind, CardKind::Recitation));
+    }
+
+    #[test]
+    fn anchor_card_falls_back_to_phrase_fill_when_recitation_active() {
+        let m = sample_material_one_verse();
+        let r = crate::builder::build(&m, 0);
+        let mut engine = ReviewEngine::new(r, 0.9);
+        // Graduate the verse → Recitation flips to Active. anchor_for_verse
+        // returns None (no New bulk_graduable card left).
+        engine.graduate_verse(0);
+        assert!(anchor_card_for_verse(&engine, 0).is_none());
     }
 }

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -414,11 +414,10 @@ mod tests {
     }
 
     fn config_150_active_300_maintenance() -> crate::material_config::MaterialConfig {
-        crate::material_config::MaterialConfig {
-            new_scope: crate::material_config::TierScope::Up150,
-            review_scope: crate::material_config::TierScope::Up300,
-            ..crate::material_config::MaterialConfig::default()
-        }
+        crate::material_config::MaterialConfig::from_scopes(
+            crate::material_config::TierScope::Up150,
+            crate::material_config::TierScope::Up300,
+        )
     }
 
     #[test]
@@ -437,7 +436,11 @@ mod tests {
         let m = sample_material_mixed_tiers();
         let r_all_active = crate::builder::build_with_config(
             &m,
-            &crate::material_config::MaterialConfig::default(),
+            // Use the test-friendly all-clubs-enabled config so the
+            // baseline really is "everything Active" — the new-user
+            // default is Club 150 only, which would silently match the
+            // Club300-Maintenance count below.
+            &crate::material_config::MaterialConfig::all_clubs_enabled(0.9),
             0,
         );
         let engine_all = ReviewEngine::new(r_all_active, 0.9);

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -313,15 +313,28 @@ pub fn next_memorize_batch(
         return Vec::new();
     }
 
-    let lookup = build_verse_lookup(engine);
     let unmemorized = unmemorized_verses_by_tier(engine, &eligible);
     let mut picked: Vec<u32> = Vec::new();
     let mut seen: HashSet<u32> = HashSet::new();
 
-    // Phase 1: CalendarCascade clubs' this-week primary.
-    if let Some(sched) = schedule
+    // Phase 1: CalendarCascade clubs' this-week primary. Only runs when
+    // a schedule is supplied AND at least one eligible club is on
+    // CalendarCascade — the (book, chapter, verse) → verse_id lookup is
+    // an O(verses) HashMap with owned String keys, so building it
+    // unconditionally would burn one full allocation on every memorize
+    // click for the common Sequential-only path.
+    let mut any_cascade = false;
+    for &club in &eligible {
+        if engine.material_config.catch_up_for(club) == CatchUp::CalendarCascade {
+            any_cascade = true;
+            break;
+        }
+    }
+    if any_cascade
+        && let Some(sched) = schedule
         && let Some(week_idx) = sched.current_week_index(now_secs)
     {
+        let lookup = build_verse_lookup(engine);
         let mut phase1: Vec<u32> = Vec::new();
         for &club in &eligible {
             if engine.material_config.catch_up_for(club) != CatchUp::CalendarCascade {
@@ -419,7 +432,16 @@ fn compute_eligible_clubs(
         let gate_open = match prev_eligible {
             None => true,
             Some(higher) => {
-                let gate = config.gate_to(club).unwrap_or(MoveToNextGate::Always);
+                // `gate_to(Club150)` is the only `None` case — that branch
+                // is structurally unreachable here because Club150 always
+                // hits the `prev_eligible: None` arm above. Any future
+                // tier added between Club150 and Club300 would need a
+                // gate entry in `MaterialConfig`; the expect catches the
+                // omission instead of silently falling through to
+                // `Always`.
+                let gate = config
+                    .gate_to(club)
+                    .expect("gate_to is Some for every non-top tier");
                 gate_is_open(engine, schedule, higher, gate, now_secs)
             }
         };
@@ -533,9 +555,11 @@ fn unmemorized_verses_by_tier(
 /// tier in this engine. `memorized` = verses with no `New` bulk-graduable
 /// cards left.
 fn tier_memorize_progress(engine: &ReviewEngine, tier: ClubTier) -> (usize, usize) {
-    let mut memorized = 0;
-    let mut total = 0;
-    let mut counted: HashSet<u32> = HashSet::new();
+    // One pass over `engine.cards` building per-verse "has any New bulk-
+    // graduable card" — the HashMap key already dedupes verse_ids, so an
+    // extra HashSet for tracking would be redundant. The second walk is
+    // over the HashMap (not the cards), so it stays O(verses) regardless
+    // of how many cards each verse has.
     let mut has_new: HashMap<u32, bool> = HashMap::new();
     for card in &engine.cards {
         if !is_bulk_graduable(&card.kind) {
@@ -546,10 +570,9 @@ fn tier_memorize_progress(engine: &ReviewEngine, tier: ClubTier) -> (usize, usiz
             *entry = true;
         }
     }
+    let mut memorized = 0;
+    let mut total = 0;
     for (&vid, &any_new) in &has_new {
-        if !counted.insert(vid) {
-            continue;
-        }
         let Some(elements) = engine.verse_index.elements_of(vid) else {
             continue;
         };

--- a/crates/core/src/schedule.rs
+++ b/crates/core/src/schedule.rs
@@ -117,10 +117,10 @@ pub fn next_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
         .iter()
         .filter(|c| matches!(c.state, CardState::Active))
         .filter(|c| !engine.is_in_cooldown(c.id, now_secs))
-        .filter_map(|c| Some((c.id, engine.card_min_r(c, now_secs)?)))
-        .filter(|(_, r)| *r < engine.schedule_params.target_retention)
+        .filter_map(|c| Some((c, engine.card_min_r(c, now_secs)?)))
+        .filter(|(c, r)| *r < engine.target_r_for_verse(c.verse_id))
         .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap())
-        .map(|(id, _)| id)
+        .map(|(c, _)| c.id)
 }
 
 /// Bucket every active card by its **weakest test's stability** —
@@ -181,7 +181,6 @@ pub fn new_verse_count(engine: &ReviewEngine) -> u32 {
 /// eligibility (active + below-target, ignoring cooldown) and
 /// applies the same verse-content filter as `new_verse_count`.
 pub fn due_verse_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
-    let target = engine.schedule_params.target_retention;
     let mut seen: HashSet<u32> = HashSet::new();
     for card in &engine.cards {
         if !matches!(card.state, CardState::Active) {
@@ -190,6 +189,7 @@ pub fn due_verse_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
         if !is_verse_content_card(&card.kind) {
             continue;
         }
+        let target = engine.target_r_for_verse(card.verse_id);
         if let Some(r) = engine.card_min_r(card, now_secs)
             && r < target
         {
@@ -261,8 +261,8 @@ pub fn due_review_count(engine: &ReviewEngine, now_secs: i64) -> u32 {
         .cards
         .iter()
         .filter(|c| matches!(c.state, CardState::Active))
-        .filter_map(|c| engine.card_min_r(c, now_secs))
-        .filter(|r| *r < engine.schedule_params.target_retention)
+        .filter_map(|c| Some((c, engine.card_min_r(c, now_secs)?)))
+        .filter(|(c, r)| *r < engine.target_r_for_verse(c.verse_id))
         .count() as u32
 }
 
@@ -585,12 +585,12 @@ pub fn new_card_count(engine: &ReviewEngine) -> u32 {
 /// Returns `None` when no lane card is due. Ties broken by earliest due time
 /// (the lapse a learner has been kept waiting longest gets cleared first).
 pub fn next_relearn_card(engine: &ReviewEngine, now_secs: i64) -> Option<CardId> {
-    let target = engine.schedule_params.target_retention;
     engine
         .cards
         .iter()
         .filter(|c| matches!(c.state, CardState::Active))
         .filter_map(|c| {
+            let target = engine.target_r_for_verse(c.verse_id);
             let atoms = engine.atoms_for(c.verse_id);
             let earliest_due = c
                 .tests(&atoms)
@@ -1112,14 +1112,17 @@ mod tests {
 
     #[test]
     fn due_review_count_is_zero_when_no_card_is_due() {
-        // Target 0.0 — no card's retrievability can fall below it,
-        // so nothing is due regardless of how stale the cards are.
+        // `new_unseen` antedates test states by 365 days from the build
+        // timestamp, so a build at `now` and a query at `now - 365 days`
+        // sees elapsed = 0 → retrievability 1.0 → nothing below target.
+        // Verifies the per-verse-retention filter still excludes not-yet-
+        // due cards after the threshold move.
+        let now = 86400 * 365;
         let m = sample_material_two_verses();
-        let r = crate::builder::build(&m, 86400 * 365);
+        let r = crate::builder::build(&m, now);
         let mut engine = ReviewEngine::new(r, 0.9);
-        engine.schedule_params.target_retention = 0.0;
         engine.graduate_all();
-        assert_eq!(due_review_count(&engine, 86400 * 365), 0);
+        assert_eq!(due_review_count(&engine, 0), 0);
     }
 
     #[test]

--- a/crates/core/src/schedule_data.rs
+++ b/crates/core/src/schedule_data.rs
@@ -1,0 +1,407 @@
+use serde::{Deserialize, Serialize};
+
+use crate::element::ClubTier;
+
+/// A per-(material, season) memorisation calendar. Carries the dated rows
+/// the user works through during a season — each row introduces verses for
+/// one or more clubs — plus the major checkpoints (quiz meets) that anchor
+/// the gates downstream. Source of truth is bundled per material in
+/// `data/schedules/<deck>-<season>.json`; the user's edits land in the
+/// API's `material_schedules` table as a full-copy override.
+///
+/// Wire form mirrors the bundled JSON exactly: camelCase fields, ISO date
+/// strings, and structured `passage` objects (rather than a parsed string
+/// like "1 Cor 1:1-31"). The structured passage avoids the cross-language
+/// book-abbreviation table that would otherwise be needed at read time.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Schedule {
+    pub version: u32,
+    pub material_id: String,
+    pub season: String,
+    pub title: String,
+    /// Three-letter abbreviation: "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+    /// "Sun". Drives schedule-editor display only — the row dates carry
+    /// the authoritative weekday.
+    pub meeting_day_of_week: String,
+    pub weeks: Vec<ScheduleWeek>,
+    #[serde(default)]
+    pub meets: Vec<Meet>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScheduleWeek {
+    /// ISO `YYYY-MM-DD`.
+    pub date: String,
+    /// `None` on Review weeks (no new verses introduced).
+    pub passage: Option<Passage>,
+    /// `None` on Review weeks. When present, lists the verse numbers (within
+    /// `passage`) that each club introduces this week. Verses in
+    /// `verses.club300` are the Club 300-tagged *additional* verses — Club
+    /// 150's set is not duplicated. The implicit Full tier covers any verse
+    /// in `passage` that's listed in neither.
+    pub verses: Option<ClubVerseLists>,
+    #[serde(default)]
+    pub is_review: bool,
+}
+
+/// Structured passage range. Each row in the SK PDF spans a single chapter,
+/// so a single `(book, chapter, start_verse, end_verse)` covers the
+/// observed shape. Multi-chapter spans would need a future shape change.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Passage {
+    /// Full book name matching the deck's `MaterialData.books` entries
+    /// (e.g. "1 Corinthians", not "1 Cor"). Avoids the abbreviation lookup.
+    pub book: String,
+    pub chapter: u16,
+    pub start_verse: u16,
+    pub end_verse: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClubVerseLists {
+    #[serde(default)]
+    pub club150: Vec<u16>,
+    #[serde(default)]
+    pub club300: Vec<u16>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Meet {
+    pub id: String,
+    pub name: String,
+    /// ISO `YYYY-MM-DD`.
+    pub start_date: String,
+    /// ISO `YYYY-MM-DD`. `None` for single-day meets.
+    #[serde(default)]
+    pub end_date: Option<String>,
+    #[serde(default)]
+    pub location: Option<String>,
+}
+
+/// Seconds per day; used everywhere a Unix timestamp converts to a calendar
+/// day for week-row comparison.
+const SECS_PER_DAY: i64 = 86_400;
+
+impl Schedule {
+    /// Index of the most-recent week whose `date` is on or before today,
+    /// per `now_secs`. `None` when the season hasn't started yet (today is
+    /// before the first week's date) or when `weeks` is empty.
+    ///
+    /// Out-of-season-past (today is after the last week) returns the index
+    /// of the final week — the season's last row is the canonical "current"
+    /// position once memorisation has reached the end of the calendar.
+    pub fn current_week_index(&self, now_secs: i64) -> Option<usize> {
+        let today = days_since_epoch_from_secs(now_secs);
+        let mut hit: Option<usize> = None;
+        for (i, w) in self.weeks.iter().enumerate() {
+            let d = parse_iso_date(&w.date)?;
+            if d <= today {
+                hit = Some(i);
+            } else {
+                break;
+            }
+        }
+        hit
+    }
+
+    /// Most-recent meet whose `start_date` is on or before today.
+    ///
+    /// Used by the `AfterMajorCheckpoint` cross-club gate: the lower club
+    /// becomes eligible once the higher club's verses through this meet's
+    /// position are all memorised. `None` before the season's first meet —
+    /// which makes `AfterMajorCheckpoint` a never-open gate at season start
+    /// (the spec calls this out as the intentional behaviour).
+    pub fn most_recent_past_meet(&self, now_secs: i64) -> Option<&Meet> {
+        let today = days_since_epoch_from_secs(now_secs);
+        self.meets
+            .iter()
+            .filter_map(|m| parse_iso_date(&m.start_date).map(|d| (d, m)))
+            .filter(|(d, _)| *d <= today)
+            .max_by_key(|(d, _)| *d)
+            .map(|(_, m)| m)
+    }
+}
+
+impl ClubVerseLists {
+    /// The list of verse numbers this club introduces this week. `Full` is
+    /// derived from the passage minus 150 ∪ 300; `for_tier` returns the
+    /// borrowed slice for the two storage-backed tiers and `None` for
+    /// `Full` (callers must compute Full's contribution from the row's
+    /// `passage` range).
+    pub fn for_tier(&self, tier: ClubTier) -> Option<&[u16]> {
+        match tier {
+            ClubTier::Club150 => Some(&self.club150),
+            ClubTier::Club300 => Some(&self.club300),
+            ClubTier::Full => None,
+        }
+    }
+}
+
+/// Parse a `YYYY-MM-DD` date string into days since the Unix epoch
+/// (1970-01-01). Implements Howard Hinnant's `days_from_civil` —
+/// well-known proleptic-Gregorian conversion with no dependency footprint.
+/// Returns `None` on malformed strings; does not validate that the day-of-
+/// month is in range (Feb 30 parses to a day-since-epoch and round-trips,
+/// matching the algorithm's convention).
+pub fn parse_iso_date(s: &str) -> Option<i64> {
+    let bytes = s.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return None;
+    }
+    let y: i32 = std::str::from_utf8(&bytes[0..4]).ok()?.parse().ok()?;
+    let m: u32 = std::str::from_utf8(&bytes[5..7]).ok()?.parse().ok()?;
+    let d: u32 = std::str::from_utf8(&bytes[8..10]).ok()?.parse().ok()?;
+    if !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return None;
+    }
+    Some(days_from_civil(y, m, d))
+}
+
+/// Howard Hinnant's `days_from_civil(y, m, d)` — `(y, m, d)` in the
+/// proleptic Gregorian calendar to days since the Unix epoch. Exact for
+/// all dates in `[-5_879_610-06-23, 5_879_611-07-11]`.
+fn days_from_civil(y: i32, m: u32, d: u32) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = (if y >= 0 { y } else { y - 399 }) / 400;
+    let yoe = (y - era * 400) as u32;
+    let m_shifted = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * m_shifted + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era as i64 * 146_097 + doe as i64 - 719_468
+}
+
+/// Truncate a Unix-second timestamp to the day, in UTC. Matches the
+/// resolution we compare schedule dates at — sub-day drift doesn't
+/// advance the `current_week_index`.
+fn days_since_epoch_from_secs(now_secs: i64) -> i64 {
+    now_secs.div_euclid(SECS_PER_DAY)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schedule_fixture() -> Schedule {
+        Schedule {
+            version: 1,
+            material_id: "3-corinthians".into(),
+            season: "2025-26".into(),
+            title: "SK Quiz 2025-26 — 1 & 2 Cor".into(),
+            meeting_day_of_week: "Mon".into(),
+            weeks: vec![
+                ScheduleWeek {
+                    date: "2025-09-08".into(),
+                    passage: Some(Passage {
+                        book: "1 Corinthians".into(),
+                        chapter: 1,
+                        start_verse: 1,
+                        end_verse: 31,
+                    }),
+                    verses: Some(ClubVerseLists {
+                        club150: vec![5, 10, 17, 18, 21, 25, 27],
+                        club300: vec![1, 2, 4, 8, 9, 19, 23],
+                    }),
+                    is_review: false,
+                },
+                ScheduleWeek {
+                    date: "2025-09-15".into(),
+                    passage: Some(Passage {
+                        book: "1 Corinthians".into(),
+                        chapter: 2,
+                        start_verse: 1,
+                        end_verse: 16,
+                    }),
+                    verses: Some(ClubVerseLists {
+                        club150: vec![4, 9, 12, 14, 16],
+                        club300: vec![5, 7, 10, 11, 13],
+                    }),
+                    is_review: false,
+                },
+                ScheduleWeek {
+                    date: "2025-11-17".into(),
+                    passage: None,
+                    verses: None,
+                    is_review: true,
+                },
+            ],
+            meets: vec![
+                Meet {
+                    id: "first-weekend".into(),
+                    name: "First Weekend Quiz Meet".into(),
+                    start_date: "2025-11-21".into(),
+                    end_date: Some("2025-11-23".into()),
+                    location: Some("Heritage Alliance Church".into()),
+                },
+                Meet {
+                    id: "final-weekend".into(),
+                    name: "Final Weekend Quiz Meet".into(),
+                    start_date: "2026-05-01".into(),
+                    end_date: Some("2026-05-03".into()),
+                    location: Some("Briercrest College, Caronport, SK".into()),
+                },
+            ],
+        }
+    }
+
+    /// Unix timestamp at UTC midnight for the given ISO date. Convenience
+    /// for tests so each `now_secs` reads as the date it represents.
+    fn ts(date: &str) -> i64 {
+        parse_iso_date(date).expect("test date") * SECS_PER_DAY
+    }
+
+    #[test]
+    fn parses_iso_dates_against_known_values() {
+        assert_eq!(parse_iso_date("1970-01-01"), Some(0));
+        assert_eq!(parse_iso_date("1970-01-02"), Some(1));
+        assert_eq!(parse_iso_date("2025-09-08"), Some(20_339));
+        assert_eq!(parse_iso_date("2026-06-14"), Some(20_618));
+        assert_eq!(parse_iso_date("1969-12-31"), Some(-1));
+    }
+
+    #[test]
+    fn rejects_malformed_dates() {
+        assert_eq!(parse_iso_date(""), None);
+        assert_eq!(parse_iso_date("2025/09/08"), None);
+        assert_eq!(parse_iso_date("25-09-08"), None);
+        assert_eq!(parse_iso_date("2025-13-08"), None);
+        assert_eq!(parse_iso_date("2025-09-32"), None);
+    }
+
+    #[test]
+    fn current_week_index_before_season_is_none() {
+        let s = schedule_fixture();
+        assert_eq!(s.current_week_index(ts("2025-09-07")), None);
+        assert_eq!(s.current_week_index(ts("2024-01-01")), None);
+    }
+
+    #[test]
+    fn current_week_index_on_first_day_returns_zero() {
+        let s = schedule_fixture();
+        assert_eq!(s.current_week_index(ts("2025-09-08")), Some(0));
+    }
+
+    #[test]
+    fn current_week_index_advances_with_each_row() {
+        let s = schedule_fixture();
+        // Sunday before week 2 still maps to week 0.
+        assert_eq!(s.current_week_index(ts("2025-09-14")), Some(0));
+        assert_eq!(s.current_week_index(ts("2025-09-15")), Some(1));
+        // After all rows, the final row's index stays current.
+        assert_eq!(s.current_week_index(ts("2030-01-01")), Some(2));
+    }
+
+    #[test]
+    fn current_week_index_handles_review_week() {
+        // Review weeks have no `passage`/`verses` but still count for
+        // positioning — the current-week index advances normally.
+        let s = schedule_fixture();
+        assert_eq!(s.current_week_index(ts("2025-11-17")), Some(2));
+    }
+
+    #[test]
+    fn empty_weeks_returns_none() {
+        let mut s = schedule_fixture();
+        s.weeks.clear();
+        assert_eq!(s.current_week_index(ts("2025-09-08")), None);
+    }
+
+    #[test]
+    fn most_recent_past_meet_handles_season_edges() {
+        let s = schedule_fixture();
+        // Before any meet.
+        assert!(s.most_recent_past_meet(ts("2025-09-08")).is_none());
+        // Day before the first meet's start.
+        assert!(s.most_recent_past_meet(ts("2025-11-20")).is_none());
+        // Day of the first meet's start.
+        assert_eq!(
+            s.most_recent_past_meet(ts("2025-11-21"))
+                .map(|m| m.id.as_str()),
+            Some("first-weekend")
+        );
+        // Between the two meets — still anchors on the first.
+        assert_eq!(
+            s.most_recent_past_meet(ts("2026-02-15"))
+                .map(|m| m.id.as_str()),
+            Some("first-weekend")
+        );
+        // After the final meet — anchors on the final.
+        assert_eq!(
+            s.most_recent_past_meet(ts("2026-12-25"))
+                .map(|m| m.id.as_str()),
+            Some("final-weekend")
+        );
+    }
+
+    #[test]
+    fn for_tier_full_returns_none() {
+        // Full's contribution isn't stored — callers derive it from the
+        // row's `passage` range minus the 150 ∪ 300 sets.
+        let lists = ClubVerseLists {
+            club150: vec![1, 2],
+            club300: vec![3, 4],
+        };
+        assert_eq!(lists.for_tier(ClubTier::Club150), Some(&[1u16, 2][..]));
+        assert_eq!(lists.for_tier(ClubTier::Club300), Some(&[3u16, 4][..]));
+        assert!(lists.for_tier(ClubTier::Full).is_none());
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let s = schedule_fixture();
+        let j = serde_json::to_string(&s).expect("serialise");
+        let back: Schedule = serde_json::from_str(&j).expect("deserialise");
+        assert_eq!(back.weeks.len(), s.weeks.len());
+        assert_eq!(back.meets.len(), s.meets.len());
+        assert_eq!(
+            back.weeks[0].verses.as_ref().unwrap().club150,
+            vec![5, 10, 17, 18, 21, 25, 27]
+        );
+        assert!(back.weeks[2].is_review);
+        assert!(back.weeks[2].passage.is_none());
+    }
+
+    #[test]
+    fn parses_external_json_shape() {
+        // Sanity check on the bundled-JSON shape (camelCase wire form, the
+        // `endDate`/`location` `Option` fields work with explicit `null`,
+        // and the `isReview` default to false on present weeks).
+        let raw = r#"{
+            "version": 1,
+            "materialId": "3-corinthians",
+            "season": "2025-26",
+            "title": "Test",
+            "meetingDayOfWeek": "Mon",
+            "weeks": [
+                {
+                    "date": "2025-09-08",
+                    "passage": {
+                        "book": "1 Corinthians",
+                        "chapter": 1,
+                        "startVerse": 1,
+                        "endVerse": 31
+                    },
+                    "verses": { "club150": [5, 10], "club300": [1] }
+                }
+            ],
+            "meets": [
+                {
+                    "id": "m1",
+                    "name": "Meet",
+                    "startDate": "2025-11-21",
+                    "endDate": null,
+                    "location": null
+                }
+            ]
+        }"#;
+        let s: Schedule = serde_json::from_str(raw).expect("parse");
+        assert_eq!(s.weeks.len(), 1);
+        assert!(!s.weeks[0].is_review);
+        assert_eq!(s.weeks[0].passage.as_ref().unwrap().end_verse, 31);
+        assert_eq!(s.meets[0].end_date, None);
+    }
+}

--- a/crates/core/src/schedule_data.rs
+++ b/crates/core/src/schedule_data.rs
@@ -200,6 +200,32 @@ impl Schedule {
         out
     }
 
+    /// Count of verses scheduled for `tier` in the single row at
+    /// `week_idx`. Skips the owned-`VerseRef` construction the gate hot
+    /// path doesn't need.
+    fn week_verse_count(&self, week_idx: usize, tier: ClubTier) -> usize {
+        let Some(week) = self.weeks.get(week_idx) else {
+            return 0;
+        };
+        if week.passage.is_none() {
+            return 0;
+        }
+        self.verse_numbers_for_tier(week, tier).len()
+    }
+
+    /// Total count of unique verses scheduled for `tier` from week 0
+    /// through `through_week_idx`. Cheaper than counting
+    /// `cumulative_verse_refs_through_week(...).len()` because it sums
+    /// per-row counts directly instead of materialising the full
+    /// `Vec<VerseRef>` (which clones `passage.book` per entry).
+    fn cumulative_count_through_week(&self, through_week_idx: usize, tier: ClubTier) -> usize {
+        if self.weeks.is_empty() {
+            return 0;
+        }
+        let cap = through_week_idx.min(self.weeks.len() - 1);
+        (0..=cap).map(|idx| self.week_verse_count(idx, tier)).sum()
+    }
+
     /// Total count of unique verses scheduled for `tier` from week 0
     /// through the schedule's current-week index. `0` when the season
     /// hasn't started yet. Used by the memorize-tab badge math and the
@@ -208,7 +234,7 @@ impl Schedule {
         let Some(idx) = self.current_week_index(now_secs) else {
             return 0;
         };
-        self.cumulative_verse_refs_through_week(idx, tier).len()
+        self.cumulative_count_through_week(idx, tier)
     }
 
     /// Cumulative count for `tier` through the schedule's most-recent
@@ -230,7 +256,7 @@ impl Schedule {
             if d > meet_day {
                 break;
             }
-            count += self.week_verse_refs(i, tier).len();
+            count += self.week_verse_count(i, tier);
         }
         count
     }
@@ -246,7 +272,7 @@ impl Schedule {
         if idx == 0 {
             return 0;
         }
-        self.cumulative_verse_refs_through_week(idx - 1, tier).len()
+        self.cumulative_count_through_week(idx - 1, tier)
     }
 
     /// Internal: verse numbers for `tier` in this single row. `Full` is

--- a/crates/core/src/schedule_data.rs
+++ b/crates/core/src/schedule_data.rs
@@ -99,7 +99,15 @@ impl Schedule {
         let today = days_since_epoch_from_secs(now_secs);
         let mut hit: Option<usize> = None;
         for (i, w) in self.weeks.iter().enumerate() {
-            let d = parse_iso_date(&w.date)?;
+            // `?` would short-circuit the whole function on a single
+            // malformed date and silently collapse the schedule into
+            // pre-season state for every caller — including the badge
+            // math and the cross-club gates. Skip the bad row instead so
+            // a typo in one week doesn't disable scheduling for the
+            // entire season.
+            let Some(d) = parse_iso_date(&w.date) else {
+                continue;
+            };
             if d <= today {
                 hit = Some(i);
             } else {

--- a/crates/core/src/schedule_data.rs
+++ b/crates/core/src/schedule_data.rs
@@ -142,6 +142,129 @@ impl ClubVerseLists {
     }
 }
 
+/// Verse reference triple `(book, chapter, verse)` used to bridge the
+/// schedule's per-row verse numbers with the engine's `(verse_id, book,
+/// chapter, verse)` render data. Owned strings — schedule rows are few,
+/// the cost is negligible, and lifetime-free returns simplify call sites.
+pub type VerseRef = (String, u16, u16);
+
+impl Schedule {
+    /// Resolve the verse numbers a given `tier` introduces in `week_idx`
+    /// into `(book, chapter, verse)` refs. Returns an empty vector for
+    /// Review weeks, for out-of-range indices, and for weeks with no
+    /// `passage`. `Full`-tier refs are derived as `passage`'s verse range
+    /// minus the explicitly-listed `club150 ∪ club300` numbers.
+    ///
+    /// Does **not** consult the engine — pure schedule-level resolution.
+    /// Callers map the refs to `verse_id`s via a lookup built from the
+    /// engine's `verse_render_data`.
+    pub fn week_verse_refs(&self, week_idx: usize, tier: ClubTier) -> Vec<VerseRef> {
+        let Some(week) = self.weeks.get(week_idx) else {
+            return Vec::new();
+        };
+        let Some(passage) = &week.passage else {
+            return Vec::new();
+        };
+        let numbers = self.verse_numbers_for_tier(week, tier);
+        numbers
+            .into_iter()
+            .map(|n| (passage.book.clone(), passage.chapter, n))
+            .collect()
+    }
+
+    /// All verse refs cumulatively introduced for `tier` across weeks
+    /// `0..=through_week_idx`. `through_week_idx` is clamped to
+    /// `weeks.len() - 1`. Refs preserve schedule (earliest-week-first)
+    /// order.
+    pub fn cumulative_verse_refs_through_week(
+        &self,
+        through_week_idx: usize,
+        tier: ClubTier,
+    ) -> Vec<VerseRef> {
+        if self.weeks.is_empty() {
+            return Vec::new();
+        }
+        let cap = through_week_idx.min(self.weeks.len() - 1);
+        let mut out: Vec<VerseRef> = Vec::new();
+        for idx in 0..=cap {
+            out.extend(self.week_verse_refs(idx, tier));
+        }
+        out
+    }
+
+    /// Total count of unique verses scheduled for `tier` from week 0
+    /// through the schedule's current-week index. `0` when the season
+    /// hasn't started yet. Used by the memorize-tab badge math and the
+    /// `AfterMinorCheckpoint` gate.
+    pub fn cumulative_count_through_current_week(&self, tier: ClubTier, now_secs: i64) -> usize {
+        let Some(idx) = self.current_week_index(now_secs) else {
+            return 0;
+        };
+        self.cumulative_verse_refs_through_week(idx, tier).len()
+    }
+
+    /// Cumulative count for `tier` through the schedule's most-recent
+    /// past meet's `start_date`. `0` when no meet has passed yet — which
+    /// makes the `AfterMajorCheckpoint` gate impossible to satisfy at
+    /// that point (intentional per the spec).
+    pub fn cumulative_count_through_last_meet(&self, tier: ClubTier, now_secs: i64) -> usize {
+        let Some(meet) = self.most_recent_past_meet(now_secs) else {
+            return 0;
+        };
+        let Some(meet_day) = parse_iso_date(&meet.start_date) else {
+            return 0;
+        };
+        let mut count = 0;
+        for (i, w) in self.weeks.iter().enumerate() {
+            let Some(d) = parse_iso_date(&w.date) else {
+                continue;
+            };
+            if d > meet_day {
+                break;
+            }
+            count += self.week_verse_refs(i, tier).len();
+        }
+        count
+    }
+
+    /// Cumulative count for `tier` through the most-recent week strictly
+    /// **before** the schedule's current week. `0` at season start (no
+    /// previous week exists). Used by the `CaughtUp` gate, which opens
+    /// when the user's position ≥ this value.
+    pub fn cumulative_count_through_previous_week(&self, tier: ClubTier, now_secs: i64) -> usize {
+        let Some(idx) = self.current_week_index(now_secs) else {
+            return 0;
+        };
+        if idx == 0 {
+            return 0;
+        }
+        self.cumulative_verse_refs_through_week(idx - 1, tier).len()
+    }
+
+    /// Internal: verse numbers for `tier` in this single row. `Full` is
+    /// derived from `passage` minus `club150 ∪ club300`.
+    fn verse_numbers_for_tier(&self, week: &ScheduleWeek, tier: ClubTier) -> Vec<u16> {
+        let Some(passage) = &week.passage else {
+            return Vec::new();
+        };
+        let Some(verses) = &week.verses else {
+            return Vec::new();
+        };
+        match tier {
+            ClubTier::Club150 => verses.club150.clone(),
+            ClubTier::Club300 => verses.club300.clone(),
+            ClubTier::Full => {
+                let mut excluded: std::collections::HashSet<u16> = std::collections::HashSet::new();
+                excluded.extend(verses.club150.iter().copied());
+                excluded.extend(verses.club300.iter().copied());
+                (passage.start_verse..=passage.end_verse)
+                    .filter(|n| !excluded.contains(n))
+                    .collect()
+            }
+        }
+    }
+}
+
 /// Parse a `YYYY-MM-DD` date string into days since the Unix epoch
 /// (1970-01-01). Implements Howard Hinnant's `days_from_civil` —
 /// well-known proleptic-Gregorian conversion with no dependency footprint.
@@ -363,6 +486,82 @@ mod tests {
         );
         assert!(back.weeks[2].is_review);
         assert!(back.weeks[2].passage.is_none());
+    }
+
+    #[test]
+    fn week_verse_refs_resolves_per_tier() {
+        let s = schedule_fixture();
+        let club150 = s.week_verse_refs(0, ClubTier::Club150);
+        assert_eq!(club150.len(), 7);
+        assert_eq!(club150[0], ("1 Corinthians".to_string(), 1, 5));
+        let club300 = s.week_verse_refs(0, ClubTier::Club300);
+        assert_eq!(club300.len(), 7);
+        assert_eq!(club300[0], ("1 Corinthians".to_string(), 1, 1));
+    }
+
+    #[test]
+    fn week_verse_refs_full_tier_derives_from_passage_minus_others() {
+        let s = schedule_fixture();
+        let full = s.week_verse_refs(0, ClubTier::Full);
+        // Passage 1 Cor 1:1-31 = 31 verses. Club150 has 7, Club300 has 7
+        // (all distinct), so Full has 31 - 14 = 17.
+        assert_eq!(full.len(), 17);
+        // Verse 3 is in neither 150 nor 300, so it's Full.
+        assert!(full.contains(&("1 Corinthians".to_string(), 1, 3)));
+        // Verse 5 is in 150; must NOT be in Full.
+        assert!(!full.contains(&("1 Corinthians".to_string(), 1, 5)));
+        // Verse 31 is in neither; must be in Full.
+        assert!(full.contains(&("1 Corinthians".to_string(), 1, 31)));
+    }
+
+    #[test]
+    fn week_verse_refs_returns_empty_for_review_or_oob() {
+        let s = schedule_fixture();
+        // Review week (idx 2) has no passage/verses.
+        assert!(s.week_verse_refs(2, ClubTier::Club150).is_empty());
+        // Out-of-range index.
+        assert!(s.week_verse_refs(99, ClubTier::Club150).is_empty());
+    }
+
+    #[test]
+    fn cumulative_through_week_aggregates_across_weeks() {
+        let s = schedule_fixture();
+        let c0 = s.cumulative_verse_refs_through_week(0, ClubTier::Club150);
+        assert_eq!(c0.len(), 7);
+        let c1 = s.cumulative_verse_refs_through_week(1, ClubTier::Club150);
+        // Week 1 adds 5 more Club150 verses.
+        assert_eq!(c1.len(), 12);
+    }
+
+    #[test]
+    fn cumulative_count_helpers_handle_edges() {
+        let s = schedule_fixture();
+        // Pre-season → 0.
+        assert_eq!(
+            s.cumulative_count_through_current_week(ClubTier::Club150, ts("2025-09-01")),
+            0
+        );
+        // On week 0's day → just that week.
+        assert_eq!(
+            s.cumulative_count_through_current_week(ClubTier::Club150, ts("2025-09-08")),
+            7
+        );
+        // Previous week from week 0 → 0 (no prior week).
+        assert_eq!(
+            s.cumulative_count_through_previous_week(ClubTier::Club150, ts("2025-09-08")),
+            0
+        );
+        // Through the first meet (Nov 21): all Club150 from weeks before
+        // the meet — covers weeks 0 and 1 (and review week 2 contributes 0).
+        assert_eq!(
+            s.cumulative_count_through_last_meet(ClubTier::Club150, ts("2025-12-01")),
+            12
+        );
+        // Before any meet → 0.
+        assert_eq!(
+            s.cumulative_count_through_last_meet(ClubTier::Club150, ts("2025-09-08")),
+            0
+        );
     }
 
     #[test]

--- a/crates/wasm/CHANGELOG.md
+++ b/crates/wasm/CHANGELOG.md
@@ -22,6 +22,61 @@ The contract is documented in `docs/wasm-api.md`.
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-06-14
+
+MAJOR bump for the schedules + per-club settings rework (Phase 1). The `WasmEngine` constructor
+signature changes — `desired_retention` is removed, `schedule_json` is added — and the per-club
+`MaterialConfig` shape now flows across the wire. Pre-0.6.0 JS callers will not type-check or run
+against this build; update the constructor call site (and the `memorize_session` call site when
+ready, see below) when bumping consumers.
+
+### `WasmEngine` constructor signature change
+
+Old:
+
+```ts
+new WasmEngine(material_json, material_config_json, persisted_states_json, desired_retention, now_secs)
+```
+
+New:
+
+```ts
+new WasmEngine(material_json, material_config_json, schedule_json, persisted_states_json, now_secs)
+```
+
+* `desired_retention` is removed. Per-club retention now lives inside
+  `MaterialConfig.review.{club}.desiredRetention`; the fallback for pseudo-verses with no tier is
+  the engine's `ScheduleParams::default().target_retention` (0.9).
+* `schedule_json` is new. Pass `""` to skip the schedule entirely — the memorize algorithm collapses
+  to pure-Sequential canonical-order fill in that case, matching pre-0.6.0 behaviour. Otherwise it's
+  a JSON `Schedule` matching the bundled `data/schedules/<deck>-<season>.json` shape from
+  `crates/core@0.6.0`.
+
+### `MaterialConfig` wire shape
+
+The flat `(new_scope, review_scope, desired_retention)` triple is replaced by per-club `memorize`,
+`review`, and a per-pair `move_to_next` gate. Legacy shape is still accepted on read via the
+migration adapter — but new clients should emit the per-club shape directly to avoid the clamp on
+legacy retention values above 0.9. See `crates/core@0.6.0`'s changelog for the field list and
+migration semantics.
+
+### New: `memorize_session_v2(limit, now_secs)`
+
+* Schedule-aware two-phase canonical-order fill. Phase 1 picks `CalendarCascade` clubs' this-week
+  primary verses, Phase 2 fills the rest from eligible clubs in canonical (deck) order. Returns the
+  same `{ verses, orphans }` JSON shape `memorize_session` returns.
+* `memorize_session(limit)` stays callable for one release as a deprecated wrapper — it invokes v2
+  with `now_secs = 0`, which collapses gracefully when no schedule is supplied. The web client's
+  call site switches in Phase 2 of the implementation train.
+
+### Test scaffolding adjustment
+
+* `parse_material_config("")` now returns `MaterialConfig::all_clubs_enabled(0.9)` instead of
+  `MaterialConfig::default()`. The new default is the spec's Club-150-only shape, which would
+  silently pause fixtures using `clubs: []` (resolves to `Full`). The TS API path always supplies a
+  real per-club JSON for production users, so this branch is reached only in tests and the WASM
+  smoke harness.
+
 ## [0.5.1] — 2026-06-11
 
 ### Fix `memorize_session` ignoring tier-scope

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "verse-vault-wasm"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -265,11 +265,12 @@ impl From<&TestUpdate> for TestUpdateWire {
     }
 }
 
-/// Engine handle exposed to JS. Wraps a `ReviewEngine` and translates JSON
-/// payloads at the boundary.
+/// Engine handle exposed to JS. Wraps a `ReviewEngine`, an optional per-
+/// material `Schedule`, and translates JSON payloads at the boundary.
 #[wasm_bindgen]
 pub struct WasmEngine {
     engine: ReviewEngine,
+    schedule: Option<verse_vault_core::schedule_data::Schedule>,
 }
 
 #[wasm_bindgen]
@@ -286,21 +287,41 @@ impl WasmEngine {
     /// fallback config (transitional — Phase 1's API path always supplies
     /// a real per-club JSON for production users; see `parse_material_config`)
     /// (everything-on); otherwise it's a JSON `MaterialConfig` carrying the
-    /// per-year toggles (headings / ftv / citation).
+    /// per-year toggles (headings / ftv / citation) plus the per-club
+    /// memorize / review / move_to_next shape.
+    /// `schedule_json` may be `""` to skip the schedule entirely — the
+    /// memorize algorithm collapses to pure-Sequential when no schedule is
+    /// supplied. Otherwise it's a JSON `Schedule` matching the bundled
+    /// `data/schedules/<deck>-<season>.json` shape.
+    ///
+    /// As of `crates/wasm@0.6.0` the standalone `desired_retention`
+    /// argument was removed: per-club retention now lives inside
+    /// `MaterialConfig.review.{club}.desired_retention`, and the
+    /// fallback for pseudo-verses with no tier is the
+    /// `ScheduleParams::default().target_retention` (0.9). Existing
+    /// callers should drop the argument and pass `schedule_json` in
+    /// its slot (empty string preserves pre-0.6.0 behaviour).
     #[wasm_bindgen(constructor)]
     pub fn new(
         material_json: &str,
         material_config_json: &str,
+        schedule_json: &str,
         persisted_states_json: &str,
-        desired_retention: f32,
         now_secs: i64,
     ) -> Result<WasmEngine, JsError> {
         let material: MaterialData = serde_json::from_str(material_json)
             .map_err(|e| JsError::new(&format!("material_json parse error: {e}")))?;
         let config = parse_material_config(material_config_json)
             .map_err(|e| JsError::new(&format!("material_config_json parse error: {e}")))?;
+        let schedule = parse_schedule(schedule_json)
+            .map_err(|e| JsError::new(&format!("schedule_json parse error: {e}")))?;
         let build_result = build_with_config(&material, &config, now_secs);
-        let mut engine = ReviewEngine::new(build_result, desired_retention);
+        // ReviewEngine::new still takes a `desired_retention` that seeds
+        // `ScheduleParams.target_retention`; that param now only services
+        // the fallback path (`target_r_for_verse` falls back to it for
+        // pseudo-verses with no tier). Per-tier retention is read from
+        // the MaterialConfig.
+        let mut engine = ReviewEngine::new(build_result, 0.9);
 
         let trimmed = persisted_states_json.trim();
         if !trimmed.is_empty() {
@@ -312,7 +333,7 @@ impl WasmEngine {
             }
         }
 
-        Ok(WasmEngine { engine })
+        Ok(WasmEngine { engine, schedule })
     }
 
     /// Apply a card review. `grade` is the FSRS-style integer rating
@@ -433,10 +454,27 @@ impl WasmEngine {
     /// / drill / graduation steps. Graduation goes through
     /// `graduate_card`, not the host verse's `graduate_verse`.
     pub fn memorize_session(&self, limit: u32) -> Result<String, JsError> {
+        // Pre-0.6.0 surface — calls v2 with `now_secs = 0` so the
+        // existing web client keeps working through the wasm bump. The
+        // empty-or-absent schedule path inside next_memorize_batch
+        // collapses to Phase 2 (pure-Sequential) which matches today's
+        // canonical-order behaviour exactly. Deprecated; remove after
+        // Phase 2 ships the v2 call site on the web client.
+        self.memorize_session_v2(limit, 0)
+    }
+
+    /// Schedule-aware memorize session — two-phase canonical fill via
+    /// `crates/core::schedule::next_memorize_batch`. Returns the same
+    /// `{ verses, orphans }` JSON shape `memorize_session` returns; only
+    /// the verse-anchor source changes.
+    ///
+    /// `now_secs` is the wall-clock used to compute the current week
+    /// (CalendarCascade Phase 1) and to evaluate cross-club gates that
+    /// reference dated checkpoints.
+    pub fn memorize_session_v2(&self, limit: u32, now_secs: i64) -> Result<String, JsError> {
         use std::collections::{HashMap, HashSet};
         use verse_vault_core::card::{CardKind, CardState};
         use verse_vault_core::element::ClubTier;
-        use verse_vault_core::engine::is_bulk_graduable;
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
         struct Entry {
@@ -471,25 +509,13 @@ impl WasmEngine {
         }
         let cards = &self.engine.cards;
 
-        // Tier-scope gate, computed once and reused across every loop
-        // below. A verse in `Maintenance` status (its tier is in
-        // `review_scope` but not in `new_scope`) keeps its cards built
-        // so already-memorized work can still be reviewed, but New
-        // cards on those verses must NOT enter the memorize queue —
-        // the user explicitly opted out of introducing new verses from
-        // that tier. `schedule::next_memorize_card` and
-        // `schedule::new_card_count` already apply this gate per-card
-        // for the next-card picker and the dashboard count; this path
-        // was independently picking the memorize batch and orphans and
-        // missed the same gate (the verse-anchor loop initially, and —
-        // discovered next — the HP/CCL assignment + conditional orphan
-        // loops). The HashSet collects verse_ids that have at least
-        // one `New` card AND pass `verse_active_for_memorize`, so
-        // every downstream loop can short-circuit with a single
-        // contains() check. Pseudo-verses (HP, CCL) carry their own
-        // `clubs` shape — HP has `Vec::new()` (no tier, gate passes),
-        // CCL has `vec![card_tier]` (gate fires on Maintenance, which
-        // is the correct exclusion).
+        // Tier gate for the HP/CCL/orphan placement loops below. A verse
+        // in `Maintenance` keeps its cards built so already-memorized
+        // work can still be reviewed, but New cards on those verses must
+        // NOT enter the memorize queue. The HashSet collects verse_ids
+        // that have at least one `New` card AND pass
+        // `verse_active_for_memorize`, so every downstream loop can
+        // short-circuit with a single contains() check.
         let memorize_active_verses: HashSet<u32> = cards
             .iter()
             .filter(|c| matches!(c.state, CardState::New))
@@ -497,31 +523,23 @@ impl WasmEngine {
             .map(|c| c.verse_id)
             .collect();
 
-        // "Fresh" verses — those with at least one New unconditional
-        // verse-bound card (the set `graduate_verse` flips). Orphan-only
-        // verses (where every New card is a conditional kind on a verse
-        // whose content was already graduated) deliberately don't anchor
-        // a session-verse; their conditional cards distribute into the
-        // orphan slot below.
-        let mut seen_verses: HashSet<u32> = HashSet::new();
-        let mut verse_order: Vec<u32> = Vec::new();
-        for card in cards.iter() {
-            if !matches!(card.state, CardState::New) {
-                continue;
-            }
-            if !is_bulk_graduable(&card.kind) {
-                continue;
-            }
-            if !memorize_active_verses.contains(&card.verse_id) {
-                continue;
-            }
-            if seen_verses.insert(card.verse_id) {
-                verse_order.push(card.verse_id);
-                if verse_order.len() >= limit as usize {
-                    break;
-                }
-            }
-        }
+        // Verse anchors come from the schedule-aware two-phase fill —
+        // Phase 1 picks CalendarCascade clubs' this-week primary verses
+        // first, Phase 2 fills the rest in canonical order. With no
+        // schedule supplied (legacy path), Phase 1 contributes nothing
+        // and Phase 2 walks every eligible verse in canonical order,
+        // matching the old card-scan behaviour byte-for-byte.
+        let batch_cap = limit.min(u8::MAX as u32) as u8;
+        let batch_card_ids = verse_vault_core::schedule::next_memorize_batch(
+            &self.engine,
+            self.schedule.as_ref(),
+            now_secs,
+            batch_cap,
+        );
+        let verse_order: Vec<u32> = batch_card_ids
+            .iter()
+            .filter_map(|cid| self.engine.card(*cid).map(|c| c.verse_id))
+            .collect();
 
         // Pre-compute pseudo-card attachments before walking the verses.
         // Two rules govern when a HeadingPassage / ChapterClubList card
@@ -881,6 +899,17 @@ impl WasmEngine {
     pub fn all_card_renders(&self) -> Result<String, JsError> {
         serde_json::to_string(&self.all_card_renders_inner())
             .map_err(|e| JsError::new(&format!("render serialise error: {e}")))
+    }
+}
+
+fn parse_schedule(
+    json: &str,
+) -> Result<Option<verse_vault_core::schedule_data::Schedule>, serde_json::Error> {
+    let trimmed = json.trim();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        serde_json::from_str(trimmed).map(Some)
     }
 }
 

--- a/crates/wasm/src/lib.rs
+++ b/crates/wasm/src/lib.rs
@@ -282,7 +282,9 @@ impl WasmEngine {
     /// same Unix-seconds value the rest of the system uses (browser callers
     /// can do `BigInt(Math.floor(Date.now() / 1000))`).
     /// `persisted_states_json` may be `""` or `"[]"` to start fresh.
-    /// `material_config_json` may be `""` to use `MaterialConfig::default()`
+    /// `material_config_json` may be `""` to use the legacy "everything on"
+    /// fallback config (transitional — Phase 1's API path always supplies
+    /// a real per-club JSON for production users; see `parse_material_config`)
     /// (everything-on); otherwise it's a JSON `MaterialConfig` carrying the
     /// per-year toggles (headings / ftv / citation).
     #[wasm_bindgen(constructor)]
@@ -885,7 +887,19 @@ impl WasmEngine {
 fn parse_material_config(json: &str) -> Result<MaterialConfig, serde_json::Error> {
     let trimmed = json.trim();
     if trimmed.is_empty() {
-        Ok(MaterialConfig::default())
+        // Empty config_json from the API means "no user settings stored yet."
+        // Pre-Phase-1, that fell through to MaterialConfig::default() which
+        // historically meant "every club Active at 0.9 retention." The new
+        // MaterialConfig::default() is the spec's Club-150-only new-user
+        // shape, so a verbatim swap would silently pause Club 300 / Full
+        // verses for any user without a settings row — including the wasm
+        // test fixtures that use clubs: [] (parse_tiers → Full).
+        //
+        // Preserve the historical contract by mapping "" to all-clubs-
+        // enabled at the legacy 0.9 default. The TS engine.ts path (commit 8
+        // in this train) writes the real per-club JSON before calling wasm,
+        // so production never relies on this branch for real users.
+        Ok(MaterialConfig::all_clubs_enabled(0.9))
     } else {
         serde_json::from_str(trimmed)
     }

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -208,9 +208,11 @@ fn material_config_json_parses_and_filters_emission() {
     // off to demonstrate that config JSON crosses the wasm boundary.
     let off_engine = WasmEngine::new(
         MATERIAL_JSON,
+        // Legacy-shape JSON; new_scope/review_scope=all keeps the Full
+        // verse out of Paused via the legacy → per-club migrator.
         r#"{"headings":false,"ftv":false,
-            "club_card_scope":"off","chapter_list_scope":"off",
-            "clubs":{"Full":"Active"}}"#,
+            "new_scope":"all","review_scope":"all",
+            "club_card_scope":"off","chapter_list_scope":"off"}"#,
         "",
         0.9,
         0,

--- a/crates/wasm/tests/roundtrip.rs
+++ b/crates/wasm/tests/roundtrip.rs
@@ -27,13 +27,13 @@ const GRADE_GOOD: u8 = 3;
 
 #[test]
 fn constructor_loads_material_without_panic() {
-    let _engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 86400 * 365)
+    let _engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 86400 * 365)
         .expect("constructor should succeed");
 }
 
 #[test]
 fn constructor_accepts_empty_persisted_states() {
-    let _engine = WasmEngine::new(MATERIAL_JSON, "", "[]", 0.9, 86400 * 365).unwrap();
+    let _engine = WasmEngine::new(MATERIAL_JSON, "", "", "[]", 86400 * 365).unwrap();
 }
 
 /// Look up the first card for verse 0 from the material.
@@ -61,7 +61,7 @@ fn first_card_id_where<F: Fn(&CardKind) -> bool>(pred: F) -> u32 {
 #[test]
 fn replay_event_returns_root_update_for_atomic_card() {
     let now = 86400 * 365;
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, now).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", now).unwrap();
     let card_id = first_card_id_where(|k| matches!(k, CardKind::PhraseFill { .. }));
     let resp = engine
         .replay_event(card_id, GRADE_GOOD, now + 86400 * 30)
@@ -74,7 +74,7 @@ fn replay_event_returns_root_update_for_atomic_card() {
 #[test]
 fn replay_event_returns_sub_updates_for_composite_card() {
     let now = 86400 * 365;
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, now).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", now).unwrap();
     let card_id = first_card_id_where(|k| matches!(k, CardKind::Recitation));
     let resp = engine
         .replay_event(card_id, GRADE_GOOD, now + 86400 * 30)
@@ -93,7 +93,7 @@ fn replay_event_returns_sub_updates_for_composite_card() {
 #[test]
 fn export_test_states_after_review_round_trips() {
     let now = 86400 * 365;
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, now).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", now).unwrap();
     let card_id = first_card_id();
     let _ = engine
         .replay_event(card_id, GRADE_GOOD, now + 86400 * 30)
@@ -110,7 +110,7 @@ fn export_test_states_after_review_round_trips() {
 #[test]
 fn replay_event_unknown_card_id_returns_error() {
     let now = 86400 * 365;
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, now).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", now).unwrap();
     let bogus_id: u32 = 999_999;
     let result = engine.replay_event_for_test(bogus_id, GRADE_GOOD, now);
     let err = result.expect_err("unknown card id should yield Err, not panic");
@@ -120,7 +120,7 @@ fn replay_event_unknown_card_id_returns_error() {
 #[test]
 fn replay_event_invalid_grade_returns_error() {
     let now = 86400 * 365;
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, now).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", now).unwrap();
     let card_id = first_card_id();
     let result = engine.replay_event_for_test(card_id, 0, now);
     let err = result.expect_err("invalid grade should yield Err, not panic");
@@ -136,7 +136,7 @@ fn next_card_returns_some_when_due_after_graduation() {
     // we ask at +60 days past t=365d, retrievability is well below 0.9. The
     // verse has to be graduated (memorize → Active) before `next_card` will
     // surface its cards — without graduation, /review is empty.
-    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     engine.graduate_verse(0);
     let pick = engine.next_review_card(86400 * 365 + 86400 * 60);
     assert!(pick.is_some(), "expected a due card");
@@ -145,13 +145,13 @@ fn next_card_returns_some_when_due_after_graduation() {
 #[test]
 fn next_card_empty_until_verse_graduates() {
     // Brand-new engine: every card is `New`. /review must be empty.
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     assert!(engine.next_review_card(86400 * 365 + 86400 * 60).is_none());
 }
 
 #[test]
 fn get_card_render_for_phrase_fill_returns_structural_metadata() {
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     let card_id = first_card_id_where(|k| matches!(k, CardKind::PhraseFill { position: 1 }));
     let json = engine.get_card_render_for_test(card_id).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -169,7 +169,7 @@ fn get_card_render_for_phrase_fill_returns_structural_metadata() {
 
 #[test]
 fn get_card_render_for_recitation_has_structural_verse_data() {
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     let card_id = first_card_id_where(|k| matches!(k, CardKind::Recitation));
     let json = engine.get_card_render_for_test(card_id).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -190,7 +190,7 @@ fn get_card_render_for_recitation_has_structural_verse_data() {
 
 #[test]
 fn get_card_render_unknown_card_id_returns_error() {
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     let err = engine.get_card_render_for_test(999_999).unwrap_err();
     assert!(err.contains("unknown card id"), "got: {err}");
 }
@@ -202,7 +202,7 @@ fn material_config_json_parses_and_filters_emission() {
     // engine produces fewer cards than the default. Core-level tests
     // verify the specific kinds dropped; this test just confirms the
     // config JSON crosses the wasm boundary and reaches `build_with_config`.
-    let default_engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let default_engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     // Turn off the year-wide toggles. Club configs stay at their map
     // entries from build_with_config; we only need `headings` and `ftv`
     // off to demonstrate that config JSON crosses the wasm boundary.
@@ -214,7 +214,7 @@ fn material_config_json_parses_and_filters_emission() {
             "new_scope":"all","review_scope":"all",
             "club_card_scope":"off","chapter_list_scope":"off"}"#,
         "",
-        0.9,
+        "",
         0,
     )
     .unwrap();
@@ -250,7 +250,7 @@ const MATERIAL_HP_CCL_JSON: &str = r#"{
 
 #[test]
 fn memorize_session_surfaces_hp_and_ccl_as_standalone_slots() {
-    let engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", "", 0).unwrap();
     let json = engine.memorize_session(10).unwrap();
     let session: serde_json::Value = serde_json::from_str(&json).unwrap();
     let entries = session["verses"].as_array().unwrap();
@@ -299,7 +299,7 @@ fn memorize_session_surfaces_orphan_conditional_cards() {
         "chapter_list_scope": "up150",
         "clubs": {"Club150": "Active"}
     }"#;
-    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", 0.9, 0).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", "", 0).unwrap();
     engine.graduate_verse(0);
     let json = engine.memorize_session(10).unwrap();
     let session: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -336,7 +336,7 @@ fn memorize_session_surfaces_orphans_when_no_fresh_verses() {
         "chapter_list_scope": "up150",
         "clubs": {"Club150": "Active"}
     }"#;
-    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", 0.9, 0).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, config_json, "", "", 0).unwrap();
     engine.graduate_verse(0);
     engine.graduate_verse(1);
     let json = engine.memorize_session(3).unwrap();
@@ -357,7 +357,7 @@ fn memorize_session_surfaces_orphans_when_no_fresh_verses() {
 
 #[test]
 fn graduate_card_flips_one_card_and_is_idempotent() {
-    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    let mut engine = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", "", 0).unwrap();
     let json = engine.memorize_session(10).unwrap();
     let session: serde_json::Value = serde_json::from_str(&json).unwrap();
     let entries = session["verses"].as_array().unwrap();
@@ -374,7 +374,7 @@ fn graduate_card_flips_one_card_and_is_idempotent() {
     // re-check the HP state through the wire shape here, but a second
     // graduate_card returns false (already Active), and a fresh engine
     // confirms graduate_verse alone leaves the HP New.
-    let mut engine2 = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", 0.9, 0).unwrap();
+    let mut engine2 = WasmEngine::new(MATERIAL_HP_CCL_JSON, "", "", "", 0).unwrap();
     engine2.graduate_verse(0);
     engine2.graduate_verse(1);
     // HP is still New, so graduate_card returns true.
@@ -383,7 +383,7 @@ fn graduate_card_flips_one_card_and_is_idempotent() {
 
 #[test]
 fn card_count_by_club_returns_buckets_for_full_tier_material() {
-    let engine = WasmEngine::new(MATERIAL_JSON, "", "", 0.9, 0).unwrap();
+    let engine = WasmEngine::new(MATERIAL_JSON, "", "", "", 0).unwrap();
     let json = engine.card_count_by_club_for_test();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
     // MATERIAL_JSON has empty clubs on its single verse, so parse_tiers

--- a/data/schedules/3-corinthians-2025-26.json
+++ b/data/schedules/3-corinthians-2025-26.json
@@ -1,0 +1,224 @@
+{
+  "version": 1,
+  "materialId": "nkjv-cor",
+  "season": "2025-26",
+  "title": "SK Quiz 2025-26 — 1 & 2 Corinthians",
+  "meetingDayOfWeek": "Mon",
+  "weeks": [
+    {
+      "date": "2025-09-08",
+      "passage": { "book": "1 Corinthians", "chapter": 1, "startVerse": 1, "endVerse": 31 },
+      "verses": { "club150": [5, 10, 17, 18, 21, 25, 27], "club300": [1, 2, 4, 8, 9, 19, 23] },
+      "isReview": false
+    },
+    {
+      "date": "2025-09-15",
+      "passage": { "book": "1 Corinthians", "chapter": 2, "startVerse": 1, "endVerse": 16 },
+      "verses": { "club150": [4, 9, 12, 14, 16], "club300": [5, 7, 10, 11, 13] },
+      "isReview": false
+    },
+    {
+      "date": "2025-09-22",
+      "passage": { "book": "1 Corinthians", "chapter": 3, "startVerse": 1, "endVerse": 23 },
+      "verses": { "club150": [1, 6, 7, 11, 13, 16], "club300": [8, 10, 12, 15, 17] },
+      "isReview": false
+    },
+    {
+      "date": "2025-09-29",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2025-10-05",
+      "passage": { "book": "1 Corinthians", "chapter": 6, "startVerse": 1, "endVerse": 20 },
+      "verses": { "club150": [2, 7, 11, 12, 18, 19, 20], "club300": [1, 8, 9, 10, 13] },
+      "isReview": false
+    },
+    {
+      "date": "2025-10-12",
+      "passage": { "book": "1 Corinthians", "chapter": 7, "startVerse": 1, "endVerse": 40 },
+      "verses": { "club150": [7, 19, 23, 24, 39], "club300": [8, 9, 13, 14, 22] },
+      "isReview": false
+    },
+    {
+      "date": "2025-10-19",
+      "passage": { "book": "1 Corinthians", "chapter": 8, "startVerse": 1, "endVerse": 13 },
+      "verses": { "club150": [2, 3, 6, 9, 12], "club300": [1, 4, 5, 13] },
+      "isReview": false
+    },
+    {
+      "date": "2025-10-26",
+      "passage": { "book": "1 Corinthians", "chapter": 9, "startVerse": 1, "endVerse": 27 },
+      "verses": { "club150": [14, 19, 22, 24, 25, 26, 27], "club300": [16, 20, 21] },
+      "isReview": false
+    },
+    {
+      "date": "2025-11-03",
+      "passage": { "book": "1 Corinthians", "chapter": 10, "startVerse": 1, "endVerse": 33 },
+      "verses": { "club150": [11, 13, 24, 31, 33], "club300": [6, 7, 8, 9, 10, 14, 23] },
+      "isReview": false
+    },
+    {
+      "date": "2025-11-10",
+      "passage": { "book": "1 Corinthians", "chapter": 11, "startVerse": 1, "endVerse": 34 },
+      "verses": { "club150": [1, 3, 24, 25, 26, 27, 28], "club300": [4, 5, 7, 10, 15, 23, 29, 30] },
+      "isReview": false
+    },
+    {
+      "date": "2025-11-17",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2025-11-24",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2025-12-01",
+      "passage": { "book": "1 Corinthians", "chapter": 12, "startVerse": 1, "endVerse": 31 },
+      "verses": { "club150": [6, 7, 12, 18, 23, 26], "club300": [3, 11, 13, 17, 24, 25, 28] },
+      "isReview": false
+    },
+    {
+      "date": "2025-12-08",
+      "passage": { "book": "1 Corinthians", "chapter": 13, "startVerse": 1, "endVerse": 13 },
+      "verses": { "club150": [4, 5, 6, 7, 13], "club300": [1, 2, 3, 8, 10, 11, 12] },
+      "isReview": false
+    },
+    {
+      "date": "2025-12-15",
+      "passage": { "book": "1 Corinthians", "chapter": 14, "startVerse": 1, "endVerse": 40 },
+      "verses": { "club150": [1, 6, 12, 33], "club300": [4, 11, 19, 22, 26, 32] },
+      "isReview": false
+    },
+    {
+      "date": "2026-01-05",
+      "passage": { "book": "1 Corinthians", "chapter": 15, "startVerse": 1, "endVerse": 34 },
+      "verses": { "club150": [3, 4, 9, 10, 14, 22, 33], "club300": [5, 6, 7, 8, 12, 17, 21, 28] },
+      "isReview": false
+    },
+    {
+      "date": "2026-01-12",
+      "passage": { "book": "1 Corinthians", "chapter": 15, "startVerse": 35, "endVerse": 58 },
+      "verses": { "club150": [49, 51, 52, 57, 58], "club300": [42, 45, 46, 50, 54, 55, 56] },
+      "isReview": false
+    },
+    {
+      "date": "2026-01-19",
+      "passage": { "book": "1 Corinthians", "chapter": 16, "startVerse": 1, "endVerse": 23 },
+      "verses": { "club150": [2, 13, 14], "club300": [1, 15, 16, 22, 23] },
+      "isReview": false
+    },
+    {
+      "date": "2026-01-26",
+      "passage": { "book": "2 Corinthians", "chapter": 1, "startVerse": 1, "endVerse": 24 },
+      "verses": { "club150": [3, 4, 5, 20, 21, 22], "club300": [6, 8, 9, 10, 11, 12] },
+      "isReview": false
+    },
+    {
+      "date": "2026-02-02",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2026-02-09",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2026-02-16",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2026-02-23",
+      "passage": { "book": "2 Corinthians", "chapter": 4, "startVerse": 1, "endVerse": 18 },
+      "verses": { "club150": [7, 14, 16, 17, 18], "club300": [1, 2, 3, 4, 5, 6] },
+      "isReview": false
+    },
+    {
+      "date": "2026-03-02",
+      "passage": { "book": "2 Corinthians", "chapter": 5, "startVerse": 1, "endVerse": 21 },
+      "verses": { "club150": [5, 7, 10, 15, 17, 20, 21], "club300": [4, 9, 11, 14, 18, 19] },
+      "isReview": false
+    },
+    {
+      "date": "2026-03-09",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    {
+      "date": "2026-03-16",
+      "passage": { "book": "2 Corinthians", "chapter": 8, "startVerse": 1, "endVerse": 24 },
+      "verses": { "club150": [2, 7, 9, 24], "club300": [1, 3, 10, 11] },
+      "isReview": false
+    },
+    {
+      "date": "2026-03-23",
+      "passage": { "book": "2 Corinthians", "chapter": 9, "startVerse": 1, "endVerse": 15 },
+      "verses": { "club150": [6, 7, 8, 10, 12, 15], "club300": [9, 11, 13, 14] },
+      "isReview": false
+    },
+    {
+      "date": "2026-03-30",
+      "passage": { "book": "2 Corinthians", "chapter": 10, "startVerse": 1, "endVerse": 18 },
+      "verses": { "club150": [3, 4, 5, 18], "club300": [1, 2, 17] },
+      "isReview": false
+    },
+    {
+      "date": "2026-04-06",
+      "passage": { "book": "2 Corinthians", "chapter": 11, "startVerse": 1, "endVerse": 33 },
+      "verses": { "club150": [2, 3, 13, 14, 15], "club300": [4, 6, 7, 8, 9] },
+      "isReview": false
+    },
+    {
+      "date": "2026-04-13",
+      "passage": { "book": "2 Corinthians", "chapter": 12, "startVerse": 1, "endVerse": 21 },
+      "verses": { "club150": [7, 8, 9, 10, 19], "club300": [20, 21] },
+      "isReview": false
+    },
+    {
+      "date": "2026-04-20",
+      "passage": { "book": "2 Corinthians", "chapter": 13, "startVerse": 1, "endVerse": 14 },
+      "verses": { "club150": [4, 5, 9, 11, 14], "club300": [7, 8, 10] },
+      "isReview": false
+    },
+    {
+      "date": "2026-04-27",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    }
+  ],
+  "meets": [
+    {
+      "id": "first-weekend",
+      "name": "First Weekend Quiz Meet",
+      "startDate": "2025-11-21",
+      "endDate": "2025-11-23",
+      "location": "Heritage Alliance Church"
+    },
+    {
+      "id": "second-weekend",
+      "name": "Second Weekend Quiz Meet",
+      "startDate": "2026-02-06",
+      "endDate": "2026-02-08",
+      "location": "TBD"
+    },
+    {
+      "id": "final-weekend",
+      "name": "Final Weekend Quiz Meet",
+      "startDate": "2026-05-01",
+      "endDate": "2026-05-03",
+      "location": "Briercrest College, Caronport, SK"
+    }
+  ]
+}

--- a/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
+++ b/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
@@ -227,6 +227,7 @@ For existing users, derive the new per-club shape from the existing flat fields:
 | `lesson_batch_size`                 | Preserved as-is.                                                                                       |
 | `move_to_next`                      | Set to `CaughtUp` for all pairs (matches the new default).                                             |
 | `catch_up` per club                 | Set to `Sequential` for all clubs (matches the new default; existing users had no equivalent setting). |
+| `enrolled` flag                     | Dropped. "Enrolled" is derived: any club enabled (memorize or review) on this material = enrolled.     |
 
 The migration is a one-shot DB transformation at first read after the upgrade. Old wire format still
 accepted via serde aliases for one release.
@@ -341,15 +342,26 @@ them — a Review week with no carry-over reads 0; with backlog, reads the backl
 
 ### Memorize-ahead
 
-A "Memorize ahead…" link on the preflight (visible whenever a single-verse default would otherwise
-auto-start) opens a multi-verse picker. The user can:
+No preflight, no separate "memorize ahead" UI. The user just presses Memorize again — the algorithm
+naturally serves the next `lesson_batch_size` eligible verses. Press Memorize as many times in a day
+or week as you want; each press advances through the same pipeline.
 
-* Increase the count for this session only (e.g. "memorize 7 verses today").
-* Pick specific verses from any enabled club (visualised by week / by tier).
-* Override the per-club mode for this session ("treat Club 150 as Sequential for today even though
-  my setting is CalendarCascade").
+When you finish this week's planned verses (badge = 0), the next press starts pulling lookahead
+verses (next week's primary if any club is `CalendarCascade`; next sequence-pointer verse if
+`Sequential`). The mechanism is identical — only the badge changes color/state to celebrate the
+"caught up to plan" milestone.
 
-Per-session overrides do not persist.
+### Empty state
+
+When no eligible un-memorized verses remain across all enabled clubs (e.g. every Club 150 verse in
+the deck is graduated and Club 300/Full are off, or the user is at season-end), Memorize shows a
+congratulations screen instead of attempting to load a verse. v1 keeps the screen minimal — "You've
+memorized everything in this material" — with a link back to /settings if the user wants to enable
+another club or pick a different material to study.
+
+The "caught up to this week" state (badge = 0 but lookahead still available) is **not** an empty
+state; the user can keep pressing Memorize to work ahead. Visual differentiation lives on the badge
+/ page header, not as a different screen.
 
 ## Review algorithm changes
 
@@ -538,9 +550,6 @@ Each phase is a separate implementation plan and a separate PR train. Phase 1 un
   source-of-truth bundled file.
 * **"Add week" passage picker.** Adding a week requires picking a passage range. UI for that is
   deferred; might be a simple text input ("1 Cor 5:1-13") with a parse + validation pass.
-* **Memorize-ahead persistence.** Per-session overrides don't persist (locked above). But should
-  there be a "save these settings to my default" shortcut on the preflight? Probably not for v1 —
-  keep the model clean.
 * **`club_card_scope` and `chapter_list_scope` consistency.** These still use the old TierScope
   ladder (Off / Up150 / Up300 / All). They could be reshaped to per-club booleans for consistency
   with the new model — leaning toward "do it during Phase 1 since we're already touching
@@ -566,8 +575,10 @@ For future-me reference. All confirmed during the 2026-06-14 brainstorm session.
 * Strict "Fully memorized" gate drains the higher club entirely (because lower club stays
   ineligible). ✓
 * Memorize tab badge: total un-memorized through end of current week, summed across enabled clubs. ✓
-* Single-click memorize: next N verses, drill, done. ✓
-* "Memorize ahead" preflight for multi-verse / power-user sessions. ✓
+* No preflight, no separate Memorize-ahead UI — user just presses Memorize repeatedly; the algorithm
+  serves the next eligible verses (including lookahead when caught up). ✓
+* Empty state = congrats screen, only when no eligible verses remain across all enabled clubs. ✓
+* No separate `enrolled` flag — "enrolled" is derived from any-club-enabled. ✓
 * Inter-club gate UI only visible when both flanking clubs are enabled. ✓
 * Review per-club: enabled + desired retention. ✓
 * Retention range: 50-90%, default 80%. ✓

--- a/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
+++ b/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
@@ -233,36 +233,41 @@ accepted via serde aliases for one release.
 
 ## Memorize algorithm
 
-### Per-click cascade
+### Per-click flow
 
-Each tap of Memorize builds the next `lesson_batch_size` verses (default 1) and runs them through
-the existing read → drill → reading-end flow.
+Each tap of Memorize fills the next `lesson_batch_size` verses (default 1) and hands them to the
+existing read → drill → reading-end pipeline.
 
 For each click:
 
-1. For each enabled club in priority order [Club150, Club300, Full]:
-   * Build the club's **ordered pool** per its `catch_up` setting.
-2. Apply the cross-club gates (`move_to_next`) to determine which clubs' pools are eligible to
-   contribute right now.
-3. Walk the eligible pools to fill `lesson_batch_size` verses, respecting:
-   * The priority order of clubs.
-   * The within-level interleave rule for backlog (see below).
-   * The soft cap rule.
+1. Determine the **eligible clubs**: enabled clubs whose cross-club gate from the higher enabled
+   club is met. The highest-priority enabled club is always eligible (it has no gate above it).
+2. **Phase 1 — this week's primary, in canonical order.** Across eligible clubs whose `catch_up` is
+   `CalendarCascade`, take all un-memorized verses in this week's calendar rows, sorted by canonical
+   (deck/passage) order. No within-phase club priority — verses interleave by deck position.
+3. **Phase 2 — everything else eligible, in canonical order.** If `lesson_batch_size` slots remain,
+   take un-memorized verses from all eligible clubs' remaining pools (Sequential clubs' full pools,
+   CalendarCascade clubs' backlog and lookahead), sorted by canonical order, until the batch is
+   full.
 
-### Per-club pool ordering (Knob 1)
+Once a club is eligible, ordering is purely canonical. Knob 2 only controls eligibility, not fill
+priority. The hierarchy (Club150 → Club300 → Full) determines gate direction; it does **not**
+prioritise one club over another in the fill.
+
+### Per-club pool definition (Knob 1)
 
 For a club with mode `Sequential`:
 
-* Pool = the un-memorized verses in this club's sequence (passage order across the deck), in order.
-* Unbounded — pulls forward through the season as needed.
+* Pool = un-memorized verses in this club's sequence (canonical deck/passage order).
+* No subdivision — every un-memorized verse contributes via Phase 2 in canonical order.
 
 For a club with mode `CalendarCascade`:
 
-* **Primary** = un-memorized verses in this week's calendar row for this club.
-* **Backlog** = un-memorized verses from prior weeks' rows for this club, in reverse-chronological
-  order (most recent missed week first).
-* **Lookahead** = un-memorized verses from future weeks' rows for this club, in order.
-* The pool walks Primary → Backlog → Lookahead.
+* **Primary** = un-memorized verses in this week's calendar row for this club. Contributes via
+  Phase 1.
+* **Remaining** = un-memorized verses from prior and future weeks' rows for this club. Contributes
+  via Phase 2 in canonical order (deck order naturally puts earlier-week verses before later-week
+  verses — backlog gets picked before lookahead).
 
 ### Cross-club gates (Knob 2)
 
@@ -281,43 +286,58 @@ For `CalendarCascade` clubs, "user position" means count of verses memorized; "c
 means cumulative verses through that week. For `Sequential` clubs, the same comparison applies — the
 sequence pointer is the user position.
 
-### Backlog interleave rule
-
-When the higher club is in `CalendarCascade` mode and has backlog, that backlog drops down to the
-next club's priority level. A `Sequential` club has no separate backlog vs primary — its entire pool
-sits at the club's own level. Effective levels in a fully-enabled three-club material:
-
-* **Level 1** (Club 150): Club 150's pool (primary verses if `CalendarCascade`; the whole Sequential
-  pool if `Sequential`).
-* **Level 2** (Club 300): Club 150 backlog (only if Club 150 is `CalendarCascade`) ∪ Club 300's pool
-  (interleaved within the level if both present, round-robin).
-* **Level 3** (Full): Club 300 backlog (only if Club 300 is `CalendarCascade`) ∪ Full's pool
-  (interleaved).
-
-The cross-club gate gates the lower club's pool from entering its level. Higher club's backlog
-enters the next level regardless of the gate — it's not "the lower club," it's "this club's missed
-verses."
-
 ### Soft cap
 
-`lesson_batch_size` is a soft cap. A `CalendarCascade` club's **primary** pool is always included in
-full, even if it overflows the cap. The cap only constrains backlog, lookahead, and lower-priority
-clubs' contributions.
+`lesson_batch_size` is a soft cap on **Phase 2** only. Phase 1 (CalendarCascade clubs' this-week
+primary) is always included in full, even when it overflows the batch. Phase 2 contributes only if
+slots remain after Phase 1; it contributes 0 if Phase 1 already met or exceeded the batch.
 
 Example (with `lesson_batch_size = 5` for illustrative overflow — the new default is 1): Club 150 in
-`CalendarCascade`, this week has 7 primary verses. The session has 7 verses (soft-cap overflow);
-lower clubs contribute 0.
+`CalendarCascade`, this week has 7 primary verses. Phase 1 takes all 7. Phase 2 contributes 0.
+Session = 7 verses.
+
+### Worked examples
+
+For each, Club 300/Full gate = `CaughtUp` unless stated.
+
+| Config                                                          | User progress                                     | Session at `batch=1`                                                                                                                                               |
+| --------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 150 Sequential, others off                                      | At verse 14                                       | 1 verse: next Club 150 verse in canonical order                                                                                                                    |
+| 150 Sequential, 300 Sequential                                  | Caught up on 150, week 5                          | 1 verse: first un-memorized in canonical order across both pools — could be either club                                                                            |
+| 150 Sequential, 300 Sequential, gate=`FullyMemorized`           | Caught up on 150 (not done)                       | 1 verse: Club 150 (gate closed, 300 not eligible)                                                                                                                  |
+| 150 CalendarCascade, 300 Off                                    | At verse 14 of week 5 (this week has 7 primary)   | 1 verse: first un-memorized of this week's 7, in canonical order                                                                                                   |
+| 150 CalendarCascade, 300 Sequential                             | This week's 150 done; 300 has un-memorized verses | Phase 1 = 0 verses (150 primary empty). Phase 2 picks next eligible in canonical order — could be 150's lookahead/backlog or 300, whichever is earlier in the deck |
+| 150 CalendarCascade with this week = 7 verses, `batch_size = 5` | Behind by 2 weeks                                 | Phase 1 = 7 (soft cap overflow). Phase 2 = 0. Session = 7 verses                                                                                                   |
 
 ### Single-club default flow
 
 For the typical user (Club 150 enabled, others off, `lesson_batch_size = 1`, catch-up Sequential):
 
-1. Sequential pool for Club 150 = next un-memorized verse in sequence.
-2. No other clubs eligible.
-3. Fill 1 verse from Club 150's pool.
+1. Phase 1 contributes nothing (Club 150 is Sequential, not CalendarCascade).
+2. Phase 2 picks the first un-memorized Club 150 verse in canonical order.
+3. Session has 1 verse.
 
-Result: each tap of Memorize shows one verse. UI shows it immediately and goes straight into the
-existing read → drill flow.
+Each tap of Memorize shows one verse. UI shows it immediately and goes straight into the existing
+read → drill flow.
+
+### Memorize tab badge
+
+The Memorize nav item carries a count badge: total un-memorized verses across enabled clubs through
+the end of the current scheduled week.
+
+```text
+badge = Σ (over enabled clubs)  max(0, cumulative_through_current_week − memorized)
+```
+
+* `cumulative_through_current_week` = sum of verse counts in the user's edited schedule rows from
+  week 1 through the current week, for this club's tier.
+* `memorized` = count of this club's verses already graduated.
+* `max(0, …)` clamps a club's contribution to 0 when the user is ahead.
+
+Display: a single sum on the pill (consistent with today's "new to memorize" badge slot). Tap or
+hover surfaces the per-club split when multiple clubs are enabled. Hitting 0 = caught up to the
+week's plan. Review weeks don't introduce new verses, so the cumulative target is unchanged through
+them — a Review week with no carry-over reads 0; with backlog, reads the backlog count.
 
 ### Memorize-ahead
 
@@ -539,8 +559,13 @@ For future-me reference. All confirmed during the 2026-06-14 brainstorm session.
 * Defaults: Club 150 = enabled + Sequential; 300/Full = off; gates = Caught up. ✓
 * `lesson_batch_size` default: 1 (down from 5). ✓
 * Soft cap rule: Calendar-cascade primary pool overflows the cap. ✓
-* Backlog from Calendar-cascade drops to next club's level, interleaved. ✓
-* Strict "Fully memorized" gate drains the higher club entirely. ✓
+* Fill order is canonical (deck/passage order) — not club-priority. ✓
+* Knob 2 gates only control eligibility, not fill priority. ✓
+* Phase 1 = CalendarCascade clubs' this-week primary (canonical order); Phase 2 = everything else
+  eligible (canonical order). ✓
+* Strict "Fully memorized" gate drains the higher club entirely (because lower club stays
+  ineligible). ✓
+* Memorize tab badge: total un-memorized through end of current week, summed across enabled clubs. ✓
 * Single-click memorize: next N verses, drill, done. ✓
 * "Memorize ahead" preflight for multi-verse / power-user sessions. ✓
 * Inter-club gate UI only visible when both flanking clubs are enabled. ✓

--- a/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
+++ b/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
@@ -1,0 +1,553 @@
+# Schedules + per-club settings design
+
+Per-material customizable schedules, per-club memorize/review configuration, and a restructured
+`/settings` page to host both. Replaces the current "scope ladder" model with a richer per-club
+shape so quizzers can lock to their league's calendar without losing self-paced flexibility.
+
+## Goals
+
+* Each enrolled material carries a **schedule** — the publicly distributed calendar of which verses
+  are due by which date for each club tier — that the user can edit (shift day-of-week, move verses
+  between weeks, add or remove weeks, manage major checkpoints / meets).
+* `/memorize` becomes **schedule-aware**: it can either follow the calendar's pace or work
+  sequentially through whichever verses the user hasn't memorized yet, with the choice made
+  per-club.
+* Multiple clubs (Club 150, Club 300, Full) compose cleanly: the user can lock Club 150 to the
+  calendar, treat Club 300 as a self-paced reservoir, and gate when Club 300 verses become eligible
+  to surface.
+* The default experience for a typical SK quizzer ("one verse per day, Club 150 only") stays trivial
+  — most users never see the multi-club / cross-club controls.
+* `/review` becomes per-club configurable: each club has its own enabled flag and desired retention
+  target, so users can keep their must-know club sharp without over-reviewing the optional ones.
+* `/settings` gets restructured into three top-level surfaces (Account, Preferences, Materials) so
+  the schedule controls have a home, account chores migrate out of `/profiles`' kebab menus (closing
+  [#92][issue-92]), and a real app-preferences surface exists for future work.
+
+## Non-goals
+
+* **Multiple schedules per material.** One schedule per user per material. If the user wants to
+  follow a different plan, they edit theirs.
+* **External schedule imports** (PDF upload, URL paste). Defaults ship in the repo; user-authored
+  schedules are edited in the in-app editor only.
+* **Pre-meet retention boost** and other schedule-coupled review behaviour. Reviews stay
+  FSRS-driven; the schedule only influences memorize. (Considered and deferred — see Open
+  questions.)
+* **Renaming clubs** (e.g. "My required tier" instead of "Club 150"). Club identities stay fixed.
+* **Multi-tier schedules beyond Club 150 / 300 / Full.** The existing tier taxonomy stands.
+
+## Concepts
+
+* **Material** — a year-deck (`materialId`, e.g. `3-corinthians`). Already exists.
+* **Club** — `Club150` / `Club300` / `Full`. Already exists as `ClubTier`. Each verse is tagged with
+  its most-specific tier; "Up300" includes Club150 ∪ Club300, "All" adds Full.
+* **Schedule** — a per-material, per-season plan of which verses are introduced in which week. New
+  concept.
+* **Week** — one row of the schedule: a date, a passage range, and per-club lists of verse numbers
+  introduced that week. May be marked as a Review week (no new verses).
+* **Meet** (major checkpoint) — a dated event in the schedule (e.g. "Nov 21-23 First Weekend Quiz
+  Meet, Heritage Alliance Church"). Used as a milestone for Knob 2's "after major checkpoint" gate.
+* **Catch-up behaviour** (Knob 1, per-club) — Sequential or Calendar cascade. Determines how a
+  club's pool is ordered when the user is behind the calendar.
+* **Move-to-next-club gate** (Knob 2, per adjacent pair) — Fully memorized / Major checkpoint /
+  Minor checkpoint / Caught up / Always. Determines when a lower-priority club's pool becomes
+  eligible.
+
+## Schedule data model
+
+### Bundled default (ships with deck)
+
+Lives at `data/schedules/<deck>-<season>.json`, e.g. `data/schedules/3-corinthians-2025-26.json`.
+One file per (deck, season). Read-only canonical version.
+
+```json
+{
+  "version": 1,
+  "materialId": "3-corinthians",
+  "season": "2025-26",
+  "title": "SK Quiz 2025-26 — 1 & 2 Corinthians",
+  "meetingDayOfWeek": "Mon",
+  "weeks": [
+    {
+      "date": "2025-09-08",
+      "passage": "1 Cor 1:1-31",
+      "verses": {
+        "Club150": [5, 10, 17, 18, 21, 25, 27],
+        "Club300": [1, 2, 4, 8, 9, 19, 23]
+      },
+      "isReview": false
+    },
+    {
+      "date": "2025-11-17",
+      "passage": null,
+      "verses": null,
+      "isReview": true
+    },
+    "..."
+  ],
+  "meets": [
+    {
+      "id": "first-weekend",
+      "name": "First Weekend Quiz Meet",
+      "startDate": "2025-11-21",
+      "endDate": "2025-11-23",
+      "location": "Heritage Alliance Church"
+    },
+    {
+      "id": "final-weekend",
+      "name": "Final Weekend Quiz Meet",
+      "startDate": "2026-05-01",
+      "endDate": "2026-05-03",
+      "location": "Briercrest College, Caronport, SK"
+    }
+  ]
+}
+```
+
+Notes:
+
+* Verse numbers in `verses.{tier}` are verse numbers **within the row's `passage`** — i.e.
+  `[5, 10, ...]` against passage `1 Cor 1:1-31` means 1 Cor 1:5, 1:10, etc. Keeps the JSON visually
+  close to the source PDF and short.
+* `verses.Club300` lists Club 300-tagged verses _additional_ to Club 150 (matches the PDF
+  convention). Club 150 verses are not duplicated in the Club 300 list.
+* Verses for the implicit "Full" tier are derived: any verse in the row's `passage` that is not in
+  `Club150` or `Club300` is in Full's contribution for that week.
+* `isReview: true` rows: no new verses introduced; the user's expected position doesn't advance for
+  that week. Useful for pacing display.
+* `meetingDayOfWeek` defines the canonical week-start. The user can override per-material in their
+  personal copy.
+
+### User customization (per-user)
+
+Stored in the API's SQLite DB, one row per (user, material). When the user makes their first edit,
+the bundled default is copied into the DB row as a starting point; subsequent edits mutate the copy.
+A "Reset to default" action drops the row, falling back to the bundled file.
+
+Schema (Drizzle-style):
+
+```ts
+materialSchedules {
+  userId: string,
+  materialId: string,
+  scheduleJson: text,   // same shape as bundled file
+  updatedAt: integer,   // unix-secs
+  PRIMARY KEY (userId, materialId)
+}
+```
+
+The full-copy approach is fine: schedules are small (~5KB per season). Avoids diff/merge logic and
+makes "reset to default" trivial. Sync via the existing event log (one event per edit, the event
+carries the new full JSON).
+
+## Per-material settings model
+
+Today's `MaterialConfig` (in `crates/core/src/material_config.rs`) carries
+`{new_scope, review_scope, heading_card, heading_passage_card, ftv, club_card_scope, chapter_list_scope}`
+plus material-wide `desiredRetention`. The new model splits the scope axes into per-club shapes.
+
+### New shape
+
+```rust
+pub struct MaterialConfig {
+    // Card-kind toggles — unchanged.
+    pub heading_card: bool,
+    pub heading_passage_card: bool,
+    pub ftv: bool,
+    pub club_card_scope: TierScope,        // unchanged: which clubs get "which club?" card
+    pub chapter_list_scope: ChapterListScope,  // unchanged
+
+    // NEW: per-club memorize config
+    pub memorize: ClubMap<ClubMemorizeConfig>,
+
+    // NEW: cross-club gates (per adjacent pair)
+    pub move_to_next: MoveToNextConfig,    // see below
+
+    // NEW: per-club review config (replaces flat review_scope + desired_retention)
+    pub review: ClubMap<ClubReviewConfig>,
+
+    // Session knob — unchanged in name, default changes 5 → 1
+    pub lesson_batch_size: u8,
+}
+
+pub struct ClubMemorizeConfig {
+    pub enabled: bool,
+    pub catch_up: CatchUp,
+}
+
+pub enum CatchUp { Sequential, CalendarCascade }
+
+pub struct MoveToNextConfig {
+    pub p150_to_300: MoveToNextGate,
+    pub p300_to_full: MoveToNextGate,
+}
+
+pub enum MoveToNextGate {
+    FullyMemorized,
+    AfterMajorCheckpoint,
+    AfterMinorCheckpoint,
+    CaughtUp,
+    Always,
+}
+
+pub struct ClubReviewConfig {
+    pub enabled: bool,
+    pub desired_retention: f32,  // 0.50 - 0.90, default 0.80
+}
+
+pub type ClubMap<T> = (T, T, T);  // (Club150, Club300, Full); shape TBD in implementation
+```
+
+### Defaults (new enrolled material)
+
+| Field                       | Value                                         | Rationale                                                                         |
+| --------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------- |
+| `memorize.Club150`          | `{ enabled: true, catch_up: Sequential }`     | "One verse a day" majority case.                                                  |
+| `memorize.Club300`          | `{ enabled: false, catch_up: Sequential }`    | Most quizzers do Club 150 only.                                                   |
+| `memorize.Full`             | `{ enabled: false, catch_up: Sequential }`    | Same.                                                                             |
+| `move_to_next.p150_to_300`  | `CaughtUp`                                    | Permissive once the user enables Club 300 — they enabled it because they want it. |
+| `move_to_next.p300_to_full` | `CaughtUp`                                    | Same.                                                                             |
+| `review.Club150`            | `{ enabled: true, desired_retention: 0.80 }`  | Reasonable default for quizzing.                                                  |
+| `review.Club300`            | `{ enabled: false, desired_retention: 0.80 }` | Paused until user opts in.                                                        |
+| `review.Full`               | `{ enabled: false, desired_retention: 0.80 }` | Same.                                                                             |
+| `lesson_batch_size`         | `1`                                           | Matches the one-verse-a-day pace; current default 5 is wrong for typical use.     |
+| Card-kind toggles           | Unchanged from today's defaults.              |                                                                                   |
+
+### Migration from today's shape
+
+For existing users, derive the new per-club shape from the existing flat fields:
+
+| Existing                            | New                                                                                                    |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `new_scope = Off`                   | All `memorize.{club}.enabled = false`.                                                                 |
+| `new_scope = Up150`                 | Only `memorize.Club150.enabled = true`.                                                                |
+| `new_scope = Up300`                 | `memorize.Club150.enabled = memorize.Club300.enabled = true`.                                          |
+| `new_scope = All`                   | All three `memorize.{club}.enabled = true`.                                                            |
+| `review_scope`                      | Same mapping for `review.{club}.enabled`.                                                              |
+| `desired_retention` (material-wide) | Applied to every enabled `review.{club}.desired_retention`.                                            |
+| `lesson_batch_size`                 | Preserved as-is.                                                                                       |
+| `move_to_next`                      | Set to `CaughtUp` for all pairs (matches the new default).                                             |
+| `catch_up` per club                 | Set to `Sequential` for all clubs (matches the new default; existing users had no equivalent setting). |
+
+The migration is a one-shot DB transformation at first read after the upgrade. Old wire format still
+accepted via serde aliases for one release.
+
+## Memorize algorithm
+
+### Per-click cascade
+
+Each tap of Memorize builds the next `lesson_batch_size` verses (default 1) and runs them through
+the existing read → drill → reading-end flow.
+
+For each click:
+
+1. For each enabled club in priority order [Club150, Club300, Full]:
+   * Build the club's **ordered pool** per its `catch_up` setting.
+2. Apply the cross-club gates (`move_to_next`) to determine which clubs' pools are eligible to
+   contribute right now.
+3. Walk the eligible pools to fill `lesson_batch_size` verses, respecting:
+   * The priority order of clubs.
+   * The within-level interleave rule for backlog (see below).
+   * The soft cap rule.
+
+### Per-club pool ordering (Knob 1)
+
+For a club with mode `Sequential`:
+
+* Pool = the un-memorized verses in this club's sequence (passage order across the deck), in order.
+* Unbounded — pulls forward through the season as needed.
+
+For a club with mode `CalendarCascade`:
+
+* **Primary** = un-memorized verses in this week's calendar row for this club.
+* **Backlog** = un-memorized verses from prior weeks' rows for this club, in reverse-chronological
+  order (most recent missed week first).
+* **Lookahead** = un-memorized verses from future weeks' rows for this club, in order.
+* The pool walks Primary → Backlog → Lookahead.
+
+### Cross-club gates (Knob 2)
+
+For each adjacent pair (`Club150 → Club300`, `Club300 → Full`), the gate condition determines when
+the lower club's pool becomes eligible.
+
+| Gate                   | Eligible when…                                                                                                                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FullyMemorized`       | Every verse in the higher club is memorized.                                                                                                                                        |
+| `AfterMajorCheckpoint` | The higher club's verses through the most recent past meet are all memorized. If no meet has occurred yet, the gate is never open (lower club waits until the season's first meet). |
+| `AfterMinorCheckpoint` | The higher club's verses through this week's row are all memorized.                                                                                                                 |
+| `CaughtUp`             | The higher club's user position ≥ previous week's checkpoint position. At season start (before any weeks have elapsed), the gate is open by default.                                |
+| `Always`               | No gate; lower club always eligible.                                                                                                                                                |
+
+For `CalendarCascade` clubs, "user position" means count of verses memorized; "checkpoint position"
+means cumulative verses through that week. For `Sequential` clubs, the same comparison applies — the
+sequence pointer is the user position.
+
+### Backlog interleave rule
+
+When the higher club is in `CalendarCascade` mode and has backlog, that backlog drops down to the
+next club's priority level. A `Sequential` club has no separate backlog vs primary — its entire pool
+sits at the club's own level. Effective levels in a fully-enabled three-club material:
+
+* **Level 1** (Club 150): Club 150's pool (primary verses if `CalendarCascade`; the whole Sequential
+  pool if `Sequential`).
+* **Level 2** (Club 300): Club 150 backlog (only if Club 150 is `CalendarCascade`) ∪ Club 300's pool
+  (interleaved within the level if both present, round-robin).
+* **Level 3** (Full): Club 300 backlog (only if Club 300 is `CalendarCascade`) ∪ Full's pool
+  (interleaved).
+
+The cross-club gate gates the lower club's pool from entering its level. Higher club's backlog
+enters the next level regardless of the gate — it's not "the lower club," it's "this club's missed
+verses."
+
+### Soft cap
+
+`lesson_batch_size` is a soft cap. A `CalendarCascade` club's **primary** pool is always included in
+full, even if it overflows the cap. The cap only constrains backlog, lookahead, and lower-priority
+clubs' contributions.
+
+Example (with `lesson_batch_size = 5` for illustrative overflow — the new default is 1): Club 150 in
+`CalendarCascade`, this week has 7 primary verses. The session has 7 verses (soft-cap overflow);
+lower clubs contribute 0.
+
+### Single-club default flow
+
+For the typical user (Club 150 enabled, others off, `lesson_batch_size = 1`, catch-up Sequential):
+
+1. Sequential pool for Club 150 = next un-memorized verse in sequence.
+2. No other clubs eligible.
+3. Fill 1 verse from Club 150's pool.
+
+Result: each tap of Memorize shows one verse. UI shows it immediately and goes straight into the
+existing read → drill flow.
+
+### Memorize-ahead
+
+A "Memorize ahead…" link on the preflight (visible whenever a single-verse default would otherwise
+auto-start) opens a multi-verse picker. The user can:
+
+* Increase the count for this session only (e.g. "memorize 7 verses today").
+* Pick specific verses from any enabled club (visualised by week / by tier).
+* Override the per-club mode for this session ("treat Club 150 as Sequential for today even though
+  my setting is CalendarCascade").
+
+Per-session overrides do not persist.
+
+## Review algorithm changes
+
+### Per-club enable
+
+Replace `review_scope` with `ClubMap<ClubReviewConfig>`. A verse is eligible for /review if its
+most-specific club's `review.{club}.enabled` is true.
+
+The existing `next_card` (in `crates/core/src/schedule.rs`) filters by this set instead of the flat
+`review_scope`. Cooldown, target-retention threshold, and most-overdue selection are unchanged.
+
+### Per-club desired retention
+
+Today's `ScheduleParams.target_retention` is per-material. Becomes per-club: when computing "is this
+card due?" and "when is this card next due?", use the card's club's `desired_retention` instead of a
+material-wide value.
+
+`FsrsBridge::due_at` and `retrievability_of` already take a `target_r: f32` parameter; we just need
+to thread the per-club value through the scheduler call sites.
+
+UI surface: a slider per enabled club in the "What to review" section. Range 50-90% (down from the
+current 70-97% — quizzers don't push as high as long-term-retention apps). Default 80% (down from
+90%).
+
+## Settings page IA
+
+### Top-level structure
+
+`/settings` becomes a three-section host:
+
+| Section         | Route                   | Contents                                                                                                                                  |
+| --------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **Account**     | `/settings/account`     | Export my data · Import data · Delete all progress (migrating [#92][issue-92] from `/profiles`'s kebab).                                  |
+| **Preferences** | `/settings/preferences` | App-wide prefs. Theme (when implemented), notification settings (when implemented). Empty section is fine at launch — see Open questions. |
+| **Materials**   | `/settings/materials`   | The existing per-material tabs. The default route for /settings is this section (matches today's behaviour).                              |
+
+Nav: a left rail (desktop) or accordion (mobile) listing the three sections, with Materials expanded
+to show the per-material tabs as sub-items.
+
+### Per-material card
+
+Inside `/settings/materials/<materialId>` (or `/settings/materials?tab=<id>`), each material card
+has these sections:
+
+1. **Header** — title, description, status pills, schedule editor link.
+2. **What to memorize** — the chain UI (Layout A): per-club enable, per-club Knob 1, cross-club
+   gates (only visible when both flanking clubs are enabled).
+3. **What to review** — per-club enable + per-club retention slider. Parallel structure to "What to
+   memorize" but simpler (no Knob 1, no gates).
+4. **Card kinds** — existing toggles (heading_card, heading_passage_card, ftv, club_card_scope,
+   chapter_list_scope) unchanged.
+5. **Offline study** — existing offline-mode toggle.
+6. **Session** — `lesson_batch_size`. The material-wide retention slider goes away (moved to
+   per-club).
+
+### Chain UI for "What to memorize"
+
+Per the brainstorm Layout A:
+
+* One card per club, in priority order [150, 300, Full].
+* Each card has: club name, progress count, Enabled checkbox, Knob 1 dropdown (visible only when
+  enabled).
+* Between two cards: an indented row with a dashed left rule, showing "Move to <next club> when:
+  <Knob 2 dropdown>". **Visible only when both flanking clubs are enabled.**
+* Disabled cards render dim with just the Enable checkbox.
+
+### Schedule editor link
+
+The material card header shows "Edit schedule →" as a small link, routing to
+`/schedule/<materialId>` (see next section).
+
+## Schedule editor
+
+Lives at `/schedule/<materialId>`. Linked from the per-material settings card. Reads the user's
+personal schedule if present, else the bundled default.
+
+### Capabilities
+
+* **Day-of-week shift**: a single setting at the top — "Meeting day: <day-picker>". Shifts every
+  week's date by the delta. Affects the whole season uniformly.
+* **Per-week edit**: each week is a row showing date, passage, per-tier verse lists. Click a week to
+  edit:
+  * Change the date (overrides the day-of-week shift for this week only).
+  * Edit the per-tier verse list (add/remove verses by number).
+  * Mark/unmark as a Review week.
+* **Add week**: insert a new row at a chosen date with a chosen passage. Useful for catch-up weeks
+  or personal study weeks beyond the canonical season.
+* **Remove week**: delete a row entirely.
+* **Manage meets**: a section below the weeks list with add/edit/remove for meet entries.
+* **Reset to default**: a button to drop the user's customisation and revert to the bundled
+  schedule.
+
+### Layout
+
+A two-pane editor (desktop) or single-pane stacked (mobile). Left/top: timeline of weeks with meet
+markers inline. Right/bottom: detail editor for the selected week or meet.
+
+Detailed visual design is deferred to the implementation plan — this spec just locks the
+capabilities and the data flow.
+
+## API + WASM changes
+
+### API endpoints
+
+* `GET /api/materials/:id/schedule` — returns the user's schedule (their personal copy if present,
+  else the bundled default).
+* `PUT /api/materials/:id/schedule` — replaces the user's schedule (full JSON). Validates shape,
+  persists to `materialSchedules`.
+* `DELETE /api/materials/:id/schedule` — drops the user's personal copy; defaults reapply.
+* Extend `GET /api/years` (or whatever surfaces `YearView`) to include the per-club shapes for
+  memorize and review. Backward-compatible additive change.
+* Extend `PUT /api/materials/:id/settings` to accept the new per-club shapes; old shape still
+  accepted for one release for client compatibility.
+
+### WASM bindings
+
+* New: `memorize_session_v2(material_id, settings, schedule, now_secs, batch_size)` returning the
+  next `batch_size` verses' worth of items (verses + standalone cards). Old `memorize_session` stays
+  for one release; deprecate after.
+* The scheduler's `next_card` (already used by /review) gains a per-club-retention-aware path.
+  Existing call signature can stay if we route the per-club retention through `ReviewEngine` state
+  rather than a parameter.
+
+### Contract version bumps
+
+Per `CLAUDE.md`'s contract crate discipline:
+
+* `crates/core`: MAJOR bump (state shape changes — `MaterialConfig` schema breaks for serde unless
+  aliased; event replay produces different state). Add the new types, keep serde aliases for old
+  fields one release.
+* `crates/wasm`: MAJOR bump (new function, deprecated old function, settings JSON shape changes).
+
+## Storage (DB)
+
+New table:
+
+```sql
+CREATE TABLE materialSchedules (
+  userId      TEXT NOT NULL,
+  materialId  TEXT NOT NULL,
+  scheduleJson TEXT NOT NULL,
+  updatedAt   INTEGER NOT NULL,
+  PRIMARY KEY (userId, materialId)
+);
+```
+
+`MaterialConfig` migration: the existing `materialSettings` (or equivalent) table column storing the
+JSON-encoded config grows. Add a one-shot migration to rewrite existing rows into the new shape,
+falling through serde aliases for new readers in the interim.
+
+## Implementation phases
+
+The design is one coherent piece but the implementation decomposes into three trains that can ship
+independently:
+
+1. **Phase 1 — Core + WASM + API** (foundation). New `MaterialConfig` shape, new schedule JSON
+   shape, new `memorize_session_v2` algorithm, per-club retention in the scheduler, DB migration,
+   API endpoints. Existing UI continues to work against the new shape via the migration. Bumps
+   `crates/core` and `crates/wasm` MAJOR.
+
+2. **Phase 2 — Web settings restructure**. Three-section IA (Account / Preferences / Materials),
+   Account section migration from `/profiles` (closes [#92][issue-92]), per-material card with the
+   chain UI (Layout A) for memorize and the per-club slider section for review. Lets the user
+   actually configure the Phase 1 mechanics.
+
+3. **Phase 3 — Schedule editor**. New `/schedule/<materialId>` route with the editing capabilities
+   listed above. Until shipped, users can only customise settings — schedule stays at the bundled
+   default.
+
+Each phase is a separate implementation plan and a separate PR train. Phase 1 unblocks Phase 2 and
+3; Phase 2 and 3 are independent of each other.
+
+## Open questions
+
+* **Preferences section contents at launch.** Theme exists in the nav backlog. Anything else worth
+  shipping with the IA change? Notification settings? Default `lesson_batch_size` preference? Picked
+  up during Phase 2 planning.
+* **"Caught up" definition precision.** Current spec says "user position ≥ previous week's
+  checkpoint." Does "previous week" mean the week before today, or the most-recent past scheduled
+  week (skipping Review weeks)? Leaning toward most-recent past scheduled week with new verses.
+* **Schedule diff at sync time.** Once schedules are user-editable and sync'd, two devices editing
+  the same schedule diverge. Last-write-wins is the simplest answer (matches the rest of the sync
+  model); confirm during Phase 1 implementation.
+* **Reset-to-default UX.** A destructive action (drops user edits). Confirm dialog? Type-to-
+  confirm? Probably just a single confirm dialog given schedules are recoverable from the
+  source-of-truth bundled file.
+* **"Add week" passage picker.** Adding a week requires picking a passage range. UI for that is
+  deferred; might be a simple text input ("1 Cor 5:1-13") with a parse + validation pass.
+* **Memorize-ahead persistence.** Per-session overrides don't persist (locked above). But should
+  there be a "save these settings to my default" shortcut on the preflight? Probably not for v1 —
+  keep the model clean.
+* **`club_card_scope` and `chapter_list_scope` consistency.** These still use the old TierScope
+  ladder (Off / Up150 / Up300 / All). They could be reshaped to per-club booleans for consistency
+  with the new model — leaning toward "do it during Phase 1 since we're already touching
+  `MaterialConfig`" but the existing ladder is also fine to leave as-is. Decide during Phase 1
+  planning.
+
+## Decisions log
+
+For future-me reference. All confirmed during the 2026-06-14 brainstorm session.
+
+* Schedules ship per material in `data/schedules/<deck>-<season>.json`. ✓
+* User clones to DB on first edit. ✓
+* Per-club enabled flag replaces the "Off" mode. ✓
+* Knob 1 (Catch-up) per-club: Sequential / Calendar cascade. Calendar-only dropped. ✓
+* Knob 2 (Move-to-next) per adjacent pair: five options as listed. ✓
+* Defaults: Club 150 = enabled + Sequential; 300/Full = off; gates = Caught up. ✓
+* `lesson_batch_size` default: 1 (down from 5). ✓
+* Soft cap rule: Calendar-cascade primary pool overflows the cap. ✓
+* Backlog from Calendar-cascade drops to next club's level, interleaved. ✓
+* Strict "Fully memorized" gate drains the higher club entirely. ✓
+* Single-click memorize: next N verses, drill, done. ✓
+* "Memorize ahead" preflight for multi-verse / power-user sessions. ✓
+* Inter-club gate UI only visible when both flanking clubs are enabled. ✓
+* Review per-club: enabled + desired retention. ✓
+* Retention range: 50-90%, default 80%. ✓
+* Settings IA: Account / Preferences / Materials. ✓
+* Chain UI (Layout A) for clubs within material. ✓
+* Schedule editor: separate route `/schedule/<materialId>`. ✓
+
+[issue-92]: https://github.com/TommyAmberson/verse-vault/issues/92

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,77 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.28] — 2026-06-14
+
+Phase 1 of the schedules + per-club settings rework. MINOR per this changelog's rubric — additive
+endpoints, both-shape acceptance on existing endpoints, and a new disk-loaded resource (bundled
+schedules) that older clients can simply ignore.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.6.0` — `MaterialConfig` restructures from the flat
+  `(new_scope, review_scope, desired_retention)` triple into per-club shapes (`memorize`, `review`,
+  `move_to_next`). New `Schedule` data model
+  * the two-phase canonical-order memorize fill. Per-verse retention threading through every
+    scheduler entry point. MAJOR — pre-0.6.0 state shape no longer drives the engine directly (read
+    through the serde-aliases migration adapter).
+* `verse-vault-wasm@0.6.0` — `WasmEngine` constructor drops `desired_retention`, adds
+  `schedule_json`. New `memorize_session_v2(limit, now_secs)` is the schedule-aware surface; legacy
+  `memorize_session(limit)` stays as a deprecated wrapper for one release. MAJOR.
+
+### New: `GET/PUT/DELETE /api/materials/:id/schedule`
+
+Per-(user, material) memorize-schedule overrides. `GET` returns the user's customised schedule if
+present, else the bundled default (`data/schedules/<deck>-<season>.json`), else
+`{ schedule: null }`. `PUT` shape-validates and upserts, invalidates the engine cache. `DELETE`
+drops the override; bundled default reapplies on the next request. Unknown `materialId` → 404;
+missing auth → 401; malformed PUT body → 400.
+
+### `POST /api/years/:id/settings` accepts the per-club shape
+
+The route detects shape via the `looksLikePerClub` heuristic (presence of `memorize` or `review` at
+the body root). Per-club shape: every field required, validated by `validatePerClubYearSettings`,
+retention clamped to `[0.5, 0.9]`. Legacy flat shape: existing partial-merge semantics preserved,
+retention still validates in the legacy `[0.7, 0.97]` range. Both paths dual-write — the legacy
+columns stay authoritative for older clients while `config_json` carries the per-club shape the
+engine reads.
+
+### Per-club desired retention
+
+Retention is now per-club, not per-material. The legacy `user_year_settings.desired_retention`
+column survives as a mirror for backward compat with pre-Phase-1 clients; the engine reads
+`config_json.review.{club}.desiredRetention` instead, with the [0.5, 0.9] clamp applied on read for
+defence-in-depth.
+
+### Schedules bundled per material
+
+`data/schedules/<deck>-<season>.json` (gitignored alongside the deck JSONs themselves, whitelisted
+via a `!data/schedules/*.json` rule). Phase 1 ships the SK 2025-26 1 & 2 Corinthians schedule
+covering 24 of 27 active weeks plus all 3 meets. Multi-chapter weeks are stubbed as Review weeks
+because Phase 1's `Schedule.Passage` model is single-chapter (the rest of the season's weeks fall
+outside that limitation).
+
+### Import / export round-trip the new fields
+
+* `YearSettingsExport.configJson` — per-club shape carried verbatim through export and import. Older
+  exports omit the field; the importer treats absent as null, preserving round-trip equality with
+  pre-Phase-1 shapes.
+* `ScheduleExport { scheduleJson, updatedAt }` — per-(user, material) schedule overrides. Optional
+  on `MaterialExport`. Applied in STEP 1 of the three-step import transaction so engine.load() in
+  STEP 2 picks up the imported schedule before the cardref index is built — preserves the
+  apply-settings-before-cardref invariant from PR #95.
+
+### DB
+
+Two new migrations:
+
+* `0022_material_schedules.sql` — new table keyed by `(user_id, material_id)` storing schedule
+  overrides as a JSON blob, with an `idx_material_schedules_user` index.
+* `0023_user_year_settings_per_club.sql` — adds the `config_json` column to `user_year_settings`,
+  materialises it from the legacy flat columns via SQLite's `json_object()` per the spec's migration
+  table. Legacy columns stay during transition; a future migration drops them once Phase 2's web UI
+  ships.
+
 ## [0.1.27] — 2026-06-12
 
 ### Bundled algorithm contract

--- a/packages/api/migrations/0022_material_schedules.sql
+++ b/packages/api/migrations/0022_material_schedules.sql
@@ -1,0 +1,19 @@
+-- Per-(user, material) memorize schedule, mirroring the bundled
+-- `data/schedules/<deck>-<season>.json` shape. Stored as a single
+-- JSON blob: schedules are small (~5 KB), and a "reset to default"
+-- action drops the row to fall back to the bundled file.
+--
+-- Sync semantics: last-write-wins across devices; no event-log
+-- replay (the row IS the authoritative state). The API layer
+-- invalidates the engine cache on every write so the next
+-- `engines.load` re-reads from disk + this table.
+CREATE TABLE `material_schedules` (
+	`user_id` text NOT NULL,
+	`material_id` text NOT NULL,
+	`schedule_json` text NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`user_id`, `material_id`),
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_material_schedules_user` ON `material_schedules` (`user_id`);

--- a/packages/api/migrations/0023_user_year_settings_per_club.sql
+++ b/packages/api/migrations/0023_user_year_settings_per_club.sql
@@ -1,0 +1,62 @@
+-- Phase 1 of the schedules + per-club settings rework.
+--
+-- Adds `config_json` to `user_year_settings` storing the new per-club
+-- shape as a JSON blob (memorize/review/moveToNext maps + the existing
+-- card-kind toggles). The legacy flat columns (`new_scope`,
+-- `review_scope`, `desired_retention`, `lesson_batch_size`, etc.) stay
+-- for one release so the route layer can dual-write during transition;
+-- a future migration drops them once Phase 2's web UI ships.
+--
+-- The UPDATE materialises `config_json` from the legacy columns per the
+-- spec's migration table:
+--   new_scope = Off    → every memorize.{club}.enabled = false
+--   new_scope = Up150  → only memorize.club150.enabled = true
+--   new_scope = Up300  → memorize.club150 + memorize.club300 enabled
+--   new_scope = All    → all three memorize clubs enabled
+--   review_scope       → same mapping for review.{club}.enabled
+--   desired_retention  → applied to every enabled review club,
+--                        clamped to the new [0.5, 0.9] range
+--   move_to_next       → CaughtUp on every pair (new default)
+--   catch_up per club  → Sequential on every club (new default)
+ALTER TABLE `user_year_settings` ADD COLUMN `config_json` text;
+--> statement-breakpoint
+UPDATE `user_year_settings` SET `config_json` = json_object(
+    'headingCard',         CASE WHEN heading_card = 1 THEN json('true') ELSE json('false') END,
+    'headingPassageCard',  CASE WHEN heading_passage_card = 1 THEN json('true') ELSE json('false') END,
+    'ftv',                 CASE WHEN ftv = 1 THEN json('true') ELSE json('false') END,
+    'clubCardScope',       club_card_scope,
+    'chapterListScope',    chapter_list_scope,
+    'lessonBatchSize',     lesson_batch_size,
+    'memorize', json_object(
+        'club150', json_object(
+            'enabled', CASE WHEN new_scope IN ('up150','up300','all') THEN json('true') ELSE json('false') END,
+            'catchUp', 'sequential'
+        ),
+        'club300', json_object(
+            'enabled', CASE WHEN new_scope IN ('up300','all') THEN json('true') ELSE json('false') END,
+            'catchUp', 'sequential'
+        ),
+        'full', json_object(
+            'enabled', CASE WHEN new_scope = 'all' THEN json('true') ELSE json('false') END,
+            'catchUp', 'sequential'
+        )
+    ),
+    'review', json_object(
+        'club150', json_object(
+            'enabled', CASE WHEN review_scope IN ('up150','up300','all') THEN json('true') ELSE json('false') END,
+            'desiredRetention', min(0.9, max(0.5, desired_retention))
+        ),
+        'club300', json_object(
+            'enabled', CASE WHEN review_scope IN ('up300','all') THEN json('true') ELSE json('false') END,
+            'desiredRetention', min(0.9, max(0.5, desired_retention))
+        ),
+        'full', json_object(
+            'enabled', CASE WHEN review_scope = 'all' THEN json('true') ELSE json('false') END,
+            'desiredRetention', min(0.9, max(0.5, desired_retention))
+        )
+    ),
+    'moveToNext', json_object(
+        'p150To300', 'caughtUp',
+        'p300ToFull', 'caughtUp'
+    )
+);

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1779472800000,
       "tag": "0021_backfill_desired_retention_storage",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1781481600000,
+      "tag": "0022_material_schedules",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1781481600000,
       "tag": "0022_material_schedules",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1781481700000,
+      "tag": "0023_user_year_settings_per_club",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -57,7 +57,7 @@ export function createApp(deps: AppDeps) {
   // (`src/index.ts`). Tests reach in via `createTestApp` and
   // construct their own short-lived processes, so they neither need
   // nor want a 60 s setInterval per `createApp` call.
-  const engines = new EngineStore(deps.db, undefined, deps.now);
+  const engines = new EngineStore(deps.db, deps.now);
   const apibibleCache = deps.bibleApiKey
     ? new ApibibleCache(deps.db, deps.bibleApiKey, deps.now)
     : undefined;

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -22,6 +22,7 @@ import { accountRoutes } from './routes/account.js';
 import { cardsRoutes } from './routes/cards.js';
 import { materialsRoutes } from './routes/materials.js';
 import { activityRoutes } from './routes/activity.js';
+import { schedulesRoutes } from './routes/schedules.js';
 import { statsRoutes } from './routes/stats.js';
 import { syncRoutes } from './routes/sync.js';
 import { yearsRoutes } from './routes/years.js';
@@ -151,6 +152,7 @@ export function createApp(deps: AppDeps) {
     }),
   );
   app.route('/api/years', yearsRoutes({ db: deps.db, engines, now: deps.now }));
+  app.route('/api/materials', schedulesRoutes({ db: deps.db, engines, now: deps.now }));
   app.route('/api/stats', statsRoutes({ db: deps.db, engines, now: deps.now }));
   app.route('/api/activity', activityRoutes({ db: deps.db, now: deps.now }));
   app.route('/api', accountRoutes({ db: deps.db, engines, now: deps.now }));

--- a/packages/api/src/db/indexes.test.ts
+++ b/packages/api/src/db/indexes.test.ts
@@ -37,6 +37,7 @@ describe('indexes', () => {
         'idx_apibible_passages_fetched_at',
         'idx_apibible_sections_fetched_at',
         'idx_graph_snapshots_user_material',
+        'idx_material_schedules_user',
         'idx_review_events_user_material_time',
         'idx_verification_identifier',
       ].sort(),

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -134,6 +134,13 @@ export const userYearSettings = sqliteTable(
     chapterListScope: text('chapter_list_scope').notNull(),
     lessonBatchSize: integer('lesson_batch_size').notNull(),
     desiredRetention: real('desired_retention').notNull().default(0.9),
+    /** Phase 1 of the schedules + per-club work: holds the per-club
+     *  MaterialConfig shape as a JSON blob, materialised from the legacy
+     *  flat columns by migration 0023. The route layer dual-writes
+     *  during transition (legacy columns + this column) so importers and
+     *  pre-Phase-2 web clients keep working. A future migration drops
+     *  the legacy columns once the web rework is shipped. */
+    configJson: text('config_json'),
     updatedAt: integer('updated_at').notNull(),
   },
   (t) => ({ pk: primaryKey({ columns: [t.userId, t.materialId] }) }),

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -99,25 +99,28 @@ export const userMaterials = sqliteTable(
   (t) => ({ pk: primaryKey({ columns: [t.userId, t.materialId] }) }),
 );
 
-// Per-year material picker toggles. One row per (user, material). Four
-// "tier scope" columns plus two booleans plus the lesson batch size
-// drive the engine's `MaterialConfig` at construction time:
+// Per-year material picker toggles. One row per (user, material).
 //
-// - active_scope: which tiers introduce new verses (and review them).
-// - maintenance_scope: which tiers (additionally) review only.
-// - club_card_scope: which tiers get the per-verse "Which club?" card.
-// - chapter_list_scope: which tiers get the chapter-list card.
+// As of Phase 1 (migration 0023) the per-club `config_json` blob is the
+// authoritative MaterialConfig shape — `readMaterialConfigJson` reads it
+// verbatim and passes it to the WASM engine. The legacy flat columns
+// stay during the transition: route writes mirror both, the importer
+// preserves whichever shape the export carried, and the engine
+// synthesises a per-club shape from the legacy columns when `config_json`
+// is NULL (rows untouched since the migration).
 //
-// Each scope is one of "off" | "up150" | "up300" | "all"
-// (chapter_list_scope omits "all" — Full never emits a chapter-list).
+// Legacy columns and how they map to the per-club shape:
+// - new_scope:    which tiers introduce new verses → memorize.{club}.enabled
+// - review_scope: which tiers surface in /review → review.{club}.enabled
+// - desired_retention: applied to every enabled review club, clamped
+//   into the new [0.5, 0.9] range. No longer an ctor arg — per-club
+//   retention lives inside `config_json.review.{club}.desiredRetention`.
+// - club_card_scope:    per-verse "Which club?" card (unchanged)
+// - chapter_list_scope: chapter-list card (unchanged)
+// - lesson_batch_size:  per-session target (now also inside config_json)
 //
-// Per-tier effective status is derived: a tier covered by active_scope
-// is Active; covered only by maintenance_scope is Maintenance; covered
-// by neither is Paused.
-//
-// `desired_retention` is read alongside `MaterialConfig` and threaded
-// as a separate ctor arg to `new WasmEngine(...)`, not part of the
-// MaterialConfig JSON.
+// A future migration drops the legacy columns once Phase 2's web UI
+// switches to the per-club shape end-to-end.
 export const userYearSettings = sqliteTable(
   'user_year_settings',
   {

--- a/packages/api/src/db/schema.ts
+++ b/packages/api/src/db/schema.ts
@@ -139,6 +139,37 @@ export const userYearSettings = sqliteTable(
   (t) => ({ pk: primaryKey({ columns: [t.userId, t.materialId] }) }),
 );
 
+// Per-(user, material) memorize schedule. Stores the user's
+// customised copy of the bundled `data/schedules/<deck>-<season>.json`
+// schedule as a single JSON blob (~5 KB). Schedules are shipped per
+// material; the user clones the default into this row on first edit.
+// A missing row means "use the bundled default"; deleting the row
+// is the "reset to default" action surfaced in the schedule editor.
+//
+// Sync semantics: last-write-wins. There is no event-log replay for
+// schedule edits — the row IS the authoritative state. Writers
+// invalidate the engine cache via `engines.invalidate(key)` so the
+// next `EngineStore.load` re-reads the schedule alongside the
+// material data.
+export const materialSchedules = sqliteTable(
+  'material_schedules',
+  {
+    userId: text('user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    materialId: text('material_id').notNull(),
+    /** Full Schedule JSON (matches the bundled `data/schedules/<deck>-<season>.json`
+     *  shape from `crates/core::schedule_data::Schedule`). The TS layer never
+     *  inspects the body — it's passed verbatim to the WASM engine. */
+    scheduleJson: text('schedule_json').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.userId, t.materialId] }),
+    userIdx: index('idx_material_schedules_user').on(t.userId),
+  }),
+);
+
 // Tracks which version of a material's bundled JSON (stored on disk under
 // `data/<materialId>.json`) each user is currently on. `content_sha` is
 // compared against the disk file's SHA on every `EngineStore.load`; a

--- a/packages/api/src/lib/engine.test.ts
+++ b/packages/api/src/lib/engine.test.ts
@@ -126,7 +126,7 @@ describe('EngineStore', () => {
       )
       .run();
 
-    const store = new EngineStore(test.db, 0.9, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
+    const store = new EngineStore(test.db, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
     const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
     const phrase1 = states.find((s) => {
@@ -166,7 +166,7 @@ describe('EngineStore', () => {
       })
       .run();
 
-    const store = new EngineStore(test.db, 0.9, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
+    const store = new EngineStore(test.db, () => 0, () => fixtureMaterial([2, 2, 2, 3]));
     const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
     const orphan = states.find((s) => {
@@ -192,7 +192,7 @@ describe('EngineStore', () => {
     });
 
     let bundled = before;
-    const store = new EngineStore(test.db, 0.9, () => 1, () => bundled);
+    const store = new EngineStore(test.db, () => 1, () => bundled);
 
     // Same content → no bump.
     const first = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
@@ -245,7 +245,7 @@ describe('EngineStore', () => {
       )
       .run();
 
-    const store = new EngineStore(test.db, 0.9, () => 1, () => fixture);
+    const store = new EngineStore(test.db, () => 1, () => fixture);
     const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     expect(loaded.snapshotVersion).toBe(2);
 
@@ -289,7 +289,7 @@ describe('EngineStore', () => {
       )
       .run();
 
-    const store = new EngineStore(test.db, 0.9, () => 1, () => fixture);
+    const store = new EngineStore(test.db, () => 1, () => fixture);
     const [a, b] = await Promise.all([
       store.load({ userId: 'u1', materialId: 'nkjv-cor' }),
       store.load({ userId: 'u1', materialId: 'nkjv-cor' }),
@@ -357,7 +357,7 @@ describe('EngineStore', () => {
       .run();
 
     let bundled = before;
-    const store = new EngineStore(test.db, 0.9, () => 1, () => bundled);
+    const store = new EngineStore(test.db, () => 1, () => bundled);
     bundled = after;
     const loaded = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     const states = JSON.parse(loaded.engine.export_test_states()) as TestStateEntry[];
@@ -425,7 +425,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u3');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock, undefined, { maxEntries: 2 });
+    const store = new EngineStore(test.db, () => clock, undefined, { maxEntries: 2 });
 
     clock = 100;
     const u1Orig = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
@@ -456,7 +456,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u3');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock, undefined, { maxEntries: 2 });
+    const store = new EngineStore(test.db, () => clock, undefined, { maxEntries: 2 });
 
     clock = 100;
     const u1Orig = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
@@ -481,7 +481,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u1');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+    const store = new EngineStore(test.db, () => clock, undefined, {
       idleTtlSecs: 50,
     });
 
@@ -509,7 +509,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u1');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+    const store = new EngineStore(test.db, () => clock, undefined, {
       idleTtlSecs: 50,
     });
 
@@ -543,7 +543,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u1');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock);
+    const store = new EngineStore(test.db, () => clock);
 
     const handle = await store.load({ userId: 'u1', materialId: 'nkjv-cor' });
     handle[Symbol.dispose]();
@@ -571,7 +571,7 @@ describe('EngineStore eviction', () => {
     seed(test.db, 'u1');
 
     let clock = 100;
-    const store = new EngineStore(test.db, 0.9, () => clock, undefined, {
+    const store = new EngineStore(test.db, () => clock, undefined, {
       idleTtlSecs: 50,
     });
 
@@ -606,7 +606,7 @@ describe('EngineStore eviction', () => {
     cleanup = test.cleanup;
 
     // Pick a long interval so the timer never actually fires under the test.
-    const store = new EngineStore(test.db, 0.9, () => 0, undefined, {
+    const store = new EngineStore(test.db, () => 0, undefined, {
       reaperIntervalSecs: 3600,
     });
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -8,6 +8,7 @@ import * as schema from '../db/schema.js';
 import { type Grade, writeTestStates } from './review-log.js';
 import { type UserMaterial, userMaterialKey } from './keys.js';
 import { getMaterialJson } from './materials.js';
+import { loadSchedule } from './schedules.js';
 
 function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
@@ -231,34 +232,28 @@ function canonicalizeKey(value: unknown): string {
   return `{${parts.join(',')}}`;
 }
 
-/** Per-(user, material) target retention. Falls back to the
- *  `EngineStore` default when the user has no `user_year_settings`
- *  row yet (the pre-enrollment picker case). The settings endpoint
- *  invalidates the cached engine on save, so a saved change takes
- *  effect on the next `load()`. */
-function readDesiredRetention(db: DB, key: EngineKey, fallback: number): number {
-  const row = db
-    .select({ desiredRetention: schema.userYearSettings.desiredRetention })
-    .from(schema.userYearSettings)
-    .where(
-      and(
-        eq(schema.userYearSettings.userId, key.userId),
-        eq(schema.userYearSettings.materialId, key.materialId),
-      ),
-    )
-    .get();
-  return row?.desiredRetention ?? fallback;
-}
+// `readDesiredRetention` was removed in Phase 1 — target retention is
+// per-club inside `MaterialConfig.review.{club}.desiredRetention`, read
+// from `config_json` by `readMaterialConfigJson`. The legacy
+// `user_year_settings.desired_retention` column still receives writes
+// during the dual-shape transition but no longer drives the engine.
 
 /**
  * Build a JSON-encoded `MaterialConfig` for this user × material from
- * the picker table. No row means defaults (the WASM constructor uses
- * `MaterialConfig::default()` directly when we return the empty string).
+ * the picker table.
  *
- * The DB stores scope values in the same camelCase form (`off` / `up150`
- * / `up300` / `all`) that the Rust enums declare via
- * `#[serde(rename_all = "camelCase")]`, so the values pass through with
- * no translation step.
+ * As of Phase 1: prefer the per-club `config_json` blob (written
+ * verbatim by the route layer for both shape-paths); fall back to
+ * synthesising the per-club shape from the legacy columns when
+ * `config_json` is NULL (pre-migration rows the user hasn't touched
+ * yet). No row → empty string → WASM uses the legacy "everything on"
+ * fallback inside `parse_material_config('')`.
+ *
+ * The synthesised path mirrors `legacyToNew` so route writes and
+ * engine reads agree on the per-club semantics. The wire form
+ * matches `crates/core@0.6.0`'s `MaterialConfig` accept-either-shape
+ * deserialiser (snake_case for the legacy fields; camelCase for the
+ * new per-club fields).
  */
 function readMaterialConfigJson(db: DB, key: EngineKey): string {
   const settings = db
@@ -274,15 +269,58 @@ function readMaterialConfigJson(db: DB, key: EngineKey): string {
 
   if (!settings) return '';
 
-  return JSON.stringify({
-    heading_card: settings.headingCard,
-    heading_passage_card: settings.headingPassageCard,
-    ftv: settings.ftv,
-    new_scope: settings.newScope,
-    review_scope: settings.reviewScope,
-    club_card_scope: settings.clubCardScope,
-    chapter_list_scope: settings.chapterListScope,
+  // Phase 1 happy path: use the per-club blob materialised by migration
+  // 0023 and re-written by the route on every save. Verbatim pass-
+  // through — the engine parses it as the new shape.
+  if (settings.configJson !== null && settings.configJson !== '') {
+    return settings.configJson;
+  }
+
+  // Fallback: synthesise the per-club shape from the legacy columns
+  // for any row where config_json hasn't been populated yet. Matches
+  // the `legacyToNew` converter in lib/year-settings.ts.
+  return JSON.stringify(synthesizeConfigJson(settings));
+}
+
+function synthesizeConfigJson(s: {
+  headingCard: boolean;
+  headingPassageCard: boolean;
+  ftv: boolean;
+  newScope: string;
+  reviewScope: string;
+  clubCardScope: string;
+  chapterListScope: string;
+  lessonBatchSize: number;
+  desiredRetention: number;
+}): Record<string, unknown> {
+  const clamp = (r: number): number => Math.max(0.5, Math.min(0.9, r));
+  const scoped = (scope: string) => ({
+    club150: scope === 'up150' || scope === 'up300' || scope === 'all',
+    club300: scope === 'up300' || scope === 'all',
+    full: scope === 'all',
   });
+  const mem = scoped(s.newScope);
+  const rev = scoped(s.reviewScope);
+  const retention = clamp(s.desiredRetention);
+  return {
+    headingCard: s.headingCard,
+    headingPassageCard: s.headingPassageCard,
+    ftv: s.ftv,
+    clubCardScope: s.clubCardScope,
+    chapterListScope: s.chapterListScope,
+    lessonBatchSize: s.lessonBatchSize,
+    memorize: {
+      club150: { enabled: mem.club150, catchUp: 'sequential' },
+      club300: { enabled: mem.club300, catchUp: 'sequential' },
+      full: { enabled: mem.full, catchUp: 'sequential' },
+    },
+    review: {
+      club150: { enabled: rev.club150, desiredRetention: retention },
+      club300: { enabled: rev.club300, desiredRetention: retention },
+      full: { enabled: rev.full, desiredRetention: retention },
+    },
+    moveToNext: { p150To300: 'caughtUp', p300ToFull: 'caughtUp' },
+  };
 }
 
 /** Cumulative-sum half-open word ranges per phrase, keyed by verse_id.
@@ -559,11 +597,12 @@ export class EngineStore {
     const materialJson = bundledJson;
     const testStates = readTestStateEntries(this.db, key, materialJson);
     const configJson = readMaterialConfigJson(this.db, key);
+    const scheduleJson = loadSchedule(this.db, key.userId, key.materialId);
     const engine = new WasmEngine(
       materialJson,
       configJson,
+      scheduleJson,
       JSON.stringify(testStates),
-      readDesiredRetention(this.db, key, this.desiredRetention),
       BigInt(this.now()),
     );
 
@@ -623,12 +662,13 @@ export class EngineStore {
     // inside readTestStateEntries handles known structural transforms.
     const materialJson = this.loadBundledJson(key.materialId);
     const configJson = readMaterialConfigJson(this.db, key);
+    const scheduleJson = loadSchedule(this.db, key.userId, key.materialId);
     const engine = new WasmEngine(
       materialJson,
       configJson,
+      scheduleJson,
       // Empty persisted states — we'll replay the full log on top.
       '[]',
-      readDesiredRetention(this.db, key, this.desiredRetention),
       BigInt(this.now()),
     );
 

--- a/packages/api/src/lib/engine.ts
+++ b/packages/api/src/lib/engine.ts
@@ -9,6 +9,7 @@ import { type Grade, writeTestStates } from './review-log.js';
 import { type UserMaterial, userMaterialKey } from './keys.js';
 import { getMaterialJson } from './materials.js';
 import { loadSchedule } from './schedules.js';
+import { legacyToNew, type YearSettings } from './year-settings.js';
 
 function sha256(s: string): string {
   return createHash('sha256').update(s).digest('hex');
@@ -83,8 +84,6 @@ export function getLatestSnapshot(db: DB, key: EngineKey) {
     .limit(1)
     .get();
 }
-
-const DEFAULT_DESIRED_RETENTION = 0.9;
 
 export type EngineKey = UserMaterial;
 
@@ -276,51 +275,12 @@ function readMaterialConfigJson(db: DB, key: EngineKey): string {
     return settings.configJson;
   }
 
-  // Fallback: synthesise the per-club shape from the legacy columns
-  // for any row where config_json hasn't been populated yet. Matches
-  // the `legacyToNew` converter in lib/year-settings.ts.
-  return JSON.stringify(synthesizeConfigJson(settings));
-}
-
-function synthesizeConfigJson(s: {
-  headingCard: boolean;
-  headingPassageCard: boolean;
-  ftv: boolean;
-  newScope: string;
-  reviewScope: string;
-  clubCardScope: string;
-  chapterListScope: string;
-  lessonBatchSize: number;
-  desiredRetention: number;
-}): Record<string, unknown> {
-  const clamp = (r: number): number => Math.max(0.5, Math.min(0.9, r));
-  const scoped = (scope: string) => ({
-    club150: scope === 'up150' || scope === 'up300' || scope === 'all',
-    club300: scope === 'up300' || scope === 'all',
-    full: scope === 'all',
-  });
-  const mem = scoped(s.newScope);
-  const rev = scoped(s.reviewScope);
-  const retention = clamp(s.desiredRetention);
-  return {
-    headingCard: s.headingCard,
-    headingPassageCard: s.headingPassageCard,
-    ftv: s.ftv,
-    clubCardScope: s.clubCardScope,
-    chapterListScope: s.chapterListScope,
-    lessonBatchSize: s.lessonBatchSize,
-    memorize: {
-      club150: { enabled: mem.club150, catchUp: 'sequential' },
-      club300: { enabled: mem.club300, catchUp: 'sequential' },
-      full: { enabled: mem.full, catchUp: 'sequential' },
-    },
-    review: {
-      club150: { enabled: rev.club150, desiredRetention: retention },
-      club300: { enabled: rev.club300, desiredRetention: retention },
-      full: { enabled: rev.full, desiredRetention: retention },
-    },
-    moveToNext: { p150To300: 'caughtUp', p300ToFull: 'caughtUp' },
-  };
+  // Fallback: synthesise the per-club shape from the legacy columns for
+  // any row where config_json hasn't been populated yet. Delegates to
+  // `legacyToNew` so the migration table (scope ladders → per-club
+  // booleans, retention clamp into [0.5, 0.9], default catch_up + gates)
+  // lives in exactly one place.
+  return JSON.stringify(legacyToNew(settings as YearSettings));
 }
 
 /** Cumulative-sum half-open word ranges per phrase, keyed by verse_id.
@@ -516,7 +476,6 @@ export class EngineStore {
 
   constructor(
     private readonly db: DB,
-    private readonly desiredRetention: number = DEFAULT_DESIRED_RETENTION,
     private readonly now: () => number = () => Math.floor(Date.now() / 1000),
     /** Source of the bundled MaterialData JSON, by material id. Tests
      *  inject a stub to drive snapshot-bump scenarios; production

--- a/packages/api/src/lib/enrollment.ts
+++ b/packages/api/src/lib/enrollment.ts
@@ -106,10 +106,14 @@ export function enrollUser(args: EnrollArgs): { snapshotId: string; version: num
   const snapshotId = randomUUID();
   const createdAt = now();
 
-  // Empty config = MaterialConfig::default() — enrollment seeds the same
-  // card set regardless of per-user picker choices; those are applied at
-  // query time (slice 1) and at /memorize introduction (slice 2).
-  const seedEngine = new WasmEngine(materialJson, '', '', desiredRetention, BigInt(createdAt));
+  // Empty config = parse_material_config('')'s test-friendly fallback
+  // (all clubs enabled) — enrollment seeds the same card set regardless
+  // of per-user picker choices; those are applied at query time (slice 1)
+  // and at /memorize introduction (slice 2). The desiredRetention arg
+  // was removed in wasm@0.6.0 (per-club inside MaterialConfig); kept as
+  // a no-op formal here since enrollment doesn't need a schedule.
+  void desiredRetention;
+  const seedEngine = new WasmEngine(materialJson, '', '', '', BigInt(createdAt));
   let testStates: TestStateEntry[];
   try {
     testStates = JSON.parse(seedEngine.export_test_states()) as TestStateEntry[];

--- a/packages/api/src/lib/enrollment.ts
+++ b/packages/api/src/lib/enrollment.ts
@@ -29,7 +29,6 @@ export interface EnrollArgs {
   /** Optional override for the bundled MaterialData JSON. Tests pass a tiny
    * inline material to avoid loading multi-hundred-kB blobs from disk. */
   materialJson?: string;
-  desiredRetention?: number;
 }
 
 export class UnknownMaterialError extends Error {
@@ -45,8 +44,6 @@ export class AlreadyEnrolledError extends Error {
     this.name = 'AlreadyEnrolledError';
   }
 }
-
-const DEFAULT_DESIRED_RETENTION = 0.9;
 
 /**
  * Returns the user_materials row for the caller, or throws NotEnrolledError.
@@ -97,7 +94,6 @@ export function isEnrolled(db: DB, key: UserMaterial): boolean {
 export function enrollUser(args: EnrollArgs): { snapshotId: string; version: number } {
   const { db, userId, materialId } = args;
   const now = args.now ?? (() => Math.floor(Date.now() / 1000));
-  const desiredRetention = args.desiredRetention ?? DEFAULT_DESIRED_RETENTION;
 
   const material = getMaterial(materialId);
   if (!material) throw new UnknownMaterialError(materialId);
@@ -109,10 +105,9 @@ export function enrollUser(args: EnrollArgs): { snapshotId: string; version: num
   // Empty config = parse_material_config('')'s test-friendly fallback
   // (all clubs enabled) — enrollment seeds the same card set regardless
   // of per-user picker choices; those are applied at query time (slice 1)
-  // and at /memorize introduction (slice 2). The desiredRetention arg
-  // was removed in wasm@0.6.0 (per-club inside MaterialConfig); kept as
-  // a no-op formal here since enrollment doesn't need a schedule.
-  void desiredRetention;
+  // and at /memorize introduction (slice 2). Empty schedule too: the
+  // seed run only needs the build/test_state pipeline, not the
+  // schedule-aware memorize batcher.
   const seedEngine = new WasmEngine(materialJson, '', '', '', BigInt(createdAt));
   let testStates: TestStateEntry[];
   try {

--- a/packages/api/src/lib/export-format.ts
+++ b/packages/api/src/lib/export-format.ts
@@ -48,7 +48,12 @@ export type CardRef =
 
 /** Per-(user, material) settings. Mirrors `user_year_settings` columns
  *  in camelCase so a new column added there propagates by re-running
- *  the export with the wider type. */
+ *  the export with the wider type.
+ *
+ *  Phase 1: `configJson` carries the per-club shape verbatim when the
+ *  row has been migrated / re-written under the new flow. Older exports
+ *  omit it (null when absent); the importer falls back to deriving the
+ *  per-club shape from the flat columns via `legacyToNew`. */
 export interface YearSettingsExport {
   headingCard: boolean;
   headingPassageCard: boolean;
@@ -59,6 +64,19 @@ export interface YearSettingsExport {
   chapterListScope: string;
   lessonBatchSize: number;
   desiredRetention: number;
+  /** Phase 1+ — per-club MaterialConfig JSON string. Null on older
+   *  exports; null on rows that haven't been touched since migration
+   *  0023 (the engine path synthesises in that case). */
+  configJson?: string | null;
+  updatedAt: number;
+}
+
+/** Per-(user, material) memorize schedule override. `null` (or absent)
+ *  when the user hasn't customised the bundled default. Exported and
+ *  imported verbatim — the importer doesn't re-validate the body
+ *  (the engine load path does on the next request). */
+export interface ScheduleExport {
+  scheduleJson: string;
   updatedAt: number;
 }
 
@@ -102,6 +120,9 @@ export interface MaterialExport {
   /** `null` when no `user_year_settings` row exists (user enrolled but
    *  never touched any setting). */
   settings: YearSettingsExport | null;
+  /** Phase 1+ — `null` when the user hasn't customised the bundled
+   *  default. Omitted (treated as null) on pre-Phase-1 exports. */
+  schedule?: ScheduleExport | null;
   snapshot: MaterialSnapshotExport;
   graduatedVerses: GraduatedVerseExport[];
   graduatedCards: GraduatedCardExport[];

--- a/packages/api/src/lib/export.ts
+++ b/packages/api/src/lib/export.ts
@@ -73,6 +73,7 @@ function buildMaterialExport(
   };
 
   const settings = readSettingsExport(db, key);
+  const schedule = readScheduleExport(db, key);
   const snapshot = readSnapshotExport(db, key, snapshotVersion);
   const graduatedVerses = readGraduatedVerseExport(db, key);
   const graduatedCards = readGraduatedCardExport(db, key, index);
@@ -82,6 +83,7 @@ function buildMaterialExport(
     materialId: key.materialId,
     enrollment,
     settings,
+    schedule,
     snapshot,
     graduatedVerses,
     graduatedCards,
@@ -114,8 +116,30 @@ function readSettingsExport(
     chapterListScope: row.chapterListScope,
     lessonBatchSize: row.lessonBatchSize,
     desiredRetention: row.desiredRetention,
+    configJson: row.configJson,
     updatedAt: row.updatedAt,
   };
+}
+
+function readScheduleExport(
+  db: DB,
+  key: { userId: string; materialId: string },
+): import('./export-format.js').ScheduleExport | null {
+  const row = db
+    .select({
+      scheduleJson: schema.materialSchedules.scheduleJson,
+      updatedAt: schema.materialSchedules.updatedAt,
+    })
+    .from(schema.materialSchedules)
+    .where(
+      and(
+        eq(schema.materialSchedules.userId, key.userId),
+        eq(schema.materialSchedules.materialId, key.materialId),
+      ),
+    )
+    .get();
+  if (!row) return null;
+  return { scheduleJson: row.scheduleJson, updatedAt: row.updatedAt };
 }
 
 function readSnapshotExport(

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -26,6 +26,7 @@ import {
 } from './review-log.js';
 import {
   ValidationError,
+  validatePerClubYearSettings,
   validateYearSettings,
   type YearSettings,
 } from './year-settings.js';
@@ -225,10 +226,49 @@ function applySettings(
   // fallback path synthesises from the legacy columns on next read.
   // Synthesising at import time would break round-trip equality with
   // pre-Phase-1 export shapes.
-  const configJson =
-    material.settings.configJson !== undefined && material.settings.configJson !== null
-      ? material.settings.configJson
-      : null;
+  //
+  // When a configJson IS present, run it through the same shape check
+  // the year-settings PUT route applies — a hostile export with a
+  // malformed per-club blob would otherwise land in the DB and surface
+  // as a 500 on the next engine.load (parse_material_config throws).
+  let configJson: string | null = null;
+  if (material.settings.configJson !== undefined && material.settings.configJson !== null) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(material.settings.configJson);
+    } catch (err) {
+      throw new ImportValidationError(
+        `settings.configJson for ${key.materialId}: invalid JSON (${(err as Error).message})`,
+      );
+    }
+    if (typeof parsed !== 'object' || parsed === null) {
+      throw new ImportValidationError(
+        `settings.configJson for ${key.materialId}: must be an object`,
+      );
+    }
+    const obj = parsed as Record<string, unknown>;
+    try {
+      validatePerClubYearSettings({
+        headingCard: obj.headingCard,
+        headingPassageCard: obj.headingPassageCard,
+        ftv: obj.ftv,
+        clubCardScope: obj.clubCardScope,
+        chapterListScope: obj.chapterListScope,
+        memorize: obj.memorize,
+        review: obj.review,
+        moveToNext: obj.moveToNext,
+        lessonBatchSize: obj.lessonBatchSize,
+      });
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        throw new ImportValidationError(
+          `settings.configJson for ${key.materialId}: ${err.message}`,
+        );
+      }
+      throw err;
+    }
+    configJson = material.settings.configJson;
+  }
 
   const row = {
     userId: key.userId,

--- a/packages/api/src/lib/import.ts
+++ b/packages/api/src/lib/import.ts
@@ -29,6 +29,7 @@ import {
   validateYearSettings,
   type YearSettings,
 } from './year-settings.js';
+import { ScheduleValidationError, validateSchedule } from './schedules.js';
 
 const SUPPORTED_EXPORT_VERSION = 1;
 
@@ -127,6 +128,7 @@ export async function applyAccountImport(
       db.transaction((tx) => {
         applyEnrollmentExtras(tx, key, material);
         applySettings(tx, key, material);
+        applySchedule(tx, key, material);
       });
       engines.invalidate(key);
 
@@ -217,10 +219,22 @@ function applySettings(
     throw err;
   }
 
+  // Phase 1: take the per-club configJson from the export when present
+  // (newer exports already carry it). Older exports omit the field —
+  // keep configJson null in that case so `readMaterialConfigJson`'s
+  // fallback path synthesises from the legacy columns on next read.
+  // Synthesising at import time would break round-trip equality with
+  // pre-Phase-1 export shapes.
+  const configJson =
+    material.settings.configJson !== undefined && material.settings.configJson !== null
+      ? material.settings.configJson
+      : null;
+
   const row = {
     userId: key.userId,
     materialId: key.materialId,
     ...validated,
+    configJson,
     // Use the export-recorded `updatedAt` verbatim. It's the next-merge
     // anchor: a later re-import with the same anchor is a no-op, and
     // any local tweak after this row goes in stamps a newer ts via the
@@ -240,6 +254,66 @@ function applySettings(
       .run();
   } else {
     tx.insert(schema.userYearSettings).values(row).run();
+  }
+}
+
+/** Phase 1: apply an imported per-material memorize schedule override.
+ *  Optional — older exports omit the field; absent → no-op. Validated
+ *  with the same shape-check the PUT route applies so bad imports
+ *  surface as a 400 instead of corrupting the row.
+ *
+ *  Merge policy mirrors `applySettings`: newer updatedAt wins. A later
+ *  re-import with the same anchor is a no-op; a local edit after this
+ *  row goes in stamps a newer ts via the PUT route and wins on the next
+ *  merge.
+ *
+ *  Lives in STEP 1 of `applyAccountImport`'s three-step transaction so
+ *  the engine.load() in STEP 2 picks up the imported schedule before
+ *  the cardref index is built. */
+function applySchedule(
+  tx: Tx,
+  key: { userId: string; materialId: string },
+  material: MaterialExport,
+): void {
+  if (!material.schedule) return;
+  try {
+    validateSchedule(material.schedule.scheduleJson);
+  } catch (err) {
+    if (err instanceof ScheduleValidationError) {
+      throw new ImportValidationError(`schedule for ${key.materialId}: ${err.message}`);
+    }
+    throw err;
+  }
+  const existing = tx
+    .select({ updatedAt: schema.materialSchedules.updatedAt })
+    .from(schema.materialSchedules)
+    .where(
+      and(
+        eq(schema.materialSchedules.userId, key.userId),
+        eq(schema.materialSchedules.materialId, key.materialId),
+      ),
+    )
+    .get();
+  if (existing && existing.updatedAt >= material.schedule.updatedAt) return;
+
+  const row = {
+    userId: key.userId,
+    materialId: key.materialId,
+    scheduleJson: material.schedule.scheduleJson,
+    updatedAt: material.schedule.updatedAt,
+  };
+  if (existing) {
+    tx.update(schema.materialSchedules)
+      .set(row)
+      .where(
+        and(
+          eq(schema.materialSchedules.userId, key.userId),
+          eq(schema.materialSchedules.materialId, key.materialId),
+        ),
+      )
+      .run();
+  } else {
+    tx.insert(schema.materialSchedules).values(row).run();
   }
 }
 

--- a/packages/api/src/lib/schedules.test.ts
+++ b/packages/api/src/lib/schedules.test.ts
@@ -133,6 +133,23 @@ describe('validateSchedule', () => {
     expect(() => validateSchedule(bad)).toThrow(/date/);
   });
 
+  it('rejects month=00 / day=00 dates that the Rust parser would also reject', () => {
+    // The regex on its own accepts these; isValidIsoDate catches them.
+    // current_week_index defensively skips bad rows now, but the API
+    // shouldn't let them through in the first place.
+    for (const date of ['2025-00-08', '2025-13-08', '2025-09-00', '2025-09-32']) {
+      const bad = JSON.stringify({
+        version: 1,
+        materialId: 'x',
+        season: 'y',
+        title: 't',
+        meetingDayOfWeek: 'Mon',
+        weeks: [{ date, isReview: false }],
+      });
+      expect(() => validateSchedule(bad)).toThrow(/date/);
+    }
+  });
+
   it('rejects non-array meets', () => {
     const bad = JSON.stringify({
       version: 1,

--- a/packages/api/src/lib/schedules.test.ts
+++ b/packages/api/src/lib/schedules.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { createTestDb, createTestUser } from '../test-utils.js';
+import * as schema from '../db/schema.js';
+import {
+  ScheduleValidationError,
+  loadBundledSchedule,
+  loadSchedule,
+  validateSchedule,
+} from './schedules.js';
+
+describe('loadBundledSchedule', () => {
+  it('returns the shipped 3-corinthians-2025-26 schedule for nkjv-cor', () => {
+    const json = loadBundledSchedule('nkjv-cor');
+    expect(json).not.toBe('');
+    const parsed = JSON.parse(json);
+    expect(parsed.materialId).toBe('nkjv-cor');
+    expect(parsed.season).toBe('2025-26');
+    expect(parsed.weeks.length).toBeGreaterThan(0);
+    expect(parsed.meets.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns empty string when no schedule ships for the material', () => {
+    // Decks beyond 3-corinthians have no bundled schedule in Phase 1.
+    expect(loadBundledSchedule('nkjv-john')).toBe('');
+  });
+
+  it('returns empty string for an unknown material id', () => {
+    expect(loadBundledSchedule('nope')).toBe('');
+  });
+});
+
+describe('loadSchedule', () => {
+  it('falls back to bundled when no user row exists', () => {
+    const test = createTestDb();
+    try {
+      createTestUser(test.db, 'u1');
+      const json = loadSchedule(test.db, 'u1', 'nkjv-cor');
+      expect(JSON.parse(json).materialId).toBe('nkjv-cor');
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it('returns the user copy when present, overriding the bundled default', () => {
+    const test = createTestDb();
+    try {
+      createTestUser(test.db, 'u1');
+      const custom = JSON.stringify({
+        version: 1,
+        materialId: 'nkjv-cor',
+        season: '2025-26',
+        title: 'Custom',
+        meetingDayOfWeek: 'Tue',
+        weeks: [],
+        meets: [],
+      });
+      test.db
+        .insert(schema.materialSchedules)
+        .values({
+          userId: 'u1',
+          materialId: 'nkjv-cor',
+          scheduleJson: custom,
+          updatedAt: 1_700_000_000,
+        })
+        .run();
+      const json = loadSchedule(test.db, 'u1', 'nkjv-cor');
+      expect(JSON.parse(json).title).toBe('Custom');
+    } finally {
+      test.cleanup();
+    }
+  });
+
+  it('returns empty for an enrolled material with no bundled and no user copy', () => {
+    const test = createTestDb();
+    try {
+      createTestUser(test.db, 'u1');
+      expect(loadSchedule(test.db, 'u1', 'nkjv-john')).toBe('');
+    } finally {
+      test.cleanup();
+    }
+  });
+});
+
+describe('validateSchedule', () => {
+  it('accepts a well-formed payload', () => {
+    const json = loadBundledSchedule('nkjv-cor');
+    expect(() => validateSchedule(json)).not.toThrow();
+  });
+
+  it('rejects malformed JSON', () => {
+    expect(() => validateSchedule('not json')).toThrow(ScheduleValidationError);
+  });
+
+  it('rejects non-object roots', () => {
+    expect(() => validateSchedule('[]')).toThrow(/object/);
+    expect(() => validateSchedule('null')).toThrow(/object/);
+    expect(() => validateSchedule('"a"')).toThrow(/object/);
+  });
+
+  it('rejects unsupported version', () => {
+    const bad = JSON.stringify({
+      version: 99,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+    });
+    expect(() => validateSchedule(bad)).toThrow(/version/);
+  });
+
+  it('rejects missing required string fields', () => {
+    const bad = JSON.stringify({
+      version: 1,
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+    });
+    expect(() => validateSchedule(bad)).toThrow(/materialId/);
+  });
+
+  it('rejects week with bad date format', () => {
+    const bad = JSON.stringify({
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [{ date: '09/08/2025', isReview: false }],
+    });
+    expect(() => validateSchedule(bad)).toThrow(/date/);
+  });
+
+  it('rejects non-array meets', () => {
+    const bad = JSON.stringify({
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+      meets: 'nope',
+    });
+    expect(() => validateSchedule(bad)).toThrow(/meets/);
+  });
+});

--- a/packages/api/src/lib/schedules.ts
+++ b/packages/api/src/lib/schedules.ts
@@ -1,0 +1,199 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { and, eq } from 'drizzle-orm';
+
+import * as schema from '../db/schema.js';
+import type { DB } from '../db/client.js';
+
+/**
+ * Per-(deck, season) memorize schedule loader.
+ *
+ * Schedules ship as `data/schedules/<deck>-<season>.json` (e.g.
+ * `3-corinthians-2025-26.json`). The user's customised copy lives in
+ * `material_schedules` and overrides the bundled default. The TS layer
+ * doesn't inspect the body — it's passed verbatim to the WASM engine.
+ *
+ * Returning `''` for a material with no bundled schedule and no user
+ * row is intentional: the WASM constructor accepts empty `schedule_json`
+ * and the memorize algorithm collapses to pure-Sequential, which matches
+ * the pre-Phase-1 behaviour exactly for decks that haven't shipped a
+ * schedule yet.
+ */
+
+/** Candidate directories where bundled schedule files might live.
+ *  Searched in order — bundle-local first because that's the production
+ *  layout, repo-root second so dev keeps working without a build step.
+ *  Mirrors `materials.ts`'s `DECK_DIRS` resolution. */
+const SCHEDULE_DIRS: readonly string[] = [
+  resolve(import.meta.dirname, '../..', 'data', 'schedules'),
+  resolve(import.meta.dirname, '../../../..', 'data', 'schedules'),
+];
+
+/** materialId → deck filename base. Mirrors the mapping in
+ *  `materials.ts:DATA_FILES`, minus the `.json` suffix. Schedules are
+ *  named `<base>-<season>.json` so the prefix lookup below picks them
+ *  up from disk. */
+const SCHEDULE_FILE_PREFIXES: Record<string, string> = {
+  'nkjv-gepc': '1-gepc',
+  'nkjv-nt': '2-nt-survey',
+  'nkjv-cor': '3-corinthians',
+  'nkjv-john': '4-john',
+  'nkjv-hp': '5-hp',
+  'nkjv-ot': '6-ot-survey',
+  'nkjv-rj': '7-rj',
+  'nkjv-luke': '8-luke',
+};
+
+interface CachedEntry {
+  mtime: number;
+  json: string;
+}
+
+const cache = new Map<string, CachedEntry>();
+
+/** Bundled-default schedule JSON for a material. Returns `''` when no
+ *  schedule ships for this material. The result is cached in process
+ *  keyed by file mtime so dev edits pick up automatically.
+ *
+ *  When multiple `<prefix>-<season>.json` files exist, picks the one
+ *  with the highest filename (lexical sort puts later seasons last —
+ *  `3-corinthians-2026-27.json > 3-corinthians-2025-26.json`). Future
+ *  improvement: pick by today's date falling within the season's
+ *  week range; for v1 the lexical pick matches the active season as
+ *  long as the file naming is monotonic. */
+export function loadBundledSchedule(materialId: string): string {
+  const prefix = SCHEDULE_FILE_PREFIXES[materialId];
+  if (prefix === undefined) return '';
+
+  for (const dir of SCHEDULE_DIRS) {
+    if (!existsSync(dir)) continue;
+    const files = readdirSync(dir);
+    const matches = files
+      .filter((f) => f.startsWith(`${prefix}-`) && f.endsWith('.json'))
+      .sort();
+    if (matches.length === 0) continue;
+    const filename = matches[matches.length - 1]!;
+    const full = resolve(dir, filename);
+    const stat = statSync(full);
+    const mtime = Number(stat.mtimeMs);
+    const key = full;
+    const cached = cache.get(key);
+    if (cached !== undefined && cached.mtime === mtime) {
+      return cached.json;
+    }
+    const json = readFileSync(full, 'utf8');
+    cache.set(key, { mtime, json });
+    return json;
+  }
+  return '';
+}
+
+/** Per-user schedule JSON for a material. Returns the user's customised
+ *  copy when present, otherwise falls back to the bundled default.
+ *  Returns `''` when neither exists; the WASM engine handles the empty
+ *  case (pure-Sequential memorize algorithm). */
+export function loadSchedule(db: DB, userId: string, materialId: string): string {
+  const row = db
+    .select({ scheduleJson: schema.materialSchedules.scheduleJson })
+    .from(schema.materialSchedules)
+    .where(
+      and(
+        eq(schema.materialSchedules.userId, userId),
+        eq(schema.materialSchedules.materialId, materialId),
+      ),
+    )
+    .get();
+  if (row !== undefined) return row.scheduleJson;
+  return loadBundledSchedule(materialId);
+}
+
+/** Shape-check a candidate schedule JSON string. Returns the parsed
+ *  object on success; throws a `ScheduleValidationError` (subclass of
+ *  Error) with a one-line message on the first violation.
+ *
+ *  Only structural fields are checked here — the WASM `parse_schedule`
+ *  call applies a stricter validation via `serde::Deserialize` when the
+ *  engine is constructed. This validator is for the PUT route's
+ *  fast-fail path so bad payloads don't reach disk. */
+export class ScheduleValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ScheduleValidationError';
+  }
+}
+
+interface SchedulePayload {
+  version: number;
+  materialId: string;
+  season: string;
+  title: string;
+  meetingDayOfWeek: string;
+  weeks: unknown[];
+  meets?: unknown[];
+}
+
+export function validateSchedule(json: string): SchedulePayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    throw new ScheduleValidationError(`invalid JSON: ${(e as Error).message}`);
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new ScheduleValidationError('schedule must be an object');
+  }
+  const obj = parsed as Record<string, unknown>;
+  const requireStr = (k: string): string => {
+    const v = obj[k];
+    if (typeof v !== 'string' || v.length === 0) {
+      throw new ScheduleValidationError(`missing string field: ${k}`);
+    }
+    return v;
+  };
+  const requireNum = (k: string): number => {
+    const v = obj[k];
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+      throw new ScheduleValidationError(`missing numeric field: ${k}`);
+    }
+    return v;
+  };
+  const requireArr = (k: string): unknown[] => {
+    const v = obj[k];
+    if (!Array.isArray(v)) {
+      throw new ScheduleValidationError(`missing array field: ${k}`);
+    }
+    return v;
+  };
+  const version = requireNum('version');
+  if (version !== 1) {
+    throw new ScheduleValidationError(`unsupported schedule version: ${version}`);
+  }
+  const materialId = requireStr('materialId');
+  const season = requireStr('season');
+  const title = requireStr('title');
+  const meetingDayOfWeek = requireStr('meetingDayOfWeek');
+  const weeks = requireArr('weeks');
+  for (let i = 0; i < weeks.length; i++) {
+    const w = weeks[i];
+    if (typeof w !== 'object' || w === null) {
+      throw new ScheduleValidationError(`weeks[${i}] must be an object`);
+    }
+    const wo = w as Record<string, unknown>;
+    if (typeof wo.date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(wo.date)) {
+      throw new ScheduleValidationError(`weeks[${i}].date must be YYYY-MM-DD`);
+    }
+  }
+  const meets = obj.meets;
+  if (meets !== undefined && !Array.isArray(meets)) {
+    throw new ScheduleValidationError('meets must be an array when present');
+  }
+  return {
+    version,
+    materialId,
+    season,
+    title,
+    meetingDayOfWeek,
+    weeks,
+    meets: meets as unknown[] | undefined,
+  };
+}

--- a/packages/api/src/lib/schedules.ts
+++ b/packages/api/src/lib/schedules.ts
@@ -122,6 +122,18 @@ export class ScheduleValidationError extends Error {
   }
 }
 
+/** `YYYY-MM-DD` with sane month/day ranges (1-12 / 1-31). The Rust-side
+ *  `parse_iso_date` rejects 0-month / 0-day, so accepting them at the API
+ *  boundary would silently disable schedule logic for that week (and via
+ *  `current_week_index`'s defensive skip, lose the week from cumulative
+ *  counts). Catch them here so the user sees a 400 instead. */
+function isValidIsoDate(s: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
+  const m = Number(s.slice(5, 7));
+  const d = Number(s.slice(8, 10));
+  return m >= 1 && m <= 12 && d >= 1 && d <= 31;
+}
+
 interface SchedulePayload {
   version: number;
   materialId: string;
@@ -179,8 +191,8 @@ export function validateSchedule(json: string): SchedulePayload {
       throw new ScheduleValidationError(`weeks[${i}] must be an object`);
     }
     const wo = w as Record<string, unknown>;
-    if (typeof wo.date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(wo.date)) {
-      throw new ScheduleValidationError(`weeks[${i}].date must be YYYY-MM-DD`);
+    if (typeof wo.date !== 'string' || !isValidIsoDate(wo.date)) {
+      throw new ScheduleValidationError(`weeks[${i}].date must be a real YYYY-MM-DD`);
     }
   }
   const meets = obj.meets;

--- a/packages/api/src/lib/year-settings.ts
+++ b/packages/api/src/lib/year-settings.ts
@@ -17,10 +17,20 @@ export const DEFAULT_LESSON_BATCH_SIZE = 3;
 const MIN_LESSON_BATCH_SIZE = 1;
 const MAX_LESSON_BATCH_SIZE = 10;
 
-// FSRS-author recommended bounds: below 0.7 lets too much fade between
-// reviews; above 0.97 explodes review count for marginal recall gains.
-const MIN_DESIRED_RETENTION = 0.7;
-const MAX_DESIRED_RETENTION = 0.97;
+// Legacy bounds used by the existing flat `YearSettings` validator.
+// Pre-Phase-1 clients shipped retention values in this range; kept here
+// so the route's accept-legacy-shape path doesn't reject what was
+// previously valid (the per-club shape clamps separately on read).
+const LEGACY_MIN_DESIRED_RETENTION = 0.7;
+const LEGACY_MAX_DESIRED_RETENTION = 0.97;
+
+// Phase 1 per-club retention bounds: tighter than the FSRS-author range.
+// Quizzers don't push as high as long-term-retention apps; the Rust
+// scheduler clamps to this range on read so out-of-range stored values
+// never reach FSRS math.
+export const MIN_DESIRED_RETENTION = 0.5;
+export const MAX_DESIRED_RETENTION = 0.9;
+export const DEFAULT_DESIRED_RETENTION = 0.8;
 
 export interface YearSettings {
   headingCard: boolean;
@@ -32,6 +42,74 @@ export interface YearSettings {
   chapterListScope: ChapterListScope;
   lessonBatchSize: number;
   desiredRetention: number;
+}
+
+// === Phase 1 per-club shape (new) ============================================
+//
+// Mirrors `crates/core::material_config::MaterialConfig`'s JSON wire form.
+// The route layer accepts EITHER `YearSettings` (legacy flat shape) or this
+// `PerClubYearSettings` shape on the POST body; the importer's reader path
+// accepts both too. Both shapes write to the DB: the legacy columns stay
+// authoritative until Phase 2 drops them, but `config_json` is mirrored on
+// every write so the engine path can read the per-club shape directly.
+
+export type Club = 'club150' | 'club300' | 'full';
+export type CatchUp = 'sequential' | 'calendarCascade';
+export type MoveToNextGate =
+  | 'fullyMemorized'
+  | 'afterMajorCheckpoint'
+  | 'afterMinorCheckpoint'
+  | 'caughtUp'
+  | 'always';
+
+export const CATCH_UP_VALUES: readonly CatchUp[] = ['sequential', 'calendarCascade'];
+export const MOVE_TO_NEXT_GATES: readonly MoveToNextGate[] = [
+  'fullyMemorized',
+  'afterMajorCheckpoint',
+  'afterMinorCheckpoint',
+  'caughtUp',
+  'always',
+];
+
+export interface ClubMemorizeConfig {
+  enabled: boolean;
+  catchUp: CatchUp;
+}
+
+export interface ClubReviewConfig {
+  enabled: boolean;
+  /** Valid range `[0.5, 0.9]`. The engine clamps on read; we still
+   *  reject out-of-range values at the boundary so the DB stays clean. */
+  desiredRetention: number;
+}
+
+export interface ClubMemorizeMap {
+  club150: ClubMemorizeConfig;
+  club300: ClubMemorizeConfig;
+  full: ClubMemorizeConfig;
+}
+
+export interface ClubReviewMap {
+  club150: ClubReviewConfig;
+  club300: ClubReviewConfig;
+  full: ClubReviewConfig;
+}
+
+export interface MoveToNextConfig {
+  p150To300: MoveToNextGate;
+  p300ToFull: MoveToNextGate;
+}
+
+export interface PerClubYearSettings {
+  headingCard: boolean;
+  headingPassageCard: boolean;
+  ftv: boolean;
+  clubCardScope: TierScope;
+  chapterListScope: ChapterListScope;
+  memorize: ClubMemorizeMap;
+  review: ClubReviewMap;
+  moveToNext: MoveToNextConfig;
+  lessonBatchSize: number;
 }
 
 export class ValidationError extends Error {
@@ -64,9 +142,9 @@ export function ensureRetention(value: unknown): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     throw new ValidationError('desiredRetention must be a number');
   }
-  if (value < MIN_DESIRED_RETENTION || value > MAX_DESIRED_RETENTION) {
+  if (value < LEGACY_MIN_DESIRED_RETENTION || value > LEGACY_MAX_DESIRED_RETENTION) {
     throw new ValidationError(
-      `desiredRetention must be between ${MIN_DESIRED_RETENTION} and ${MAX_DESIRED_RETENTION}`,
+      `desiredRetention must be between ${LEGACY_MIN_DESIRED_RETENTION} and ${LEGACY_MAX_DESIRED_RETENTION}`,
     );
   }
   return value;
@@ -108,5 +186,190 @@ export function validateYearSettings(raw: {
     chapterListScope: ensureEnum(raw.chapterListScope, 'chapterListScope', CHAPTER_LIST_SCOPES),
     lessonBatchSize: ensureBatchSize(raw.lessonBatchSize),
     desiredRetention: ensureRetention(raw.desiredRetention),
+  };
+}
+
+// === Phase 1 helpers ========================================================
+
+function clampRetention(value: number): number {
+  if (value < MIN_DESIRED_RETENTION) return MIN_DESIRED_RETENTION;
+  if (value > MAX_DESIRED_RETENTION) return MAX_DESIRED_RETENTION;
+  return value;
+}
+
+function memorizeFromScope(scope: TierScope): ClubMemorizeMap {
+  return {
+    club150: { enabled: scope === 'up150' || scope === 'up300' || scope === 'all', catchUp: 'sequential' },
+    club300: { enabled: scope === 'up300' || scope === 'all', catchUp: 'sequential' },
+    full: { enabled: scope === 'all', catchUp: 'sequential' },
+  };
+}
+
+function reviewFromScope(scope: TierScope, retention: number): ClubReviewMap {
+  const r = clampRetention(retention);
+  return {
+    club150: { enabled: scope === 'up150' || scope === 'up300' || scope === 'all', desiredRetention: r },
+    club300: { enabled: scope === 'up300' || scope === 'all', desiredRetention: r },
+    full: { enabled: scope === 'all', desiredRetention: r },
+  };
+}
+
+/** Convert the legacy flat `YearSettings` shape into the per-club
+ *  shape per the spec's migration table. Used by:
+ *
+ *    * the POST settings route's accept-old-shape branch,
+ *    * the importer's read path when an old-shape export comes in,
+ *    * `readMaterialConfigJson` when `config_json` is NULL.
+ *
+ *  Retention values above `MAX_DESIRED_RETENTION` (a common pre-Phase 1
+ *  preference of 0.95) clamp to 0.9; below `MIN_DESIRED_RETENTION` clamp
+ *  to 0.5. Catch-up defaults to Sequential on every club, and the
+ *  cross-club gates default to CaughtUp on every pair. */
+export function legacyToNew(old: YearSettings): PerClubYearSettings {
+  return {
+    headingCard: old.headingCard,
+    headingPassageCard: old.headingPassageCard,
+    ftv: old.ftv,
+    clubCardScope: old.clubCardScope,
+    chapterListScope: old.chapterListScope,
+    memorize: memorizeFromScope(old.newScope),
+    review: reviewFromScope(old.reviewScope, old.desiredRetention),
+    moveToNext: { p150To300: 'caughtUp', p300ToFull: 'caughtUp' },
+    lessonBatchSize: old.lessonBatchSize,
+  };
+}
+
+/** Per-club retention validator. Tighter range than the legacy
+ *  `ensureRetention`: bounded to `[0.5, 0.9]`. */
+export function ensureClubRetention(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new ValidationError(`${field} must be a number`);
+  }
+  if (value < MIN_DESIRED_RETENTION || value > MAX_DESIRED_RETENTION) {
+    throw new ValidationError(
+      `${field} must be between ${MIN_DESIRED_RETENTION} and ${MAX_DESIRED_RETENTION}`,
+    );
+  }
+  return value;
+}
+
+export function ensureCatchUp(value: unknown, field: string): CatchUp {
+  return ensureEnum(value, field, CATCH_UP_VALUES);
+}
+
+export function ensureGate(value: unknown, field: string): MoveToNextGate {
+  return ensureEnum(value, field, MOVE_TO_NEXT_GATES);
+}
+
+function ensureClubMemorizeConfig(value: unknown, field: string): ClubMemorizeConfig {
+  if (typeof value !== 'object' || value === null) {
+    throw new ValidationError(`${field} must be an object`);
+  }
+  const o = value as Record<string, unknown>;
+  return {
+    enabled: ensureBoolean(o.enabled, `${field}.enabled`),
+    catchUp: ensureCatchUp(o.catchUp, `${field}.catchUp`),
+  };
+}
+
+function ensureClubReviewConfig(value: unknown, field: string): ClubReviewConfig {
+  if (typeof value !== 'object' || value === null) {
+    throw new ValidationError(`${field} must be an object`);
+  }
+  const o = value as Record<string, unknown>;
+  return {
+    enabled: ensureBoolean(o.enabled, `${field}.enabled`),
+    desiredRetention: ensureClubRetention(o.desiredRetention, `${field}.desiredRetention`),
+  };
+}
+
+/** Validate a per-club settings object (every field required), returning
+ *  a clean `PerClubYearSettings`. Symmetric to `validateYearSettings`. */
+export function validatePerClubYearSettings(raw: {
+  headingCard: unknown;
+  headingPassageCard: unknown;
+  ftv: unknown;
+  clubCardScope: unknown;
+  chapterListScope: unknown;
+  memorize: unknown;
+  review: unknown;
+  moveToNext: unknown;
+  lessonBatchSize: unknown;
+}): PerClubYearSettings {
+  if (typeof raw.memorize !== 'object' || raw.memorize === null) {
+    throw new ValidationError('memorize must be an object');
+  }
+  if (typeof raw.review !== 'object' || raw.review === null) {
+    throw new ValidationError('review must be an object');
+  }
+  if (typeof raw.moveToNext !== 'object' || raw.moveToNext === null) {
+    throw new ValidationError('moveToNext must be an object');
+  }
+  const memorizeRaw = raw.memorize as Record<string, unknown>;
+  const reviewRaw = raw.review as Record<string, unknown>;
+  const moveRaw = raw.moveToNext as Record<string, unknown>;
+  return {
+    headingCard: ensureBoolean(raw.headingCard, 'headingCard'),
+    headingPassageCard: ensureBoolean(raw.headingPassageCard, 'headingPassageCard'),
+    ftv: ensureBoolean(raw.ftv, 'ftv'),
+    clubCardScope: ensureEnum(raw.clubCardScope, 'clubCardScope', TIER_SCOPES),
+    chapterListScope: ensureEnum(raw.chapterListScope, 'chapterListScope', CHAPTER_LIST_SCOPES),
+    memorize: {
+      club150: ensureClubMemorizeConfig(memorizeRaw.club150, 'memorize.club150'),
+      club300: ensureClubMemorizeConfig(memorizeRaw.club300, 'memorize.club300'),
+      full: ensureClubMemorizeConfig(memorizeRaw.full, 'memorize.full'),
+    },
+    review: {
+      club150: ensureClubReviewConfig(reviewRaw.club150, 'review.club150'),
+      club300: ensureClubReviewConfig(reviewRaw.club300, 'review.club300'),
+      full: ensureClubReviewConfig(reviewRaw.full, 'review.full'),
+    },
+    moveToNext: {
+      p150To300: ensureGate(moveRaw.p150To300, 'moveToNext.p150To300'),
+      p300ToFull: ensureGate(moveRaw.p300ToFull, 'moveToNext.p300ToFull'),
+    },
+    lessonBatchSize: ensureBatchSize(raw.lessonBatchSize),
+  };
+}
+
+/** Heuristic: does the payload look like the new per-club shape? True
+ *  if it has either a `memorize` object or a `review` object (the two
+ *  required top-level fields unique to PerClubYearSettings). Used by
+ *  the route's accept-either-shape branch. */
+export function looksLikePerClub(raw: Record<string, unknown>): boolean {
+  return (
+    (typeof raw.memorize === 'object' && raw.memorize !== null)
+    || (typeof raw.review === 'object' && raw.review !== null)
+  );
+}
+
+/** Highest enabled tier in a per-club map collapses to a cumulative
+ *  TierScope. Lossy when an intermediate tier is enabled without its
+ *  predecessor — but that's a per-club-shape-only configuration that
+ *  the legacy columns can't represent anyway. */
+function highestEnabledScope(m: { club150: { enabled: boolean }; club300: { enabled: boolean }; full: { enabled: boolean } }): TierScope {
+  if (m.full.enabled) return 'all';
+  if (m.club300.enabled) return 'up300';
+  if (m.club150.enabled) return 'up150';
+  return 'off';
+}
+
+/** Derive a legacy `YearSettings` from the new per-club shape, lossy on
+ *  the scope ladders (see `highestEnabledScope`). Retention picks the
+ *  Club 150 value (the user's primary tier) or falls back to the
+ *  per-club default. The legacy columns aren't engine-load-driving as
+ *  of commit 8 of the Phase 1 train — they're written as a mirror so
+ *  importers and pre-Phase-2 clients keep reading sensible defaults. */
+export function perClubToLegacy(p: PerClubYearSettings): YearSettings {
+  return {
+    headingCard: p.headingCard,
+    headingPassageCard: p.headingPassageCard,
+    ftv: p.ftv,
+    newScope: highestEnabledScope(p.memorize),
+    reviewScope: highestEnabledScope(p.review),
+    clubCardScope: p.clubCardScope,
+    chapterListScope: p.chapterListScope,
+    lessonBatchSize: p.lessonBatchSize,
+    desiredRetention: p.review.club150.desiredRetention,
   };
 }

--- a/packages/api/src/routes/cards.ts
+++ b/packages/api/src/routes/cards.ts
@@ -90,7 +90,10 @@ export function cardsRoutes(deps: CardsRoutesDeps) {
     const raw = await deps.engines.tryLoad({ userId: user.id, materialId });
     if (raw === null) return c.json({ error: 'Not enrolled' }, 404);
     using loaded = raw;
-    const session = JSON.parse(loaded.engine.memorize_session(max)) as {
+    // Schedule-aware two-phase canonical fill via wasm@0.6.0's v2 surface.
+    // The engine carries the schedule passed at construction; the algorithm
+    // collapses to pure-Sequential when none ships for the material.
+    const session = JSON.parse(loaded.engine.memorize_session_v2(max, BigInt(now()))) as {
       verses: { verseId: number; cardIds: number[] }[];
       orphans?: number[];
     };

--- a/packages/api/src/routes/schedules.test.ts
+++ b/packages/api/src/routes/schedules.test.ts
@@ -76,6 +76,32 @@ describe('schedules routes', () => {
     expect(body.title).toBe('My Edited Schedule');
   });
 
+  it('PUT 400s when body materialId mismatches URL materialId', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const wrong = {
+      version: 1,
+      materialId: 'nkjv-john',
+      season: '2025-26',
+      title: 'Mismatched',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+      meets: [],
+    };
+    const put = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify(wrong),
+      },
+    );
+    expect(put.status).toBe(400);
+    const body = (await put.json()) as { error: string };
+    expect(body.error).toMatch(/materialId/);
+  });
+
   it('PUT 400s on malformed payload', async () => {
     const test = createTestApp();
     cleanup = test.cleanup;

--- a/packages/api/src/routes/schedules.test.ts
+++ b/packages/api/src/routes/schedules.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createTestApp, signUpTestUser } from '../test-utils.js';
+
+const MATERIAL_ID = 'nkjv-cor';
+
+describe('schedules routes', () => {
+  let cleanup: (() => void) | null = null;
+  afterEach(() => {
+    cleanup?.();
+    cleanup = null;
+  });
+
+  it('returns 401 without auth', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    expect(
+      (await test.app.request(`/api/materials/${MATERIAL_ID}/schedule`)).status,
+    ).toBe(401);
+  });
+
+  it('returns the bundled default when no user override exists', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const res = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      { headers: { cookie } },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { materialId: string };
+    expect(body.materialId).toBe('nkjv-cor');
+  });
+
+  it('returns { schedule: null } when no bundled and no user override', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const res = await test.app.request(`/api/materials/nkjv-john/schedule`, {
+      headers: { cookie },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { schedule: null };
+    expect(body.schedule).toBeNull();
+  });
+
+  it('PUT persists a customised schedule and a subsequent GET reflects it', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const custom = {
+      version: 1,
+      materialId: 'nkjv-cor',
+      season: '2025-26',
+      title: 'My Edited Schedule',
+      meetingDayOfWeek: 'Tue',
+      weeks: [],
+      meets: [],
+    };
+    const put = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify(custom),
+      },
+    );
+    expect(put.status).toBe(200);
+
+    const get = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      { headers: { cookie } },
+    );
+    expect(get.status).toBe(200);
+    const body = (await get.json()) as { title: string };
+    expect(body.title).toBe('My Edited Schedule');
+  });
+
+  it('PUT 400s on malformed payload', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const put = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', cookie },
+        body: JSON.stringify({ not: 'a schedule' }),
+      },
+    );
+    expect(put.status).toBe(400);
+  });
+
+  it('DELETE drops the user override and bundled becomes visible again', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const custom = {
+      version: 1,
+      materialId: 'nkjv-cor',
+      season: '2025-26',
+      title: 'My Edited Schedule',
+      meetingDayOfWeek: 'Tue',
+      weeks: [],
+      meets: [],
+    };
+    await test.app.request(`/api/materials/${MATERIAL_ID}/schedule`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify(custom),
+    });
+
+    const del = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      { method: 'DELETE', headers: { cookie } },
+    );
+    expect(del.status).toBe(200);
+    const delBody = (await del.json()) as { fallbackToBundled: boolean };
+    expect(delBody.fallbackToBundled).toBe(true);
+
+    // Subsequent GET should now return the bundled title, not 'My Edited Schedule'.
+    const get = await test.app.request(
+      `/api/materials/${MATERIAL_ID}/schedule`,
+      { headers: { cookie } },
+    );
+    const body = (await get.json()) as { title: string };
+    expect(body.title).not.toBe('My Edited Schedule');
+  });
+
+  it('404 on unknown materialId across all methods', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    const get = await test.app.request('/api/materials/nope/schedule', {
+      headers: { cookie },
+    });
+    expect(get.status).toBe(404);
+    const put = await test.app.request('/api/materials/nope/schedule', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({}),
+    });
+    expect(put.status).toBe(404);
+    const del = await test.app.request('/api/materials/nope/schedule', {
+      method: 'DELETE',
+      headers: { cookie },
+    });
+    expect(del.status).toBe(404);
+  });
+});

--- a/packages/api/src/routes/schedules.ts
+++ b/packages/api/src/routes/schedules.ts
@@ -60,7 +60,20 @@ export function schedulesRoutes(deps: SchedulesRoutesDeps) {
     }
     const text = await c.req.text();
     try {
-      validateSchedule(text);
+      const parsed = validateSchedule(text);
+      // Cross-check the body's materialId against the URL so a user
+      // can't accidentally (or deliberately) store nkjv-john's schedule
+      // under nkjv-cor's row — the WASM engine wouldn't crash, but
+      // book/chapter refs in the schedule wouldn't match any verse in
+      // the running engine, silently producing an empty Phase 1.
+      if (parsed.materialId !== materialId) {
+        return c.json(
+          {
+            error: `body materialId (${parsed.materialId}) does not match URL materialId (${materialId})`,
+          },
+          400,
+        );
+      }
     } catch (err) {
       if (err instanceof ScheduleValidationError) {
         return c.json({ error: err.message }, 400);

--- a/packages/api/src/routes/schedules.ts
+++ b/packages/api/src/routes/schedules.ts
@@ -1,0 +1,106 @@
+import { and, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+
+import type { DB } from '../db/client.js';
+import * as schema from '../db/schema.js';
+import type { EngineStore } from '../lib/engine.js';
+import { MATERIALS } from '../lib/materials.js';
+import {
+  ScheduleValidationError,
+  loadBundledSchedule,
+  loadSchedule,
+  validateSchedule,
+} from '../lib/schedules.js';
+import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
+
+export interface SchedulesRoutesDeps {
+  db: DB;
+  engines: EngineStore;
+  now?: () => number;
+}
+
+/**
+ * `/api/materials/:materialId/schedule` — per-user customisable
+ * memorize schedule overrides.
+ *
+ *   GET     → returns the user's customised schedule if present, else
+ *             the bundled default. Returns `{ schedule: null }` when
+ *             neither exists (the material ships without one — engine
+ *             collapses to pure-Sequential).
+ *   PUT     → validates the body's shape, upserts into
+ *             material_schedules, invalidates the cached engine so the
+ *             next request rebuilds against the new schedule.
+ *   DELETE  → drops the user's override; bundled default reapplies.
+ *             Same engine-cache invalidation as PUT.
+ *
+ * No auth → 401. Unknown materialId → 404. Invalid PUT body → 400.
+ */
+export function schedulesRoutes(deps: SchedulesRoutesDeps) {
+  const app = new Hono<{ Variables: SessionVariables }>();
+  const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
+
+  app.use('*', requireAuth());
+
+  app.get('/:materialId/schedule', (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+    if (!MATERIALS.some((m) => m.id === materialId)) {
+      return c.json({ error: `Unknown material: ${materialId}` }, 404);
+    }
+    const json = loadSchedule(deps.db, user.id, materialId);
+    if (json === '') return c.json({ schedule: null });
+    return c.body(json, 200, { 'Content-Type': 'application/json' });
+  });
+
+  app.put('/:materialId/schedule', async (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+    if (!MATERIALS.some((m) => m.id === materialId)) {
+      return c.json({ error: `Unknown material: ${materialId}` }, 404);
+    }
+    const text = await c.req.text();
+    try {
+      validateSchedule(text);
+    } catch (err) {
+      if (err instanceof ScheduleValidationError) {
+        return c.json({ error: err.message }, 400);
+      }
+      throw err;
+    }
+    const updatedAt = now();
+    deps.db
+      .insert(schema.materialSchedules)
+      .values({ userId: user.id, materialId, scheduleJson: text, updatedAt })
+      .onConflictDoUpdate({
+        target: [schema.materialSchedules.userId, schema.materialSchedules.materialId],
+        set: { scheduleJson: text, updatedAt },
+      })
+      .run();
+    deps.engines.invalidate({ userId: user.id, materialId });
+    return c.json({ ok: true });
+  });
+
+  app.delete('/:materialId/schedule', (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
+    if (!MATERIALS.some((m) => m.id === materialId)) {
+      return c.json({ error: `Unknown material: ${materialId}` }, 404);
+    }
+    deps.db
+      .delete(schema.materialSchedules)
+      .where(
+        and(
+          eq(schema.materialSchedules.userId, user.id),
+          eq(schema.materialSchedules.materialId, materialId),
+        ),
+      )
+      .run();
+    deps.engines.invalidate({ userId: user.id, materialId });
+    // Surface what the GET path would now return so the client can
+    // re-render without a follow-up round-trip.
+    const fallback = loadBundledSchedule(materialId);
+    return c.json({ ok: true, fallbackToBundled: fallback !== '' });
+  });
+
+  return app;
+}

--- a/packages/api/src/routes/schedules.ts
+++ b/packages/api/src/routes/schedules.ts
@@ -41,12 +41,20 @@ export function schedulesRoutes(deps: SchedulesRoutesDeps) {
 
   app.use('*', requireAuth());
 
-  app.get('/:materialId/schedule', (c) => {
-    const user = getUser(c);
+  // Single guard for the 404-on-unknown-material check so every method
+  // can't silently forget it (and a future PATCH / HEAD doesn't add a
+  // fourth copy of the same `!MATERIALS.some(...)` predicate).
+  app.use('/:materialId/schedule', async (c, next) => {
     const materialId = c.req.param('materialId');
     if (!MATERIALS.some((m) => m.id === materialId)) {
       return c.json({ error: `Unknown material: ${materialId}` }, 404);
     }
+    return next();
+  });
+
+  app.get('/:materialId/schedule', (c) => {
+    const user = getUser(c);
+    const materialId = c.req.param('materialId');
     const json = loadSchedule(deps.db, user.id, materialId);
     if (json === '') return c.json({ schedule: null });
     return c.body(json, 200, { 'Content-Type': 'application/json' });
@@ -55,9 +63,6 @@ export function schedulesRoutes(deps: SchedulesRoutesDeps) {
   app.put('/:materialId/schedule', async (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
-    if (!MATERIALS.some((m) => m.id === materialId)) {
-      return c.json({ error: `Unknown material: ${materialId}` }, 404);
-    }
     const text = await c.req.text();
     try {
       const parsed = validateSchedule(text);
@@ -96,9 +101,6 @@ export function schedulesRoutes(deps: SchedulesRoutesDeps) {
   app.delete('/:materialId/schedule', (c) => {
     const user = getUser(c);
     const materialId = c.req.param('materialId');
-    if (!MATERIALS.some((m) => m.id === materialId)) {
-      return c.json({ error: `Unknown material: ${materialId}` }, 404);
-    }
     deps.db
       .delete(schema.materialSchedules)
       .where(

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -93,7 +93,10 @@ describe('years routes', () => {
       clubCardScope: 'off',
       chapterListScope: 'up150',
       lessonBatchSize: 3,
-      desiredRetention: 0.9,
+      // ENROLLED_DEFAULTS shifted from 0.9 to 0.8 in Phase 1 so the
+      // per-club configJson synthesised via legacyToNew agrees with
+      // the spec's 0.8 new-user default.
+      desiredRetention: 0.8,
     });
     for (const tier of ['150', '300', 'full'] as const) {
       expect(year.clubs[tier].status).toBe('active');

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -208,4 +208,79 @@ describe('years routes', () => {
     });
     expect(res.status).toBe(404);
   });
+
+  it('accepts the new per-club shape and derives legacy scopes', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await enrollViaApi(test, cookie, MATERIAL_ID, 150);
+
+    const res = await test.app.request(`/api/years/${MATERIAL_ID}/settings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        headingCard: false,
+        headingPassageCard: true,
+        ftv: true,
+        clubCardScope: 'off',
+        chapterListScope: 'up150',
+        memorize: {
+          club150: { enabled: true, catchUp: 'calendarCascade' },
+          club300: { enabled: true, catchUp: 'sequential' },
+          full: { enabled: false, catchUp: 'sequential' },
+        },
+        review: {
+          club150: { enabled: true, desiredRetention: 0.85 },
+          club300: { enabled: false, desiredRetention: 0.8 },
+          full: { enabled: false, desiredRetention: 0.8 },
+        },
+        moveToNext: { p150To300: 'fullyMemorized', p300ToFull: 'caughtUp' },
+        lessonBatchSize: 1,
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const get = await test.app.request('/api/years', { headers: { cookie } });
+    const body = (await get.json()) as YearsResponse;
+    const year = body.years.find((y) => y.materialId === MATERIAL_ID)!;
+    // perClubToLegacy collapses memorize.{150,300}.enabled → up300.
+    expect(year.settings.newScope).toBe('up300');
+    // Only review.club150 enabled → up150.
+    expect(year.settings.reviewScope).toBe('up150');
+    expect(year.settings.lessonBatchSize).toBe(1);
+    // desiredRetention picks club150's value.
+    expect(year.settings.desiredRetention).toBe(0.85);
+  });
+
+  it('rejects per-club retention out of [0.5, 0.9]', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await enrollViaApi(test, cookie, MATERIAL_ID, 150);
+
+    const res = await test.app.request(`/api/years/${MATERIAL_ID}/settings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        headingCard: false,
+        headingPassageCard: true,
+        ftv: true,
+        clubCardScope: 'off',
+        chapterListScope: 'up150',
+        memorize: {
+          club150: { enabled: true, catchUp: 'sequential' },
+          club300: { enabled: false, catchUp: 'sequential' },
+          full: { enabled: false, catchUp: 'sequential' },
+        },
+        review: {
+          club150: { enabled: true, desiredRetention: 0.95 },
+          club300: { enabled: false, desiredRetention: 0.8 },
+          full: { enabled: false, desiredRetention: 0.8 },
+        },
+        moveToNext: { p150To300: 'caughtUp', p300ToFull: 'caughtUp' },
+        lessonBatchSize: 1,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -97,8 +97,8 @@ function effectiveStatus(settings: YearSettings, tier: ClubTier): ClubStatus {
 }
 
 // Two fallbacks when the user has no user_year_settings row. Enrolled
-// users default to "study everything" (every tier covered by both
-// scopes — wider than the post-Phase-1 `MaterialConfig::default()`,
+// users default to "study everything" — every tier covered by both
+// scopes (wider than the post-Phase-1 `MaterialConfig::default()`,
 // which is Club-150-only, but matches the *legacy* shape this route
 // still surfaces alongside the per-club `configJson`). Unenrolled
 // users default to paused so the per-tier chip doesn't lie ("Active"
@@ -107,11 +107,13 @@ function effectiveStatus(settings: YearSettings, tier: ClubTier): ClubStatus {
 // VerseInHeading defaults off; HeadingPassage defaults on. Matches the
 // core defaults after the heading config split (core 0.2.0): the
 // passage-cued card is the primary heading test and the per-verse
-// "which heading?" card is now opt-in. Retention stays at 0.9 — the
-// /api/years legacy response is still the high-retention default for
-// pre-Phase-1 clients; per-club retention (clamped into [0.5, 0.9]
-// with default 0.8) lives inside `config_json` and is what the engine
-// actually reads.
+// "which heading?" card is now opt-in.
+// `desiredRetention: 0.8` matches the post-Phase-1 spec — `legacyToNew`
+// uses this value verbatim when synthesising `config_json`, so the
+// engine's per-club retention agrees with the spec for users who post
+// partial legacy bodies. Pre-Phase-1 clients reading the /api/years
+// response receive 0.8 instead of the old 0.9 default; both values are
+// inside the legacy `ensureRetention` range so no client breaks.
 const ENROLLED_DEFAULTS: YearSettings = {
   headingCard: false,
   headingPassageCard: true,
@@ -121,7 +123,7 @@ const ENROLLED_DEFAULTS: YearSettings = {
   clubCardScope: 'off',
   chapterListScope: 'up150',
   lessonBatchSize: DEFAULT_LESSON_BATCH_SIZE,
-  desiredRetention: 0.9,
+  desiredRetention: 0.8,
 };
 
 const UNENROLLED_DEFAULTS: YearSettings = {

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -14,9 +14,13 @@ import {
   ensureBoolean,
   ensureEnum,
   ensureRetention,
+  legacyToNew,
+  looksLikePerClub,
+  perClubToLegacy,
   TIER_SCOPES,
   type TierScope,
   ValidationError,
+  validatePerClubYearSettings,
   type YearSettings,
 } from '../lib/year-settings.js';
 import { type SessionVariables, getUser, requireAuth } from '../middleware/session.js';
@@ -234,12 +238,16 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
       return c.json({ error: `Unknown material: ${materialId}` }, 404);
     }
 
-    let body: SettingsBody;
+    let rawBody: unknown;
     try {
-      body = (await c.req.json()) as SettingsBody;
+      rawBody = await c.req.json();
     } catch {
       return c.json({ error: 'invalid JSON body' }, 400);
     }
+    if (typeof rawBody !== 'object' || rawBody === null) {
+      return c.json({ error: 'body must be an object' }, 400);
+    }
+    const bodyObj = rawBody as Record<string, unknown>;
 
     // For partial-body merging, pick defaults based on whether the
     // user is already enrolled. Enrolled-without-row falls back to
@@ -253,31 +261,58 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
       materialId,
       alreadyEnrolled ? ENROLLED_DEFAULTS : UNENROLLED_DEFAULTS,
     );
-    let next: YearSettings;
-    try {
-      const pick = <K extends keyof YearSettings>(
-        field: K,
-        validate: (v: unknown) => YearSettings[K],
-      ): YearSettings[K] =>
-        body[field] === undefined ? existing[field] : validate(body[field]);
 
-      next = {
-        headingCard: pick('headingCard', (v) => ensureBoolean(v, 'headingCard')),
-        headingPassageCard: pick('headingPassageCard', (v) =>
-          ensureBoolean(v, 'headingPassageCard'),
-        ),
-        ftv: pick('ftv', (v) => ensureBoolean(v, 'ftv')),
-        newScope: pick('newScope', (v) => ensureEnum(v, 'newScope', TIER_SCOPES)),
-        reviewScope: pick('reviewScope', (v) => ensureEnum(v, 'reviewScope', TIER_SCOPES)),
-        clubCardScope: pick('clubCardScope', (v) =>
-          ensureEnum(v, 'clubCardScope', TIER_SCOPES),
-        ),
-        chapterListScope: pick('chapterListScope', (v) =>
-          ensureEnum(v, 'chapterListScope', CHAPTER_LIST_SCOPES),
-        ),
-        lessonBatchSize: pick('lessonBatchSize', ensureBatchSize),
-        desiredRetention: pick('desiredRetention', ensureRetention),
-      };
+    let next: YearSettings;
+    let configJson: string;
+    try {
+      if (looksLikePerClub(bodyObj)) {
+        // New per-club shape: validate (every field required — no
+        // partial merge for the per-club path), then derive the legacy
+        // YearSettings via perClubToLegacy. The legacy columns get the
+        // lossy collapse; the configJson stores the verbatim per-club
+        // shape that the engine reads on load (commit 8).
+        const perClub = validatePerClubYearSettings({
+          headingCard: bodyObj.headingCard,
+          headingPassageCard: bodyObj.headingPassageCard,
+          ftv: bodyObj.ftv,
+          clubCardScope: bodyObj.clubCardScope,
+          chapterListScope: bodyObj.chapterListScope,
+          memorize: bodyObj.memorize,
+          review: bodyObj.review,
+          moveToNext: bodyObj.moveToNext,
+          lessonBatchSize: bodyObj.lessonBatchSize,
+        });
+        next = perClubToLegacy(perClub);
+        configJson = JSON.stringify(perClub);
+      } else {
+        // Legacy flat shape: existing partial-merge path. Derive the
+        // per-club shape via legacyToNew so configJson stays in sync.
+        const body = bodyObj as SettingsBody;
+        const pick = <K extends keyof YearSettings>(
+          field: K,
+          validate: (v: unknown) => YearSettings[K],
+        ): YearSettings[K] =>
+          body[field] === undefined ? existing[field] : validate(body[field]);
+
+        next = {
+          headingCard: pick('headingCard', (v) => ensureBoolean(v, 'headingCard')),
+          headingPassageCard: pick('headingPassageCard', (v) =>
+            ensureBoolean(v, 'headingPassageCard'),
+          ),
+          ftv: pick('ftv', (v) => ensureBoolean(v, 'ftv')),
+          newScope: pick('newScope', (v) => ensureEnum(v, 'newScope', TIER_SCOPES)),
+          reviewScope: pick('reviewScope', (v) => ensureEnum(v, 'reviewScope', TIER_SCOPES)),
+          clubCardScope: pick('clubCardScope', (v) =>
+            ensureEnum(v, 'clubCardScope', TIER_SCOPES),
+          ),
+          chapterListScope: pick('chapterListScope', (v) =>
+            ensureEnum(v, 'chapterListScope', CHAPTER_LIST_SCOPES),
+          ),
+          lessonBatchSize: pick('lessonBatchSize', ensureBatchSize),
+          desiredRetention: pick('desiredRetention', ensureRetention),
+        };
+        configJson = JSON.stringify(legacyToNew(next));
+      }
     } catch (err) {
       if (err instanceof ValidationError) return c.json({ error: err.message }, 400);
       throw err;
@@ -296,7 +331,7 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
     }
 
     const ts = now();
-    const row = { ...next, updatedAt: ts };
+    const row = { ...next, configJson, updatedAt: ts };
     deps.db
       .insert(schema.userYearSettings)
       .values({ userId: user.id, materialId, ...row })

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -97,15 +97,21 @@ function effectiveStatus(settings: YearSettings, tier: ClubTier): ClubStatus {
 }
 
 // Two fallbacks when the user has no user_year_settings row. Enrolled
-// users default to "study everything" (mirrors the engine's
-// MaterialConfig::default); unenrolled users default to paused so the
-// per-tier chip doesn't lie ("Active" on a year the user hasn't
-// touched would be misleading). Either way, the user can opt in or
-// out from the picker.
-// VerseInHeading defaults off; HeadingPassage defaults on. Mirrors
-// `MaterialConfig::default()` after the heading config split (core
-// 0.2.0): the passage-cued card is the primary heading test and the
-// per-verse "which heading?" card is now opt-in.
+// users default to "study everything" (every tier covered by both
+// scopes — wider than the post-Phase-1 `MaterialConfig::default()`,
+// which is Club-150-only, but matches the *legacy* shape this route
+// still surfaces alongside the per-club `configJson`). Unenrolled
+// users default to paused so the per-tier chip doesn't lie ("Active"
+// on a year the user hasn't touched would be misleading). Either way,
+// the user can opt in or out from the picker.
+// VerseInHeading defaults off; HeadingPassage defaults on. Matches the
+// core defaults after the heading config split (core 0.2.0): the
+// passage-cued card is the primary heading test and the per-verse
+// "which heading?" card is now opt-in. Retention stays at 0.9 — the
+// /api/years legacy response is still the high-retention default for
+// pre-Phase-1 clients; per-club retention (clamped into [0.5, 0.9]
+// with default 0.8) lives inside `config_json` and is what the engine
+// actually reads.
 const ENROLLED_DEFAULTS: YearSettings = {
   headingCard: false,
   headingPassageCard: true,


### PR DESCRIPTION
## Summary

Phase 1 of the schedules + per-club settings rework (spec: [`docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md`](https://github.com/TommyAmberson/verse-vault/blob/docs/schedules-and-settings-design/docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md)). Covers the core algorithm + WASM contract + API foundation; the web UI rework (Phase 2) and schedule editor (Phase 3) follow in separate trains.

Three logical sub-trains, eleven commits:

- **`crates/core` (commits 1-4)** — `Schedule` data model, per-club `MaterialConfig` with legacy migration, two-phase canonical memorize fill, per-club retention threading. Bumps **0.5.1 → 0.6.0** (MAJOR — state shape change; legacy JSON still parses via serde aliases).
- **`crates/wasm` (commit 5)** — `WasmEngine` constructor drops `desired_retention`, adds `schedule_json`. New `memorize_session_v2(limit, now_secs)`; legacy `memorize_session` stays as deprecated wrapper. Bumps **0.5.1 → 0.6.0** (MAJOR — constructor signature break).
- **`packages/api` (commits 6-11)** — `material_schedules` table + bundled loader, per-club `config_json` column with dual-shape accept, schedule threaded into engine load + `memorize_session_v2`, new `GET/PUT/DELETE /api/materials/:id/schedule` routes, import/export round-trip new fields. Bumps **0.1.27 → 0.1.28** (MINOR — additive endpoints, both-shape acceptance).

Defaults shift to match the spec: new users get Club 150 only at 0.8 retention, batch size 1, all gates at CaughtUp. Existing users migrate transparently via the legacy → per-club adapter (both on the Rust side via serde aliases and on the DB side via migration 0023's `json_object()`).

Ships the SK 2025-26 1 & 2 Corinthians schedule (24 of 27 active weeks plus all 3 meets); multi-chapter weeks are stubbed as Review weeks pending a `Vec<Passage>` schema extension.

## Test plan

- [x] `cargo test --workspace` — all green (165+ tests across core/wasm/sim, including 12 new for the two-phase canonical fill and the cross-club gates)
- [x] `pnpm -F @verse-vault/api test` — 183 tests passing (9 new: schedule loader + routes, per-club POST settings, retention bounds)
- [x] `wasm-pack build crates/wasm --target nodejs --out-dir pkg` — clean rebuild against the new constructor signature
- [x] Manual round-trip: POST per-club settings → GET reflects collapsed legacy scopes; PUT schedule → GET returns user copy; DELETE schedule → GET falls back to bundled
- [x] Pre-Phase-1 export → import on 0.1.28 → re-export round-trip preserves equality (configJson stays null, schedule absent preserved)
- [ ] CI on this PR (Rust + typos + dprint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)