### PR TITLE
feat: Phase 2 — per-club settings + chain UI

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,85 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-06-15
+
+Phase 2 of the schedules + per-club settings rework. MINOR — the engine boot paths swap onto the
+`verse-vault-wasm@0.6.0` constructor signature (schedule arg in, `desired_retention` arg out), the
+`/settings` page picks up the spec's three-section IA with the chain UI replacing the legacy scope
+ladder, and the Memorize tab badge reads the bundled schedule. No state-shape break for end users;
+the IDB cache rebuilds against the new engine signature on first load after deploy.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.6.0` — per-club `MaterialConfig`, two-phase canonical-order memorize fill,
+  per-verse target retention. Shipped with API 0.1.28.
+* `verse-vault-wasm@0.6.0` — `WasmEngine` constructor takes `schedule_json`, drops
+  `desired_retention`. `memorize_session_v2(limit, now_secs)` is the new fill entry point. Shipped
+  with API 0.1.28.
+
+### Engine boot wires up schedule + per-club config
+
+`engineLoader.createEngine` now calls
+`new WasmEngine(materialData, materialConfig, schedule, testStates, BigInt(nowSecs))`, mirroring the
+wasm@0.6.0 signature. `engineStore.loadEngine` takes the schedule alongside the per-material config
+and threads it through every code path that builds or rebuilds the engine — initial load,
+post-rebuild after sync, refetchSyncState. `useEngine.init` gains an optional `schedule` parameter
+(defaults to `''` so callers that don't have one collapse to the pre-Phase-1 Sequential behaviour).
+`memorizeSession` switches to `memorize_session_v2` and passes `now_secs` so Phase 1 of the fill can
+read the schedule.
+
+`ReviewView` and `MemorizeView` fetch the schedule via `api.getSchedule(materialId)` before calling
+`engine.init` so the engine always boots with the user's authoritative schedule (or the bundled
+default, or `''` when neither exists).
+
+### Per-club settings + API client
+
+New TypeScript types in `api.ts` for the per-club shape: `Club`, `CatchUp`, `MoveToNextGate`,
+`ClubMemorizeConfig`, `ClubReviewConfig`, `MoveToNextConfig`, `PerClubYearSettings`. New `ApiClient`
+methods:
+
+* `updateYearSettingsPerClub(materialId, settings)` — POSTs the per-club shape to
+  `/api/years/:id/settings`. Symmetric to the legacy `updateYearSettings` for the new chain UI.
+* `getSchedule(materialId)` / `putSchedule(materialId, schedule)` / `deleteSchedule(materialId)` —
+  wrappers around `/api/materials/:id/schedule`. `getSchedule` normalises the server's
+  `{ schedule: null }` envelope to a plain `null` so callers can branch on truthiness.
+
+`YearView.perClub: PerClubYearSettings` mirrors the new server field — the chain UI reads it for
+round-trip-safe loads.
+
+### Settings page: three-section IA (Account / Preferences / Materials)
+
+`/settings` is now a section host with a left rail (desktop) / horizontal scrolling chips (mobile)
+and child routes:
+
+* `/settings/account` — Export my data, Import data, Delete all progress. Closes [#92][issue-92] by
+  migrating the three account-level actions out of `ProfilePickerView`'s profile-card kebab (which
+  now only carries Sign out + Delete profile). `AppAvatar` gains an "Account" item that deep-links
+  into the section. `/profiles` goes back to being purely sign-in plus multi-profile switching.
+* `/settings/preferences` — placeholder shell. Empty at launch per the spec.
+* `/settings/materials` — the per-material card, default route. Carries the chain UI for "What to
+  memorize" (per-club Enable + Catch-up dropdown, indented dashed gate rows between flanking enabled
+  clubs carrying the Move-to-next-club selector) and per-club "What to review" cards with individual
+  retention sliders (50–90%). The material-wide retention slider is gone; per-club status chips
+  (Active / Maintenance / Paused) derive from the user's edits in real time. Card kinds, Offline
+  study, and Session sections unchanged. Saves call `api.updateYearSettingsPerClub`.
+
+### Schedule-aware Memorize tab badge
+
+The nav-bar Memorize pill switches from a flat sum of every year's `newCardCount` to a
+schedule-aware count. Per-year contribution:
+
+* No memorize club enabled → 0.
+* No schedule → `newCardCount` (pre-Phase-2 fallback for decks without a published schedule).
+* Schedule present → `min(newCardCount, cumulative_through_current_week)` where `cumulative` is
+  summed across enabled clubs' tiers in weeks [0, current_week]. Caps the badge at this week's plan
+  when behind; falls back to `newCardCount` when caught up with leftover.
+
+Math lives in `lib/badges.ts` so it's swap-out-ready when a future API surface exposes per-club
+graduated counts and the v1 approximation can be replaced by the spec's exact formula.
+
+[issue-92]: https://github.com/tommyamberson/verse-vault/issues/92
+
 ## [0.2.0] — 2026-06-12
 
 MINOR bump for the nav redesign (identity popover, mobile bottom tab bar, route renames). Also packs

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -8,6 +8,7 @@ import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import MobileTabBar from '@/components/MobileTabBar.vue'
 import OfflineBanner from '@/components/OfflineBanner.vue'
 import { useAuth } from '@/composables/useAuth'
+import { memorizeBadgeCount } from '@/lib/badges'
 
 const { activeProfile, conflict, acceptPendingSignIn, cancelPendingSignIn } = useAuth()
 const route = useRoute()
@@ -28,7 +29,8 @@ async function refreshMemorizeCount() {
   if (!user.value) return
   try {
     const res = await api.getYears()
-    newToMemorize.value = res.years.reduce((sum, y) => sum + y.newCardCount, 0)
+    const todayIso = new Date().toISOString().slice(0, 10)
+    newToMemorize.value = await memorizeBadgeCount(res.years, api.getSchedule, todayIso)
   } catch {
     // Don't fail nav rendering on a count fetch error; leave at 0.
   }

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -245,7 +245,13 @@ export interface YearView {
   /** True when the user has opted into bulk-renders download for this
    *  year. Server returns false for unenrolled years. */
   offlineMode: boolean
+  /** Legacy flat settings — kept for backward compat with code paths
+   *  not yet migrated to `perClub`. The engine reads `perClub`. */
   settings: YearSettings
+  /** Per-club configuration as stored on the server (Phase 1+). The
+   *  chain UI in /settings/materials reads this so user-customised
+   *  `catchUp` and `moveToNext` choices round-trip cleanly. */
+  perClub: PerClubYearSettings
   clubs: Record<ClubTier, ClubView>
   /** Total `New` cards in the engine — drives the "N to memorize" pill. */
   newCardCount: number

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -160,9 +160,72 @@ export interface YearSettings {
   clubCardScope: TierScope
   chapterListScope: ChapterListScope
   lessonBatchSize: number
-  /** FSRS target retention in `[0.7, 0.97]`. Higher = more reviews +
-   *  better recall; lower = fewer reviews + more lapses. */
+  /** Legacy FSRS target retention. Pre-Phase-1 clients honoured this
+   *  as the per-material slider. As of Phase 1 it survives only as a
+   *  mirror for backward compat — the engine reads per-club retention
+   *  from `configJson.review.{club}.desiredRetention`. */
   desiredRetention: number
+}
+
+// === Phase 1+ per-club shape ===============================================
+//
+// Mirrors `crates/core::material_config::MaterialConfig`'s JSON wire form and
+// the API's `PerClubYearSettings` (`packages/api/src/lib/year-settings.ts`).
+// The `POST /api/years/:materialId/settings` route accepts EITHER this shape
+// or the legacy flat `YearSettings`; per-club is required complete (no
+// partial-merge), legacy keeps its existing partial-merge semantics.
+
+export type Club = 'club150' | 'club300' | 'full'
+export type CatchUp = 'sequential' | 'calendarCascade'
+export type MoveToNextGate =
+  | 'fullyMemorized'
+  | 'afterMajorCheckpoint'
+  | 'afterMinorCheckpoint'
+  | 'caughtUp'
+  | 'always'
+
+export interface ClubMemorizeConfig {
+  enabled: boolean
+  catchUp: CatchUp
+}
+
+export interface ClubReviewConfig {
+  enabled: boolean
+  /** Valid range `[0.5, 0.9]`. The engine clamps on read for defence-
+   *  in-depth; the API rejects out-of-range values at the boundary. */
+  desiredRetention: number
+}
+
+export interface ClubMemorizeMap {
+  club150: ClubMemorizeConfig
+  club300: ClubMemorizeConfig
+  full: ClubMemorizeConfig
+}
+
+export interface ClubReviewMap {
+  club150: ClubReviewConfig
+  club300: ClubReviewConfig
+  full: ClubReviewConfig
+}
+
+export interface MoveToNextConfig {
+  p150To300: MoveToNextGate
+  p300ToFull: MoveToNextGate
+}
+
+/** New per-club settings shape. The POST settings route accepts this
+ *  as a complete body (every field required); the chain UI on the
+ *  Phase 2 settings page builds + sends this directly. */
+export interface PerClubYearSettings {
+  headingCard: boolean
+  headingPassageCard: boolean
+  ftv: boolean
+  clubCardScope: TierScope
+  chapterListScope: ChapterListScope
+  memorize: ClubMemorizeMap
+  review: ClubReviewMap
+  moveToNext: MoveToNextConfig
+  lessonBatchSize: number
 }
 
 export interface ClubView {
@@ -267,6 +330,26 @@ export interface ApiClient {
   getActivity(days?: number): Promise<ActivityResponse>
   getYears(): Promise<YearsResponse>
   updateYearSettings(materialId: string, settings: Partial<YearSettings>): Promise<{ settings: YearSettings }>
+  /** Phase 2 per-club POST. Sends the new shape; the API detects via
+   *  the `looksLikePerClub` heuristic (presence of `memorize` or
+   *  `review`) and validates every field. Returns the round-tripped
+   *  legacy view (server collapses per-club → legacy YearSettings for
+   *  the response). */
+  updateYearSettingsPerClub(
+    materialId: string,
+    settings: PerClubYearSettings,
+  ): Promise<{ settings: YearSettings }>
+  /** GET /api/materials/:materialId/schedule — returns the user's
+   *  customised schedule if present, else the bundled default, else
+   *  `null` when no schedule ships for the material (memorize then
+   *  collapses to pure-Sequential on the engine side). */
+  getSchedule(materialId: string): Promise<unknown | null>
+  /** PUT /api/materials/:materialId/schedule — upserts the user's copy.
+   *  Server validates the body's shape AND cross-checks `materialId`. */
+  putSchedule(materialId: string, schedule: unknown): Promise<{ ok: true }>
+  /** DELETE /api/materials/:materialId/schedule — drops the user's
+   *  override; bundled default reapplies on next read. */
+  deleteSchedule(materialId: string): Promise<{ ok: true; fallbackToBundled: boolean }>
   /** Fat-client sync: snapshot + materialised test states + last
    *  applied event id. Mirrors `/sync/:materialId/state` on the API. */
   getSyncState(materialId: string): Promise<SyncStateResponse>
@@ -290,7 +373,7 @@ export interface ApiClient {
  *  so the Better Auth session cookie flows through on every call. */
 export function createApiClient(apiUrl: string): ApiClient {
   async function request<T>(
-    method: 'GET' | 'POST' | 'PATCH' | 'DELETE',
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
     path: string,
     body?: unknown,
   ): Promise<T> {
@@ -334,6 +417,31 @@ export function createApiClient(apiUrl: string): ApiClient {
     getYears: () => request('GET', '/api/years'),
     updateYearSettings: (materialId, settings) =>
       request('POST', `/api/years/${encodeURIComponent(materialId)}/settings`, settings),
+    updateYearSettingsPerClub: (materialId, settings) =>
+      request('POST', `/api/years/${encodeURIComponent(materialId)}/settings`, settings),
+    getSchedule: async (materialId) => {
+      // The GET route returns either the schedule JSON verbatim (with
+      // content-type application/json) or `{ schedule: null }` when no
+      // schedule ships for this material. Normalise both into a single
+      // `unknown | null` for callers.
+      const body = await request<unknown>(
+        'GET',
+        `/api/materials/${encodeURIComponent(materialId)}/schedule`,
+      )
+      if (
+        body !== null
+        && typeof body === 'object'
+        && 'schedule' in body
+        && (body as { schedule: unknown }).schedule === null
+      ) {
+        return null
+      }
+      return body
+    },
+    putSchedule: (materialId, schedule) =>
+      request('PUT', `/api/materials/${encodeURIComponent(materialId)}/schedule`, schedule),
+    deleteSchedule: (materialId) =>
+      request('DELETE', `/api/materials/${encodeURIComponent(materialId)}/schedule`),
     getSyncState: (materialId) =>
       request('GET', `/api/sync/${encodeURIComponent(materialId)}/state`),
     postSyncEvents: (materialId, body) =>

--- a/apps/web/src/components/AppAvatar.vue
+++ b/apps/web/src/components/AppAvatar.vue
@@ -59,6 +59,11 @@ onBeforeUnmount(() => {
   window.removeEventListener('keydown', onWindowKeydown, true)
 })
 
+function goAccount() {
+  close()
+  void router.push('/settings/account')
+}
+
 function goSwitchProfile() {
   close()
   void router.push('/profiles?force=1')
@@ -115,6 +120,9 @@ async function onSignOut() {
           <p class="name">{{ activeProfile.displayName }}</p>
           <p class="email">{{ activeProfile.email }}</p>
         </div>
+        <button type="button" class="menu-item" role="menuitem" @click="goAccount">
+          Account
+        </button>
         <button type="button" class="menu-item" role="menuitem" @click="goSwitchProfile">
           Switch profile
         </button>

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -65,9 +65,10 @@ function menuAction(ev: Event, action: 'sign-out' | 'delete') {
   closeMenu()
   // `defineEmits` types `emit` as an overload set — one signature per
   // declared event — and TS can't match a union argument against
-  // overloads. `action` is always one of the declared events, so
-  // narrowing to a single name is sound.
-  emit(action as 'sign-out')
+  // overloads. Branch on the narrow type so each call site hits the
+  // correct overload at compile time.
+  if (action === 'sign-out') emit('sign-out')
+  else emit('delete')
 }
 
 // The card surface is a role="button" div rather than a native

--- a/apps/web/src/components/ProfileCard.vue
+++ b/apps/web/src/components/ProfileCard.vue
@@ -20,9 +20,6 @@ const emit = defineEmits<{
   /** Clicked a signed-out card — re-auth required to use it. */
   reauth: []
   'sign-out': []
-  export: []
-  import: []
-  'delete-progress': []
   delete: []
 }>()
 
@@ -63,17 +60,14 @@ const lastUsedLabel = computed(() => {
 // Every kebab item does the same three things — stop the card's click
 // handler firing, close the menu, then emit. One helper keeps the
 // handler list from growing 1:1 with the menu.
-function menuAction(
-  ev: Event,
-  action: 'export' | 'import' | 'sign-out' | 'delete-progress' | 'delete',
-) {
+function menuAction(ev: Event, action: 'sign-out' | 'delete') {
   ev.stopPropagation()
   closeMenu()
   // `defineEmits` types `emit` as an overload set — one signature per
   // declared event — and TS can't match a union argument against
   // overloads. `action` is always one of the declared events, so
   // narrowing to a single name is sound.
-  emit(action as 'export')
+  emit(action as 'sign-out')
 }
 
 // The card surface is a role="button" div rather than a native
@@ -132,36 +126,9 @@ function onCardKeydown(ev: KeyboardEvent) {
           type="button"
           class="menu-item"
           role="menuitem"
-          @click="menuAction($event, 'export')"
-        >
-          Export my data
-        </button>
-        <button
-          v-if="signedIn"
-          type="button"
-          class="menu-item"
-          role="menuitem"
-          @click="menuAction($event, 'import')"
-        >
-          Import data
-        </button>
-        <button
-          v-if="signedIn"
-          type="button"
-          class="menu-item"
-          role="menuitem"
           @click="menuAction($event, 'sign-out')"
         >
           Sign out
-        </button>
-        <button
-          v-if="signedIn"
-          type="button"
-          class="menu-item destructive"
-          role="menuitem"
-          @click="menuAction($event, 'delete-progress')"
-        >
-          Delete all progress
         </button>
         <button
           type="button"

--- a/apps/web/src/composables/useEngine.ts
+++ b/apps/web/src/composables/useEngine.ts
@@ -148,17 +148,17 @@ export function useEngine() {
    *
    *  Pass `config` to apply the user's year-settings (scope toggles,
    *  headings/ftv) when constructing the engine. Without it the engine
-   *  uses `MaterialConfig::default()` — fine on a brand-new account,
-   *  but surfaces the wrong card set after /settings is touched.
+   *  uses the wasm-side fallback (all-clubs-enabled) — fine on a brand-
+   *  new account, but surfaces the wrong card set after /settings is
+   *  touched.
    *
-   *  Pass `desiredRetention` to honour the user's `/settings` target-
-   *  retention slider in the local-first hot path. Omitting it falls
-   *  back to the engine's default (0.9), which silently disagrees with
-   *  the server scheduler whenever the user has set a non-default
-   *  value. */
-  async function init(id: string, config?: WireMaterialConfig, desiredRetention?: number) {
+   *  `schedule` is the per-(user, material) memorize schedule (bundled
+   *  default or user override) — wasm@0.6.0's schedule-aware Phase 1 of
+   *  the memorize fill reads it. Empty string skips it; behaviour
+   *  collapses to pure-Sequential, matching pre-Phase-1. */
+  async function init(id: string, config?: WireMaterialConfig, schedule: unknown | '' = '') {
     try {
-      await engineStore.loadEngine(id, nowSecs(), config, desiredRetention)
+      await engineStore.loadEngine(id, nowSecs(), config, schedule)
       active.add(id)
       await refreshCounts()
       ready.value = true
@@ -212,7 +212,7 @@ export function useEngine() {
   }
 
   function memorizeSession(materialId: string, limit: number) {
-    return engineStore.memorizeSession(materialId, limit)
+    return engineStore.memorizeSession(materialId, limit, nowSecs())
   }
 
   function newCardCount(materialId: string): number {

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -38,12 +38,6 @@ import type { Club, YearView } from '@/api'
 
 const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
 
-const CLUB_TO_TIER_KEY: Record<Club, 'club150' | 'club300' | 'full'> = {
-  club150: 'club150',
-  club300: 'club300',
-  full: 'full',
-}
-
 interface ScheduleWeek {
   date: string
   verses: Partial<Record<Club, number[]>> | null
@@ -79,7 +73,7 @@ function cumulativeThroughWeek(
     const w = weeks[i]?.verses
     if (!w) continue
     for (const club of enabledClubs) {
-      sum += w[CLUB_TO_TIER_KEY[club]]?.length ?? 0
+      sum += w[club]?.length ?? 0
     }
   }
   return sum
@@ -96,14 +90,25 @@ export function badgeContribution(
   if (enabledClubs.length === 0) return 0
   if (!schedule || schedule.weeks.length === 0) return year.newCardCount
   const idx = currentWeekIndex(schedule.weeks, today)
-  if (idx < 0) return 0
+  // Today before week 0 of a published schedule (e.g. the user installs
+  // the deck weeks before the season starts): the user can still
+  // sequentially memorize verses, so fall back to newCardCount rather
+  // than zeroing the badge. The schedule cap only kicks in once week 0
+  // has arrived.
+  if (idx < 0) return year.newCardCount
   const cumulative = cumulativeThroughWeek(schedule.weeks, idx, enabledClubs)
   return Math.min(year.newCardCount, cumulative)
 }
 
 /** Compute the schedule-aware Memorize badge count across every year.
- *  Driver fetches schedules in parallel — one round-trip per enrolled
- *  year on top of the existing `getYears()` call. */
+ *  Skips years with no enabled memorize club before any network call —
+ *  pressing Memorize on those years wouldn't introduce a verse anyway,
+ *  and the badge fires on every navigation, so the saved round-trips
+ *  add up for users with many catalog years.
+ *
+ *  Per-year fetch failures degrade gracefully: a single transient
+ *  network error on one year falls back to `newCardCount` for that
+ *  year rather than blanking the whole badge via Promise.all rejection. */
 export async function memorizeBadgeCount(
   years: readonly YearView[],
   getSchedule: (materialId: string) => Promise<unknown | null>,
@@ -111,8 +116,14 @@ export async function memorizeBadgeCount(
 ): Promise<number> {
   const contributions = await Promise.all(
     years.map(async (year) => {
-      const raw = await getSchedule(year.materialId)
-      const schedule = (raw as Schedule | null) ?? null
+      if (!CLUBS.some((c) => year.perClub.memorize[c].enabled)) return 0
+      let schedule: Schedule | null = null
+      try {
+        schedule = ((await getSchedule(year.materialId)) as Schedule | null) ?? null
+      } catch {
+        // Treat as schedule-absent — badgeContribution falls back to
+        // newCardCount for this year.
+      }
       return badgeContribution(year, schedule, todayIso)
     }),
   )

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -1,0 +1,120 @@
+/**
+ * Memorize-tab badge math.
+ *
+ * Spec (docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
+ * §"Memorize tab badge"):
+ *
+ *   badge = Σ over enabled clubs of  max(0, cumulative_through_current_week − memorized)
+ *
+ * v1 approximation: the API doesn't surface per-club graduated counts
+ * yet, so we can't compute the exact spec formula. We use these signals:
+ *
+ *   - `cumulative_through_current_week` = sum of `verses.{enabled-club}.length`
+ *     across schedule weeks up to and including the current week (the
+ *     latest week whose `date <= today`). Derivable client-side from
+ *     the schedule JSON.
+ *
+ *   - `newCardCount` = the engine's count of cards still in `New` state
+ *     for this material, summed across all clubs. Used as a per-year
+ *     ceiling: even if the schedule says many verses are due this week,
+ *     the user can only memorize what's not already graduated.
+ *
+ * Per-year contribution = `min(newCardCount, cumulative)`:
+ *
+ *   - User caught up to plan (newCardCount < cumulative)  → newCardCount
+ *     (the small leftover the user can still memorize)
+ *   - User behind plan (newCardCount > cumulative)        → cumulative
+ *     (this week's plan; doesn't blame them for lookahead)
+ *
+ * Years with no enabled memorize club contribute 0 — pressing Memorize
+ * on that year wouldn't introduce any verse anyway.
+ *
+ * Years where `api.getSchedule()` returns null fall through to the
+ * pre-Phase-2 behaviour (newCardCount verbatim) so the badge stays
+ * useful for materials without a published schedule.
+ */
+
+import type { Club, YearView } from '@/api'
+
+const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
+
+const CLUB_TO_TIER_KEY: Record<Club, 'club150' | 'club300' | 'full'> = {
+  club150: 'club150',
+  club300: 'club300',
+  full: 'full',
+}
+
+interface ScheduleWeek {
+  date: string
+  verses: Partial<Record<Club, number[]>> | null
+  isReview?: boolean
+}
+
+interface Schedule {
+  weeks: ScheduleWeek[]
+}
+
+/** Return the index of the latest week whose date is on or before
+ *  `today`, or -1 when today is before week 0. `weeks` is assumed
+ *  sorted ascending by date (the server enforces this on PUT). Date
+ *  comparison is purely string-lexicographic on ISO `YYYY-MM-DD`. */
+function currentWeekIndex(weeks: readonly ScheduleWeek[], today: string): number {
+  let idx = -1
+  for (let i = 0; i < weeks.length; i++) {
+    if (weeks[i].date <= today) idx = i
+    else break
+  }
+  return idx
+}
+
+/** Sum verse counts in schedule weeks [0, currentIdx] for each enabled
+ *  club. Review weeks (verses === null) contribute zero. */
+function cumulativeThroughWeek(
+  weeks: readonly ScheduleWeek[],
+  currentIdx: number,
+  enabledClubs: readonly Club[],
+): number {
+  let sum = 0
+  for (let i = 0; i <= currentIdx; i++) {
+    const w = weeks[i]?.verses
+    if (!w) continue
+    for (const club of enabledClubs) {
+      sum += w[CLUB_TO_TIER_KEY[club]]?.length ?? 0
+    }
+  }
+  return sum
+}
+
+/** Per-year badge contribution. Exported for unit testing; consumers
+ *  use `memorizeBadgeCount` instead. */
+export function badgeContribution(
+  year: YearView,
+  schedule: Schedule | null,
+  today: string,
+): number {
+  const enabledClubs = CLUBS.filter((c) => year.perClub.memorize[c].enabled)
+  if (enabledClubs.length === 0) return 0
+  if (!schedule || schedule.weeks.length === 0) return year.newCardCount
+  const idx = currentWeekIndex(schedule.weeks, today)
+  if (idx < 0) return 0
+  const cumulative = cumulativeThroughWeek(schedule.weeks, idx, enabledClubs)
+  return Math.min(year.newCardCount, cumulative)
+}
+
+/** Compute the schedule-aware Memorize badge count across every year.
+ *  Driver fetches schedules in parallel — one round-trip per enrolled
+ *  year on top of the existing `getYears()` call. */
+export async function memorizeBadgeCount(
+  years: readonly YearView[],
+  getSchedule: (materialId: string) => Promise<unknown | null>,
+  todayIso: string,
+): Promise<number> {
+  const contributions = await Promise.all(
+    years.map(async (year) => {
+      const raw = await getSchedule(year.materialId)
+      const schedule = (raw as Schedule | null) ?? null
+      return badgeContribution(year, schedule, todayIso)
+    }),
+  )
+  return contributions.reduce((sum, c) => sum + c, 0)
+}

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -38,6 +38,24 @@ import type { Club, YearView } from '@/api'
 
 const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
 
+/** Module-level cache for the schedule fetches `memorizeBadgeCount`
+ *  fires on every navigation. Schedules are essentially static within
+ *  a tab session — they only change via PUT/DELETE
+ *  `/api/materials/:id/schedule` (Phase 3 UI; not yet wired). Without
+ *  this cache, every nav re-fetches one schedule per enrolled year,
+ *  multiplying the per-route badge cost N+1 times.
+ *
+ *  Caches the in-flight promise so concurrent calls (e.g. two
+ *  fast back-to-back nav events) share one round-trip rather than
+ *  racing two. Exported so future schedule-write paths can invalidate
+ *  it explicitly when the editor lands. */
+const scheduleCache = new Map<string, Promise<unknown | null>>()
+
+export function invalidateScheduleCache(materialId?: string): void {
+  if (materialId === undefined) scheduleCache.clear()
+  else scheduleCache.delete(materialId)
+}
+
 interface ScheduleWeek {
   date: string
   verses: Partial<Record<Club, number[]>> | null
@@ -117,12 +135,19 @@ export async function memorizeBadgeCount(
   const contributions = await Promise.all(
     years.map(async (year) => {
       if (!CLUBS.some((c) => year.perClub.memorize[c].enabled)) return 0
+      let pending = scheduleCache.get(year.materialId)
+      if (pending === undefined) {
+        pending = getSchedule(year.materialId)
+        scheduleCache.set(year.materialId, pending)
+      }
       let schedule: Schedule | null = null
       try {
-        schedule = ((await getSchedule(year.materialId)) as Schedule | null) ?? null
+        schedule = ((await pending) as Schedule | null) ?? null
       } catch {
-        // Treat as schedule-absent — badgeContribution falls back to
-        // newCardCount for this year.
+        // Drop the cache so a transient failure doesn't pin a rejected
+        // promise for the rest of the session. The retry hits the
+        // network next nav; until then, fall back to newCardCount.
+        scheduleCache.delete(year.materialId)
       }
       return badgeContribution(year, schedule, todayIso)
     }),

--- a/apps/web/src/lib/engine/engineLoader.ts
+++ b/apps/web/src/lib/engine/engineLoader.ts
@@ -17,28 +17,38 @@ import type { TestStateEntry } from './types'
 export interface CreateEngineOpts {
   /** Parsed MaterialData JSON (one deck of structural verse data). */
   materialData: unknown
-  /** Per-user MaterialConfig (year/scope toggles). Empty string for
-   *  the engine's `MaterialConfig::default()`. */
+  /** Per-user MaterialConfig (year/scope toggles, per-club shape). Empty
+   *  string for the engine's test-friendly `all_clubs_enabled` fallback
+   *  inside `parse_material_config('')` — production always supplies a
+   *  real JSON blob. */
   materialConfig: unknown | ''
+  /** Per-(user, material) schedule override. Empty string skips the
+   *  schedule entirely — the memorize algorithm collapses to pure-
+   *  Sequential, matching pre-Phase-1 behaviour for decks that ship no
+   *  schedule. Otherwise a JSON `Schedule` matching the bundled shape.
+   *  Added in wasm@0.6.0. */
+  schedule: unknown | ''
   /** Persisted test states to overlay onto the freshly-seeded engine.
    *  Pass `[]` for a baseline rebuild. */
   testStates: TestStateEntry[]
-  /** Desired-retention parameter for FSRS scheduling (0..=1). 0.9 matches
-   *  the server default. */
-  desiredRetention: number
   /** Unix-seconds wall clock used to seed unseen tests. */
   nowSecs: number
 }
 
 /** Build a fresh `WasmEngine` from the given inputs. Callers are
  *  responsible for `.free()`-ing the result when discarding (e.g. on
- *  snapshot version bump). */
+ *  snapshot version bump).
+ *
+ *  As of wasm@0.6.0 the standalone `desired_retention` constructor arg
+ *  was removed — per-club retention lives inside
+ *  `MaterialConfig.review.{club}.desiredRetention`. The `schedule_json`
+ *  arg lands in the freed slot. */
 export function createEngine(opts: CreateEngineOpts): WasmEngine {
   return new WasmEngine(
     JSON.stringify(opts.materialData),
     opts.materialConfig === '' ? '' : JSON.stringify(opts.materialConfig),
+    opts.schedule === '' ? '' : JSON.stringify(opts.schedule),
     JSON.stringify(opts.testStates),
-    opts.desiredRetention,
     BigInt(opts.nowSecs),
   )
 }

--- a/apps/web/src/lib/engine/engineStore.ts
+++ b/apps/web/src/lib/engine/engineStore.ts
@@ -37,7 +37,10 @@ import type {
   WireMaterialConfig,
 } from './types'
 
-const DEFAULT_DESIRED_RETENTION = 0.9
+// Per-club retention now lives inside MaterialConfig (wasm@0.6.0).
+// Schedules are optional per material — empty string skips the
+// schedule-aware Phase 1 of the memorize fill, matching the legacy
+// pre-Phase-1 behaviour for decks that don't ship one.
 
 interface EngineSession {
   materialId: string
@@ -46,13 +49,11 @@ interface EngineSession {
   /** Cached so refetch + rebuild paths can re-pass it to `createEngine`
    *  without the caller having to reload year settings every time. */
   materialConfig: WireMaterialConfig | undefined
-  /** FSRS target retention the engine was constructed with. Same
-   *  motivation as `materialConfig`: refetch + rebuild paths re-pass
-   *  it, and the server-side scheduler uses the same per-user value
-   *  (packages/api/src/lib/enrollment.ts), so the local engine has to
-   *  honour the user's `/settings` slider rather than falling back to
-   *  the constant default. */
-  desiredRetention: number
+  /** Per-(user, material) schedule override or bundled default, cached
+   *  for the same reason as `materialConfig` — refetch + rebuild paths
+   *  rebuild the engine and need to re-pass it. Empty string when no
+   *  schedule applies (memorize collapses to pure-Sequential). */
+  schedule: unknown | ''
 }
 
 function requireSession(materialId: string, caller: string): EngineSession {
@@ -114,14 +115,19 @@ export interface FlushResult {
  *  return the cached session.
  *
  *  `materialConfig` lets callers pass the user's year settings so the
- *  engine respects scope toggles (newScope, reviewScope, etc.). Omit
- *  to use `MaterialConfig::default()` — only safe before the user has
- *  touched settings; after that the wrong card set surfaces. */
+ *  engine respects per-club enables, retention, and gates. Omit to use
+ *  the wasm-side fallback (all-clubs-enabled at the legacy retention)
+ *  — only safe before the user has touched settings; after that the
+ *  wrong card set surfaces.
+ *
+ *  `schedule` is the per-(user, material) memorize schedule (bundled
+ *  default or user override). Empty string skips schedule-aware Phase 1
+ *  of the memorize fill — pure-Sequential behaviour. */
 export async function loadEngine(
   materialId: string,
   nowSecs: number,
   materialConfig?: WireMaterialConfig,
-  desiredRetention: number = DEFAULT_DESIRED_RETENTION,
+  schedule: unknown | '' = '',
 ): Promise<EngineSession> {
   const existing = sessions.get(materialId)
   if (existing) return existing
@@ -149,8 +155,8 @@ export async function loadEngine(
   const engine = createEngine({
     materialData: snapshot.materialData,
     materialConfig: materialConfig ?? '',
+    schedule,
     testStates,
-    desiredRetention,
     nowSecs,
   })
   applyGraduations(engine, snapshot.graduatedVerseIds, snapshot.graduatedCardIds)
@@ -160,7 +166,7 @@ export async function loadEngine(
     engine,
     snapshotVersion: snapshot.version,
     materialConfig,
-    desiredRetention,
+    schedule,
   }
   sessions.set(materialId, session)
   return session
@@ -194,8 +200,8 @@ async function refetchSyncState(session: EngineSession, nowSecs: number): Promis
   const replacement = createEngine({
     materialData: fetched.snapshot.materialData,
     materialConfig: session.materialConfig ?? '',
+    schedule: session.schedule,
     testStates: fetched.testStates,
-    desiredRetention: session.desiredRetention,
     nowSecs,
   })
   const previous = session.engine
@@ -371,13 +377,19 @@ interface MemorizeSessionEntry {
 
 /** Build a memorize session payload locally. Mirrors the server's
  *  `/api/cards/memorize/session` route. See `MemorizeSessionResponse`
- *  in `@/api` for field semantics. */
+ *  in `@/api` for field semantics.
+ *
+ *  Uses wasm@0.6.0's `memorize_session_v2(limit, now_secs)` — the
+ *  schedule-aware two-phase canonical-order fill. Falls back to pure-
+ *  Sequential when no schedule was passed to the engine constructor,
+ *  matching pre-Phase-1 behaviour for decks without a schedule. */
 export function memorizeSession(
   materialId: string,
   limit: number,
+  nowSecs: number,
 ): { verses: MemorizeSessionEntry[]; orphans: number[] } {
   const session = requireSession(materialId, 'memorizeSession')
-  const parsed = JSON.parse(session.engine.memorize_session(limit)) as {
+  const parsed = JSON.parse(session.engine.memorize_session_v2(limit, BigInt(nowSecs))) as {
     verses: MemorizeSessionEntry[]
     orphans?: number[]
   }
@@ -549,8 +561,8 @@ async function doFlush(
       const replacement = createEngine({
         materialData: snapshot.materialData,
         materialConfig: session.materialConfig ?? '',
+        schedule: session.schedule,
         testStates: response.testStates,
-        desiredRetention: session.desiredRetention,
         nowSecs,
       })
       const previous = session.engine

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -57,8 +57,27 @@ const router = createRouter({
     },
     {
       path: '/settings',
-      name: 'settings',
       component: () => import('@/views/SettingsView.vue'),
+      children: [
+        // Materials is the default — matches today's behaviour where
+        // /settings opens straight onto the per-material tabs.
+        { path: '', redirect: '/settings/materials' },
+        {
+          path: 'account',
+          name: 'settings-account',
+          component: () => import('@/views/SettingsAccountView.vue'),
+        },
+        {
+          path: 'preferences',
+          name: 'settings-preferences',
+          component: () => import('@/views/SettingsPreferencesView.vue'),
+        },
+        {
+          path: 'materials',
+          name: 'settings-materials',
+          component: () => import('@/views/SettingsMaterialsView.vue'),
+        },
+      ],
     },
   ],
 })

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -96,14 +96,16 @@ async function buildSession() {
   )
   // Boot the engine for every eligible year in parallel, then compute
   // each year's session payload locally. Settings pass through so the
-  // engine respects per-year scope toggles. Schedule wiring lands in
-  // commit 2 of the Phase 2 train; the engine ctor currently receives
-  // '' for schedule_json, collapsing memorize_session_v2 to pure-
-  // Sequential — matches pre-Phase-1 behaviour for now.
+  // engine respects per-year scope toggles + per-club retention; the
+  // schedule (bundled default or user override) drives Phase 1 of the
+  // memorize_session_v2 canonical fill — null falls through to pure-
+  // Sequential, matching pre-Phase-1 behaviour for materials that
+  // don't ship a schedule.
   await Promise.all(
-    eligibleYears.map((y) =>
-      engine.init(y.materialId, buildMaterialConfig(y.settings)),
-    ),
+    eligibleYears.map(async (y) => {
+      const schedule = await api.getSchedule(y.materialId)
+      await engine.init(y.materialId, buildMaterialConfig(y.settings), schedule ?? '')
+    }),
   )
   const sessions: {
     materialId: string

--- a/apps/web/src/views/MemorizeView.vue
+++ b/apps/web/src/views/MemorizeView.vue
@@ -96,10 +96,13 @@ async function buildSession() {
   )
   // Boot the engine for every eligible year in parallel, then compute
   // each year's session payload locally. Settings pass through so the
-  // engine respects per-year scope toggles (e.g. chapter_list_scope).
+  // engine respects per-year scope toggles. Schedule wiring lands in
+  // commit 2 of the Phase 2 train; the engine ctor currently receives
+  // '' for schedule_json, collapsing memorize_session_v2 to pure-
+  // Sequential — matches pre-Phase-1 behaviour for now.
   await Promise.all(
     eligibleYears.map((y) =>
-      engine.init(y.materialId, buildMaterialConfig(y.settings), y.settings.desiredRetention),
+      engine.init(y.materialId, buildMaterialConfig(y.settings)),
     ),
   )
   const sessions: {

--- a/apps/web/src/views/ProfilePickerView.vue
+++ b/apps/web/src/views/ProfilePickerView.vue
@@ -2,14 +2,10 @@
 import { ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 
-import { api, ApiError, type ImportSummary } from '@/api'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
-import ImportResultDialog from '@/components/ImportResultDialog.vue'
 import ProfileCard from '@/components/ProfileCard.vue'
 import SignInForm from '@/components/SignInForm.vue'
-import TypeToConfirmDialog from '@/components/TypeToConfirmDialog.vue'
 import { useAuth } from '@/composables/useAuth'
-import { downloadJson, exportFilename, readJsonFile } from '@/lib/account-file'
 import { safeRedirect } from '@/router'
 import type { ProfileRow } from '@/lib/engine/registry'
 
@@ -22,7 +18,6 @@ const {
   signOut,
   enterProfile,
   deleteProfile,
-  resetProfileLocalData,
 } = useAuth()
 
 const router = useRouter()
@@ -34,21 +29,6 @@ const pendingDelete = ref<ProfileRow | null>(null)
 const deleteBusy = ref(false)
 
 const banner = ref<string | null>(null)
-
-const fileInput = ref<HTMLInputElement | null>(null)
-// The parsed payload awaiting the import confirm. `switchTo` has already
-// made the target the active profile by the time this is set, so the
-// confirm dialog reads the account from `activeProfile`, not from here.
-const pendingImportPayload = ref<unknown | null>(null)
-const importBusy = ref(false)
-// Mutually exclusive: a summary on success, a message on failure. Both
-// null while no result dialog is showing.
-const importSummary = ref<ImportSummary | null>(null)
-const importError = ref<string | null>(null)
-const showImportResult = ref(false)
-
-const pendingDeleteProgress = ref<ProfileRow | null>(null)
-const deleteProgressBusy = ref(false)
 
 // Keep mode in sync with the shared profiles list (reconcile, sign-in
 // from another flow, etc.). Skip when the user is mid-add — don't
@@ -93,143 +73,6 @@ async function onCardSignOut(profile: ProfileRow) {
   // in-memory active state — both branches handled inside signOut().
   // The shared profiles list refreshes automatically.
   await signOut(profile.profileId)
-}
-
-/** Make `profile`'s session active (no-op if it already is). Returns
- *  false and routes to the reauth form when the token is dead. */
-async function switchTo(profile: ProfileRow): Promise<boolean> {
-  if (activeProfile.value?.profileId === profile.profileId) return true
-  let result: { ok: boolean }
-  try {
-    result = await enterProfile(profile.profileId)
-  } catch {
-    // enterProfile normally resolves { ok: false } for a dead token, but
-    // a network error during the multiSession switch can reject — surface
-    // it as a banner rather than an unhandled rejection.
-    banner.value = 'Could not switch to that profile. Please try again.'
-    return false
-  }
-  if (result.ok) return true
-  prefillEmail.value = profile.email
-  mode.value = 'add'
-  return false
-}
-
-/** Clear the banner, switch to `profile`, then run `fn` against the
- *  now-active account. Skips `fn` if the switch needed reauth. The
- *  shared preamble for every per-card account action. */
-async function withActiveProfile(profile: ProfileRow, fn: () => Promise<void>) {
-  banner.value = null
-  if (!(await switchTo(profile))) return
-  await fn()
-}
-
-/** Download the active account's full export. Shared by the kebab
- *  Export item and the backup button inside the delete dialog. */
-async function exportActiveAccount() {
-  const email = activeProfile.value?.email ?? 'account'
-  const data = await api.exportAccount()
-  const isoDate = new Date().toISOString().slice(0, 10)
-  downloadJson(exportFilename(email, isoDate), data)
-}
-
-function onCardExport(profile: ProfileRow) {
-  return withActiveProfile(profile, async () => {
-    try {
-      await exportActiveAccount()
-    } catch (err) {
-      banner.value = err instanceof ApiError ? err.message : 'Export failed.'
-    }
-  })
-}
-
-async function onBackupClick() {
-  banner.value = null
-  try {
-    await exportActiveAccount()
-  } catch (err) {
-    banner.value = err instanceof ApiError ? err.message : 'Backup download failed.'
-  }
-}
-
-function onCardImport(profile: ProfileRow) {
-  return withActiveProfile(profile, async () => {
-    // The active profile is now the import target; open the OS file
-    // picker and let `onFilePicked` carry on from the change event.
-    fileInput.value?.click()
-  })
-}
-
-async function onFilePicked(ev: Event) {
-  const input = ev.target as HTMLInputElement
-  const file = input.files?.[0]
-  input.value = '' // allow re-picking the same file later
-  if (!file) return
-  try {
-    pendingImportPayload.value = await readJsonFile(file)
-  } catch {
-    pendingImportPayload.value = null
-    importSummary.value = null
-    importError.value = 'That file isn’t valid JSON.'
-    showImportResult.value = true
-  }
-}
-
-function cancelImport() {
-  pendingImportPayload.value = null
-}
-
-async function confirmImport() {
-  if (pendingImportPayload.value === null) return
-  importBusy.value = true
-  try {
-    importSummary.value = await api.importAccount(pendingImportPayload.value)
-    importError.value = null
-    // The import mutated this account server-side but didn't bump the
-    // snapshot version, so the local fat-client cache won't notice. Drop
-    // it so the next deck open cold-loads the imported state.
-    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
-  } catch (err) {
-    importSummary.value = null
-    importError.value = err instanceof ApiError ? err.message : 'Import failed.'
-  } finally {
-    importBusy.value = false
-    pendingImportPayload.value = null
-    showImportResult.value = true
-  }
-}
-
-function closeImportResult() {
-  showImportResult.value = false
-}
-
-function cancelDeleteProgress() {
-  pendingDeleteProgress.value = null
-}
-
-function onCardDeleteProgress(profile: ProfileRow) {
-  return withActiveProfile(profile, async () => {
-    pendingDeleteProgress.value = profile
-  })
-}
-
-async function confirmDeleteProgress() {
-  const target = pendingDeleteProgress.value
-  if (!target) return
-  deleteProgressBusy.value = true
-  try {
-    const summary = await api.deleteAllProgress()
-    banner.value = `Reset ${summary.materialsReset} deck(s): removed ${summary.eventsDeleted} reviews and ${summary.graduationsDeleted} graduations.`
-    // The wipe didn't bump the snapshot version; without dropping the
-    // local cache the engine would keep serving (and could re-sync) the
-    // now-deleted progress.
-    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
-  } catch (err) {
-    banner.value = err instanceof ApiError ? err.message : 'Delete failed.'
-  } finally {
-    deleteProgressBusy.value = false
-    pendingDeleteProgress.value = null
-  }
 }
 
 function requestDelete(profile: ProfileRow) {
@@ -287,9 +130,6 @@ async function onSignInSuccess() {
           @reauth="onCardReauth(p)"
           @sign-out="onCardSignOut(p)"
           @delete="requestDelete(p)"
-          @export="onCardExport(p)"
-          @import="onCardImport(p)"
-          @delete-progress="onCardDeleteProgress(p)"
         />
       </div>
       <button type="button" class="add-btn" @click="startAdd">
@@ -325,55 +165,6 @@ async function onSignInSuccess() {
         can sign in again later to start fresh.
       </p>
     </ConfirmDialog>
-
-    <input
-      ref="fileInput"
-      type="file"
-      accept="application/json"
-      class="hidden-file"
-      @change="onFilePicked"
-    />
-
-    <ConfirmDialog
-      v-if="pendingImportPayload !== null"
-      title="Import data?"
-      confirm-label="Import"
-      :busy="importBusy"
-      @confirm="confirmImport"
-      @cancel="cancelImport"
-    >
-      <p>
-        Import data into <strong>{{ activeProfile?.email }}</strong>?
-        This adds review history and graduations from the file. Existing
-        data is kept, and re-importing the same file is safe.
-      </p>
-    </ConfirmDialog>
-
-    <ImportResultDialog
-      v-if="showImportResult"
-      :summary="importSummary"
-      :error="importError"
-      @close="closeImportResult"
-    />
-
-    <TypeToConfirmDialog
-      v-if="pendingDeleteProgress"
-      title="Delete all progress?"
-      confirm-label="Delete all progress"
-      :match-text="pendingDeleteProgress.email"
-      :busy="deleteProgressBusy"
-      @confirm="confirmDeleteProgress"
-      @cancel="cancelDeleteProgress"
-    >
-      <p>
-        This permanently deletes <strong>all review history, graduations,
-        and progress</strong> for <strong>{{ pendingDeleteProgress.email }}</strong>
-        across every deck. Your decks and settings stay. This cannot be undone.
-      </p>
-      <button type="button" class="backup-btn" @click="onBackupClick">
-        ⬇ Download a backup (.json)
-      </button>
-    </TypeToConfirmDialog>
   </div>
 </template>
 
@@ -439,25 +230,5 @@ h2 {
   border-radius: 6px;
   font-size: 0.85rem;
   text-align: center;
-}
-
-.hidden-file {
-  display: none;
-}
-
-.backup-btn {
-  align-self: flex-start;
-  padding: 0.45rem 0.75rem;
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  color: var(--color-text);
-  font-family: inherit;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.backup-btn:hover {
-  border-color: var(--color-accent);
 }
 </style>

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -18,7 +18,6 @@ const engine = useEngine()
 
 const materialId = ref<string | null>(null)
 const materialConfig = shallowRef<ReturnType<typeof buildMaterialConfig> | null>(null)
-const desiredRetention = ref<number | null>(null)
 const card = ref<CardRender | null>(null)
 const revealed = ref(false)
 const done = ref(false)
@@ -35,7 +34,6 @@ async function resolveMaterial() {
   if (target) {
     materialId.value = target.materialId
     materialConfig.value = buildMaterialConfig(target.settings)
-    desiredRetention.value = target.settings.desiredRetention
     return true
   }
   return false
@@ -98,11 +96,10 @@ onMounted(async () => {
       done.value = true
       return
     }
-    await engine.init(
-      materialId.value,
-      materialConfig.value ?? undefined,
-      desiredRetention.value ?? undefined,
-    )
+    // Schedule wiring lands in commit 2 of the Phase 2 train; for now
+    // the engine ctor receives '' for schedule_json, collapsing to
+    // pure-Sequential — matches pre-Phase-1 behaviour byte-for-byte.
+    await engine.init(materialId.value, materialConfig.value ?? undefined)
     await loadNext()
   } catch (err) {
     error.value = formatError(err)

--- a/apps/web/src/views/ReviewView.vue
+++ b/apps/web/src/views/ReviewView.vue
@@ -96,10 +96,12 @@ onMounted(async () => {
       done.value = true
       return
     }
-    // Schedule wiring lands in commit 2 of the Phase 2 train; for now
-    // the engine ctor receives '' for schedule_json, collapsing to
-    // pure-Sequential — matches pre-Phase-1 behaviour byte-for-byte.
-    await engine.init(materialId.value, materialConfig.value ?? undefined)
+    // Pull the schedule alongside settings so the engine ctor receives
+    // it on the first call. /review doesn't actually use Phase 1 of the
+    // memorize fill, but the engine is shared with /memorize via the
+    // session cache — a later /memorize visit gets the schedule too.
+    const schedule = await api.getSchedule(materialId.value)
+    await engine.init(materialId.value, materialConfig.value ?? undefined, schedule ?? '')
     await loadNext()
   } catch (err) {
     error.value = formatError(err)

--- a/apps/web/src/views/SettingsAccountView.vue
+++ b/apps/web/src/views/SettingsAccountView.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+// Placeholder shell. The next commit migrates Export · Import · Delete-all-progress
+// out of ProfilePickerView's kebab into this section (closes issue #92).
+</script>
+
+<template>
+  <div class="account">
+    <p class="placeholder">Account-management actions will live here.</p>
+  </div>
+</template>
+
+<style scoped>
+.account {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.placeholder {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+  background: var(--color-bg-card);
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+  font-style: italic;
+}
+</style>

--- a/apps/web/src/views/SettingsAccountView.vue
+++ b/apps/web/src/views/SettingsAccountView.vue
@@ -1,11 +1,253 @@
 <script setup lang="ts">
-// Placeholder shell. The next commit migrates Export · Import · Delete-all-progress
-// out of ProfilePickerView's kebab into this section (closes issue #92).
+import { computed, ref } from 'vue'
+
+import { api, ApiError, type ImportSummary } from '@/api'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import ImportResultDialog from '@/components/ImportResultDialog.vue'
+import TypeToConfirmDialog from '@/components/TypeToConfirmDialog.vue'
+import { useAuth } from '@/composables/useAuth'
+import { downloadJson, exportFilename, readJsonFile } from '@/lib/account-file'
+
+const { activeProfile, resetProfileLocalData } = useAuth()
+
+const banner = ref<{ kind: 'info' | 'error'; text: string } | null>(null)
+
+// Export
+const exportBusy = ref(false)
+
+// Import
+const fileInput = ref<HTMLInputElement | null>(null)
+const pendingImportPayload = ref<unknown | null>(null)
+const importBusy = ref(false)
+// Mutually exclusive: a summary on success, a message on failure. Both
+// null while no result dialog is showing.
+const importSummary = ref<ImportSummary | null>(null)
+const importError = ref<string | null>(null)
+const showImportResult = ref(false)
+
+// Delete all progress
+const showDeleteProgress = ref(false)
+const deleteProgressBusy = ref(false)
+
+const email = computed(() => activeProfile.value?.email ?? '')
+
+async function downloadActiveExport() {
+  const targetEmail = activeProfile.value?.email ?? 'account'
+  const data = await api.exportAccount()
+  const isoDate = new Date().toISOString().slice(0, 10)
+  downloadJson(exportFilename(targetEmail, isoDate), data)
+}
+
+async function onExport() {
+  if (exportBusy.value) return
+  banner.value = null
+  exportBusy.value = true
+  try {
+    await downloadActiveExport()
+    banner.value = { kind: 'info', text: 'Export downloaded.' }
+  } catch (err) {
+    banner.value = {
+      kind: 'error',
+      text: err instanceof ApiError ? err.message : 'Export failed.',
+    }
+  } finally {
+    exportBusy.value = false
+  }
+}
+
+function onImportClick() {
+  banner.value = null
+  fileInput.value?.click()
+}
+
+async function onFilePicked(ev: Event) {
+  const input = ev.target as HTMLInputElement
+  const file = input.files?.[0]
+  input.value = '' // allow re-picking the same file later
+  if (!file) return
+  try {
+    pendingImportPayload.value = await readJsonFile(file)
+  } catch {
+    pendingImportPayload.value = null
+    importSummary.value = null
+    importError.value = 'That file isn’t valid JSON.'
+    showImportResult.value = true
+  }
+}
+
+function cancelImport() {
+  pendingImportPayload.value = null
+}
+
+async function confirmImport() {
+  if (pendingImportPayload.value === null) return
+  importBusy.value = true
+  try {
+    importSummary.value = await api.importAccount(pendingImportPayload.value)
+    importError.value = null
+    // The import mutated this account server-side but didn't bump the
+    // snapshot version, so the local fat-client cache won't notice. Drop
+    // it so the next deck open cold-loads the imported state.
+    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
+  } catch (err) {
+    importSummary.value = null
+    importError.value = err instanceof ApiError ? err.message : 'Import failed.'
+  } finally {
+    importBusy.value = false
+    pendingImportPayload.value = null
+    showImportResult.value = true
+  }
+}
+
+function closeImportResult() {
+  showImportResult.value = false
+}
+
+function onDeleteProgressClick() {
+  banner.value = null
+  showDeleteProgress.value = true
+}
+
+function cancelDeleteProgress() {
+  showDeleteProgress.value = false
+}
+
+async function confirmDeleteProgress() {
+  deleteProgressBusy.value = true
+  try {
+    const summary = await api.deleteAllProgress()
+    banner.value = {
+      kind: 'info',
+      text: `Reset ${summary.materialsReset} deck(s): removed ${summary.eventsDeleted} reviews and ${summary.graduationsDeleted} graduations.`,
+    }
+    // The wipe didn't bump the snapshot version; without dropping the
+    // local cache the engine would keep serving (and could re-sync) the
+    // now-deleted progress.
+    if (activeProfile.value) await resetProfileLocalData(activeProfile.value.profileId)
+  } catch (err) {
+    banner.value = {
+      kind: 'error',
+      text: err instanceof ApiError ? err.message : 'Delete failed.',
+    }
+  } finally {
+    deleteProgressBusy.value = false
+    showDeleteProgress.value = false
+  }
+}
+
+// Lets the delete dialog offer a one-click backup without re-opening
+// the result banner. Errors here surface inline rather than as a
+// page-level banner so the user stays inside the dialog.
+const backupErrorInDialog = ref<string | null>(null)
+async function onBackupInsideDialog() {
+  backupErrorInDialog.value = null
+  try {
+    await downloadActiveExport()
+  } catch (err) {
+    backupErrorInDialog.value =
+      err instanceof ApiError ? err.message : 'Backup download failed.'
+  }
+}
 </script>
 
 <template>
   <div class="account">
-    <p class="placeholder">Account-management actions will live here.</p>
+    <p v-if="!activeProfile" class="status">No active profile.</p>
+    <template v-else>
+      <p v-if="banner" :class="['banner', `banner-${banner.kind}`]">{{ banner.text }}</p>
+
+      <article class="action-card">
+        <header>
+          <h3>Export my data</h3>
+          <p>
+            Download a JSON snapshot of this account's review history, graduations,
+            and per-material settings.
+          </p>
+        </header>
+        <button type="button" class="btn" :disabled="exportBusy" @click="onExport">
+          {{ exportBusy ? 'Exporting…' : 'Download export' }}
+        </button>
+      </article>
+
+      <article class="action-card">
+        <header>
+          <h3>Import data</h3>
+          <p>
+            Merge a previous export back into this account. Existing data is kept;
+            re-importing the same file is safe.
+          </p>
+        </header>
+        <button type="button" class="btn" @click="onImportClick">
+          Choose file…
+        </button>
+      </article>
+
+      <article class="action-card action-card-destructive">
+        <header>
+          <h3>Delete all progress</h3>
+          <p>
+            Permanently removes review history and graduations across every deck.
+            Your decks and settings stay. Download a backup first if you might want
+            to restore.
+          </p>
+        </header>
+        <button type="button" class="btn btn-destructive" @click="onDeleteProgressClick">
+          Delete all progress…
+        </button>
+      </article>
+    </template>
+
+    <input
+      ref="fileInput"
+      type="file"
+      accept="application/json"
+      class="hidden-file"
+      @change="onFilePicked"
+    />
+
+    <ConfirmDialog
+      v-if="pendingImportPayload !== null"
+      title="Import data?"
+      confirm-label="Import"
+      :busy="importBusy"
+      @confirm="confirmImport"
+      @cancel="cancelImport"
+    >
+      <p>
+        Import data into <strong>{{ email }}</strong>?
+        This adds review history and graduations from the file. Existing
+        data is kept, and re-importing the same file is safe.
+      </p>
+    </ConfirmDialog>
+
+    <ImportResultDialog
+      v-if="showImportResult"
+      :summary="importSummary"
+      :error="importError"
+      @close="closeImportResult"
+    />
+
+    <TypeToConfirmDialog
+      v-if="showDeleteProgress && activeProfile"
+      title="Delete all progress?"
+      confirm-label="Delete all progress"
+      :match-text="email"
+      :busy="deleteProgressBusy"
+      @confirm="confirmDeleteProgress"
+      @cancel="cancelDeleteProgress"
+    >
+      <p>
+        This permanently deletes <strong>all review history, graduations,
+        and progress</strong> for <strong>{{ email }}</strong>
+        across every deck. Your decks and settings stay. This cannot be undone.
+      </p>
+      <button type="button" class="backup-btn" @click="onBackupInsideDialog">
+        ⬇ Download a backup (.json)
+      </button>
+      <p v-if="backupErrorInDialog" class="dialog-error" role="alert">
+        {{ backupErrorInDialog }}
+      </p>
+    </TypeToConfirmDialog>
   </div>
 </template>
 
@@ -16,14 +258,110 @@
   gap: 1rem;
 }
 
-.placeholder {
+.status {
   margin: 0;
   padding: 2rem;
   text-align: center;
   color: var(--color-muted);
-  background: var(--color-bg-card);
-  border: 1px dashed var(--color-border);
-  border-radius: 8px;
   font-style: italic;
+}
+
+.banner {
+  margin: 0;
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.banner-info {
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+}
+
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.action-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+}
+
+.action-card-destructive {
+  border-color: var(--color-grade-again);
+}
+
+.action-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.action-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.action-card p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  line-height: 1.4;
+}
+
+.btn {
+  align-self: flex-start;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border: none;
+  border-radius: 4px;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.btn:disabled {
+  background: var(--color-border);
+  color: var(--color-muted);
+  cursor: not-allowed;
+}
+
+.btn-destructive {
+  background: var(--color-grade-again);
+  color: var(--color-on-accent);
+}
+
+.hidden-file {
+  display: none;
+}
+
+.backup-btn {
+  align-self: flex-start;
+  padding: 0.45rem 0.75rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.backup-btn:hover {
+  border-color: var(--color-accent);
+}
+
+.dialog-error {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-error);
 }
 </style>

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -5,10 +5,15 @@ import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
 import StatusChip from '@/components/StatusChip.vue'
 import {
   type ChapterListScope,
+  type CatchUp,
+  type Club,
+  type ClubMemorizeConfig,
+  type ClubReviewConfig,
   type ClubStatus,
   type ClubTier,
+  type MoveToNextGate,
+  type PerClubYearSettings,
   type TierScope,
-  type YearSettings,
   type YearView,
   api,
 } from '@/api'
@@ -18,11 +23,24 @@ import { bulkPutRenders, clearRenders, newestRenderFetchedAt } from '@/lib/engin
 const SECS_PER_DAY = 86400
 
 const CLUB_TIERS: ClubTier[] = ['150', '300', 'full']
+const CLUBS: Club[] = ['club150', 'club300', 'full']
 
 const TIER_LABELS: Record<ClubTier, string> = {
   '150': 'Club 150',
   '300': 'Club 300',
   full: 'Full',
+}
+
+const CLUB_LABELS: Record<Club, string> = {
+  club150: 'Club 150',
+  club300: 'Club 300',
+  full: 'Full',
+}
+
+const CLUB_TO_TIER: Record<Club, ClubTier> = {
+  club150: '150',
+  club300: '300',
+  full: 'full',
 }
 
 const STATUS_LABELS: Record<ClubStatus, string> = {
@@ -37,34 +55,18 @@ const STATUS_VARIANTS: Record<ClubStatus, 'accent' | 'warning' | 'muted'> = {
   paused: 'muted',
 }
 
-// All four scope tracks share the same 4-stop shape (chapter-list is
-// missing the Full stop). Stops are ordered: Off ── 150 ── 300 ── Full.
-const TIER_SCOPE_LEVELS: { value: TierScope; label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'up150', label: '150' },
-  { value: 'up300', label: '300' },
-  { value: 'all', label: 'Full' },
-]
-
 const CHAPTER_LIST_LEVELS: { value: ChapterListScope; label: string }[] = [
   { value: 'off', label: 'Off' },
   { value: 'up150', label: '150' },
   { value: 'up300', label: '300' },
 ]
 
-const NEW_DESCRIPTIONS: Record<TierScope, string> = {
-  off: 'No tier is introducing new verses.',
-  up150: 'Memorizing Club 150 verses.',
-  up300: 'Memorizing Club 150 and Club 300 verses.',
-  all: 'Memorizing every tier, including Full.',
-}
-
-const REVIEW_DESCRIPTIONS: Record<TierScope, string> = {
-  off: 'No reviews surfaced.',
-  up150: 'Reviewing Club 150 verses.',
-  up300: 'Reviewing Club 150 and Club 300 verses.',
-  all: 'Reviewing every tier, including Full.',
-}
+const TIER_SCOPE_LEVELS: { value: TierScope; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'up150', label: '150' },
+  { value: 'up300', label: '300' },
+  { value: 'all', label: 'Full' },
+]
 
 const CLUB_CARD_DESCRIPTIONS: Record<TierScope, string> = {
   off: 'No "which club?" prompts.',
@@ -79,9 +81,30 @@ const CHAPTER_LIST_DESCRIPTIONS: Record<ChapterListScope, string> = {
   up300: 'Two cards per chapter: Club 150 list and Club 300 list.',
 }
 
+const CATCH_UP_OPTIONS: { value: CatchUp; label: string }[] = [
+  { value: 'sequential', label: 'Sequential (next un-memorized verse)' },
+  { value: 'calendarCascade', label: 'Calendar cascade (this week first, then backlog)' },
+]
+
+const GATE_OPTIONS: { value: MoveToNextGate; label: string }[] = [
+  { value: 'fullyMemorized', label: 'Fully memorized' },
+  { value: 'afterMajorCheckpoint', label: 'After major checkpoint (meet)' },
+  { value: 'afterMinorCheckpoint', label: 'After minor checkpoint (this week)' },
+  { value: 'caughtUp', label: 'Caught up to last week' },
+  { value: 'always', label: 'Always (no gate)' },
+]
+
+// Per-club retention range from the spec. Tighter than the legacy
+// material-wide [0.7, 0.97] band so the slider exposes the meaningful
+// region without trailing into asymptotic stability blow-ups.
+const MIN_RETENTION_PCT = 50
+const MAX_RETENTION_PCT = 90
+
 interface YearCard {
   view: YearView
-  draft: YearSettings
+  /** Per-club draft, the source of truth for the form. Saving the card
+   *  POSTs this verbatim via `updateYearSettingsPerClub`. */
+  draft: PerClubYearSettings
   saving: boolean
   /** True while the toggle's flip-and-fetch (or flip-and-clear) is
    *  in flight. Drives the row's spinner state independent of the
@@ -103,13 +126,21 @@ const selected = computed<YearCard | null>(() => {
   return cards.value.find((c) => c.view.materialId === id) ?? null
 })
 
-/** A year reads as "studying" iff at least one of `newScope` or
- *  `reviewScope` is on. Provisioned-but-all-paused years (e.g. the
- *  user touched the year once then turned everything off) display the
- *  same as never-touched years: no enrolled marker, no card counts. */
+/** "Studying" iff enrolled AND any club is enabled for memorize OR
+ *  review. Provisioned-but-everything-off years (e.g. the user touched
+ *  the year once then disabled every club) read the same as
+ *  never-touched: no enrolled marker, no card counts. */
 function isStudying(c: YearCard): boolean {
   if (!c.view.enrolled) return false
-  return c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off'
+  return CLUBS.some((k) => c.view.perClub.memorize[k].enabled || c.view.perClub.review[k].enabled)
+}
+
+/** Clone a per-club settings object for the editable draft. JSON
+ *  round-trip is safe — the shape is pure data, no functions or
+ *  cycles — and saves a stack of `{...x, memorize: {...x.memorize, club150: {...x.memorize.club150}}}`
+ *  spread expressions every time a nested field is read for v-model. */
+function clonePerClub(p: PerClubYearSettings): PerClubYearSettings {
+  return JSON.parse(JSON.stringify(p)) as PerClubYearSettings
 }
 
 async function refresh() {
@@ -120,7 +151,7 @@ async function refresh() {
     const enriched = await Promise.all(
       res.years.map(async (view) => ({
         view,
-        draft: { ...view.settings },
+        draft: clonePerClub(view.perClub),
         saving: false,
         offlineBusy: false,
         newestRenderAt: view.offlineMode ? await newestRenderFetchedAt(view.materialId) : 0,
@@ -128,9 +159,9 @@ async function refresh() {
     )
     cards.value = enriched
     // Re-resolve the active tab after the list changes. Prefer the year
-    // the user is actively studying (any scope above off) so the picker
-    // opens on a working panel; otherwise fall back to any enrolled year,
-    // and finally to the first listed.
+    // the user is actively studying so the picker opens on a working
+    // panel; otherwise fall back to any enrolled year, then to the first
+    // listed.
     if (cards.value.length === 0) {
       selectedMaterialId.value = null
     } else if (!cards.value.some((c) => c.view.materialId === selectedMaterialId.value)) {
@@ -151,59 +182,25 @@ function tabTitle(full: string): string {
   return full.replace(/\s*\(NKJV\)\s*$/, '')
 }
 
-const TIER_SCOPE_RANK: Record<TierScope, number> = {
-  off: 0,
-  up150: 1,
-  up300: 2,
-  all: 3,
-}
-
-/** True when Review's reach is narrower than New's — i.e. the user is
- *  memorising verses at a tier they don't review, so freshly-introduced
- *  verses won't re-surface. Worth surfacing because it's almost always
- *  an oversight rather than an intentional config. */
-function reviewBehindNew(s: YearSettings): boolean {
-  return TIER_SCOPE_RANK[s.reviewScope] < TIER_SCOPE_RANK[s.newScope]
-}
-
-/** Settings that affect engine construction — flipping any of these
- *  means the cached WasmEngine + render cache must be rebuilt so the
- *  next session uses the new value. `lessonBatchSize` is intentionally
- *  excluded; it's a session-size knob the engine doesn't consume. */
-const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
-  'headingCard',
-  'headingPassageCard',
-  'ftv',
-  'newScope',
-  'reviewScope',
-  'clubCardScope',
-  'chapterListScope',
-  'desiredRetention',
-]
-
-function affectsEngine(draft: YearSettings, current: YearSettings): boolean {
-  return ENGINE_AFFECTING_SETTINGS.some((k) => draft[k] !== current[k])
+/** True when the chain has a "memorize this club but don't review it"
+ *  gap — the user is introducing verses that won't re-surface in
+ *  /review. Almost always an oversight rather than intent. */
+function memorizeBehindReview(draft: PerClubYearSettings): boolean {
+  return CLUBS.some((k) => draft.memorize[k].enabled && !draft.review[k].enabled)
 }
 
 async function onSave(card: YearCard) {
   card.saving = true
   try {
-    const shouldInvalidate = affectsEngine(card.draft, card.view.settings)
-    // Capture before invalidate — its IDB clear happens before the
-    // refresh that would update card.view.offlineMode.
     const wasOfflineMode = card.view.offlineMode
-    await api.updateYearSettings(card.view.materialId, card.draft)
-    if (shouldInvalidate) {
-      // invalidateSession drops the cached engine AND the render cache
-      // so the next ReviewView/MemorizeView visit rebuilds with the new
-      // MaterialConfig. When offline mode is on, the user has committed
-      // to "this deck works offline" — re-seed the bulk renders rather
-      // than leaving them in a checked-toggle/empty-IDB limbo.
-      await invalidateSession(card.view.materialId)
-      if (wasOfflineMode) {
-        await seedOfflineRenders(card.view.materialId)
-      }
-    }
+    await api.updateYearSettingsPerClub(card.view.materialId, card.draft)
+    // Every per-club save can shift the MaterialConfig (enabled clubs,
+    // catchUp choices, retention bands) — always drop the cached engine
+    // and the render cache so the next session rebuilds. lessonBatchSize
+    // alone doesn't move the engine, but the round-trip cost of a
+    // diff-and-skip check isn't worth it vs. the one IDB clear.
+    await invalidateSession(card.view.materialId)
+    if (wasOfflineMode) await seedOfflineRenders(card.view.materialId)
     await refresh()
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)
@@ -211,17 +208,42 @@ async function onSave(card: YearCard) {
   }
 }
 
-function onRetentionInput(card: YearCard, event: Event) {
-  const pct = Number((event.target as HTMLInputElement).value)
-  if (Number.isFinite(pct)) {
-    card.draft.desiredRetention = pct / 100
-  }
+/** Deep-equality check between draft and view.perClub — used to gate
+ *  the Save button. JSON.stringify is fine here because the shapes are
+ *  pure data with stable key order (constructed object-literally by
+ *  the API). */
+function settingsAreDirty(card: YearCard): boolean {
+  return JSON.stringify(card.draft) !== JSON.stringify(card.view.perClub)
 }
 
-function settingsAreDirty(card: YearCard): boolean {
-  return (Object.keys(card.draft) as Array<keyof YearSettings>).some(
-    (k) => card.draft[k] !== card.view.settings[k],
-  )
+function retentionPctFor(card: YearCard, club: Club): number {
+  return Math.round(card.draft.review[club].desiredRetention * 100)
+}
+
+function onRetentionInput(card: YearCard, club: Club, event: Event) {
+  const pct = Number((event.target as HTMLInputElement).value)
+  if (!Number.isFinite(pct)) return
+  card.draft.review[club].desiredRetention = pct / 100
+}
+
+/** Memorized-verse progress per club, sourced from the engine-loaded
+ *  card counts. The chain UI shows this next to each club's enable
+ *  checkbox so the user can see how far along they are. */
+function memorizedFor(card: YearCard, club: Club): number {
+  return card.view.clubs[CLUB_TO_TIER[club]].cardCount
+}
+
+/** Status chip variant for the per-club card. The legacy "status" enum
+ *  collapsed memorize+review intent into Active/Maintenance/Paused;
+ *  with per-club shapes that's now derivable: memorize+review enabled
+ *  → Active, review only → Maintenance, neither → Paused. */
+function clubStatusFor(
+  memorize: ClubMemorizeConfig,
+  review: ClubReviewConfig,
+): ClubStatus {
+  if (memorize.enabled) return 'active'
+  if (review.enabled) return 'maintenance'
+  return 'paused'
 }
 
 function refreshedLabel(card: YearCard): string {
@@ -337,37 +359,132 @@ onMounted(refresh)
         </header>
 
         <section class="settings-section">
-          <div class="section-title">Study scopes</div>
-          <div class="scope-stack">
-            <div class="scope-row">
-              <span class="scope-row-label">Memorize new verses</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.newScope"
-                :levels="TIER_SCOPE_LEVELS"
-                :description="NEW_DESCRIPTIONS[selected.draft.newScope]"
-                :disabled="selected.saving"
-                aria-label="New verses scope"
-              />
-            </div>
-            <div class="scope-row">
-              <span class="scope-row-label">Review existing verses</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.reviewScope"
-                :levels="TIER_SCOPE_LEVELS"
-                :description="REVIEW_DESCRIPTIONS[selected.draft.reviewScope]"
-                :disabled="selected.saving"
-                aria-label="Review scope"
-              />
-              <p v-if="reviewBehindNew(selected.draft)" class="scope-warning" role="alert">
-                Review is narrower than New — verses you introduce above this level
-                won't re-surface in /review.
-              </p>
-              <p class="scope-fineprint">
-                A tier in both becomes Active; review-only becomes Maintenance; neither is
-                Paused.
-              </p>
-            </div>
+          <div class="section-title">What to memorize</div>
+          <div class="chain">
+            <template v-for="(club, idx) in CLUBS" :key="club">
+              <article
+                class="chain-card"
+                :class="{ 'chain-card-disabled': !selected.draft.memorize[club].enabled }"
+              >
+                <header class="chain-card-header">
+                  <label class="chain-enable">
+                    <input
+                      v-model="selected.draft.memorize[club].enabled"
+                      type="checkbox"
+                      :disabled="selected.saving"
+                      :aria-label="`Enable memorize for ${CLUB_LABELS[club]}`"
+                    />
+                    <span class="chain-card-name">{{ CLUB_LABELS[club] }}</span>
+                  </label>
+                  <span class="chain-card-progress">
+                    {{ memorizedFor(selected, club) }} cards
+                  </span>
+                </header>
+                <label
+                  v-if="selected.draft.memorize[club].enabled"
+                  class="chain-knob"
+                >
+                  <span class="chain-knob-label">Catch-up</span>
+                  <select
+                    v-model="selected.draft.memorize[club].catchUp"
+                    :disabled="selected.saving"
+                  >
+                    <option v-for="opt in CATCH_UP_OPTIONS" :key="opt.value" :value="opt.value">
+                      {{ opt.label }}
+                    </option>
+                  </select>
+                </label>
+              </article>
+
+              <!-- Gate row between clubs[idx] and clubs[idx+1]. Only
+                   render when both flanking clubs are enabled — the
+                   gate's irrelevant when either side is off. -->
+              <div
+                v-if="
+                  idx < CLUBS.length - 1
+                    && selected.draft.memorize[club].enabled
+                    && selected.draft.memorize[CLUBS[idx + 1]].enabled
+                "
+                class="chain-gate"
+              >
+                <span class="chain-gate-label">
+                  Move to {{ CLUB_LABELS[CLUBS[idx + 1]] }} when:
+                </span>
+                <select
+                  v-if="club === 'club150'"
+                  v-model="selected.draft.moveToNext.p150To300"
+                  :disabled="selected.saving"
+                >
+                  <option v-for="opt in GATE_OPTIONS" :key="opt.value" :value="opt.value">
+                    {{ opt.label }}
+                  </option>
+                </select>
+                <select
+                  v-else
+                  v-model="selected.draft.moveToNext.p300ToFull"
+                  :disabled="selected.saving"
+                >
+                  <option v-for="opt in GATE_OPTIONS" :key="opt.value" :value="opt.value">
+                    {{ opt.label }}
+                  </option>
+                </select>
+              </div>
+            </template>
           </div>
+
+          <div class="section-title section-title-spaced">What to review</div>
+          <div class="chain">
+            <article
+              v-for="club in CLUBS"
+              :key="club"
+              class="chain-card"
+              :class="{ 'chain-card-disabled': !selected.draft.review[club].enabled }"
+            >
+              <header class="chain-card-header">
+                <label class="chain-enable">
+                  <input
+                    v-model="selected.draft.review[club].enabled"
+                    type="checkbox"
+                    :disabled="selected.saving"
+                    :aria-label="`Enable review for ${CLUB_LABELS[club]}`"
+                  />
+                  <span class="chain-card-name">
+                    {{ CLUB_LABELS[club] }}
+                    <StatusChip
+                      :variant="STATUS_VARIANTS[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])]"
+                    >
+                      {{ STATUS_LABELS[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])] }}
+                    </StatusChip>
+                  </span>
+                </label>
+              </header>
+              <label
+                v-if="selected.draft.review[club].enabled"
+                class="range-row"
+              >
+                <span class="range-label">
+                  Target retention
+                  <span class="range-value">{{ retentionPctFor(selected, club) }}%</span>
+                </span>
+                <input
+                  :value="retentionPctFor(selected, club)"
+                  type="range"
+                  :min="MIN_RETENTION_PCT"
+                  :max="MAX_RETENTION_PCT"
+                  step="1"
+                  :disabled="selected.saving"
+                  @input="onRetentionInput(selected, club, $event)"
+                />
+              </label>
+            </article>
+          </div>
+          <p v-if="memorizeBehindReview(selected.draft)" class="scope-warning" role="alert">
+            One or more clubs are set to memorize but not review — newly-introduced verses won't re-surface in /review.
+          </p>
+          <p class="scope-fineprint">
+            Higher target → more reviews + stronger recall. Lower → fewer reviews + more lapses.
+            Range is {{ MIN_RETENTION_PCT }}–{{ MAX_RETENTION_PCT }}%.
+          </p>
 
           <div class="section-title section-title-spaced">Card kinds</div>
           <div class="scope-stack">
@@ -453,26 +570,6 @@ onMounted(refresh)
               :disabled="selected.saving"
             />
           </label>
-
-          <label class="range-row">
-            <span class="range-label">
-              Target retention
-              <span class="range-value">{{ Math.round(selected.draft.desiredRetention * 100) }}%</span>
-            </span>
-            <input
-              :value="Math.round(selected.draft.desiredRetention * 100)"
-              type="range"
-              min="70"
-              max="97"
-              step="1"
-              :disabled="selected.saving"
-              @input="onRetentionInput(selected, $event)"
-            />
-          </label>
-          <p class="scope-fineprint">
-            Higher target → more reviews + stronger recall. Lower → fewer reviews + more lapses.
-            FSRS recommends 80–95%.
-          </p>
 
           <button
             type="button"
@@ -574,8 +671,6 @@ onMounted(refresh)
 }
 
 .year-card-unenrolled {
-  /* Subtle dimming so unenrolled years read as "available, not yet
-     activated" without disappearing into the background. */
   border-style: dashed;
 }
 
@@ -660,6 +755,94 @@ onMounted(refresh)
   gap: 0.75rem;
 }
 
+.chain {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.chain-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 0.75rem 0.9rem;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.chain-card-disabled {
+  opacity: 0.6;
+}
+
+.chain-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.chain-enable {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.chain-enable input[type='checkbox'] {
+  accent-color: var(--color-accent);
+}
+
+.chain-card-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.chain-card-progress {
+  color: var(--color-muted);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.chain-knob {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chain-knob-label {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+.chain-knob select,
+.chain-gate select {
+  padding: 0.3rem 0.5rem;
+  background: var(--color-bg-card);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+
+.chain-gate {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-left: 1rem;
+  padding: 0.4rem 0.75rem;
+  border-left: 2px dashed var(--color-border);
+}
+
+.chain-gate-label {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
 .scope-stack {
   display: flex;
   flex-direction: column;
@@ -740,6 +923,7 @@ onMounted(refresh)
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
+  font-size: 0.85rem;
 }
 
 .range-value {

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -43,22 +43,13 @@ const CLUB_TO_TIER: Record<Club, ClubTier> = {
   full: 'full',
 }
 
-const TIER_TO_CLUB: Record<ClubTier, Club> = {
-  '150': 'club150',
-  '300': 'club300',
-  full: 'full',
-}
-
-const STATUS_LABELS: Record<ClubStatus, string> = {
-  active: 'Active',
-  maintenance: 'Maintenance',
-  paused: 'Paused',
-}
-
-const STATUS_VARIANTS: Record<ClubStatus, 'accent' | 'warning' | 'muted'> = {
-  active: 'accent',
-  maintenance: 'warning',
-  paused: 'muted',
+const STATUS_CHIP: Record<
+  ClubStatus,
+  { label: string; variant: 'accent' | 'warning' | 'muted' }
+> = {
+  active: { label: 'Active', variant: 'accent' },
+  maintenance: { label: 'Maintenance', variant: 'warning' },
+  paused: { label: 'Paused', variant: 'muted' },
 }
 
 const CHAPTER_LIST_LEVELS: { value: ChapterListScope; label: string }[] = [
@@ -99,6 +90,12 @@ const GATE_OPTIONS: { value: MoveToNextGate; label: string }[] = [
   { value: 'caughtUp', label: 'Caught up to last week' },
   { value: 'always', label: 'Always (no gate)' },
 ]
+
+/** Maps the gate position (between clubs[idx] and clubs[idx+1]) to the
+ *  `moveToNext` field name. One entry per inter-club gap so the
+ *  template can bind via `selected.draft.moveToNext[GATE_FIELDS[idx]]`
+ *  instead of branching on `club === 'club150'`. */
+const GATE_FIELDS = ['p150To300', 'p300ToFull'] as const
 
 // Per-club retention range from the spec. Tighter than the legacy
 // material-wide [0.7, 0.97] band so the slider exposes the meaningful
@@ -141,12 +138,13 @@ function isStudying(c: YearCard): boolean {
   return CLUBS.some((k) => c.view.perClub.memorize[k].enabled || c.view.perClub.review[k].enabled)
 }
 
-/** Clone a per-club settings object for the editable draft. JSON
- *  round-trip is safe — the shape is pure data, no functions or
- *  cycles — and saves a stack of `{...x, memorize: {...x.memorize, club150: {...x.memorize.club150}}}`
- *  spread expressions every time a nested field is read for v-model. */
+/** Clone a per-club settings object for the editable draft. The shape
+ *  is pure data (no functions, no cycles) so `structuredClone` is
+ *  fully equivalent to a JSON round-trip and avoids the
+ *  `{...x, memorize: {...x.memorize, club150: {...x.memorize.club150}}}`
+ *  manual-spread stack every time a nested field is bound to v-model. */
 function clonePerClub(p: PerClubYearSettings): PerClubYearSettings {
-  return JSON.parse(JSON.stringify(p)) as PerClubYearSettings
+  return structuredClone(p)
 }
 
 async function refresh() {
@@ -214,13 +212,18 @@ async function onSave(card: YearCard) {
   }
 }
 
-/** Deep-equality check between draft and view.perClub — used to gate
- *  the Save button. JSON.stringify is fine here because the shapes are
- *  pure data with stable key order (constructed object-literally by
- *  the API). */
-function settingsAreDirty(card: YearCard): boolean {
-  return JSON.stringify(card.draft) !== JSON.stringify(card.view.perClub)
-}
+/** Deep-equality check between the active card's draft and its
+ *  saved view.perClub — used to gate the Save button. As a computed
+ *  it caches the serialise pair between mutations, so the user
+ *  rapidly clicking through checkboxes doesn't fire two
+ *  `JSON.stringify` passes per keystroke. JSON.stringify is sound
+ *  here because both objects originate from the same construction
+ *  path (server → `clonePerClub` → draft) so key order matches. */
+const selectedIsDirty = computed<boolean>(() => {
+  const c = selected.value
+  if (!c) return false
+  return JSON.stringify(c.draft) !== JSON.stringify(c.view.perClub)
+})
 
 function retentionPctFor(card: YearCard, club: Club): number {
   return Math.round(card.draft.review[club].desiredRetention * 100)
@@ -373,21 +376,8 @@ onMounted(refresh)
               <span v-if="isStudying(selected)" class="tier-pill-count">
                 {{ selected.view.clubs[tier].cardCount }}
               </span>
-              <!-- Derived from view.perClub, not view.clubs[tier].status:
-                   the latter goes through the lossy perClubToLegacy
-                   collapse on the API side, so a non-monotonic config
-                   (e.g. Club 300 enabled but Club 150 off) would show
-                   the wrong pill. Per-club is the source of truth. -->
-              <StatusChip
-                :variant="STATUS_VARIANTS[clubStatusFor(
-                  selected.view.perClub.memorize[TIER_TO_CLUB[tier]],
-                  selected.view.perClub.review[TIER_TO_CLUB[tier]],
-                )]"
-              >
-                {{ STATUS_LABELS[clubStatusFor(
-                  selected.view.perClub.memorize[TIER_TO_CLUB[tier]],
-                  selected.view.perClub.review[TIER_TO_CLUB[tier]],
-                )] }}
+              <StatusChip :variant="STATUS_CHIP[selected.view.clubs[tier].status].variant">
+                {{ STATUS_CHIP[selected.view.clubs[tier].status].label }}
               </StatusChip>
             </span>
           </div>
@@ -446,17 +436,7 @@ onMounted(refresh)
                   Move to {{ CLUB_LABELS[CLUBS[idx + 1]] }} when:
                 </span>
                 <select
-                  v-if="club === 'club150'"
-                  v-model="selected.draft.moveToNext.p150To300"
-                  :disabled="selected.saving"
-                >
-                  <option v-for="opt in GATE_OPTIONS" :key="opt.value" :value="opt.value">
-                    {{ opt.label }}
-                  </option>
-                </select>
-                <select
-                  v-else
-                  v-model="selected.draft.moveToNext.p300ToFull"
+                  v-model="selected.draft.moveToNext[GATE_FIELDS[idx]]"
                   :disabled="selected.saving"
                 >
                   <option v-for="opt in GATE_OPTIONS" :key="opt.value" :value="opt.value">
@@ -486,9 +466,9 @@ onMounted(refresh)
                   <span class="chain-card-name">
                     {{ CLUB_LABELS[club] }}
                     <StatusChip
-                      :variant="STATUS_VARIANTS[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])]"
+                      :variant="STATUS_CHIP[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])].variant"
                     >
-                      {{ STATUS_LABELS[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])] }}
+                      {{ STATUS_CHIP[clubStatusFor(selected.draft.memorize[club], selected.draft.review[club])].label }}
                     </StatusChip>
                   </span>
                 </label>
@@ -610,7 +590,7 @@ onMounted(refresh)
           <button
             type="button"
             class="save-button"
-            :disabled="!settingsAreDirty(selected) || selected.saving"
+            :disabled="!selectedIsDirty || selected.saving"
             @click="onSave(selected)"
           >
             {{ selected.saving ? 'Saving…' : 'Save settings' }}

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -1,0 +1,771 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+
+import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
+import StatusChip from '@/components/StatusChip.vue'
+import {
+  type ChapterListScope,
+  type ClubStatus,
+  type ClubTier,
+  type TierScope,
+  type YearSettings,
+  type YearView,
+  api,
+} from '@/api'
+import { invalidateSession } from '@/lib/engine/engineStore'
+import { bulkPutRenders, clearRenders, newestRenderFetchedAt } from '@/lib/engine/persistence'
+
+const SECS_PER_DAY = 86400
+
+const CLUB_TIERS: ClubTier[] = ['150', '300', 'full']
+
+const TIER_LABELS: Record<ClubTier, string> = {
+  '150': 'Club 150',
+  '300': 'Club 300',
+  full: 'Full',
+}
+
+const STATUS_LABELS: Record<ClubStatus, string> = {
+  active: 'Active',
+  maintenance: 'Maintenance',
+  paused: 'Paused',
+}
+
+const STATUS_VARIANTS: Record<ClubStatus, 'accent' | 'warning' | 'muted'> = {
+  active: 'accent',
+  maintenance: 'warning',
+  paused: 'muted',
+}
+
+// All four scope tracks share the same 4-stop shape (chapter-list is
+// missing the Full stop). Stops are ordered: Off ── 150 ── 300 ── Full.
+const TIER_SCOPE_LEVELS: { value: TierScope; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'up150', label: '150' },
+  { value: 'up300', label: '300' },
+  { value: 'all', label: 'Full' },
+]
+
+const CHAPTER_LIST_LEVELS: { value: ChapterListScope; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'up150', label: '150' },
+  { value: 'up300', label: '300' },
+]
+
+const NEW_DESCRIPTIONS: Record<TierScope, string> = {
+  off: 'No tier is introducing new verses.',
+  up150: 'Memorizing Club 150 verses.',
+  up300: 'Memorizing Club 150 and Club 300 verses.',
+  all: 'Memorizing every tier, including Full.',
+}
+
+const REVIEW_DESCRIPTIONS: Record<TierScope, string> = {
+  off: 'No reviews surfaced.',
+  up150: 'Reviewing Club 150 verses.',
+  up300: 'Reviewing Club 150 and Club 300 verses.',
+  all: 'Reviewing every tier, including Full.',
+}
+
+const CLUB_CARD_DESCRIPTIONS: Record<TierScope, string> = {
+  off: 'No "which club?" prompts.',
+  up150: 'Asks for Club 150 verses only.',
+  up300: 'Asks for Club 150 and Club 300 verses (not Full).',
+  all: 'Asks for every verse, including Full-tier.',
+}
+
+const CHAPTER_LIST_DESCRIPTIONS: Record<ChapterListScope, string> = {
+  off: 'No chapter-list prompts.',
+  up150: 'One card per chapter listing its Club 150 verses.',
+  up300: 'Two cards per chapter: Club 150 list and Club 300 list.',
+}
+
+interface YearCard {
+  view: YearView
+  draft: YearSettings
+  saving: boolean
+  /** True while the toggle's flip-and-fetch (or flip-and-clear) is
+   *  in flight. Drives the row's spinner state independent of the
+   *  larger settings-form `saving` flag. */
+  offlineBusy: boolean
+  /** Unix-secs of the newest IDB render for this material, or 0 if
+   *  none cached. Used to render "Last refreshed N days ago". */
+  newestRenderAt: number
+}
+
+const cards = ref<YearCard[]>([])
+const loading = ref(true)
+const error = ref<string | null>(null)
+const selectedMaterialId = ref<string | null>(null)
+
+const selected = computed<YearCard | null>(() => {
+  const id = selectedMaterialId.value
+  if (!id) return null
+  return cards.value.find((c) => c.view.materialId === id) ?? null
+})
+
+/** A year reads as "studying" iff at least one of `newScope` or
+ *  `reviewScope` is on. Provisioned-but-all-paused years (e.g. the
+ *  user touched the year once then turned everything off) display the
+ *  same as never-touched years: no enrolled marker, no card counts. */
+function isStudying(c: YearCard): boolean {
+  if (!c.view.enrolled) return false
+  return c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off'
+}
+
+async function refresh() {
+  loading.value = true
+  error.value = null
+  try {
+    const res = await api.getYears()
+    const enriched = await Promise.all(
+      res.years.map(async (view) => ({
+        view,
+        draft: { ...view.settings },
+        saving: false,
+        offlineBusy: false,
+        newestRenderAt: view.offlineMode ? await newestRenderFetchedAt(view.materialId) : 0,
+      })),
+    )
+    cards.value = enriched
+    // Re-resolve the active tab after the list changes. Prefer the year
+    // the user is actively studying (any scope above off) so the picker
+    // opens on a working panel; otherwise fall back to any enrolled year,
+    // and finally to the first listed.
+    if (cards.value.length === 0) {
+      selectedMaterialId.value = null
+    } else if (!cards.value.some((c) => c.view.materialId === selectedMaterialId.value)) {
+      const next =
+        cards.value.find(isStudying) ?? cards.value.find((c) => c.view.enrolled) ?? cards.value[0]
+      selectedMaterialId.value = next?.view.materialId ?? null
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+/** Strip the "(NKJV)" suffix some titles carry — saves horizontal space
+ *  in the tab strip without losing meaning. */
+function tabTitle(full: string): string {
+  return full.replace(/\s*\(NKJV\)\s*$/, '')
+}
+
+const TIER_SCOPE_RANK: Record<TierScope, number> = {
+  off: 0,
+  up150: 1,
+  up300: 2,
+  all: 3,
+}
+
+/** True when Review's reach is narrower than New's — i.e. the user is
+ *  memorising verses at a tier they don't review, so freshly-introduced
+ *  verses won't re-surface. Worth surfacing because it's almost always
+ *  an oversight rather than an intentional config. */
+function reviewBehindNew(s: YearSettings): boolean {
+  return TIER_SCOPE_RANK[s.reviewScope] < TIER_SCOPE_RANK[s.newScope]
+}
+
+/** Settings that affect engine construction — flipping any of these
+ *  means the cached WasmEngine + render cache must be rebuilt so the
+ *  next session uses the new value. `lessonBatchSize` is intentionally
+ *  excluded; it's a session-size knob the engine doesn't consume. */
+const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
+  'headingCard',
+  'headingPassageCard',
+  'ftv',
+  'newScope',
+  'reviewScope',
+  'clubCardScope',
+  'chapterListScope',
+  'desiredRetention',
+]
+
+function affectsEngine(draft: YearSettings, current: YearSettings): boolean {
+  return ENGINE_AFFECTING_SETTINGS.some((k) => draft[k] !== current[k])
+}
+
+async function onSave(card: YearCard) {
+  card.saving = true
+  try {
+    const shouldInvalidate = affectsEngine(card.draft, card.view.settings)
+    // Capture before invalidate — its IDB clear happens before the
+    // refresh that would update card.view.offlineMode.
+    const wasOfflineMode = card.view.offlineMode
+    await api.updateYearSettings(card.view.materialId, card.draft)
+    if (shouldInvalidate) {
+      // invalidateSession drops the cached engine AND the render cache
+      // so the next ReviewView/MemorizeView visit rebuilds with the new
+      // MaterialConfig. When offline mode is on, the user has committed
+      // to "this deck works offline" — re-seed the bulk renders rather
+      // than leaving them in a checked-toggle/empty-IDB limbo.
+      await invalidateSession(card.view.materialId)
+      if (wasOfflineMode) {
+        await seedOfflineRenders(card.view.materialId)
+      }
+    }
+    await refresh()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+    card.saving = false
+  }
+}
+
+function onRetentionInput(card: YearCard, event: Event) {
+  const pct = Number((event.target as HTMLInputElement).value)
+  if (Number.isFinite(pct)) {
+    card.draft.desiredRetention = pct / 100
+  }
+}
+
+function settingsAreDirty(card: YearCard): boolean {
+  return (Object.keys(card.draft) as Array<keyof YearSettings>).some(
+    (k) => card.draft[k] !== card.view.settings[k],
+  )
+}
+
+function refreshedLabel(card: YearCard): string {
+  if (card.newestRenderAt === 0) return 'Not yet downloaded.'
+  const days = Math.floor((Date.now() / 1000 - card.newestRenderAt) / SECS_PER_DAY)
+  if (days <= 0) return 'Refreshed today.'
+  if (days === 1) return 'Refreshed 1 day ago.'
+  return `Refreshed ${days} days ago.`
+}
+
+/** Fetch the bulk renders payload and seed IDB with it. Drops any
+ *  composed=null rows the server emitted (chapter-fetch failures or
+ *  unset BIBLE_API_KEY) so we don't shadow recovery for 30 days — the
+ *  lazy `getRender` path applies the same filter and would refuse to
+ *  cache them on the single-card route. */
+async function seedOfflineRenders(materialId: string): Promise<void> {
+  const { renders } = await api.getMaterialRenders(materialId)
+  await bulkPutRenders(
+    materialId,
+    renders
+      .filter((r) => r.composed !== null)
+      .map((r) => {
+        const { fetchedAt, ...cardRender } = r
+        return { materialId, cardId: r.cardId, composed: cardRender, fetchedAt }
+      }),
+  )
+}
+
+async function onToggleOffline(card: YearCard) {
+  if (card.offlineBusy) return
+  const next = !card.view.offlineMode
+  card.offlineBusy = true
+  try {
+    if (next) {
+      // Flip the flag first so a partial failure mid-download still
+      // leaves the user's intent on record (they can retry the
+      // download from the toggle without re-flipping).
+      await api.setOfflineMode(card.view.materialId, true)
+      await seedOfflineRenders(card.view.materialId)
+    } else {
+      await clearRenders(card.view.materialId)
+      await api.setOfflineMode(card.view.materialId, false)
+    }
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    card.offlineBusy = false
+    // Always re-sync from the server, even on failure, so the toggle
+    // state reflects authoritative truth instead of stale local state.
+    await refresh()
+  }
+}
+
+onMounted(refresh)
+</script>
+
+<template>
+  <div class="materials">
+    <div v-if="error" class="banner banner-error">{{ error }}</div>
+    <div v-if="loading" class="status">Loading…</div>
+    <div v-else-if="cards.length === 0" class="status">
+      No materials in the catalog.
+    </div>
+    <template v-else>
+      <nav class="year-tabs" role="tablist" aria-label="Year">
+        <button
+          v-for="c in cards"
+          :key="c.view.materialId"
+          type="button"
+          role="tab"
+          :class="[
+            'year-tab',
+            {
+              'tab-active': c.view.materialId === selectedMaterialId,
+              'tab-unenrolled': !isStudying(c),
+            },
+          ]"
+          :aria-selected="c.view.materialId === selectedMaterialId"
+          :tabindex="c.view.materialId === selectedMaterialId ? 0 : -1"
+          @click="selectedMaterialId = c.view.materialId"
+        >
+          <span class="tab-title">{{ tabTitle(c.view.title) }}</span>
+          <span
+            v-if="isStudying(c)"
+            class="tab-marker tab-marker-enrolled"
+            aria-hidden="true"
+          />
+        </button>
+      </nav>
+      <article
+        v-if="selected"
+        :key="selected.view.materialId"
+        class="year-card"
+        :class="{ 'year-card-unenrolled': !isStudying(selected) }"
+      >
+        <header class="year-header">
+          <div class="year-title-row">
+            <h3>{{ selected.view.title }}</h3>
+            <span v-if="!isStudying(selected)" class="enrollment-badge">Not enrolled</span>
+          </div>
+          <p class="year-description">{{ selected.view.description }}</p>
+          <div class="tier-summary">
+            <span v-for="tier in CLUB_TIERS" :key="tier" class="tier-pill">
+              <span class="tier-pill-name">{{ TIER_LABELS[tier] }}</span>
+              <span v-if="isStudying(selected)" class="tier-pill-count">
+                {{ selected.view.clubs[tier].cardCount }}
+              </span>
+              <StatusChip :variant="STATUS_VARIANTS[selected.view.clubs[tier].status]">
+                {{ STATUS_LABELS[selected.view.clubs[tier].status] }}
+              </StatusChip>
+            </span>
+          </div>
+        </header>
+
+        <section class="settings-section">
+          <div class="section-title">Study scopes</div>
+          <div class="scope-stack">
+            <div class="scope-row">
+              <span class="scope-row-label">Memorize new verses</span>
+              <ScopeLevelSelector
+                v-model="selected.draft.newScope"
+                :levels="TIER_SCOPE_LEVELS"
+                :description="NEW_DESCRIPTIONS[selected.draft.newScope]"
+                :disabled="selected.saving"
+                aria-label="New verses scope"
+              />
+            </div>
+            <div class="scope-row">
+              <span class="scope-row-label">Review existing verses</span>
+              <ScopeLevelSelector
+                v-model="selected.draft.reviewScope"
+                :levels="TIER_SCOPE_LEVELS"
+                :description="REVIEW_DESCRIPTIONS[selected.draft.reviewScope]"
+                :disabled="selected.saving"
+                aria-label="Review scope"
+              />
+              <p v-if="reviewBehindNew(selected.draft)" class="scope-warning" role="alert">
+                Review is narrower than New — verses you introduce above this level
+                won't re-surface in /review.
+              </p>
+              <p class="scope-fineprint">
+                A tier in both becomes Active; review-only becomes Maintenance; neither is
+                Paused.
+              </p>
+            </div>
+          </div>
+
+          <div class="section-title section-title-spaced">Card kinds</div>
+          <div class="scope-stack">
+            <label class="toggle">
+              <input
+                v-model="selected.draft.headingPassageCard"
+                type="checkbox"
+                :disabled="selected.saving"
+              />
+              <span>Heading passage prompts <span class="toggle-hint">— "what heading is this passage under?"</span></span>
+            </label>
+            <label class="toggle">
+              <input
+                v-model="selected.draft.headingCard"
+                type="checkbox"
+                :disabled="selected.saving"
+              />
+              <span>Per-verse heading prompts <span class="toggle-hint">— "which heading is this verse in?" (one card per verse)</span></span>
+            </label>
+            <label class="toggle">
+              <input
+                v-model="selected.draft.ftv"
+                type="checkbox"
+                :disabled="selected.saving"
+              />
+              <span>FTV (finish-the-verse) prompts</span>
+            </label>
+            <div class="scope-row">
+              <span class="scope-row-label">"Which club is this verse in?" prompts</span>
+              <ScopeLevelSelector
+                v-model="selected.draft.clubCardScope"
+                :levels="TIER_SCOPE_LEVELS"
+                :description="CLUB_CARD_DESCRIPTIONS[selected.draft.clubCardScope]"
+                :disabled="selected.saving"
+                aria-label="Per-verse club-card scope"
+              />
+            </div>
+            <div class="scope-row">
+              <span class="scope-row-label">Chapter-list prompts</span>
+              <ScopeLevelSelector
+                v-model="selected.draft.chapterListScope"
+                :levels="CHAPTER_LIST_LEVELS"
+                :description="CHAPTER_LIST_DESCRIPTIONS[selected.draft.chapterListScope]"
+                :disabled="selected.saving"
+                aria-label="Chapter-list scope"
+              />
+            </div>
+          </div>
+
+          <div class="section-title section-title-spaced">Offline study</div>
+          <div class="scope-stack">
+            <label class="toggle">
+              <input
+                type="checkbox"
+                :checked="selected.view.offlineMode"
+                :disabled="selected.offlineBusy || !selected.view.enrolled"
+                @change="onToggleOffline(selected)"
+              />
+              <span>Make this year available offline</span>
+            </label>
+            <p class="scope-fineprint">
+              Downloads ~5&nbsp;MB of pre-composed verse HTML so reviews work
+              without a network. Refreshes every 30&nbsp;days from
+              <a href="https://api.bible" target="_blank" rel="noopener">api.bible</a>
+              per the cache policy.
+            </p>
+            <p v-if="selected.offlineBusy" class="scope-fineprint" aria-live="polite">
+              {{ selected.view.offlineMode ? 'Clearing offline copy…' : 'Downloading offline copy…' }}
+            </p>
+            <p v-else-if="selected.view.offlineMode" class="scope-fineprint">
+              {{ refreshedLabel(selected) }}
+            </p>
+          </div>
+
+          <div class="section-title section-title-spaced">Session</div>
+          <label class="number-row">
+            <span>Verses per memorize session</span>
+            <input
+              v-model.number="selected.draft.lessonBatchSize"
+              type="number"
+              min="1"
+              max="10"
+              :disabled="selected.saving"
+            />
+          </label>
+
+          <label class="range-row">
+            <span class="range-label">
+              Target retention
+              <span class="range-value">{{ Math.round(selected.draft.desiredRetention * 100) }}%</span>
+            </span>
+            <input
+              :value="Math.round(selected.draft.desiredRetention * 100)"
+              type="range"
+              min="70"
+              max="97"
+              step="1"
+              :disabled="selected.saving"
+              @input="onRetentionInput(selected, $event)"
+            />
+          </label>
+          <p class="scope-fineprint">
+            Higher target → more reviews + stronger recall. Lower → fewer reviews + more lapses.
+            FSRS recommends 80–95%.
+          </p>
+
+          <button
+            type="button"
+            class="save-button"
+            :disabled="!settingsAreDirty(selected) || selected.saving"
+            @click="onSave(selected)"
+          >
+            {{ selected.saving ? 'Saving…' : 'Save settings' }}
+          </button>
+        </section>
+      </article>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.materials {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.banner {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+}
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.status {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.year-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.year-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px 6px 0 0;
+  padding: 0.4rem 0.85rem;
+  margin-bottom: -1px; /* lap the bottom border for the "tab joins panel" look */
+  color: var(--color-muted);
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.year-tab:hover {
+  color: var(--color-text);
+}
+
+.year-tab.tab-active {
+  color: var(--color-text);
+  background: var(--color-bg-card);
+  border-color: var(--color-border);
+  border-bottom-color: var(--color-bg-card);
+  font-weight: 500;
+}
+
+.year-tab.tab-unenrolled .tab-title {
+  font-style: italic;
+}
+
+.tab-marker {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 999px;
+}
+
+.tab-marker-enrolled {
+  background: var(--color-accent);
+}
+
+.year-card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.year-card-unenrolled {
+  /* Subtle dimming so unenrolled years read as "available, not yet
+     activated" without disappearing into the background. */
+  border-style: dashed;
+}
+
+.year-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.year-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.year-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.year-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  line-height: 1.4;
+}
+
+.enrollment-badge {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  white-space: nowrap;
+}
+
+.tier-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tier-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-bg);
+  font-size: 0.82rem;
+}
+
+.tier-pill-name {
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.tier-pill-count {
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.section-title {
+  font-size: 0.78rem;
+  color: var(--color-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.section-title-spaced {
+  margin-top: 0.75rem;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.scope-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.toggle input[type='checkbox'] {
+  accent-color: var(--color-accent);
+}
+
+.toggle-hint {
+  color: var(--color-muted);
+  font-size: 0.85em;
+}
+
+.scope-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.scope-row-label {
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.scope-fineprint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.scope-warning {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-grade-hard);
+  background: var(--color-grade-hard-bg);
+  border-left: 3px solid var(--color-grade-hard);
+  border-radius: 3px;
+  padding: 0.35rem 0.6rem;
+}
+
+.number-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.number-row input {
+  padding: 0.25rem 0.5rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  width: 4rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.range-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.range-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.range-value {
+  color: var(--color-accent);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.range-row input[type='range'] {
+  width: 100%;
+  accent-color: var(--color-accent);
+}
+
+.save-button {
+  align-self: flex-start;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border: none;
+  border-radius: 4px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+.save-button:disabled {
+  background: var(--color-border);
+  color: var(--color-muted);
+  cursor: not-allowed;
+}
+</style>

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -43,6 +43,12 @@ const CLUB_TO_TIER: Record<Club, ClubTier> = {
   full: 'full',
 }
 
+const TIER_TO_CLUB: Record<ClubTier, Club> = {
+  '150': 'club150',
+  '300': 'club300',
+  full: 'full',
+}
+
 const STATUS_LABELS: Record<ClubStatus, string> = {
   active: 'Active',
   maintenance: 'Maintenance',
@@ -226,6 +232,20 @@ function onRetentionInput(card: YearCard, club: Club, event: Event) {
   card.draft.review[club].desiredRetention = pct / 100
 }
 
+/** Clamp `lessonBatchSize` to a valid integer on every input change.
+ *  `v-model.number` would happily yield `NaN` when the user clears the
+ *  field or types a non-numeric character, and `JSON.stringify(NaN)` is
+ *  `null` — which the API rejects with a 400. Holding the prior valid
+ *  value while the input is in a transient invalid state keeps the
+ *  Save button reliable. Out-of-range values clamp to `[1, 10]` to
+ *  match the validator on the server. */
+function onLessonBatchSizeInput(card: YearCard, event: Event) {
+  const raw = Number((event.target as HTMLInputElement).value)
+  if (!Number.isFinite(raw)) return
+  const clamped = Math.max(1, Math.min(10, Math.round(raw)))
+  card.draft.lessonBatchSize = clamped
+}
+
 /** Memorized-verse progress per club, sourced from the engine-loaded
  *  card counts. The chain UI shows this next to each club's enable
  *  checkbox so the user can see how far along they are. */
@@ -233,10 +253,12 @@ function memorizedFor(card: YearCard, club: Club): number {
   return card.view.clubs[CLUB_TO_TIER[club]].cardCount
 }
 
-/** Status chip variant for the per-club card. The legacy "status" enum
- *  collapsed memorize+review intent into Active/Maintenance/Paused;
- *  with per-club shapes that's now derivable: memorize+review enabled
- *  → Active, review only → Maintenance, neither → Paused. */
+/** Status chip variant for the per-club card. Memorize-on (with or
+ *  without review) reads as Active — the club is actively introducing
+ *  verses, and the `memorizeBehindReview` warning calls out the
+ *  memorize-without-review oversight separately so the status chip
+ *  doesn't need a fourth state. Review-only reads as Maintenance,
+ *  matching the legacy semantics. Neither enabled reads as Paused. */
 function clubStatusFor(
   memorize: ClubMemorizeConfig,
   review: ClubReviewConfig,
@@ -351,8 +373,21 @@ onMounted(refresh)
               <span v-if="isStudying(selected)" class="tier-pill-count">
                 {{ selected.view.clubs[tier].cardCount }}
               </span>
-              <StatusChip :variant="STATUS_VARIANTS[selected.view.clubs[tier].status]">
-                {{ STATUS_LABELS[selected.view.clubs[tier].status] }}
+              <!-- Derived from view.perClub, not view.clubs[tier].status:
+                   the latter goes through the lossy perClubToLegacy
+                   collapse on the API side, so a non-monotonic config
+                   (e.g. Club 300 enabled but Club 150 off) would show
+                   the wrong pill. Per-club is the source of truth. -->
+              <StatusChip
+                :variant="STATUS_VARIANTS[clubStatusFor(
+                  selected.view.perClub.memorize[TIER_TO_CLUB[tier]],
+                  selected.view.perClub.review[TIER_TO_CLUB[tier]],
+                )]"
+              >
+                {{ STATUS_LABELS[clubStatusFor(
+                  selected.view.perClub.memorize[TIER_TO_CLUB[tier]],
+                  selected.view.perClub.review[TIER_TO_CLUB[tier]],
+                )] }}
               </StatusChip>
             </span>
           </div>
@@ -563,11 +598,12 @@ onMounted(refresh)
           <label class="number-row">
             <span>Verses per memorize session</span>
             <input
-              v-model.number="selected.draft.lessonBatchSize"
+              :value="selected.draft.lessonBatchSize"
               type="number"
               min="1"
               max="10"
               :disabled="selected.saving"
+              @input="onLessonBatchSizeInput(selected, $event)"
             />
           </label>
 

--- a/apps/web/src/views/SettingsPreferencesView.vue
+++ b/apps/web/src/views/SettingsPreferencesView.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+// Placeholder shell for app-wide preferences (theme, notifications, etc.).
+// Empty at launch — the spec explicitly allows this.
+</script>
+
+<template>
+  <div class="preferences">
+    <p class="placeholder">App-wide preferences will live here.</p>
+  </div>
+</template>
+
+<style scoped>
+.preferences {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.placeholder {
+  margin: 0;
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+  background: var(--color-bg-card);
+  border: 1px dashed var(--color-border);
+  border-radius: 8px;
+  font-style: italic;
+}
+</style>

--- a/apps/web/src/views/SettingsView.vue
+++ b/apps/web/src/views/SettingsView.vue
@@ -18,11 +18,15 @@ const route = useRoute()
 
 // Match either by route name (set on the child routes) or by path prefix,
 // so the rail highlights even when a future child route nests deeper
-// (e.g. /settings/materials/<materialId>).
+// (e.g. /settings/materials/<materialId>). The path branch requires an
+// exact match OR a `/`-anchored prefix so a future sibling like
+// `/settings/materials-archive` won't incorrectly highlight Materials.
 const activeSection = computed<string>(() => {
   const byName = SECTIONS.find((s) => s.name === route.name)
   if (byName) return byName.name
-  const byPath = SECTIONS.find((s) => route.path.startsWith(s.path))
+  const byPath = SECTIONS.find(
+    (s) => route.path === s.path || route.path.startsWith(s.path + '/'),
+  )
   return byPath?.name ?? SECTIONS[0].name
 })
 

--- a/apps/web/src/views/SettingsView.vue
+++ b/apps/web/src/views/SettingsView.vue
@@ -1,498 +1,62 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed } from 'vue'
+import { RouterLink, RouterView, useRoute } from 'vue-router'
 
-import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
-import StatusChip from '@/components/StatusChip.vue'
-import {
-  type ChapterListScope,
-  type ClubStatus,
-  type ClubTier,
-  type TierScope,
-  type YearSettings,
-  type YearView,
-  api,
-} from '@/api'
-import { invalidateSession } from '@/lib/engine/engineStore'
-import { bulkPutRenders, clearRenders, newestRenderFetchedAt } from '@/lib/engine/persistence'
-
-const SECS_PER_DAY = 86400
-
-const CLUB_TIERS: ClubTier[] = ['150', '300', 'full']
-
-const TIER_LABELS: Record<ClubTier, string> = {
-  '150': 'Club 150',
-  '300': 'Club 300',
-  full: 'Full',
+interface Section {
+  name: string
+  label: string
+  path: string
 }
 
-const STATUS_LABELS: Record<ClubStatus, string> = {
-  active: 'Active',
-  maintenance: 'Maintenance',
-  paused: 'Paused',
-}
-
-const STATUS_VARIANTS: Record<ClubStatus, 'accent' | 'warning' | 'muted'> = {
-  active: 'accent',
-  maintenance: 'warning',
-  paused: 'muted',
-}
-
-// All four scope tracks share the same 4-stop shape (chapter-list is
-// missing the Full stop). Stops are ordered: Off ── 150 ── 300 ── Full.
-const TIER_SCOPE_LEVELS: { value: TierScope; label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'up150', label: '150' },
-  { value: 'up300', label: '300' },
-  { value: 'all', label: 'Full' },
+const SECTIONS: Section[] = [
+  { name: 'settings-account', label: 'Account', path: '/settings/account' },
+  { name: 'settings-preferences', label: 'Preferences', path: '/settings/preferences' },
+  { name: 'settings-materials', label: 'Materials', path: '/settings/materials' },
 ]
 
-const CHAPTER_LIST_LEVELS: { value: ChapterListScope; label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'up150', label: '150' },
-  { value: 'up300', label: '300' },
-]
+const route = useRoute()
 
-const NEW_DESCRIPTIONS: Record<TierScope, string> = {
-  off: 'No tier is introducing new verses.',
-  up150: 'Memorizing Club 150 verses.',
-  up300: 'Memorizing Club 150 and Club 300 verses.',
-  all: 'Memorizing every tier, including Full.',
-}
-
-const REVIEW_DESCRIPTIONS: Record<TierScope, string> = {
-  off: 'No reviews surfaced.',
-  up150: 'Reviewing Club 150 verses.',
-  up300: 'Reviewing Club 150 and Club 300 verses.',
-  all: 'Reviewing every tier, including Full.',
-}
-
-const CLUB_CARD_DESCRIPTIONS: Record<TierScope, string> = {
-  off: 'No "which club?" prompts.',
-  up150: 'Asks for Club 150 verses only.',
-  up300: 'Asks for Club 150 and Club 300 verses (not Full).',
-  all: 'Asks for every verse, including Full-tier.',
-}
-
-const CHAPTER_LIST_DESCRIPTIONS: Record<ChapterListScope, string> = {
-  off: 'No chapter-list prompts.',
-  up150: 'One card per chapter listing its Club 150 verses.',
-  up300: 'Two cards per chapter: Club 150 list and Club 300 list.',
-}
-
-interface YearCard {
-  view: YearView
-  draft: YearSettings
-  saving: boolean
-  /** True while the toggle's flip-and-fetch (or flip-and-clear) is
-   *  in flight. Drives the row's spinner state independent of the
-   *  larger settings-form `saving` flag. */
-  offlineBusy: boolean
-  /** Unix-secs of the newest IDB render for this material, or 0 if
-   *  none cached. Used to render "Last refreshed N days ago". */
-  newestRenderAt: number
-}
-
-const cards = ref<YearCard[]>([])
-const loading = ref(true)
-const error = ref<string | null>(null)
-const selectedMaterialId = ref<string | null>(null)
-
-const selected = computed<YearCard | null>(() => {
-  const id = selectedMaterialId.value
-  if (!id) return null
-  return cards.value.find((c) => c.view.materialId === id) ?? null
+// Match either by route name (set on the child routes) or by path prefix,
+// so the rail highlights even when a future child route nests deeper
+// (e.g. /settings/materials/<materialId>).
+const activeSection = computed<string>(() => {
+  const byName = SECTIONS.find((s) => s.name === route.name)
+  if (byName) return byName.name
+  const byPath = SECTIONS.find((s) => route.path.startsWith(s.path))
+  return byPath?.name ?? SECTIONS[0].name
 })
 
-/** A year reads as "studying" iff at least one of `newScope` or
- *  `reviewScope` is on. Provisioned-but-all-paused years (e.g. the
- *  user touched the year once then turned everything off) display the
- *  same as never-touched years: no enrolled marker, no card counts. */
-function isStudying(c: YearCard): boolean {
-  if (!c.view.enrolled) return false
-  return c.view.settings.newScope !== 'off' || c.view.settings.reviewScope !== 'off'
-}
-
-async function refresh() {
-  loading.value = true
-  error.value = null
-  try {
-    const res = await api.getYears()
-    const enriched = await Promise.all(
-      res.years.map(async (view) => ({
-        view,
-        draft: { ...view.settings },
-        saving: false,
-        offlineBusy: false,
-        newestRenderAt: view.offlineMode ? await newestRenderFetchedAt(view.materialId) : 0,
-      })),
-    )
-    cards.value = enriched
-    // Re-resolve the active tab after the list changes. Prefer the year
-    // the user is actively studying (any scope above off) so the picker
-    // opens on a working panel; otherwise fall back to any enrolled year,
-    // and finally to the first listed.
-    if (cards.value.length === 0) {
-      selectedMaterialId.value = null
-    } else if (!cards.value.some((c) => c.view.materialId === selectedMaterialId.value)) {
-      const next =
-        cards.value.find(isStudying) ?? cards.value.find((c) => c.view.enrolled) ?? cards.value[0]
-      selectedMaterialId.value = next?.view.materialId ?? null
-    }
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : String(err)
-  } finally {
-    loading.value = false
-  }
-}
-
-/** Strip the "(NKJV)" suffix some titles carry — saves horizontal space
- *  in the tab strip without losing meaning. */
-function tabTitle(full: string): string {
-  return full.replace(/\s*\(NKJV\)\s*$/, '')
-}
-
-const TIER_SCOPE_RANK: Record<TierScope, number> = {
-  off: 0,
-  up150: 1,
-  up300: 2,
-  all: 3,
-}
-
-/** True when Review's reach is narrower than New's — i.e. the user is
- *  memorising verses at a tier they don't review, so freshly-introduced
- *  verses won't re-surface. Worth surfacing because it's almost always
- *  an oversight rather than an intentional config. */
-function reviewBehindNew(s: YearSettings): boolean {
-  return TIER_SCOPE_RANK[s.reviewScope] < TIER_SCOPE_RANK[s.newScope]
-}
-
-/** Settings that affect engine construction — flipping any of these
- *  means the cached WasmEngine + render cache must be rebuilt so the
- *  next session uses the new value. `lessonBatchSize` is intentionally
- *  excluded; it's a session-size knob the engine doesn't consume. */
-const ENGINE_AFFECTING_SETTINGS: ReadonlyArray<keyof YearSettings> = [
-  'headingCard',
-  'headingPassageCard',
-  'ftv',
-  'newScope',
-  'reviewScope',
-  'clubCardScope',
-  'chapterListScope',
-  'desiredRetention',
-]
-
-function affectsEngine(draft: YearSettings, current: YearSettings): boolean {
-  return ENGINE_AFFECTING_SETTINGS.some((k) => draft[k] !== current[k])
-}
-
-async function onSave(card: YearCard) {
-  card.saving = true
-  try {
-    const shouldInvalidate = affectsEngine(card.draft, card.view.settings)
-    // Capture before invalidate — its IDB clear happens before the
-    // refresh that would update card.view.offlineMode.
-    const wasOfflineMode = card.view.offlineMode
-    await api.updateYearSettings(card.view.materialId, card.draft)
-    if (shouldInvalidate) {
-      // invalidateSession drops the cached engine AND the render cache
-      // so the next ReviewView/MemorizeView visit rebuilds with the new
-      // MaterialConfig. When offline mode is on, the user has committed
-      // to "this deck works offline" — re-seed the bulk renders rather
-      // than leaving them in a checked-toggle/empty-IDB limbo.
-      await invalidateSession(card.view.materialId)
-      if (wasOfflineMode) {
-        await seedOfflineRenders(card.view.materialId)
-      }
-    }
-    await refresh()
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : String(err)
-    card.saving = false
-  }
-}
-
-function onRetentionInput(card: YearCard, event: Event) {
-  const pct = Number((event.target as HTMLInputElement).value)
-  if (Number.isFinite(pct)) {
-    card.draft.desiredRetention = pct / 100
-  }
-}
-
-function settingsAreDirty(card: YearCard): boolean {
-  return (Object.keys(card.draft) as Array<keyof YearSettings>).some(
-    (k) => card.draft[k] !== card.view.settings[k],
-  )
-}
-
-function refreshedLabel(card: YearCard): string {
-  if (card.newestRenderAt === 0) return 'Not yet downloaded.'
-  const days = Math.floor((Date.now() / 1000 - card.newestRenderAt) / SECS_PER_DAY)
-  if (days <= 0) return 'Refreshed today.'
-  if (days === 1) return 'Refreshed 1 day ago.'
-  return `Refreshed ${days} days ago.`
-}
-
-/** Fetch the bulk renders payload and seed IDB with it. Drops any
- *  composed=null rows the server emitted (chapter-fetch failures or
- *  unset BIBLE_API_KEY) so we don't shadow recovery for 30 days — the
- *  lazy `getRender` path applies the same filter and would refuse to
- *  cache them on the single-card route. */
-async function seedOfflineRenders(materialId: string): Promise<void> {
-  const { renders } = await api.getMaterialRenders(materialId)
-  await bulkPutRenders(
-    materialId,
-    renders
-      .filter((r) => r.composed !== null)
-      .map((r) => {
-        const { fetchedAt, ...cardRender } = r
-        return { materialId, cardId: r.cardId, composed: cardRender, fetchedAt }
-      }),
-  )
-}
-
-async function onToggleOffline(card: YearCard) {
-  if (card.offlineBusy) return
-  const next = !card.view.offlineMode
-  card.offlineBusy = true
-  try {
-    if (next) {
-      // Flip the flag first so a partial failure mid-download still
-      // leaves the user's intent on record (they can retry the
-      // download from the toggle without re-flipping).
-      await api.setOfflineMode(card.view.materialId, true)
-      await seedOfflineRenders(card.view.materialId)
-    } else {
-      await clearRenders(card.view.materialId)
-      await api.setOfflineMode(card.view.materialId, false)
-    }
-  } catch (err) {
-    error.value = err instanceof Error ? err.message : String(err)
-  } finally {
-    card.offlineBusy = false
-    // Always re-sync from the server, even on failure, so the toggle
-    // state reflects authoritative truth instead of stale local state.
-    await refresh()
-  }
-}
-
-onMounted(refresh)
+const activeLabel = computed(
+  () => SECTIONS.find((s) => s.name === activeSection.value)?.label ?? '',
+)
 </script>
 
 <template>
   <div class="settings">
     <h2>Settings</h2>
-    <div v-if="error" class="banner banner-error">{{ error }}</div>
-    <div v-if="loading" class="status">Loading…</div>
-    <div v-else-if="cards.length === 0" class="status">
-      No materials in the catalog.
-    </div>
-    <template v-else>
-      <nav class="year-tabs" role="tablist" aria-label="Year">
-        <button
-          v-for="c in cards"
-          :key="c.view.materialId"
-          type="button"
-          role="tab"
-          :class="[
-            'year-tab',
-            {
-              'tab-active': c.view.materialId === selectedMaterialId,
-              'tab-unenrolled': !isStudying(c),
-            },
-          ]"
-          :aria-selected="c.view.materialId === selectedMaterialId"
-          :tabindex="c.view.materialId === selectedMaterialId ? 0 : -1"
-          @click="selectedMaterialId = c.view.materialId"
+    <div class="layout">
+      <nav class="rail" aria-label="Settings sections">
+        <RouterLink
+          v-for="s in SECTIONS"
+          :key="s.name"
+          :to="s.path"
+          class="rail-link"
+          :class="{ 'rail-link-active': s.name === activeSection }"
         >
-          <span class="tab-title">{{ tabTitle(c.view.title) }}</span>
-          <span
-            v-if="isStudying(c)"
-            class="tab-marker tab-marker-enrolled"
-            aria-hidden="true"
-          />
-        </button>
+          {{ s.label }}
+        </RouterLink>
       </nav>
-      <article
-        v-if="selected"
-        :key="selected.view.materialId"
-        class="year-card"
-        :class="{ 'year-card-unenrolled': !isStudying(selected) }"
-      >
-        <header class="year-header">
-          <div class="year-title-row">
-            <h3>{{ selected.view.title }}</h3>
-            <span v-if="!isStudying(selected)" class="enrollment-badge">Not enrolled</span>
-          </div>
-          <p class="year-description">{{ selected.view.description }}</p>
-          <div class="tier-summary">
-            <span v-for="tier in CLUB_TIERS" :key="tier" class="tier-pill">
-              <span class="tier-pill-name">{{ TIER_LABELS[tier] }}</span>
-              <span v-if="isStudying(selected)" class="tier-pill-count">
-                {{ selected.view.clubs[tier].cardCount }}
-              </span>
-              <StatusChip :variant="STATUS_VARIANTS[selected.view.clubs[tier].status]">
-                {{ STATUS_LABELS[selected.view.clubs[tier].status] }}
-              </StatusChip>
-            </span>
-          </div>
-        </header>
-
-        <section class="settings">
-          <div class="section-title">Study scopes</div>
-          <div class="scope-stack">
-            <div class="scope-row">
-              <span class="scope-row-label">Memorize new verses</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.newScope"
-                :levels="TIER_SCOPE_LEVELS"
-                :description="NEW_DESCRIPTIONS[selected.draft.newScope]"
-                :disabled="selected.saving"
-                aria-label="New verses scope"
-              />
-            </div>
-            <div class="scope-row">
-              <span class="scope-row-label">Review existing verses</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.reviewScope"
-                :levels="TIER_SCOPE_LEVELS"
-                :description="REVIEW_DESCRIPTIONS[selected.draft.reviewScope]"
-                :disabled="selected.saving"
-                aria-label="Review scope"
-              />
-              <p v-if="reviewBehindNew(selected.draft)" class="scope-warning" role="alert">
-                Review is narrower than New — verses you introduce above this level
-                won't re-surface in /review.
-              </p>
-              <p class="scope-fineprint">
-                A tier in both becomes Active; review-only becomes Maintenance; neither is
-                Paused.
-              </p>
-            </div>
-          </div>
-
-          <div class="section-title section-title-spaced">Card kinds</div>
-          <div class="scope-stack">
-            <label class="toggle">
-              <input
-                v-model="selected.draft.headingPassageCard"
-                type="checkbox"
-                :disabled="selected.saving"
-              />
-              <span>Heading passage prompts <span class="toggle-hint">— "what heading is this passage under?"</span></span>
-            </label>
-            <label class="toggle">
-              <input
-                v-model="selected.draft.headingCard"
-                type="checkbox"
-                :disabled="selected.saving"
-              />
-              <span>Per-verse heading prompts <span class="toggle-hint">— "which heading is this verse in?" (one card per verse)</span></span>
-            </label>
-            <label class="toggle">
-              <input
-                v-model="selected.draft.ftv"
-                type="checkbox"
-                :disabled="selected.saving"
-              />
-              <span>FTV (finish-the-verse) prompts</span>
-            </label>
-            <div class="scope-row">
-              <span class="scope-row-label">"Which club is this verse in?" prompts</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.clubCardScope"
-                :levels="TIER_SCOPE_LEVELS"
-                :description="CLUB_CARD_DESCRIPTIONS[selected.draft.clubCardScope]"
-                :disabled="selected.saving"
-                aria-label="Per-verse club-card scope"
-              />
-            </div>
-            <div class="scope-row">
-              <span class="scope-row-label">Chapter-list prompts</span>
-              <ScopeLevelSelector
-                v-model="selected.draft.chapterListScope"
-                :levels="CHAPTER_LIST_LEVELS"
-                :description="CHAPTER_LIST_DESCRIPTIONS[selected.draft.chapterListScope]"
-                :disabled="selected.saving"
-                aria-label="Chapter-list scope"
-              />
-            </div>
-          </div>
-
-          <div class="section-title section-title-spaced">Offline study</div>
-          <div class="scope-stack">
-            <label class="toggle">
-              <input
-                type="checkbox"
-                :checked="selected.view.offlineMode"
-                :disabled="selected.offlineBusy || !selected.view.enrolled"
-                @change="onToggleOffline(selected)"
-              />
-              <span>Make this year available offline</span>
-            </label>
-            <p class="scope-fineprint">
-              Downloads ~5&nbsp;MB of pre-composed verse HTML so reviews work
-              without a network. Refreshes every 30&nbsp;days from
-              <a href="https://api.bible" target="_blank" rel="noopener">api.bible</a>
-              per the cache policy.
-            </p>
-            <p v-if="selected.offlineBusy" class="scope-fineprint" aria-live="polite">
-              {{ selected.view.offlineMode ? 'Clearing offline copy…' : 'Downloading offline copy…' }}
-            </p>
-            <p v-else-if="selected.view.offlineMode" class="scope-fineprint">
-              {{ refreshedLabel(selected) }}
-            </p>
-          </div>
-
-          <div class="section-title section-title-spaced">Session</div>
-          <label class="number-row">
-            <span>Verses per memorize session</span>
-            <input
-              v-model.number="selected.draft.lessonBatchSize"
-              type="number"
-              min="1"
-              max="10"
-              :disabled="selected.saving"
-            />
-          </label>
-
-          <label class="range-row">
-            <span class="range-label">
-              Target retention
-              <span class="range-value">{{ Math.round(selected.draft.desiredRetention * 100) }}%</span>
-            </span>
-            <input
-              :value="Math.round(selected.draft.desiredRetention * 100)"
-              type="range"
-              min="70"
-              max="97"
-              step="1"
-              :disabled="selected.saving"
-              @input="onRetentionInput(selected, $event)"
-            />
-          </label>
-          <p class="scope-fineprint">
-            Higher target → more reviews + stronger recall. Lower → fewer reviews + more lapses.
-            FSRS recommends 80–95%.
-          </p>
-
-          <button
-            type="button"
-            class="save-button"
-            :disabled="!settingsAreDirty(selected) || selected.saving"
-            @click="onSave(selected)"
-          >
-            {{ selected.saving ? 'Saving…' : 'Save settings' }}
-          </button>
-        </section>
-      </article>
-    </template>
+      <section class="content" :aria-label="activeLabel">
+        <RouterView />
+      </section>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .settings {
   width: 100%;
-  max-width: 720px;
+  max-width: 960px;
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
@@ -503,277 +67,70 @@ h2 {
   margin: 0;
 }
 
-.banner {
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-}
-.banner-error {
-  background: var(--color-error-bg);
-  color: var(--color-error);
+.layout {
+  display: grid;
+  grid-template-columns: 11rem 1fr;
+  gap: 1.5rem;
+  align-items: start;
 }
 
-.status {
-  padding: 2rem;
-  text-align: center;
-  color: var(--color-muted);
-}
-
-.year-tabs {
+.rail {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid var(--color-border);
-}
-
-.year-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 6px 6px 0 0;
-  padding: 0.4rem 0.85rem;
-  margin-bottom: -1px; /* lap the bottom border for the "tab joins panel" look */
-  color: var(--color-muted);
-  font-family: inherit;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    background 0.15s ease,
-    border-color 0.15s ease;
-}
-
-.year-tab:hover {
-  color: var(--color-text);
-}
-
-.year-tab.tab-active {
-  color: var(--color-text);
-  background: var(--color-bg-card);
-  border-color: var(--color-border);
-  border-bottom-color: var(--color-bg-card);
-  font-weight: 500;
-}
-
-.year-tab.tab-unenrolled .tab-title {
-  font-style: italic;
-}
-
-.tab-marker {
-  width: 0.4rem;
-  height: 0.4rem;
-  border-radius: 999px;
-}
-
-.tab-marker-enrolled {
-  background: var(--color-accent);
-}
-
-.year-card {
+  flex-direction: column;
+  gap: 0.15rem;
+  padding: 0.4rem;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 1.25rem 1.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
 }
 
-.year-card-unenrolled {
-  /* Subtle dimming so unenrolled years read as "available, not yet
-     activated" without disappearing into the background. */
-  border-style: dashed;
-}
-
-.year-header {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.year-title-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.75rem;
-}
-
-.year-header h3 {
-  margin: 0;
-  font-size: 1.15rem;
-  font-weight: 600;
-}
-
-.year-description {
-  margin: 0;
-  font-size: 0.85rem;
+.rail-link {
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
   color: var(--color-muted);
-  line-height: 1.4;
-}
-
-.enrollment-badge {
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  padding: 0.1rem 0.5rem;
-  white-space: nowrap;
-}
-
-.tier-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.tier-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.25rem 0.6rem;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-bg);
-  font-size: 0.82rem;
-}
-
-.tier-pill-name {
-  font-weight: 500;
-  color: var(--color-text);
-}
-
-.tier-pill-count {
-  color: var(--color-muted);
-  font-variant-numeric: tabular-nums;
-}
-
-.section-title {
-  font-size: 0.78rem;
-  color: var(--color-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.section-title-spaced {
-  margin-top: 0.75rem;
-}
-
-.settings {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.scope-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 0.9rem;
-}
-
-.toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-}
-
-.toggle input[type='checkbox'] {
-  accent-color: var(--color-accent);
-}
-
-.toggle-hint {
-  color: var(--color-muted);
-  font-size: 0.85em;
-}
-
-.scope-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.scope-row-label {
+  text-decoration: none;
   font-size: 0.95rem;
+  font-weight: 500;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.rail-link:hover {
   color: var(--color-text);
 }
 
-.scope-fineprint {
-  margin: 0;
-  font-size: 0.78rem;
-  color: var(--color-muted);
-  font-style: italic;
-}
-
-.scope-warning {
-  margin: 0;
-  font-size: 0.82rem;
-  color: var(--color-grade-hard);
-  background: var(--color-grade-hard-bg);
-  border-left: 3px solid var(--color-grade-hard);
-  border-radius: 3px;
-  padding: 0.35rem 0.6rem;
-}
-
-.number-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.number-row input {
-  padding: 0.25rem 0.5rem;
-  background: var(--color-bg);
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  border-radius: 4px;
-  font-family: inherit;
-  font-size: 0.9rem;
-  width: 4rem;
-  font-variant-numeric: tabular-nums;
-}
-
-.range-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.range-label {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.range-value {
+.rail-link-active {
   color: var(--color-accent);
-  font-variant-numeric: tabular-nums;
-  font-weight: 500;
+  background: var(--color-accent-soft);
 }
 
-.range-row input[type='range'] {
-  width: 100%;
-  accent-color: var(--color-accent);
+.rail-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
-.save-button {
-  align-self: flex-start;
-  background: var(--color-accent);
-  color: var(--color-on-accent);
-  border: none;
-  border-radius: 4px;
-  padding: 0.4rem 0.9rem;
-  font-size: 0.95rem;
-  cursor: pointer;
+.content {
+  min-width: 0;
 }
-.save-button:disabled {
-  background: var(--color-border);
-  color: var(--color-muted);
-  cursor: not-allowed;
+
+/* On narrow viewports the rail becomes a horizontal scrolling strip
+   above the content. Same routes, same DOM — only the rail flips
+   between column (desktop) and row (mobile). */
+@media (max-width: 720px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .rail {
+    flex-direction: row;
+    gap: 0.25rem;
+    overflow-x: auto;
+    padding: 0.3rem;
+  }
+
+  .rail-link {
+    flex: 0 0 auto;
+    padding: 0.4rem 0.85rem;
+    font-size: 0.9rem;
+  }
 }
 </style>

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,18 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+## [0.1.29] — 2026-06-15
+
+`GET /api/years` now surfaces `perClub` (parsed `PerClubYearSettings`) alongside the legacy
+`settings` field. The web client's Phase 2 chain UI reads it so user-customised `catchUp` and
+`moveToNext` selections round-trip through a save → reload — values the lossy legacy-column collapse
+can't carry. No client breaks: the existing `settings` field is unchanged.
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.6.0` — unchanged.
+* `verse-vault-wasm@0.6.0` — unchanged.
+
 ## [0.1.28] — 2026-06-14
 
 Phase 1 of the schedules + per-club settings rework. MINOR per this changelog's rubric — additive

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/api",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/api/src/routes/years.test.ts
+++ b/packages/api/src/routes/years.test.ts
@@ -10,6 +10,34 @@ type TierScope = 'off' | 'up150' | 'up300' | 'all';
 type ChapterListScope = 'off' | 'up150' | 'up300';
 type ClubStatus = 'active' | 'maintenance' | 'paused';
 
+type CatchUp = 'sequential' | 'calendarCascade';
+type MoveToNextGate =
+  | 'fullyMemorized'
+  | 'afterMajorCheckpoint'
+  | 'afterMinorCheckpoint'
+  | 'caughtUp'
+  | 'always';
+
+interface PerClubSettings {
+  headingCard: boolean;
+  headingPassageCard: boolean;
+  ftv: boolean;
+  clubCardScope: TierScope;
+  chapterListScope: ChapterListScope;
+  memorize: {
+    club150: { enabled: boolean; catchUp: CatchUp };
+    club300: { enabled: boolean; catchUp: CatchUp };
+    full: { enabled: boolean; catchUp: CatchUp };
+  };
+  review: {
+    club150: { enabled: boolean; desiredRetention: number };
+    club300: { enabled: boolean; desiredRetention: number };
+    full: { enabled: boolean; desiredRetention: number };
+  };
+  moveToNext: { p150To300: MoveToNextGate; p300ToFull: MoveToNextGate };
+  lessonBatchSize: number;
+}
+
 interface YearsResponse {
   years: Array<{
     materialId: string;
@@ -27,6 +55,7 @@ interface YearsResponse {
       lessonBatchSize: number;
       desiredRetention: number;
     };
+    perClub: PerClubSettings;
     clubs: Record<'150' | '300' | 'full', { status: ClubStatus; cardCount: number }>;
   }>;
 }
@@ -101,6 +130,83 @@ describe('years routes', () => {
     for (const tier of ['150', '300', 'full'] as const) {
       expect(year.clubs[tier].status).toBe('active');
     }
+  });
+
+  it('returns perClub alongside legacy settings', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await enrollViaApi(test, cookie, MATERIAL_ID, 150);
+
+    const res = await test.app.request('/api/years', { headers: { cookie } });
+    const body = (await res.json()) as YearsResponse;
+    const year = body.years.find((y) => y.materialId === MATERIAL_ID)!;
+    // legacyToNew of ENROLLED_DEFAULTS (newScope=all, reviewScope=all,
+    // desiredRetention=0.8) → every club enabled, sequential catchUp,
+    // CaughtUp gates.
+    expect(year.perClub).toEqual({
+      headingCard: false,
+      headingPassageCard: true,
+      ftv: true,
+      clubCardScope: 'off',
+      chapterListScope: 'up150',
+      memorize: {
+        club150: { enabled: true, catchUp: 'sequential' },
+        club300: { enabled: true, catchUp: 'sequential' },
+        full: { enabled: true, catchUp: 'sequential' },
+      },
+      review: {
+        club150: { enabled: true, desiredRetention: 0.8 },
+        club300: { enabled: true, desiredRetention: 0.8 },
+        full: { enabled: true, desiredRetention: 0.8 },
+      },
+      moveToNext: { p150To300: 'caughtUp', p300ToFull: 'caughtUp' },
+      lessonBatchSize: 3,
+    });
+  });
+
+  it('round-trips perClub catchUp + moveToNext through a save', async () => {
+    const test = createTestApp();
+    cleanup = test.cleanup;
+    const { cookie } = await signUpTestUser(test, 'alice@example.com');
+    await enrollViaApi(test, cookie, MATERIAL_ID, 150);
+
+    // Save a per-club shape that exercises fields the legacy columns
+    // can't represent: catchUp=calendarCascade on Club 150 and a
+    // fullyMemorized gate between 150 and 300. The lossy legacy
+    // collapse loses these — only the perClub field can carry them
+    // back to the chain UI on next load.
+    const save = await test.app.request(`/api/years/${MATERIAL_ID}/settings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', cookie },
+      body: JSON.stringify({
+        headingCard: false,
+        headingPassageCard: true,
+        ftv: true,
+        clubCardScope: 'off',
+        chapterListScope: 'up150',
+        memorize: {
+          club150: { enabled: true, catchUp: 'calendarCascade' },
+          club300: { enabled: true, catchUp: 'sequential' },
+          full: { enabled: false, catchUp: 'sequential' },
+        },
+        review: {
+          club150: { enabled: true, desiredRetention: 0.75 },
+          club300: { enabled: true, desiredRetention: 0.8 },
+          full: { enabled: false, desiredRetention: 0.8 },
+        },
+        moveToNext: { p150To300: 'fullyMemorized', p300ToFull: 'caughtUp' },
+        lessonBatchSize: 1,
+      }),
+    });
+    expect(save.status).toBe(200);
+
+    const res = await test.app.request('/api/years', { headers: { cookie } });
+    const body = (await res.json()) as YearsResponse;
+    const year = body.years.find((y) => y.materialId === MATERIAL_ID)!;
+    expect(year.perClub.memorize.club150.catchUp).toBe('calendarCascade');
+    expect(year.perClub.moveToNext.p150To300).toBe('fullyMemorized');
+    expect(year.perClub.review.club150.desiredRetention).toBe(0.75);
   });
 
   it('derives Maintenance status from scope settings', async () => {

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -177,7 +177,14 @@ function readYearSettings(
  *  `config_json` blob, fall back to synthesising from the legacy
  *  columns so the route, the engine, and the UI agree on what's on
  *  disk. The two readers are intentionally parallel — both swap to
- *  a shared parsed helper if we add a third consumer. */
+ *  a shared parsed helper if we add a third consumer.
+ *
+ *  Reads `configJson` directly off the row but defers to the explicit
+ *  `readYearSettings` extractor for the legacy-column path: the raw
+ *  Drizzle row carries non-settings columns (`userId`, `materialId`,
+ *  `updatedAt`, …) and the scope/retention columns aren't enum-narrowed
+ *  to `TierScope`/`ChapterListScope` at the schema level, so passing
+ *  the raw row to `legacyToNew` would trust un-narrowed strings. */
 function readPerClubSettings(
   db: DB,
   userId: string,
@@ -197,7 +204,7 @@ function readPerClubSettings(
   if (row?.configJson != null && row.configJson !== '') {
     return JSON.parse(row.configJson) as PerClubYearSettings;
   }
-  return legacyToNew(row ? (row as YearSettings) : legacyFallback);
+  return legacyToNew(readYearSettings(db, userId, materialId, legacyFallback));
 }
 
 export function yearsRoutes(deps: YearsRoutesDeps) {

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -38,11 +38,20 @@ type ClubTier = '150' | '300' | 'full';
 const CLUB_TIERS: readonly ClubTier[] = ['150', '300', 'full'];
 
 interface ClubView {
-  /** Effective per-tier status derived from active_scope and
-   *  maintenance_scope. Read-only on the API; clients set the two
-   *  scopes via the year-settings endpoint. */
+  /** Effective per-tier status derived from the per-club `enabled`
+   *  booleans in `MaterialConfig`. Read-only on the API; clients set
+   *  enable flags via `POST /api/years/:id/settings`. */
   status: ClubStatus;
   cardCount: number;
+  // TODO(phase-3): expose per-club `graduated` count here. The web
+  // client's Memorize-tab badge in apps/web/src/lib/badges.ts is
+  // approximating `max(0, cumulative_through_current_week - memorized)`
+  // by `min(newCardCount, cumulative)` because there's no per-club
+  // graduated count on this response. The engine already knows the
+  // value via `WasmEngine.card_count_by_club()` plus a graduated-set
+  // filter; surfacing it lets the badge match the spec formula
+  // exactly. Spec: docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md
+  // §"Memorize tab badge".
 }
 
 interface YearView {
@@ -93,16 +102,22 @@ interface ClubCounts {
   Full?: number;
 }
 
-function tierScopeIncludes(scope: TierScope, tier: ClubTier): boolean {
-  if (scope === 'off') return false;
-  if (scope === 'all') return true;
-  if (scope === 'up150') return tier === '150';
-  return tier === '150' || tier === '300';
-}
+const TIER_TO_CLUB_KEY: Record<ClubTier, 'club150' | 'club300' | 'full'> = {
+  '150': 'club150',
+  '300': 'club300',
+  full: 'full',
+};
 
-function effectiveStatus(settings: YearSettings, tier: ClubTier): ClubStatus {
-  if (tierScopeIncludes(settings.newScope, tier)) return 'active';
-  if (tierScopeIncludes(settings.reviewScope, tier)) return 'maintenance';
+/** Effective per-tier status derived from the per-club booleans —
+ *  memorize-on (with or without review) → active, review-only →
+ *  maintenance, neither → paused. Matches the chip semantics shown in
+ *  /settings/materials' per-club cards. Reading per-club instead of the
+ *  legacy `newScope`/`reviewScope` ladders avoids the lossy collapse
+ *  for non-monotonic configs (e.g. only Club 300 enabled). */
+function effectiveStatus(perClub: PerClubYearSettings, tier: ClubTier): ClubStatus {
+  const club = TIER_TO_CLUB_KEY[tier];
+  if (perClub.memorize[club].enabled) return 'active';
+  if (perClub.review[club].enabled) return 'maintenance';
   return 'paused';
 }
 
@@ -142,23 +157,13 @@ const UNENROLLED_DEFAULTS: YearSettings = {
   reviewScope: 'off',
 };
 
-function readYearSettings(
-  db: DB,
-  userId: string,
-  materialId: string,
-  fallback: YearSettings,
-): YearSettings {
-  const row = db
-    .select()
-    .from(schema.userYearSettings)
-    .where(
-      and(
-        eq(schema.userYearSettings.userId, userId),
-        eq(schema.userYearSettings.materialId, materialId),
-      ),
-    )
-    .get();
-  if (!row) return fallback;
+type SettingsRow = typeof schema.userYearSettings.$inferSelect;
+
+/** Narrow a raw Drizzle row to the legacy `YearSettings` shape. The DB
+ *  schema declares scope/chapterListScope as plain `text` (not the
+ *  string-literal unions), so the cast is the boundary where we trust
+ *  the writer to have validated. */
+function rowToYearSettings(row: SettingsRow): YearSettings {
   return {
     headingCard: row.headingCard,
     headingPassageCard: row.headingPassageCard,
@@ -172,26 +177,12 @@ function readYearSettings(
   };
 }
 
-/** Build the per-club settings object the chain UI consumes. Mirrors
- *  `readMaterialConfigJson` in lib/engine.ts: prefer the stored
- *  `config_json` blob, fall back to synthesising from the legacy
- *  columns so the route, the engine, and the UI agree on what's on
- *  disk. The two readers are intentionally parallel — both swap to
- *  a shared parsed helper if we add a third consumer.
- *
- *  Reads `configJson` directly off the row but defers to the explicit
- *  `readYearSettings` extractor for the legacy-column path: the raw
- *  Drizzle row carries non-settings columns (`userId`, `materialId`,
- *  `updatedAt`, …) and the scope/retention columns aren't enum-narrowed
- *  to `TierScope`/`ChapterListScope` at the schema level, so passing
- *  the raw row to `legacyToNew` would trust un-narrowed strings. */
-function readPerClubSettings(
+function fetchSettingsRow(
   db: DB,
   userId: string,
   materialId: string,
-  legacyFallback: YearSettings,
-): PerClubYearSettings {
-  const row = db
+): SettingsRow | undefined {
+  return db
     .select()
     .from(schema.userYearSettings)
     .where(
@@ -201,10 +192,42 @@ function readPerClubSettings(
       ),
     )
     .get();
-  if (row?.configJson != null && row.configJson !== '') {
-    return JSON.parse(row.configJson) as PerClubYearSettings;
-  }
-  return legacyToNew(readYearSettings(db, userId, materialId, legacyFallback));
+}
+
+function readYearSettings(
+  db: DB,
+  userId: string,
+  materialId: string,
+  fallback: YearSettings,
+): YearSettings {
+  const row = fetchSettingsRow(db, userId, materialId);
+  return row ? rowToYearSettings(row) : fallback;
+}
+
+/** Build both the legacy `YearSettings` and the per-club shape from a
+ *  single DB read. The GET `/api/years` loop calls this once per
+ *  enrolled material — splitting the query into two helpers (the
+ *  pre-cleanup shape) doubled the SQLite queries on this endpoint,
+ *  which is hit on every navigation.
+ *
+ *  Per-club derivation mirrors `readMaterialConfigJson` in lib/engine.ts:
+ *  prefer the stored `config_json` blob, fall back to synthesising via
+ *  `legacyToNew(legacySettings)` when the column hasn't been populated
+ *  yet. The legacy path runs through `rowToYearSettings` so the scope
+ *  fields are narrowed to their enums before `legacyToNew` reads them. */
+function readSettingsBundle(
+  db: DB,
+  userId: string,
+  materialId: string,
+  fallback: YearSettings,
+): { legacy: YearSettings; perClub: PerClubYearSettings } {
+  const row = fetchSettingsRow(db, userId, materialId);
+  const legacy = row ? rowToYearSettings(row) : fallback;
+  const perClub =
+    row?.configJson != null && row.configJson !== ''
+      ? (JSON.parse(row.configJson) as PerClubYearSettings)
+      : legacyToNew(legacy);
+  return { legacy, perClub };
 }
 
 export function yearsRoutes(deps: YearsRoutesDeps) {
@@ -227,8 +250,12 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
     for (const material of MATERIALS) {
       const enrolled = enrolledIds.has(material.id);
       const fallback = enrolled ? ENROLLED_DEFAULTS : UNENROLLED_DEFAULTS;
-      const settings = readYearSettings(deps.db, user.id, material.id, fallback);
-      const perClub = readPerClubSettings(deps.db, user.id, material.id, fallback);
+      const { legacy: settings, perClub } = readSettingsBundle(
+        deps.db,
+        user.id,
+        material.id,
+        fallback,
+      );
 
       // Only load the engine for enrolled years — unenrolled ones have
       // no graph_snapshot yet. Card counts stay at zero until the user
@@ -253,15 +280,15 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
 
       const clubs: YearView['clubs'] = {
         '150': {
-          status: effectiveStatus(settings, '150'),
+          status: effectiveStatus(perClub, '150'),
           cardCount: counts.Club150 ?? 0,
         },
         '300': {
-          status: effectiveStatus(settings, '300'),
+          status: effectiveStatus(perClub, '300'),
           cardCount: counts.Club300 ?? 0,
         },
         full: {
-          status: effectiveStatus(settings, 'full'),
+          status: effectiveStatus(perClub, 'full'),
           cardCount: counts.Full ?? 0,
         },
       };

--- a/packages/api/src/routes/years.ts
+++ b/packages/api/src/routes/years.ts
@@ -16,6 +16,7 @@ import {
   ensureRetention,
   legacyToNew,
   looksLikePerClub,
+  type PerClubYearSettings,
   perClubToLegacy,
   TIER_SCOPES,
   type TierScope,
@@ -58,7 +59,16 @@ interface YearView {
    *  this year. Sourced from the `offline_mode` column on the
    *  `user_materials` row (false for unenrolled years). */
   offlineMode: boolean;
+  /** Legacy flat settings — kept on the response for clients that
+   *  haven't migrated to `perClub`. The engine reads `perClub`. */
   settings: YearSettings;
+  /** Phase 1+ per-club configuration. Mirrors what's stored in
+   *  `user_year_settings.config_json` (synthesised via `legacyToNew`
+   *  when the column hasn't been populated yet). Lossless: includes
+   *  `catchUp` and `moveToNext` choices that the legacy `settings`
+   *  field can't represent, so the chain UI in /settings/materials can
+   *  round-trip them without dropping the user's selections. */
+  perClub: PerClubYearSettings;
   clubs: Record<ClubTier, ClubView>;
   /** Count of cards still in `CardState::New` — drives the
    *  "N to memorize" nudge in the web nav. */
@@ -162,6 +172,34 @@ function readYearSettings(
   };
 }
 
+/** Build the per-club settings object the chain UI consumes. Mirrors
+ *  `readMaterialConfigJson` in lib/engine.ts: prefer the stored
+ *  `config_json` blob, fall back to synthesising from the legacy
+ *  columns so the route, the engine, and the UI agree on what's on
+ *  disk. The two readers are intentionally parallel — both swap to
+ *  a shared parsed helper if we add a third consumer. */
+function readPerClubSettings(
+  db: DB,
+  userId: string,
+  materialId: string,
+  legacyFallback: YearSettings,
+): PerClubYearSettings {
+  const row = db
+    .select()
+    .from(schema.userYearSettings)
+    .where(
+      and(
+        eq(schema.userYearSettings.userId, userId),
+        eq(schema.userYearSettings.materialId, materialId),
+      ),
+    )
+    .get();
+  if (row?.configJson != null && row.configJson !== '') {
+    return JSON.parse(row.configJson) as PerClubYearSettings;
+  }
+  return legacyToNew(row ? (row as YearSettings) : legacyFallback);
+}
+
 export function yearsRoutes(deps: YearsRoutesDeps) {
   const now = deps.now ?? (() => Math.floor(Date.now() / 1000));
   const app = new Hono<{ Variables: SessionVariables }>();
@@ -181,12 +219,9 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
     const out: YearView[] = [];
     for (const material of MATERIALS) {
       const enrolled = enrolledIds.has(material.id);
-      const settings = readYearSettings(
-        deps.db,
-        user.id,
-        material.id,
-        enrolled ? ENROLLED_DEFAULTS : UNENROLLED_DEFAULTS,
-      );
+      const fallback = enrolled ? ENROLLED_DEFAULTS : UNENROLLED_DEFAULTS;
+      const settings = readYearSettings(deps.db, user.id, material.id, fallback);
+      const perClub = readPerClubSettings(deps.db, user.id, material.id, fallback);
 
       // Only load the engine for enrolled years — unenrolled ones have
       // no graph_snapshot yet. Card counts stay at zero until the user
@@ -231,6 +266,7 @@ export function yearsRoutes(deps: YearsRoutesDeps) {
         enrolled,
         offlineMode: offlineModeByMaterial.get(material.id) ?? false,
         settings,
+        perClub,
         clubs,
         newCardCount,
       });


### PR DESCRIPTION
## Summary

Phase 2 of the schedules + per-club settings rework (spec: `docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md`). Builds on Phase 1 (#97) to land the user-facing UI for the new per-club model, plus a small additive API change so user-customised `catchUp` and `moveToNext` selections round-trip cleanly.

8 commits:

- `feat(web): switch to wasm 0.6.0 ctor + v2 memorize` — engine boot paths take the new `schedule` arg, drop `desired_retention`. `memorize_session_v2(limit, now_secs)` is the new fill entry point.
- `feat(web): per-club types + schedule API client` — new TS types (`Club`, `CatchUp`, `MoveToNextGate`, `PerClubYearSettings`, …) and `ApiClient` methods (`updateYearSettingsPerClub`, `getSchedule`, `putSchedule`, `deleteSchedule`).
- `feat(web): /settings 3-section IA` — Account / Preferences / Materials child routes under `/settings` with a left-rail (desktop) / horizontal-scroll (mobile) section nav. Materials is the default.
- `feat(web): /settings/account migrates #92` — moves Export my data, Import data, Delete all progress out of `ProfilePickerView`'s kebab into the new Account section. AppAvatar gains an "Account" deep-link. **Closes #92.**
- `feat(api): /api/years returns perClub` — exposes the parsed `PerClubYearSettings` alongside the legacy `settings` field. Bumps API to `0.1.29`.
- `feat(web): chain UI + per-club retention` — the Layout A chain UI for "What to memorize" (per-club Enable + Catch-up, indented dashed gate rows between flanking enabled clubs) and "What to review" (per-club Enable + retention slider 50–90%). The material-wide retention slider is gone.
- `feat(web): schedule-aware Memorize badge` — nav-bar Memorize pill now respects per-club enable flags + clamps by the schedule's `cumulative_through_current_week`. Math lives in `lib/badges.ts`.
- `chore(web): release 0.3.0` — apps/web release bump with the full Phase 2 CHANGELOG entry referencing the bundled contract crates.

State stays compatible with `0.2.0` — the IDB cache rebuilds against the new engine signature on first load.

## Test plan

- [ ] Open `/settings/account` from the AppAvatar's "Account" item; export downloads, import + delete-all-progress dialogs open and round-trip.
- [ ] `/profiles` kebab no longer shows Export/Import/Delete-all-progress; only Sign out + Delete profile remain.
- [ ] `/settings` left rail flips between Account / Preferences / Materials; Materials renders the existing year tabs.
- [ ] On `/settings/materials`, the per-club chain UI shows three cards with Enable checkboxes. Toggling Club 150 on alone shows no gate row; enabling Club 300 makes the 150→300 gate dashed row appear with the Move-to-next-club selector.
- [ ] Catch-up dropdown saves; reload shows the saved value (round-trip through `perClub`).
- [ ] Per-club retention sliders persist independently; the material-wide slider is gone.
- [ ] Memorize tab badge shows a lower count when memorize is disabled on every year; with a published schedule (3-corinthians-2025-26), badge caps at this week's cumulative verse count.
- [ ] `pnpm -F @verse-vault/api test` green; `pnpm -F @verse-vault/web exec vue-tsc --noEmit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)