### PR TITLE
feat: Phase 3 — schedule editor

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -9,6 +9,74 @@ Released via `.github/workflows/deploy-web.yml` (Cloudflare Pages, `verse-vault-
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-06-17
+
+Phase 3 — the schedule editor at `/schedule/<materialId>`. MINOR — additive UI surface on top of the
+Phase 1 schedule data model and API, no engine or wire-format change. Closes the Phase 2 spec
+deferral of the "Edit schedule →" link on the per-material card. Bundles tighter Meet validation on
+the API as part of the same train (also additive, doesn't bump the API contract).
+
+### Bundled algorithm contract
+
+* `verse-vault-core@0.6.0` — unchanged.
+* `verse-vault-wasm@0.6.0` — unchanged.
+
+### Schedule editor
+
+New `/schedule/:materialId` route mounted under the existing router. The editor:
+
+* Loads via `api.getSchedule`, holds two refs (`saved` and `draft` — a `structuredClone` of saved
+  that the user mutates), and a `mode: 'view' | 'edit'` switch.
+* Gates Save behind a `JSON.stringify` dirty-check; Discard reclones saved into draft and returns to
+  view mode.
+* Guards nav-away via both `onBeforeRouteLeave` (in-app) and `beforeunload` (tab close / refresh /
+  external nav) — the SPA router doesn't fire `beforeunload` on its own and `beforeunload` doesn't
+  fire on in-app nav, so both are needed.
+
+Left pane / top stack: a chronologically interleaved timeline of weeks and meets. Items sort by date
+with weeks ahead of meets on ties (practice precedes the weekend). Weeks show date, passage label,
+per-tier verse counts; meets show as italicized rows with a ⛺ tag and location.
+
+Right pane / bottom stack: detail editor for the selected item.
+
+* **Per-week editor.** Review-week toggle. Passage editor (book / chapter / start verse / end
+  verse). Per-tier verse-number inputs — comma- or space-separated text, parsed on blur via
+  `parseVerseList`, normalized (sorted) on commit. Invalid tokens surface an inline error and leave
+  the draft untouched. Remove-this-week button. Add-a-week affordance below the timeline; new weeks
+  default to the practice cycle (7 days) after the last existing week.
+* **Per-meet editor.** Name, start/end dates, location. Inline endDate-before-startDate hint (soft
+  warning; server-side `validateSchedule` is the hard gate on save). Add-a-meet affordance next to
+  add-a-week; new meets get a `slugifyMeetId`-derived stable id so the chain UI's `move_to_next`
+  gates referencing the meet survive renames.
+
+Top-level controls.
+
+* **Meeting-day picker** (edit mode only). Bound to `meetingDayOfWeek`; changes run
+  `applyMeetingDayShift` from `lib/schedule.ts` to translate every week's date by the signed delta.
+  Meets stay on their own dates per the no-per-week-override design.
+* **Reset to default** (view mode only, in the header). `ConfirmDialog`-gated; on confirm fires
+  `DELETE /api/materials/:id/schedule`, banner reflects the response's `fallbackToBundled` flag.
+
+`/settings/materials` gets the "Edit schedule →" RouterLink the Phase 2 spec deferred, rendered next
+to the title for every material so it's discoverable without scrolling past the chain UI. The
+editor's empty-state path keeps schedule-less decks from dead-ending.
+
+### Library helpers + canonical types
+
+New `apps/web/src/lib/schedule.ts` is the source of truth for the editor:
+
+* Canonical TS types (`Schedule`, `ScheduleWeek`, `ScheduleMeet`, `SchedulePassage`, `DayOfWeek`)
+  mirroring the on-disk JSON and the API's `SchedulePayload`. `api.ts` re-exports `Schedule` and now
+  types `getSchedule`/`putSchedule` against the parsed shape.
+* Pure data-mutating helpers — `applyMeetingDayShift`, `addWeekAt`, `removeWeekAt`, `addMeet`,
+  `updateMeet`, `removeMeet`, `slugifyMeetId`, `cloneSchedule`. Used by the editor for every draft
+  mutation.
+* Display + arithmetic primitives — `shiftDate`, `formatPassage`, `verseCountsForWeek`,
+  `parseVerseList`, `formatVerseList`.
+
+`lib/badges.ts` drops its inline `Schedule`/`ScheduleWeek` interfaces and imports the canonical pair
+— a drift risk surfaced in the Phase 2 simplify pass.
+
 ## [0.3.0] — 2026-06-15
 
 Phase 2 of the schedules + per-club settings rework. MINOR — the engine boot paths swap onto the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verse-vault/web",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -10,6 +10,9 @@ import type {
   SyncEventsResponse,
   SyncStateResponse,
 } from './lib/engine/types'
+import type { Schedule } from './lib/schedule'
+
+export type { Schedule } from './lib/schedule'
 
 export type Grade = 1 | 2 | 3 | 4
 
@@ -348,11 +351,15 @@ export interface ApiClient {
   /** GET /api/materials/:materialId/schedule — returns the user's
    *  customised schedule if present, else the bundled default, else
    *  `null` when no schedule ships for the material (memorize then
-   *  collapses to pure-Sequential on the engine side). */
-  getSchedule(materialId: string): Promise<unknown | null>
+   *  collapses to pure-Sequential on the engine side). Result is
+   *  typed as the parsed `Schedule` shape; callers in hot paths (the
+   *  Memorize-tab badge math) treat it as a structural `unknown` so a
+   *  shape mismatch from a future server change degrades gracefully
+   *  instead of throwing at the boundary. */
+  getSchedule(materialId: string): Promise<Schedule | null>
   /** PUT /api/materials/:materialId/schedule — upserts the user's copy.
    *  Server validates the body's shape AND cross-checks `materialId`. */
-  putSchedule(materialId: string, schedule: unknown): Promise<{ ok: true }>
+  putSchedule(materialId: string, schedule: Schedule): Promise<{ ok: true }>
   /** DELETE /api/materials/:materialId/schedule — drops the user's
    *  override; bundled default reapplies on next read. */
   deleteSchedule(materialId: string): Promise<{ ok: true; fallbackToBundled: boolean }>

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -449,7 +449,20 @@ export function createApiClient(apiUrl: string): ApiClient {
       ) {
         return null
       }
-      return body
+      // The API's SchedulePayload types `meets` as optional and weeks
+      // are present-but-passed-verbatim. The web's Schedule shape
+      // declares `meets: ScheduleMeet[]` and `weeks: ScheduleWeek[]`
+      // as required arrays — the editor iterates and reads `.length`
+      // off both unconditionally. Bundled JSONs older than Phase 3
+      // (or future ones written without a `meets` block) would crash
+      // the editor on `undefined.forEach`. Backfill the arrays here
+      // so the type assertion at the boundary holds.
+      if (body !== null && typeof body === 'object') {
+        const obj = body as Record<string, unknown>
+        if (!Array.isArray(obj.meets)) obj.meets = []
+        if (!Array.isArray(obj.weeks)) obj.weeks = []
+      }
+      return body as Schedule | null
     },
     putSchedule: (materialId, schedule) =>
       request('PUT', `/api/materials/${encodeURIComponent(materialId)}/schedule`, schedule),

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -35,6 +35,7 @@
  */
 
 import type { Club, YearView } from '@/api'
+import type { Schedule, ScheduleWeek } from '@/lib/schedule'
 
 const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
 
@@ -54,16 +55,6 @@ const scheduleCache = new Map<string, Promise<unknown | null>>()
 export function invalidateScheduleCache(materialId?: string): void {
   if (materialId === undefined) scheduleCache.clear()
   else scheduleCache.delete(materialId)
-}
-
-interface ScheduleWeek {
-  date: string
-  verses: Partial<Record<Club, number[]>> | null
-  isReview?: boolean
-}
-
-interface Schedule {
-  weeks: ScheduleWeek[]
 }
 
 /** Return the index of the latest week whose date is on or before

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -42,14 +42,21 @@ const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
 /** Module-level cache for the schedule fetches `memorizeBadgeCount`
  *  fires on every navigation. Schedules are essentially static within
  *  a tab session — they only change via PUT/DELETE
- *  `/api/materials/:id/schedule` (Phase 3 UI; not yet wired). Without
- *  this cache, every nav re-fetches one schedule per enrolled year,
- *  multiplying the per-route badge cost N+1 times.
+ *  `/api/materials/:id/schedule` (the Phase 3 editor invalidates here
+ *  after each write). Without this cache, every nav re-fetches one
+ *  schedule per enrolled year, multiplying the per-route badge cost
+ *  N+1 times.
  *
  *  Caches the in-flight promise so concurrent calls (e.g. two
  *  fast back-to-back nav events) share one round-trip rather than
- *  racing two. Exported so future schedule-write paths can invalidate
- *  it explicitly when the editor lands. */
+ *  racing two. Exported so callers can invalidate per-material on
+ *  schedule writes.
+ *
+ *  TODO(#100): the cache is keyed by `materialId` only, so a profile
+ *  switch leaks the prior profile's schedule into the new profile's
+ *  badge count for the same material. Fix: clear on profile switch
+ *  inside `useAuth`, or rekey by (userId, materialId). Out of scope
+ *  for the Phase 3 PR — see github.com/TommyAmberson/verse-vault/issues/100. */
 const scheduleCache = new Map<string, Promise<unknown | null>>()
 
 export function invalidateScheduleCache(materialId?: string): void {

--- a/apps/web/src/lib/schedule.ts
+++ b/apps/web/src/lib/schedule.ts
@@ -1,0 +1,218 @@
+/**
+ * Schedule data model + pure manipulation helpers for the schedule
+ * editor at /schedule/<materialId>. Mirrors the on-disk JSON shape
+ * (`data/schedules/<deck>-<season>.json`) and the server-side
+ * `SchedulePayload` in `packages/api/src/lib/schedules.ts`. Everything
+ * here is data-only — no Vue, no network — so the view can hold a
+ * draft, mutate it through these helpers, then PUT it verbatim.
+ *
+ * Day-of-week shift semantics: per the Phase 3 design, the user picks
+ * the weekly practice day and all weeks move by the signed delta from
+ * the old day to the new day. There are no per-week date overrides —
+ * `meetingDayOfWeek` plus the relative spacing between weeks fully
+ * determines week dates. Meets keep their own dates (often weekend
+ * dates that don't align with the practice day) and are unaffected by
+ * the shift.
+ */
+
+export const DAYS_OF_WEEK = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+export type DayOfWeek = (typeof DAYS_OF_WEEK)[number]
+
+export interface SchedulePassage {
+  book: string
+  chapter: number
+  startVerse: number
+  endVerse: number
+}
+
+export interface ScheduleVerses {
+  club150?: number[]
+  club300?: number[]
+}
+
+export interface ScheduleWeek {
+  /** ISO `YYYY-MM-DD`. Falls on `meetingDayOfWeek` by construction;
+   *  changing the schedule's meeting day shifts all week dates by
+   *  the signed delta. */
+  date: string
+  /** Null on Review weeks. */
+  passage: SchedulePassage | null
+  /** Per-tier verse arrays for memorize Phase 1's "this week's primary"
+   *  pull. Null on Review weeks. */
+  verses: ScheduleVerses | null
+  isReview: boolean
+}
+
+export interface ScheduleMeet {
+  id: string
+  name: string
+  startDate: string
+  endDate: string
+  location: string
+}
+
+export interface Schedule {
+  version: 1
+  materialId: string
+  season: string
+  title: string
+  meetingDayOfWeek: DayOfWeek
+  weeks: ScheduleWeek[]
+  meets: ScheduleMeet[]
+}
+
+// =============================================================================
+// Date helpers
+// =============================================================================
+
+const MS_PER_DAY = 86_400_000
+
+/** Parse `YYYY-MM-DD` into a UTC-anchored Date so the arithmetic
+ *  stays timezone-free. */
+function parseIsoDate(s: string): Date {
+  return new Date(`${s}T00:00:00Z`)
+}
+
+/** Format a UTC Date back to `YYYY-MM-DD`. */
+function formatIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+function dayOfWeekIndex(day: DayOfWeek): number {
+  return DAYS_OF_WEEK.indexOf(day)
+}
+
+/** Shift an ISO date string by `deltaDays` (signed). */
+export function shiftDate(iso: string, deltaDays: number): string {
+  const d = parseIsoDate(iso)
+  d.setUTCDate(d.getUTCDate() + deltaDays)
+  return formatIsoDate(d)
+}
+
+// =============================================================================
+// Schedule helpers (pure)
+// =============================================================================
+
+/** Deep-clone a schedule. Pure data shape so structuredClone is sound. */
+export function cloneSchedule(s: Schedule): Schedule {
+  return structuredClone(s)
+}
+
+/** Shift every week's date by the delta from the schedule's current
+ *  meeting day to `newDay`, and update `meetingDayOfWeek` itself.
+ *  Returns a new schedule; doesn't mutate the input. Meets are left
+ *  alone — they have their own dates independent of the practice day. */
+export function applyMeetingDayShift(s: Schedule, newDay: DayOfWeek): Schedule {
+  const deltaDays = dayOfWeekIndex(newDay) - dayOfWeekIndex(s.meetingDayOfWeek)
+  if (deltaDays === 0) return cloneSchedule(s)
+  const next = cloneSchedule(s)
+  next.meetingDayOfWeek = newDay
+  for (const w of next.weeks) {
+    w.date = shiftDate(w.date, deltaDays)
+  }
+  return next
+}
+
+/** Insert a new week at `index`. The caller picks the date + passage;
+ *  this helper just slots the row in. */
+export function addWeekAt(s: Schedule, index: number, week: ScheduleWeek): Schedule {
+  const next = cloneSchedule(s)
+  const clamped = Math.max(0, Math.min(next.weeks.length, index))
+  next.weeks.splice(clamped, 0, structuredClone(week))
+  return next
+}
+
+export function removeWeekAt(s: Schedule, index: number): Schedule {
+  if (index < 0 || index >= s.weeks.length) return cloneSchedule(s)
+  const next = cloneSchedule(s)
+  next.weeks.splice(index, 1)
+  return next
+}
+
+/** Build a stable, URL-safe meet id from a name. Used when the user
+ *  creates a meet — the chain UI's "after major checkpoint" gate
+ *  references meets by id, so we want deterministic ids that survive
+ *  small typos in the name. */
+export function slugifyMeetId(name: string, existing: readonly string[]): string {
+  const base = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  let candidate = base || 'meet'
+  let suffix = 2
+  const seen = new Set(existing)
+  while (seen.has(candidate)) {
+    candidate = `${base}-${suffix}`
+    suffix += 1
+  }
+  return candidate
+}
+
+export function addMeet(s: Schedule, meet: ScheduleMeet): Schedule {
+  const next = cloneSchedule(s)
+  next.meets.push(structuredClone(meet))
+  return next
+}
+
+export function updateMeet(s: Schedule, id: string, patch: ScheduleMeet): Schedule {
+  const next = cloneSchedule(s)
+  const i = next.meets.findIndex((m) => m.id === id)
+  if (i < 0) return next
+  next.meets[i] = structuredClone(patch)
+  return next
+}
+
+export function removeMeet(s: Schedule, id: string): Schedule {
+  const next = cloneSchedule(s)
+  next.meets = next.meets.filter((m) => m.id !== id)
+  return next
+}
+
+// =============================================================================
+// Display helpers
+// =============================================================================
+
+/** Pretty passage label, e.g. "1 Corinthians 5:1-13". Returns "Review"
+ *  for review weeks (passage === null). */
+export function formatPassage(passage: SchedulePassage | null): string {
+  if (passage === null) return 'Review'
+  const { book, chapter, startVerse, endVerse } = passage
+  if (startVerse === endVerse) return `${book} ${chapter}:${startVerse}`
+  return `${book} ${chapter}:${startVerse}-${endVerse}`
+}
+
+/** Count verses across enabled tiers for a single week. Used by the
+ *  timeline pane to show a `5 / 5` summary per week. */
+export function verseCountsForWeek(week: ScheduleWeek): { club150: number; club300: number } {
+  return {
+    club150: week.verses?.club150?.length ?? 0,
+    club300: week.verses?.club300?.length ?? 0,
+  }
+}
+
+// =============================================================================
+// Verse-list parsing (comma-text editor input → number[])
+// =============================================================================
+
+/** Parse a comma- or space-separated verse list string into an array of
+ *  positive integers, dropping invalid tokens. Used by the per-week
+ *  editor when the user blurs a text input. Returns null when the input
+ *  is non-empty but contains no valid tokens, so the caller can decide
+ *  whether to keep the old value or accept the empty list. */
+export function parseVerseList(input: string): number[] | null {
+  const tokens = input.split(/[\s,]+/).filter((t) => t.length > 0)
+  if (tokens.length === 0) return []
+  const out: number[] = []
+  for (const t of tokens) {
+    const n = Number(t)
+    if (!Number.isInteger(n) || n <= 0) return null
+    out.push(n)
+  }
+  return out.sort((a, b) => a - b)
+}
+
+/** Format a verse list back to the text the editor displays. */
+export function formatVerseList(verses: readonly number[] | undefined): string {
+  return verses ? verses.join(', ') : ''
+}

--- a/apps/web/src/lib/schedule.ts
+++ b/apps/web/src/lib/schedule.ts
@@ -106,12 +106,21 @@ export function cloneSchedule(s: Schedule): Schedule {
   return structuredClone(s)
 }
 
-/** Shift every week's date by the delta from the schedule's current
- *  meeting day to `newDay`, and update `meetingDayOfWeek` itself.
- *  Returns a new schedule; doesn't mutate the input. Meets are left
- *  alone — they have their own dates independent of the practice day. */
+/** Shift every week's date by the shortest-path delta from the
+ *  schedule's current meeting day to `newDay`, and update
+ *  `meetingDayOfWeek` itself. Returns a new schedule; doesn't mutate
+ *  the input. Meets are left alone — they have their own dates
+ *  independent of the practice day.
+ *
+ *  The shortest-path delta wraps `[-3, +3]` so that crossings of the
+ *  Sun/Sat boundary take the short way around: Sat→Sun is +1 (not
+ *  -6), Sun→Sat is -1 (not +6). A user picking the adjacent day
+ *  expects each week to nudge by one day, never to lurch the long
+ *  way around the week. */
 export function applyMeetingDayShift(s: Schedule, newDay: DayOfWeek): Schedule {
-  const deltaDays = dayOfWeekIndex(newDay) - dayOfWeekIndex(s.meetingDayOfWeek)
+  let deltaDays
+    = (dayOfWeekIndex(newDay) - dayOfWeekIndex(s.meetingDayOfWeek) + 7) % 7
+  if (deltaDays > 3) deltaDays -= 7
   if (deltaDays === 0) return cloneSchedule(s)
   const next = cloneSchedule(s)
   next.meetingDayOfWeek = newDay
@@ -145,15 +154,16 @@ export function removeWeekAt(s: Schedule, index: number): Schedule {
  *  references meets by id, so we want deterministic ids that survive
  *  small typos in the name. */
 export function slugifyMeetId(name: string, existing: readonly string[]): string {
-  const base = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-  let candidate = base || 'meet'
+  const stem
+    = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'meet'
+  let candidate = stem
   let suffix = 2
   const seen = new Set(existing)
   while (seen.has(candidate)) {
-    candidate = `${base}-${suffix}`
+    candidate = `${stem}-${suffix}`
     suffix += 1
   }
   return candidate

--- a/apps/web/src/lib/schedule.ts
+++ b/apps/web/src/lib/schedule.ts
@@ -34,7 +34,16 @@ export interface ScheduleVerses {
 export interface ScheduleWeek {
   /** ISO `YYYY-MM-DD`. Falls on `meetingDayOfWeek` by construction;
    *  changing the schedule's meeting day shifts all week dates by
-   *  the signed delta. */
+   *  the signed delta.
+   *
+   *  TODO(schedule-shape-bump): this is a stored invariant —
+   *  `applyMeetingDayShift` has to rewrite every week's `date` each
+   *  time the meeting day changes, and the on-disk JSONs carry
+   *  redundant information (every week's date is derivable from
+   *  schedule.weeks[0].date + index * 7). The cleaner shape is a
+   *  single `startDate` on `Schedule` with per-week dates derived.
+   *  Deferred — touches the on-disk schedules, the API validator's
+   *  per-week loop, and the WASM `parse_schedule` deserialiser. */
   date: string
   /** Null on Review weeks. */
   passage: SchedulePassage | null
@@ -65,8 +74,6 @@ export interface Schedule {
 // =============================================================================
 // Date helpers
 // =============================================================================
-
-const MS_PER_DAY = 86_400_000
 
 /** Parse `YYYY-MM-DD` into a UTC-anchored Date so the arithmetic
  *  stays timezone-free. */
@@ -115,11 +122,14 @@ export function applyMeetingDayShift(s: Schedule, newDay: DayOfWeek): Schedule {
 }
 
 /** Insert a new week at `index`. The caller picks the date + passage;
- *  this helper just slots the row in. */
+ *  this helper just slots the row in. The incoming `week` is trusted
+ *  to be caller-owned (every call site builds it as a fresh literal),
+ *  so we skip the per-argument clone — `cloneSchedule` above already
+ *  produced an owned copy of the destination. */
 export function addWeekAt(s: Schedule, index: number, week: ScheduleWeek): Schedule {
   const next = cloneSchedule(s)
   const clamped = Math.max(0, Math.min(next.weeks.length, index))
-  next.weeks.splice(clamped, 0, structuredClone(week))
+  next.weeks.splice(clamped, 0, week)
   return next
 }
 
@@ -151,7 +161,7 @@ export function slugifyMeetId(name: string, existing: readonly string[]): string
 
 export function addMeet(s: Schedule, meet: ScheduleMeet): Schedule {
   const next = cloneSchedule(s)
-  next.meets.push(structuredClone(meet))
+  next.meets.push(meet)
   return next
 }
 
@@ -159,7 +169,7 @@ export function updateMeet(s: Schedule, id: string, patch: ScheduleMeet): Schedu
   const next = cloneSchedule(s)
   const i = next.meets.findIndex((m) => m.id === id)
   if (i < 0) return next
-  next.meets[i] = structuredClone(patch)
+  next.meets[i] = patch
   return next
 }
 

--- a/apps/web/src/lib/schedule.ts
+++ b/apps/web/src/lib/schedule.ts
@@ -106,21 +106,21 @@ export function cloneSchedule(s: Schedule): Schedule {
   return structuredClone(s)
 }
 
-/** Shift every week's date by the shortest-path delta from the
- *  schedule's current meeting day to `newDay`, and update
- *  `meetingDayOfWeek` itself. Returns a new schedule; doesn't mutate
+/** Shift every week's date to land on `newDay` within the same
+ *  calendar week (Sun-Sat). Returns a new schedule; doesn't mutate
  *  the input. Meets are left alone — they have their own dates
  *  independent of the practice day.
  *
- *  The shortest-path delta wraps `[-3, +3]` so that crossings of the
- *  Sun/Sat boundary take the short way around: Sat→Sun is +1 (not
- *  -6), Sun→Sat is -1 (not +6). A user picking the adjacent day
- *  expects each week to nudge by one day, never to lurch the long
- *  way around the week. */
+ *  The week is the contiguous Sun-Sat block containing the current
+ *  date. The new date is `weekStartSunday + newDayIndex`, which is
+ *  equivalent to `oldDate + (newDayIndex - oldDayIndex)` when every
+ *  week already falls on `meetingDayOfWeek` (the schedule's
+ *  invariant). So Mon→Fri is +4 (Friday of the same week), Sat→Sun
+ *  is -6 (Sunday that starts the same week containing that
+ *  Saturday), Sun→Sat is +6. Never wraps to an adjacent calendar
+ *  week. */
 export function applyMeetingDayShift(s: Schedule, newDay: DayOfWeek): Schedule {
-  let deltaDays
-    = (dayOfWeekIndex(newDay) - dayOfWeekIndex(s.meetingDayOfWeek) + 7) % 7
-  if (deltaDays > 3) deltaDays -= 7
+  const deltaDays = dayOfWeekIndex(newDay) - dayOfWeekIndex(s.meetingDayOfWeek)
   if (deltaDays === 0) return cloneSchedule(s)
   const next = cloneSchedule(s)
   next.meetingDayOfWeek = newDay

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -56,6 +56,11 @@ const router = createRouter({
       component: () => import('@/views/StatsView.vue'),
     },
     {
+      path: '/schedule/:materialId',
+      name: 'schedule',
+      component: () => import('@/views/ScheduleEditorView.vue'),
+    },
+    {
       path: '/settings',
       component: () => import('@/views/SettingsView.vue'),
       children: [

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -5,7 +5,11 @@ import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 import { api } from '@/api'
 import {
   type Schedule,
+  type ScheduleMeet,
+  type ScheduleWeek,
   cloneSchedule,
+  formatPassage,
+  verseCountsForWeek,
 } from '@/lib/schedule'
 
 type Mode = 'view' | 'edit'
@@ -29,6 +33,86 @@ const error = ref<string | null>(null)
 const display = computed<Schedule | null>(() =>
   mode.value === 'edit' ? draft.value : saved.value,
 )
+
+/** Timeline selection. Tracks the WEEK INDEX (into display.weeks) or
+ *  the MEET ID — never both at once. Stays null on first render so the
+ *  detail pane shows a "pick something" hint instead of a stale
+ *  selection from the prior route visit. */
+type Selection =
+  | { kind: 'week'; weekIdx: number }
+  | { kind: 'meet'; meetId: string }
+  | null
+
+const selection = ref<Selection>(null)
+
+interface TimelineItem {
+  kind: 'week' | 'meet'
+  /** Primary sort key — week.date or meet.startDate. */
+  sortKey: string
+  /** Original index into display.weeks; only meaningful when kind === 'week'. */
+  weekIdx: number
+  week?: ScheduleWeek
+  meet?: ScheduleMeet
+}
+
+/** Single chronological list of weeks + meets for the left pane. Meets
+ *  sort after a week on the same date (the practice happens first,
+ *  the meet weekend lands during/after). Within meets on the same
+ *  startDate, the array order wins. */
+const timeline = computed<TimelineItem[]>(() => {
+  const s = display.value
+  if (s === null) return []
+  const items: TimelineItem[] = []
+  s.weeks.forEach((week, weekIdx) => {
+    items.push({ kind: 'week', sortKey: week.date, weekIdx, week })
+  })
+  s.meets.forEach((meet) => {
+    // weekIdx is unused for meet items; -1 makes that explicit.
+    items.push({ kind: 'meet', sortKey: meet.startDate, weekIdx: -1, meet })
+  })
+  return items.sort((a, b) => {
+    if (a.sortKey !== b.sortKey) return a.sortKey.localeCompare(b.sortKey)
+    // Same date: weeks before meets.
+    if (a.kind !== b.kind) return a.kind === 'week' ? -1 : 1
+    return 0
+  })
+})
+
+function selectWeek(weekIdx: number) {
+  selection.value = { kind: 'week', weekIdx }
+}
+
+function selectMeet(meetId: string) {
+  selection.value = { kind: 'meet', meetId }
+}
+
+/** Long-form weekday + month-day label for the timeline. ISO `YYYY-MM-DD`
+ *  parses to a Date at UTC midnight; reading the UTC weekday avoids the
+ *  user's timezone shifting the label by a day. */
+function formatTimelineDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00Z`)
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+function formatMeetDateRange(meet: ScheduleMeet): string {
+  if (meet.startDate === meet.endDate) return formatTimelineDate(meet.startDate)
+  return `${formatTimelineDate(meet.startDate)} – ${formatTimelineDate(meet.endDate)}`
+}
+
+const selectedWeek = computed<ScheduleWeek | null>(() => {
+  if (selection.value?.kind !== 'week') return null
+  return display.value?.weeks[selection.value.weekIdx] ?? null
+})
+
+const selectedMeet = computed<ScheduleMeet | null>(() => {
+  if (selection.value?.kind !== 'meet') return null
+  return display.value?.meets.find((m) => m.id === selection.value!.meetId) ?? null
+})
 
 /** Dirty iff the user has actually edited the draft. JSON.stringify
  *  is sound because both objects originate from the same construction
@@ -190,21 +274,80 @@ function backToSettings() {
         </div>
       </header>
 
-      <!-- Body panes land in commits 4 — 7. The shell + draft state +
-           nav-away guard are intentionally in place first so the
-           interactive surface can be built incrementally without
-           re-architecting the host every commit. -->
       <section class="editor-body">
-        <div class="placeholder">
-          <p>
-            Schedule editor panes (timeline, week detail, meets, meeting-day
-            picker) land in subsequent commits.
+        <nav class="timeline" aria-label="Schedule timeline">
+          <ol>
+            <li
+              v-for="(item, i) in timeline"
+              :key="`${item.kind}-${item.kind === 'week' ? item.weekIdx : item.meet?.id}-${i}`"
+              :class="[
+                `timeline-item timeline-${item.kind}`,
+                {
+                  'is-selected':
+                    (item.kind === 'week'
+                      && selection?.kind === 'week'
+                      && selection.weekIdx === item.weekIdx)
+                    || (item.kind === 'meet'
+                      && selection?.kind === 'meet'
+                      && selection.meetId === item.meet?.id),
+                },
+              ]"
+            >
+              <button
+                v-if="item.kind === 'week' && item.week"
+                type="button"
+                class="timeline-button"
+                @click="selectWeek(item.weekIdx)"
+              >
+                <span class="row-date">{{ formatTimelineDate(item.week.date) }}</span>
+                <span class="row-body">
+                  <span class="row-title">{{ formatPassage(item.week.passage) }}</span>
+                  <span v-if="!item.week.isReview" class="row-meta">
+                    {{ verseCountsForWeek(item.week).club150 }} / {{ verseCountsForWeek(item.week).club300 }}
+                  </span>
+                  <span v-else class="row-meta">Review week</span>
+                </span>
+              </button>
+              <button
+                v-else-if="item.kind === 'meet' && item.meet"
+                type="button"
+                class="timeline-button meet"
+                @click="selectMeet(item.meet.id)"
+              >
+                <span class="row-date">{{ formatMeetDateRange(item.meet) }}</span>
+                <span class="row-body">
+                  <span class="row-title">⛺ {{ item.meet.name }}</span>
+                  <span v-if="item.meet.location" class="row-meta">{{ item.meet.location }}</span>
+                </span>
+              </button>
+            </li>
+          </ol>
+        </nav>
+
+        <!-- Detail pane lands in commits 5 (week) and 6 (meet). For now
+             this is a read-only display of whatever the user selected so
+             the timeline is useful even before the editors arrive. -->
+        <section class="detail" aria-label="Selected item">
+          <p v-if="selection === null" class="placeholder">
+            Pick a week or meet from the timeline.
           </p>
-          <p class="meta">
-            Mode: <strong>{{ mode }}</strong>
-            · Dirty: <strong>{{ isDirty ? 'yes' : 'no' }}</strong>
-          </p>
-        </div>
+          <div v-else-if="selectedWeek" class="detail-week">
+            <h3>{{ formatPassage(selectedWeek.passage) }}</h3>
+            <p class="detail-date">{{ formatTimelineDate(selectedWeek.date) }}</p>
+            <dl v-if="!selectedWeek.isReview">
+              <dt>Club 150</dt>
+              <dd>{{ (selectedWeek.verses?.club150 ?? []).join(', ') || '—' }}</dd>
+              <dt>Club 300</dt>
+              <dd>{{ (selectedWeek.verses?.club300 ?? []).join(', ') || '—' }}</dd>
+            </dl>
+            <p v-else class="detail-review">Review week — no new verses.</p>
+          </div>
+          <div v-else-if="selectedMeet" class="detail-meet">
+            <h3>⛺ {{ selectedMeet.name }}</h3>
+            <p class="detail-date">{{ formatMeetDateRange(selectedMeet) }}</p>
+            <p v-if="selectedMeet.location" class="detail-location">{{ selectedMeet.location }}</p>
+          </div>
+        </section>
       </section>
     </template>
   </div>
@@ -336,22 +479,155 @@ button.secondary:hover:not(:disabled) {
 }
 
 .editor-body {
+  display: grid;
+  grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border);
   border-radius: 8px;
-  padding: 1.25rem 1.5rem;
-  min-height: 12rem;
+  padding: 1rem;
+  min-height: 18rem;
+}
+
+@media (max-width: 720px) {
+  .editor-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+.timeline {
+  max-height: 60vh;
+  overflow-y: auto;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+}
+
+.timeline ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.timeline-item {
+  border-bottom: 1px solid var(--color-border);
+}
+
+.timeline-item:last-child {
+  border-bottom: none;
+}
+
+.timeline-item.is-selected {
+  background: var(--color-accent-soft);
+}
+
+.timeline-button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: minmax(7rem, auto) 1fr;
+  gap: 0.7rem;
+  align-items: center;
+  background: none;
+  border: none;
+  padding: 0.5rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  text-align: left;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.timeline-button:hover {
+  background: var(--color-accent-soft);
+}
+
+.timeline-button.meet {
+  background: var(--color-bg-card);
+  font-style: italic;
+}
+
+.timeline-button.meet:hover {
+  background: var(--color-accent-soft);
+}
+
+.row-date {
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.row-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.row-title {
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row-meta {
+  color: var(--color-muted);
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.detail {
+  padding: 0.5rem 0.5rem 1rem;
+}
+
+.detail h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.detail-date {
+  margin: 0 0 1rem;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.detail-location {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.85rem;
+}
+
+.detail-review {
+  margin: 0;
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+.detail dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.4rem 1rem;
+  font-size: 0.9rem;
+}
+
+.detail dt {
+  color: var(--color-muted);
+  font-weight: 500;
+}
+
+.detail dd {
+  margin: 0;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
 }
 
 .placeholder {
+  margin: 0;
+  padding: 2rem 1rem;
   color: var(--color-muted);
-  font-size: 0.9rem;
+  font-style: italic;
   text-align: center;
-}
-
-.placeholder .meta {
-  margin-top: 1rem;
-  font-family: monospace;
-  font-size: 0.8rem;
 }
 </style>

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -4,6 +4,7 @@ import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 
 import { api } from '@/api'
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import { invalidateScheduleCache } from '@/lib/badges'
 import {
   DAYS_OF_WEEK,
   type DayOfWeek,
@@ -107,6 +108,19 @@ function selectWeek(weekIdx: number) {
 
 function selectMeet(meetId: string) {
   selection.value = { kind: 'meet', meetId }
+}
+
+/** Single predicate that drives both the .is-selected class (visual
+ *  highlight) and the button's aria-current (assistive-tech signal).
+ *  Without it the template carried two parallel boolean expressions
+ *  that could drift; one helper keeps them in sync. */
+function isItemSelected(item: TimelineItem): boolean {
+  const sel = selection.value
+  if (sel === null) return false
+  if (item.kind === 'week') {
+    return sel.kind === 'week' && sel.weekIdx === item.weekIdx
+  }
+  return sel.kind === 'meet' && sel.meetId === item.meet?.id
 }
 
 /** Long-form weekday + month-day label for the timeline. ISO `YYYY-MM-DD`
@@ -358,6 +372,11 @@ async function confirmReset() {
   resetState.value = { kind: 'busy' }
   try {
     const { fallbackToBundled } = await api.deleteSchedule(materialId.value)
+    // The Memorize-tab badge memoizes the per-material schedule for
+    // the tab session; without explicit invalidation, navigating to
+    // /memorize after a reset would keep computing the badge against
+    // the user's (now-deleted) override. Same invariant on save below.
+    invalidateScheduleCache(materialId.value)
     const banner = fallbackToBundled
       ? 'Reset complete — bundled schedule reapplied.'
       : 'No user customization existed; nothing to reset.'
@@ -417,6 +436,7 @@ async function save() {
   error.value = null
   try {
     await api.putSchedule(materialId.value, draft.value)
+    invalidateScheduleCache(materialId.value)
     saved.value = cloneSchedule(draft.value)
     mode.value = 'view'
   } catch (err) {
@@ -565,21 +585,14 @@ function backToSettings() {
               :key="`${item.kind}-${item.kind === 'week' ? item.weekIdx : item.meet?.id}-${i}`"
               :class="[
                 `timeline-item timeline-${item.kind}`,
-                {
-                  'is-selected':
-                    (item.kind === 'week'
-                      && selection?.kind === 'week'
-                      && selection.weekIdx === item.weekIdx)
-                    || (item.kind === 'meet'
-                      && selection?.kind === 'meet'
-                      && selection.meetId === item.meet?.id),
-                },
+                { 'is-selected': isItemSelected(item) },
               ]"
             >
               <button
                 v-if="item.kind === 'week' && item.week"
                 type="button"
                 class="timeline-button"
+                :aria-current="isItemSelected(item) ? 'true' : undefined"
                 @click="selectWeek(item.weekIdx)"
               >
                 <span class="row-date">{{ formatTimelineDate(item.week.date) }}</span>
@@ -595,6 +608,7 @@ function backToSettings() {
                 v-else-if="item.kind === 'meet' && item.meet"
                 type="button"
                 class="timeline-button meet"
+                :aria-current="isItemSelected(item) ? 'true' : undefined"
                 @click="selectMeet(item.meet.id)"
               >
                 <span class="row-date">{{ formatMeetDateRange(item.meet) }}</span>

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -3,12 +3,16 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 
 import { api } from '@/api'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import {
+  DAYS_OF_WEEK,
+  type DayOfWeek,
   type Schedule,
   type ScheduleMeet,
   type ScheduleWeek,
   addMeet,
   addWeekAt,
+  applyMeetingDayShift,
   cloneSchedule,
   formatPassage,
   formatVerseList,
@@ -310,6 +314,48 @@ watch(
   },
 )
 
+// =============================================================================
+// Day-of-week shift + reset
+// =============================================================================
+
+const pendingReset = ref(false)
+const resetBusy = ref(false)
+const resetBanner = ref<string | null>(null)
+
+function onMeetingDayChange(newDay: DayOfWeek) {
+  if (draft.value === null) return
+  // Pure helper returns a new schedule with every week's date shifted
+  // by the signed (newDow - oldDow) delta; meets are untouched (they
+  // have their own weekend dates that don't track the practice day).
+  draft.value = applyMeetingDayShift(draft.value, newDay)
+}
+
+function onResetClick() {
+  resetBanner.value = null
+  pendingReset.value = true
+}
+
+function cancelReset() {
+  pendingReset.value = false
+}
+
+async function confirmReset() {
+  if (resetBusy.value) return
+  resetBusy.value = true
+  try {
+    const { fallbackToBundled } = await api.deleteSchedule(materialId.value)
+    resetBanner.value = fallbackToBundled
+      ? 'Reset complete — bundled schedule reapplied.'
+      : 'No user customization existed; nothing to reset.'
+    await refresh()
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    resetBusy.value = false
+    pendingReset.value = false
+  }
+}
+
 /** Dirty iff the user has actually edited the draft. JSON.stringify
  *  is sound because both objects originate from the same construction
  *  path (server JSON → structuredClone), so key order matches. */
@@ -445,6 +491,14 @@ function backToSettings() {
 
         <div class="mode-controls">
           <template v-if="mode === 'view'">
+            <button
+              type="button"
+              class="secondary"
+              :disabled="resetBusy"
+              @click="onResetClick"
+            >
+              Reset to default
+            </button>
             <button type="button" class="primary" @click="enterEdit">
               Edit schedule
             </button>
@@ -469,6 +523,26 @@ function backToSettings() {
           </template>
         </div>
       </header>
+
+      <p v-if="resetBanner" class="banner banner-info">{{ resetBanner }}</p>
+
+      <div v-if="mode === 'edit'" class="day-picker">
+        <label>
+          <span>Meets on</span>
+          <select
+            :value="display.meetingDayOfWeek"
+            @change="onMeetingDayChange(($event.target as HTMLSelectElement).value as DayOfWeek)"
+          >
+            <option v-for="d in DAYS_OF_WEEK" :key="d" :value="d">
+              {{ d }}days
+            </option>
+          </select>
+        </label>
+        <p class="day-picker-hint">
+          Changing the meeting day shifts every practice week by the same
+          delta. Meet weekends stay on their own dates.
+        </p>
+      </div>
 
       <section class="editor-body">
         <nav class="timeline-pane" aria-label="Schedule timeline">
@@ -710,6 +784,21 @@ function backToSettings() {
         </section>
       </section>
     </template>
+
+    <ConfirmDialog
+      v-if="pendingReset"
+      title="Reset to bundled schedule?"
+      confirm-label="Reset"
+      destructive
+      :busy="resetBusy"
+      @confirm="confirmReset"
+      @cancel="cancelReset"
+    >
+      <p>
+        This discards your customizations for this material and reapplies
+        the bundled schedule. Existing memorize progress is unaffected.
+      </p>
+    </ConfirmDialog>
   </div>
 </template>
 
@@ -730,6 +819,47 @@ function backToSettings() {
 .banner-error {
   background: var(--color-error-bg);
   color: var(--color-error);
+}
+
+.banner-info {
+  background: var(--color-accent-soft);
+  color: var(--color-text);
+}
+
+.day-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1rem;
+  padding: 0.6rem 1rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+}
+
+.day-picker label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.day-picker select {
+  padding: 0.3rem 0.5rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.day-picker-hint {
+  margin: 0;
+  flex: 1 1 18rem;
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  font-style: italic;
 }
 
 .status {

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -1,0 +1,357 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
+
+import { api } from '@/api'
+import {
+  type Schedule,
+  cloneSchedule,
+} from '@/lib/schedule'
+
+type Mode = 'view' | 'edit'
+
+const route = useRoute()
+const router = useRouter()
+
+const materialId = computed(() => String(route.params.materialId ?? ''))
+
+const saved = ref<Schedule | null>(null)
+const draft = ref<Schedule | null>(null)
+const mode = ref<Mode>('view')
+const loading = ref(true)
+const saving = ref(false)
+const error = ref<string | null>(null)
+
+/** Source of truth for both the read-only view and the edit panes.
+ *  Reading from `draft` in view mode is fine too (it's a clone of
+ *  saved with no edits), but binding to `saved` while not editing
+ *  keeps the contract clear: never mutate `saved` outside of refresh. */
+const display = computed<Schedule | null>(() =>
+  mode.value === 'edit' ? draft.value : saved.value,
+)
+
+/** Dirty iff the user has actually edited the draft. JSON.stringify
+ *  is sound because both objects originate from the same construction
+ *  path (server JSON → structuredClone), so key order matches. */
+const isDirty = computed<boolean>(() => {
+  if (saved.value === null || draft.value === null) return false
+  return JSON.stringify(draft.value) !== JSON.stringify(saved.value)
+})
+
+async function refresh() {
+  if (!materialId.value) return
+  loading.value = true
+  error.value = null
+  try {
+    const s = await api.getSchedule(materialId.value)
+    saved.value = s
+    draft.value = s === null ? null : cloneSchedule(s)
+    // Drop back to view mode after a refresh — a save commits then
+    // returns here, and a route change that re-enters the view should
+    // never land in edit by surprise.
+    mode.value = 'view'
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    loading.value = false
+  }
+}
+
+function enterEdit() {
+  if (saved.value === null) return
+  draft.value = cloneSchedule(saved.value)
+  mode.value = 'edit'
+}
+
+function discard() {
+  // Restoring draft from saved is enough — the next enterEdit() reclones
+  // anyway. Resetting `mode` first so a draft watcher (added in later
+  // commits for live previews) sees the view-mode flag before the
+  // reset hits.
+  mode.value = 'view'
+  if (saved.value !== null) draft.value = cloneSchedule(saved.value)
+}
+
+async function save() {
+  if (draft.value === null || saving.value) return
+  saving.value = true
+  error.value = null
+  try {
+    await api.putSchedule(materialId.value, draft.value)
+    saved.value = cloneSchedule(draft.value)
+    mode.value = 'view'
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err)
+  } finally {
+    saving.value = false
+  }
+}
+
+/** Browser-level guard for tab-close / refresh / external URL nav.
+ *  The router-level guard below covers in-app nav. Both are needed
+ *  because beforeunload doesn't fire for SPA route changes. */
+function onBeforeUnload(ev: BeforeUnloadEvent) {
+  if (!isDirty.value) return
+  ev.preventDefault()
+  // Modern browsers ignore the returnValue text but require it to be set.
+  ev.returnValue = ''
+}
+
+onBeforeRouteLeave((_to, _from, next) => {
+  if (!isDirty.value) {
+    next()
+    return
+  }
+  const ok = window.confirm(
+    'You have unsaved schedule changes. Leave without saving?',
+  )
+  next(ok)
+})
+
+onMounted(async () => {
+  window.addEventListener('beforeunload', onBeforeUnload)
+  await refresh()
+})
+
+// onBeforeRouteLeave is component-scoped and clears itself; the
+// beforeunload listener needs an explicit removal.
+onBeforeUnmount(() => {
+  window.removeEventListener('beforeunload', onBeforeUnload)
+})
+
+function backToSettings() {
+  void router.push('/settings/materials')
+}
+</script>
+
+<template>
+  <div class="schedule-editor">
+    <div v-if="error" class="banner banner-error">{{ error }}</div>
+
+    <div v-if="loading" class="status">Loading schedule…</div>
+
+    <div v-else-if="saved === null" class="status">
+      <h2>No schedule for this material</h2>
+      <p>
+        This material doesn't ship a published schedule yet, and you haven't
+        created a custom one. Memorize will fall back to sequential ordering.
+      </p>
+      <button type="button" class="back-button" @click="backToSettings">
+        ← Back to /settings/materials
+      </button>
+    </div>
+
+    <template v-else-if="display !== null">
+      <header class="editor-header">
+        <div class="title-row">
+          <button
+            type="button"
+            class="back-link"
+            aria-label="Back to settings"
+            @click="backToSettings"
+          >
+            ←
+          </button>
+          <div class="title-block">
+            <h2>{{ display.title }}</h2>
+            <p class="subtitle">
+              {{ display.season }} · meets {{ display.meetingDayOfWeek
+              }}s ·
+              {{ display.weeks.length }} weeks ·
+              {{ display.meets.length }} meets
+            </p>
+          </div>
+        </div>
+
+        <div class="mode-controls">
+          <template v-if="mode === 'view'">
+            <button type="button" class="primary" @click="enterEdit">
+              Edit schedule
+            </button>
+          </template>
+          <template v-else>
+            <button
+              type="button"
+              class="secondary"
+              :disabled="saving"
+              @click="discard"
+            >
+              Discard
+            </button>
+            <button
+              type="button"
+              class="primary"
+              :disabled="!isDirty || saving"
+              @click="save"
+            >
+              {{ saving ? 'Saving…' : 'Save schedule' }}
+            </button>
+          </template>
+        </div>
+      </header>
+
+      <!-- Body panes land in commits 4 — 7. The shell + draft state +
+           nav-away guard are intentionally in place first so the
+           interactive surface can be built incrementally without
+           re-architecting the host every commit. -->
+      <section class="editor-body">
+        <div class="placeholder">
+          <p>
+            Schedule editor panes (timeline, week detail, meets, meeting-day
+            picker) land in subsequent commits.
+          </p>
+          <p class="meta">
+            Mode: <strong>{{ mode }}</strong>
+            · Dirty: <strong>{{ isDirty ? 'yes' : 'no' }}</strong>
+          </p>
+        </div>
+      </section>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.schedule-editor {
+  width: 100%;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.banner {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+}
+
+.banner-error {
+  background: var(--color-error-bg);
+  color: var(--color-error);
+}
+
+.status {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-muted);
+}
+
+.status h2 {
+  margin: 0 0 0.5rem;
+  color: var(--color-text);
+}
+
+.editor-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.back-link {
+  background: none;
+  border: none;
+  color: var(--color-muted);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.back-link:hover {
+  color: var(--color-text);
+  background: var(--color-accent-soft);
+}
+
+.title-block h2 {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.mode-controls {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+button.primary {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border: none;
+  border-radius: 4px;
+  padding: 0.45rem 1rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+button.primary:disabled {
+  background: var(--color-border);
+  color: var(--color-muted);
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.45rem 1rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+button.secondary:hover:not(:disabled) {
+  border-color: var(--color-accent);
+}
+
+.back-button {
+  margin-top: 1rem;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.back-button:hover {
+  border-color: var(--color-accent);
+}
+
+.editor-body {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+  min-height: 12rem;
+}
+
+.placeholder {
+  color: var(--color-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.placeholder .meta {
+  margin-top: 1rem;
+  font-family: monospace;
+  font-size: 0.8rem;
+}
+</style>

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -7,13 +7,17 @@ import {
   type Schedule,
   type ScheduleMeet,
   type ScheduleWeek,
+  addMeet,
   addWeekAt,
   cloneSchedule,
   formatPassage,
   formatVerseList,
   parseVerseList,
+  removeMeet,
   removeWeekAt,
   shiftDate,
+  slugifyMeetId,
+  updateMeet,
   verseCountsForWeek,
 } from '@/lib/schedule'
 
@@ -247,6 +251,65 @@ function removeSelectedWeek() {
   }
 }
 
+// =============================================================================
+// Meet editor state
+// =============================================================================
+
+const meetEndDateError = ref<string | null>(null)
+
+/** Patch a single field on the selected meet in the draft. `id` is
+ *  intentionally excluded — meets get a slug-derived id at creation
+ *  and stay stable so the chain UI's gate references survive renames. */
+function updateMeetField<K extends 'name' | 'startDate' | 'endDate' | 'location'>(
+  key: K,
+  value: string,
+) {
+  if (draft.value === null || selection.value?.kind !== 'meet') return
+  const meet = draft.value.meets.find((m) => m.id === selection.value!.meetId)
+  if (!meet) return
+  const next: ScheduleMeet = { ...meet, [key]: value }
+  // Inline endDate sanity check — surfaced as a hint, not a hard block,
+  // so the user can correct without losing focus. Server-side
+  // validateSchedule rejects on save if it's still inverted.
+  if (next.endDate < next.startDate) {
+    meetEndDateError.value = 'End date is before start date.'
+  } else {
+    meetEndDateError.value = null
+  }
+  draft.value = updateMeet(draft.value, meet.id, next)
+}
+
+function addMeetAfterLast() {
+  if (draft.value === null) return
+  const existingIds = draft.value.meets.map((m) => m.id)
+  const today = new Date().toISOString().slice(0, 10)
+  const blank: ScheduleMeet = {
+    id: slugifyMeetId('new-meet', existingIds),
+    name: 'New meet',
+    startDate: today,
+    endDate: today,
+    location: '',
+  }
+  draft.value = addMeet(draft.value, blank)
+  selectMeet(blank.id)
+}
+
+function removeSelectedMeet() {
+  if (draft.value === null || selection.value?.kind !== 'meet') return
+  const meetId = selection.value.meetId
+  draft.value = removeMeet(draft.value, meetId)
+  selection.value = null
+  meetEndDateError.value = null
+}
+
+// Clear the meet end-date error whenever selection moves off the meet.
+watch(
+  () => selection.value?.kind,
+  () => {
+    meetEndDateError.value = null
+  },
+)
+
 /** Dirty iff the user has actually edited the draft. JSON.stringify
  *  is sound because both objects originate from the same construction
  *  path (server JSON → structuredClone), so key order matches. */
@@ -455,14 +518,14 @@ function backToSettings() {
               </button>
             </li>
           </ol>
-          <button
-            v-if="mode === 'edit'"
-            type="button"
-            class="add-week"
-            @click="addWeekAfterLast"
-          >
-            + Add a week
-          </button>
+          <div v-if="mode === 'edit'" class="add-row">
+            <button type="button" class="add-week" @click="addWeekAfterLast">
+              + Add a week
+            </button>
+            <button type="button" class="add-week" @click="addMeetAfterLast">
+              + Add a meet
+            </button>
+          </div>
         </nav>
 
         <section class="detail" aria-label="Selected item">
@@ -586,11 +649,64 @@ function backToSettings() {
             </button>
           </form>
 
-          <div v-else-if="selectedMeet" class="detail-meet">
+          <!-- View-mode meet display. -->
+          <div
+            v-else-if="selectedMeet && mode === 'view'"
+            class="detail-meet"
+          >
             <h3>⛺ {{ selectedMeet.name }}</h3>
             <p class="detail-date">{{ formatMeetDateRange(selectedMeet) }}</p>
             <p v-if="selectedMeet.location" class="detail-location">{{ selectedMeet.location }}</p>
           </div>
+
+          <!-- Edit-mode meet form. -->
+          <form
+            v-else-if="selectedMeet && mode === 'edit'"
+            class="meet-form"
+            @submit.prevent
+          >
+            <fieldset>
+              <legend>Meet</legend>
+              <label class="field">
+                <span>Name</span>
+                <input
+                  type="text"
+                  :value="selectedMeet.name"
+                  @input="updateMeetField('name', ($event.target as HTMLInputElement).value)"
+                />
+              </label>
+              <label class="field">
+                <span>Start date</span>
+                <input
+                  type="date"
+                  :value="selectedMeet.startDate"
+                  @input="updateMeetField('startDate', ($event.target as HTMLInputElement).value)"
+                />
+              </label>
+              <label class="field">
+                <span>End date</span>
+                <input
+                  type="date"
+                  :value="selectedMeet.endDate"
+                  @input="updateMeetField('endDate', ($event.target as HTMLInputElement).value)"
+                />
+              </label>
+              <label class="field meet-location">
+                <span>Location (optional, may be "TBD")</span>
+                <input
+                  type="text"
+                  :value="selectedMeet.location"
+                  @input="updateMeetField('location', ($event.target as HTMLInputElement).value)"
+                />
+              </label>
+              <p v-if="meetEndDateError" class="field-error" role="alert">
+                {{ meetEndDateError }}
+              </p>
+            </fieldset>
+            <button type="button" class="danger" @click="removeSelectedMeet">
+              Remove this meet
+            </button>
+          </form>
         </section>
       </section>
     </template>
@@ -757,8 +873,13 @@ button.secondary:hover:not(:disabled) {
   background: var(--color-bg);
 }
 
+.add-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .add-week {
-  align-self: flex-start;
   background: none;
   border: 1px dashed var(--color-border);
   border-radius: 6px;
@@ -995,5 +1116,33 @@ button.danger {
 
 button.danger:hover {
   filter: brightness(1.1);
+}
+
+.meet-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.meet-form fieldset {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 1rem;
+}
+
+.meet-form fieldset legend {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  padding: 0 0.3rem;
+}
+
+.meet-location {
+  grid-column: 1 / -1;
 }
 </style>

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -66,6 +66,10 @@ interface TimelineItem {
   weekIdx: number
   week?: ScheduleWeek
   meet?: ScheduleMeet
+  /** Pre-computed verse counts for week rows so the template doesn't
+   *  call `verseCountsForWeek` twice per row to read club150 then
+   *  club300 off two separate return objects. */
+  weekCounts?: { club150: number; club300: number }
 }
 
 /** Single chronological list of weeks + meets for the left pane. Meets
@@ -77,7 +81,13 @@ const timeline = computed<TimelineItem[]>(() => {
   if (s === null) return []
   const items: TimelineItem[] = []
   s.weeks.forEach((week, weekIdx) => {
-    items.push({ kind: 'week', sortKey: week.date, weekIdx, week })
+    items.push({
+      kind: 'week',
+      sortKey: week.date,
+      weekIdx,
+      week,
+      weekCounts: verseCountsForWeek(week),
+    })
   })
   s.meets.forEach((meet) => {
     // weekIdx is unused for meet items; -1 makes that explicit.
@@ -174,14 +184,6 @@ function commitVerseInput(tier: 'club150' | 'club300') {
   // responsibility) so the user sees the normalized value after blur.
   if (tier === 'club150') verseInput150.value = formatVerseList(parsed)
   else verseInput300.value = formatVerseList(parsed)
-}
-
-function updateWeekField<K extends keyof ScheduleWeek>(key: K, value: ScheduleWeek[K]) {
-  if (draft.value === null || selection.value?.kind !== 'week') return
-  const idx = selection.value.weekIdx
-  const week = draft.value.weeks[idx]
-  if (!week) return
-  draft.value.weeks[idx] = { ...week, [key]: value }
 }
 
 function updatePassageField<K extends 'book' | 'chapter' | 'startVerse' | 'endVerse'>(
@@ -318,9 +320,22 @@ watch(
 // Day-of-week shift + reset
 // =============================================================================
 
-const pendingReset = ref(false)
-const resetBusy = ref(false)
-const resetBanner = ref<string | null>(null)
+/** Reset flow as a single discriminated union so structurally
+ *  impossible combinations (e.g. dialog open AND banner showing AND
+ *  busy spinner) can't arise. The three prior refs encoded the same
+ *  state space with three booleans that, taken together, could
+ *  represent 2^3 combos most of which had no UI meaning. */
+type ResetState =
+  | { kind: 'idle' }
+  | { kind: 'confirming' }
+  | { kind: 'busy' }
+  | { kind: 'done'; banner: string }
+
+const resetState = ref<ResetState>({ kind: 'idle' })
+
+const resetBanner = computed<string | null>(() =>
+  resetState.value.kind === 'done' ? resetState.value.banner : null,
+)
 
 function onMeetingDayChange(newDay: DayOfWeek) {
   if (draft.value === null) return
@@ -331,28 +346,26 @@ function onMeetingDayChange(newDay: DayOfWeek) {
 }
 
 function onResetClick() {
-  resetBanner.value = null
-  pendingReset.value = true
+  resetState.value = { kind: 'confirming' }
 }
 
 function cancelReset() {
-  pendingReset.value = false
+  resetState.value = { kind: 'idle' }
 }
 
 async function confirmReset() {
-  if (resetBusy.value) return
-  resetBusy.value = true
+  if (resetState.value.kind === 'busy') return
+  resetState.value = { kind: 'busy' }
   try {
     const { fallbackToBundled } = await api.deleteSchedule(materialId.value)
-    resetBanner.value = fallbackToBundled
+    const banner = fallbackToBundled
       ? 'Reset complete — bundled schedule reapplied.'
       : 'No user customization existed; nothing to reset.'
+    resetState.value = { kind: 'done', banner }
     await refresh()
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err)
-  } finally {
-    resetBusy.value = false
-    pendingReset.value = false
+    resetState.value = { kind: 'idle' }
   }
 }
 
@@ -494,7 +507,7 @@ function backToSettings() {
             <button
               type="button"
               class="secondary"
-              :disabled="resetBusy"
+              :disabled="resetState.kind === 'busy'"
               @click="onResetClick"
             >
               Reset to default
@@ -573,7 +586,7 @@ function backToSettings() {
                 <span class="row-body">
                   <span class="row-title">{{ formatPassage(item.week.passage) }}</span>
                   <span v-if="!item.week.isReview" class="row-meta">
-                    {{ verseCountsForWeek(item.week).club150 }} / {{ verseCountsForWeek(item.week).club300 }}
+                    {{ item.weekCounts?.club150 ?? 0 }} / {{ item.weekCounts?.club300 ?? 0 }}
                   </span>
                   <span v-else class="row-meta">Review week</span>
                 </span>
@@ -739,7 +752,7 @@ function backToSettings() {
             class="meet-form"
             @submit.prevent
           >
-            <fieldset>
+            <fieldset class="meet-fields">
               <legend>Meet</legend>
               <label class="field">
                 <span>Name</span>
@@ -786,11 +799,11 @@ function backToSettings() {
     </template>
 
     <ConfirmDialog
-      v-if="pendingReset"
+      v-if="resetState.kind === 'confirming' || resetState.kind === 'busy'"
       title="Reset to bundled schedule?"
       confirm-label="Reset"
       destructive
-      :busy="resetBusy"
+      :busy="resetState.kind === 'busy'"
       @confirm="confirmReset"
       @cancel="cancelReset"
     >
@@ -1165,7 +1178,8 @@ button.secondary:hover:not(:disabled) {
 }
 
 fieldset.passage,
-fieldset.verses {
+fieldset.verses,
+fieldset.meet-fields {
   border: 1px solid var(--color-border);
   border-radius: 6px;
   padding: 0.75rem 1rem;
@@ -1252,24 +1266,6 @@ button.danger:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.meet-form fieldset {
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 0.75rem 1rem;
-  margin: 0;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.6rem 1rem;
-}
-
-.meet-form fieldset legend {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-muted);
-  padding: 0 0.3rem;
 }
 
 .meet-location {

--- a/apps/web/src/views/ScheduleEditorView.vue
+++ b/apps/web/src/views/ScheduleEditorView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { onBeforeRouteLeave, useRoute, useRouter } from 'vue-router'
 
 import { api } from '@/api'
@@ -7,8 +7,13 @@ import {
   type Schedule,
   type ScheduleMeet,
   type ScheduleWeek,
+  addWeekAt,
   cloneSchedule,
   formatPassage,
+  formatVerseList,
+  parseVerseList,
+  removeWeekAt,
+  shiftDate,
   verseCountsForWeek,
 } from '@/lib/schedule'
 
@@ -113,6 +118,134 @@ const selectedMeet = computed<ScheduleMeet | null>(() => {
   if (selection.value?.kind !== 'meet') return null
   return display.value?.meets.find((m) => m.id === selection.value!.meetId) ?? null
 })
+
+// =============================================================================
+// Per-week editor state
+// =============================================================================
+
+/** Local text mirrors for the per-tier comma-separated verse inputs.
+ *  Bound directly via v-model so the user sees what they typed before
+ *  the parser runs; on blur we parse + commit into the draft and the
+ *  mirror re-syncs from the formatted draft value. Per-tier rather
+ *  than per-week so swapping selection wipes them cleanly via the
+ *  watcher below. */
+const verseInput150 = ref('')
+const verseInput300 = ref('')
+const verseInputError = ref<string | null>(null)
+
+/** Re-seed the mirrors whenever the selected week changes (including
+ *  null → some-week). Without this the prior week's text would linger
+ *  in the inputs after the user clicks a new row. */
+watch(
+  () => (selection.value?.kind === 'week' ? selection.value.weekIdx : -1),
+  () => {
+    const w = selectedWeek.value
+    verseInputError.value = null
+    verseInput150.value = formatVerseList(w?.verses?.club150)
+    verseInput300.value = formatVerseList(w?.verses?.club300)
+  },
+  { immediate: true },
+)
+
+function commitVerseInput(tier: 'club150' | 'club300') {
+  if (draft.value === null || selection.value?.kind !== 'week') return
+  const raw = tier === 'club150' ? verseInput150.value : verseInput300.value
+  const parsed = parseVerseList(raw)
+  if (parsed === null) {
+    verseInputError.value
+      = 'Verses must be positive whole numbers separated by commas or spaces.'
+    return
+  }
+  verseInputError.value = null
+  const idx = selection.value.weekIdx
+  const week = draft.value.weeks[idx]
+  if (!week) return
+  const nextVerses = { ...(week.verses ?? {}), [tier]: parsed }
+  draft.value.weeks[idx] = { ...week, verses: nextVerses }
+  // Re-format from canonical (sorted, deduped is the parser's
+  // responsibility) so the user sees the normalized value after blur.
+  if (tier === 'club150') verseInput150.value = formatVerseList(parsed)
+  else verseInput300.value = formatVerseList(parsed)
+}
+
+function updateWeekField<K extends keyof ScheduleWeek>(key: K, value: ScheduleWeek[K]) {
+  if (draft.value === null || selection.value?.kind !== 'week') return
+  const idx = selection.value.weekIdx
+  const week = draft.value.weeks[idx]
+  if (!week) return
+  draft.value.weeks[idx] = { ...week, [key]: value }
+}
+
+function updatePassageField<K extends 'book' | 'chapter' | 'startVerse' | 'endVerse'>(
+  key: K,
+  value: K extends 'book' ? string : number,
+) {
+  if (draft.value === null || selection.value?.kind !== 'week') return
+  const idx = selection.value.weekIdx
+  const week = draft.value.weeks[idx]
+  if (!week) return
+  // Coerce review week toggle: starting a passage edit on a review week
+  // implicitly de-reviews it via the dedicated toggle, not by side
+  // effect — guard so the editor doesn't silently un-mark.
+  if (week.passage === null) return
+  draft.value.weeks[idx] = {
+    ...week,
+    passage: { ...week.passage, [key]: value },
+  }
+}
+
+function toggleReviewWeek() {
+  if (draft.value === null || selection.value?.kind !== 'week') return
+  const idx = selection.value.weekIdx
+  const week = draft.value.weeks[idx]
+  if (!week) return
+  if (week.isReview) {
+    // De-reviewing: rehydrate empty passage + verses so the editor has
+    // something to bind. The user fills in the actual passage details.
+    draft.value.weeks[idx] = {
+      ...week,
+      isReview: false,
+      passage: { book: '', chapter: 0, startVerse: 0, endVerse: 0 },
+      verses: { club150: [], club300: [] },
+    }
+  } else {
+    draft.value.weeks[idx] = { ...week, isReview: true, passage: null, verses: null }
+  }
+  // Re-seed the verse mirrors after the structural change.
+  const next = draft.value.weeks[idx]
+  verseInput150.value = formatVerseList(next.verses?.club150)
+  verseInput300.value = formatVerseList(next.verses?.club300)
+}
+
+function addWeekAfterLast() {
+  if (draft.value === null) return
+  const last = draft.value.weeks[draft.value.weeks.length - 1]
+  // Default the new week's date to one week after the last existing
+  // week, falling back to today when the schedule has none yet. The
+  // user can pick a passage from the edit form once selected.
+  const newDate = last ? shiftDate(last.date, 7) : new Date().toISOString().slice(0, 10)
+  const blank: ScheduleWeek = {
+    date: newDate,
+    passage: { book: '', chapter: 0, startVerse: 0, endVerse: 0 },
+    verses: { club150: [], club300: [] },
+    isReview: false,
+  }
+  draft.value = addWeekAt(draft.value, draft.value.weeks.length, blank)
+  selectWeek(draft.value.weeks.length - 1)
+}
+
+function removeSelectedWeek() {
+  if (draft.value === null || selection.value?.kind !== 'week') return
+  const idx = selection.value.weekIdx
+  draft.value = removeWeekAt(draft.value, idx)
+  // Move selection to the previous week if there is one; otherwise drop.
+  if (draft.value.weeks.length === 0) {
+    selection.value = null
+  } else {
+    const nextIdx = Math.min(idx, draft.value.weeks.length - 1)
+    selectWeek(nextIdx)
+  }
+}
 
 /** Dirty iff the user has actually edited the draft. JSON.stringify
  *  is sound because both objects originate from the same construction
@@ -275,8 +408,8 @@ function backToSettings() {
       </header>
 
       <section class="editor-body">
-        <nav class="timeline" aria-label="Schedule timeline">
-          <ol>
+        <nav class="timeline-pane" aria-label="Schedule timeline">
+          <ol class="timeline">
             <li
               v-for="(item, i) in timeline"
               :key="`${item.kind}-${item.kind === 'week' ? item.weekIdx : item.meet?.id}-${i}`"
@@ -322,16 +455,27 @@ function backToSettings() {
               </button>
             </li>
           </ol>
+          <button
+            v-if="mode === 'edit'"
+            type="button"
+            class="add-week"
+            @click="addWeekAfterLast"
+          >
+            + Add a week
+          </button>
         </nav>
 
-        <!-- Detail pane lands in commits 5 (week) and 6 (meet). For now
-             this is a read-only display of whatever the user selected so
-             the timeline is useful even before the editors arrive. -->
         <section class="detail" aria-label="Selected item">
           <p v-if="selection === null" class="placeholder">
             Pick a week or meet from the timeline.
           </p>
-          <div v-else-if="selectedWeek" class="detail-week">
+
+          <!-- View-mode week display: same read-only shape regardless of
+               whether the user is editing the schedule overall. -->
+          <div
+            v-else-if="selectedWeek && mode === 'view'"
+            class="detail-week"
+          >
             <h3>{{ formatPassage(selectedWeek.passage) }}</h3>
             <p class="detail-date">{{ formatTimelineDate(selectedWeek.date) }}</p>
             <dl v-if="!selectedWeek.isReview">
@@ -342,6 +486,106 @@ function backToSettings() {
             </dl>
             <p v-else class="detail-review">Review week — no new verses.</p>
           </div>
+
+          <!-- Edit-mode week form. Date is derived from the schedule's
+               meetingDayOfWeek + week ordering and isn't editable per
+               the Phase 3 design (no per-week overrides). -->
+          <form
+            v-else-if="selectedWeek && mode === 'edit'"
+            class="week-form"
+            @submit.prevent
+          >
+            <p class="detail-date">{{ formatTimelineDate(selectedWeek.date) }}</p>
+
+            <label class="toggle">
+              <input
+                type="checkbox"
+                :checked="selectedWeek.isReview"
+                @change="toggleReviewWeek"
+              />
+              <span>Review week (no new verses introduced)</span>
+            </label>
+
+            <template v-if="!selectedWeek.isReview && selectedWeek.passage">
+              <fieldset class="passage">
+                <legend>Passage</legend>
+                <label class="field passage-book">
+                  <span>Book</span>
+                  <input
+                    type="text"
+                    :value="selectedWeek.passage.book"
+                    @input="updatePassageField('book', ($event.target as HTMLInputElement).value)"
+                  />
+                </label>
+                <label class="field passage-chapter">
+                  <span>Chapter</span>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="selectedWeek.passage.chapter || ''"
+                    @input="updatePassageField('chapter', Number(($event.target as HTMLInputElement).value) || 0)"
+                  />
+                </label>
+                <label class="field passage-start">
+                  <span>Start verse</span>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="selectedWeek.passage.startVerse || ''"
+                    @input="updatePassageField('startVerse', Number(($event.target as HTMLInputElement).value) || 0)"
+                  />
+                </label>
+                <label class="field passage-end">
+                  <span>End verse</span>
+                  <input
+                    type="number"
+                    min="1"
+                    :value="selectedWeek.passage.endVerse || ''"
+                    @input="updatePassageField('endVerse', Number(($event.target as HTMLInputElement).value) || 0)"
+                  />
+                </label>
+              </fieldset>
+
+              <fieldset class="verses">
+                <legend>Verse numbers</legend>
+                <label class="field">
+                  <span>Club 150</span>
+                  <input
+                    v-model="verseInput150"
+                    type="text"
+                    inputmode="numeric"
+                    placeholder="e.g. 5, 10, 17, 18"
+                    @blur="commitVerseInput('club150')"
+                  />
+                </label>
+                <label class="field">
+                  <span>Club 300</span>
+                  <input
+                    v-model="verseInput300"
+                    type="text"
+                    inputmode="numeric"
+                    placeholder="e.g. 1, 2, 4, 8"
+                    @blur="commitVerseInput('club300')"
+                  />
+                </label>
+                <p v-if="verseInputError" class="field-error" role="alert">
+                  {{ verseInputError }}
+                </p>
+                <p class="field-hint">
+                  Comma- or space-separated verse numbers. Saved to the draft on blur.
+                </p>
+              </fieldset>
+            </template>
+
+            <button
+              type="button"
+              class="danger"
+              @click="removeSelectedWeek"
+            >
+              Remove this week
+            </button>
+          </form>
+
           <div v-else-if="selectedMeet" class="detail-meet">
             <h3>⛺ {{ selectedMeet.name }}</h3>
             <p class="detail-date">{{ formatMeetDateRange(selectedMeet) }}</p>
@@ -496,7 +740,16 @@ button.secondary:hover:not(:disabled) {
   }
 }
 
+.timeline-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   max-height: 60vh;
   overflow-y: auto;
   border: 1px solid var(--color-border);
@@ -504,10 +757,21 @@ button.secondary:hover:not(:disabled) {
   background: var(--color-bg);
 }
 
-.timeline ol {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+.add-week {
+  align-self: flex-start;
+  background: none;
+  border: 1px dashed var(--color-border);
+  border-radius: 6px;
+  padding: 0.4rem 0.75rem;
+  color: var(--color-muted);
+  font-family: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.add-week:hover {
+  border-color: var(--color-accent);
+  color: var(--color-text);
 }
 
 .timeline-item {
@@ -629,5 +893,107 @@ button.secondary:hover:not(:disabled) {
   color: var(--color-muted);
   font-style: italic;
   text-align: center;
+}
+
+.week-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.toggle input[type='checkbox'] {
+  accent-color: var(--color-accent);
+}
+
+fieldset.passage,
+fieldset.verses {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 1rem;
+}
+
+fieldset legend {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  padding: 0 0.3rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.field span {
+  color: var(--color-muted);
+  font-size: 0.78rem;
+}
+
+.field input {
+  padding: 0.35rem 0.55rem;
+  background: var(--color-bg);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+
+.field input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -1px;
+  border-color: var(--color-accent);
+}
+
+.passage-book {
+  grid-column: 1 / -1;
+}
+
+fieldset.verses {
+  grid-template-columns: 1fr;
+}
+
+.field-error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--color-error);
+}
+
+.field-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+button.danger {
+  align-self: flex-start;
+  background: var(--color-grade-again);
+  color: var(--color-on-accent);
+  border: none;
+  border-radius: 4px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+button.danger:hover {
+  filter: brightness(1.1);
 }
 </style>

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { onBeforeRouteLeave, RouterLink } from 'vue-router'
 
 import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
 import StatusChip from '@/components/StatusChip.vue'
@@ -324,6 +324,20 @@ async function onToggleOffline(card: YearCard) {
 }
 
 onMounted(refresh)
+
+/** Same nav-away guard pattern as ScheduleEditorView — the chain UI
+ *  holds an editable draft, and the new "Edit schedule →" RouterLink
+ *  in the per-material header is a one-click way to leave the route
+ *  with unsaved per-club changes. Without this prompt the user's
+ *  edits silently vanish on click. */
+onBeforeRouteLeave((_to, _from, next) => {
+  if (!selectedIsDirty.value) {
+    next()
+    return
+  }
+  const ok = window.confirm('You have unsaved settings. Leave without saving?')
+  next(ok)
+})
 </script>
 
 <template>

--- a/apps/web/src/views/SettingsMaterialsView.vue
+++ b/apps/web/src/views/SettingsMaterialsView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { RouterLink } from 'vue-router'
 
 import ScopeLevelSelector from '@/components/ScopeLevelSelector.vue'
 import StatusChip from '@/components/StatusChip.vue'
@@ -368,6 +369,12 @@ onMounted(refresh)
           <div class="year-title-row">
             <h3>{{ selected.view.title }}</h3>
             <span v-if="!isStudying(selected)" class="enrollment-badge">Not enrolled</span>
+            <RouterLink
+              :to="`/schedule/${encodeURIComponent(selected.view.materialId)}`"
+              class="schedule-link"
+            >
+              Edit schedule →
+            </RouterLink>
           </div>
           <p class="year-description">{{ selected.view.description }}</p>
           <div class="tier-summary">
@@ -725,6 +732,22 @@ onMounted(refresh)
   border-radius: 999px;
   padding: 0.1rem 0.5rem;
   white-space: nowrap;
+}
+
+/* Anchors the schedule-editor entry point. Sits next to the title so
+   it's discoverable without burying the per-club chain UI below the
+   fold. The card header already uses justify-content: space-between
+   on the title row; the link rides the right edge there. */
+.schedule-link {
+  margin-left: auto;
+  color: var(--color-accent);
+  font-size: 0.85rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.schedule-link:hover {
+  text-decoration: underline;
 }
 
 .tier-summary {

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -10,6 +10,19 @@ Released via `.github/workflows/deploy-api.yml` (rsync to VPS, atomic symlink-fl
 
 ## [Unreleased]
 
+### `validateSchedule` tightens Meet + passage validation
+
+Shipped with apps/web 0.4.0 (Phase 3 schedule editor). The user-customisable surface behind
+`PUT /api/materials/:id/schedule` now field-checks meets and per-week passages so a malformed editor
+payload can't reach disk.
+
+* Meets: each entry must carry `id`, `name`, `startDate`, `endDate` as non-empty strings; dates are
+  `YYYY-MM-DD` with sane month/day; `endDate >= startDate`; `id` unique within the schedule.
+  `location` accepts empty/missing/"TBD" (the bundled schedules use both forms as placeholders).
+* Per-week passage on non-Review weeks: `book` non-empty; `chapter`, `startVerse`, `endVerse`
+  positive integers; `endVerse >= startVerse`. Closes a gap where the editor's de-review toggle
+  could save zeroed placeholders the server silently accepted.
+
 ## [0.1.29] — 2026-06-15
 
 `GET /api/years` now surfaces `perClub` (parsed `PerClubYearSettings`) alongside the legacy

--- a/packages/api/src/lib/schedules.test.ts
+++ b/packages/api/src/lib/schedules.test.ts
@@ -162,4 +162,126 @@ describe('validateSchedule', () => {
     });
     expect(() => validateSchedule(bad)).toThrow(/meets/);
   });
+
+  it('accepts a well-formed meets array', () => {
+    const ok = JSON.stringify({
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+      meets: [
+        {
+          id: 'first',
+          name: 'First Quiz Meet',
+          startDate: '2026-01-10',
+          endDate: '2026-01-12',
+          location: 'Heritage Alliance Church',
+        },
+      ],
+    });
+    const parsed = validateSchedule(ok);
+    expect(parsed.meets).toHaveLength(1);
+    expect(parsed.meets?.[0].id).toBe('first');
+  });
+
+  it('rejects meets with missing or malformed fields', () => {
+    const base = {
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+    };
+    const validMeet = {
+      id: 'first',
+      name: 'First',
+      startDate: '2026-01-10',
+      endDate: '2026-01-12',
+      location: 'X',
+    };
+    // Missing each required field in turn.
+    for (const k of ['id', 'name', 'startDate', 'endDate'] as const) {
+      const { [k]: _omit, ...partial } = validMeet;
+      const bad = JSON.stringify({ ...base, meets: [partial] });
+      expect(() => validateSchedule(bad)).toThrow(new RegExp(k));
+    }
+    // Malformed dates.
+    for (const field of ['startDate', 'endDate'] as const) {
+      const bad = JSON.stringify({
+        ...base,
+        meets: [{ ...validMeet, [field]: '2026-13-99' }],
+      });
+      expect(() => validateSchedule(bad)).toThrow(new RegExp(field));
+    }
+  });
+
+  it('accepts meets with empty or missing location', () => {
+    const base = {
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+    };
+    const meet = {
+      id: 'first',
+      name: 'First',
+      startDate: '2026-01-10',
+      endDate: '2026-01-12',
+    };
+    // Empty string — common for "to be announced" cases. "TBD" is also
+    // legitimate but it's just a regular non-empty string.
+    const empty = validateSchedule(JSON.stringify({ ...base, meets: [{ ...meet, location: '' }] }));
+    expect(empty.meets?.[0].location).toBe('');
+    // Missing field falls through to ''.
+    const missing = validateSchedule(JSON.stringify({ ...base, meets: [meet] }));
+    expect(missing.meets?.[0].location).toBe('');
+  });
+
+  it('rejects meets where endDate precedes startDate', () => {
+    const bad = JSON.stringify({
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+      meets: [
+        {
+          id: 'first',
+          name: 'First',
+          startDate: '2026-01-12',
+          endDate: '2026-01-10',
+          location: 'X',
+        },
+      ],
+    });
+    expect(() => validateSchedule(bad)).toThrow(/endDate/);
+  });
+
+  it('rejects meets with duplicate ids', () => {
+    const meet = {
+      name: 'First',
+      startDate: '2026-01-10',
+      endDate: '2026-01-12',
+      location: 'X',
+    };
+    const bad = JSON.stringify({
+      version: 1,
+      materialId: 'x',
+      season: 'y',
+      title: 't',
+      meetingDayOfWeek: 'Mon',
+      weeks: [],
+      meets: [
+        { id: 'first', ...meet },
+        { id: 'first', ...meet },
+      ],
+    });
+    expect(() => validateSchedule(bad)).toThrow(/duplicated/);
+  });
 });

--- a/packages/api/src/lib/schedules.ts
+++ b/packages/api/src/lib/schedules.ts
@@ -161,6 +161,23 @@ export interface ValidatedMeet {
   location: string;
 }
 
+/** Pull a non-empty string field off a record. Shared by the top-level
+ *  schedule fields and the per-meet field-checks — both error formats
+ *  differ only in the prefix, so the caller passes a lazy label
+ *  builder rather than two near-identical closures inside the same
+ *  file. */
+function requireNonEmptyStr(
+  src: Record<string, unknown>,
+  k: string,
+  label: () => string,
+): string {
+  const v = src[k];
+  if (typeof v !== 'string' || v.length === 0) {
+    throw new ScheduleValidationError(label());
+  }
+  return v;
+}
+
 export function validateSchedule(json: string): SchedulePayload {
   let parsed: unknown;
   try {
@@ -172,13 +189,8 @@ export function validateSchedule(json: string): SchedulePayload {
     throw new ScheduleValidationError('schedule must be an object');
   }
   const obj = parsed as Record<string, unknown>;
-  const requireStr = (k: string): string => {
-    const v = obj[k];
-    if (typeof v !== 'string' || v.length === 0) {
-      throw new ScheduleValidationError(`missing string field: ${k}`);
-    }
-    return v;
-  };
+  const requireStr = (k: string): string =>
+    requireNonEmptyStr(obj, k, () => `missing string field: ${k}`);
   const requireNum = (k: string): number => {
     const v = obj[k];
     if (typeof v !== 'number' || !Number.isFinite(v)) {
@@ -242,13 +254,12 @@ function validateMeets(raw: unknown): ValidatedMeet[] | undefined {
       throw new ScheduleValidationError(`meets[${i}] must be an object`);
     }
     const mo = m as Record<string, unknown>;
-    const requireMeetStr = (k: string): string => {
-      const v = mo[k];
-      if (typeof v !== 'string' || v.length === 0) {
-        throw new ScheduleValidationError(`meets[${i}].${k} must be a non-empty string`);
-      }
-      return v;
-    };
+    const requireMeetStr = (k: string): string =>
+      requireNonEmptyStr(
+        mo,
+        k,
+        () => `meets[${i}].${k} must be a non-empty string`,
+      );
     const id = requireMeetStr('id');
     if (seenIds.has(id)) {
       throw new ScheduleValidationError(`meets[${i}].id "${id}" is duplicated`);

--- a/packages/api/src/lib/schedules.ts
+++ b/packages/api/src/lib/schedules.ts
@@ -141,7 +141,24 @@ interface SchedulePayload {
   title: string;
   meetingDayOfWeek: string;
   weeks: unknown[];
-  meets?: unknown[];
+  meets?: ValidatedMeet[];
+}
+
+/** Spec'd Meet shape from data/schedules/*.json. `id` is a stable slug
+ *  the chain UI's `move_to_next` gates may reference; `startDate` and
+ *  `endDate` define the major-checkpoint window for those gates. The
+ *  Phase 3 editor writes user customisations to this surface, so the
+ *  server has to defend the shape.
+ *
+ *  `location` is intentionally an arbitrary string and may be empty —
+ *  the bundled schedules already use "TBD" as a placeholder for the
+ *  Second Weekend Meet, and the editor lets users clear the field. */
+export interface ValidatedMeet {
+  id: string;
+  name: string;
+  startDate: string;
+  endDate: string;
+  location: string;
 }
 
 export function validateSchedule(json: string): SchedulePayload {
@@ -195,10 +212,7 @@ export function validateSchedule(json: string): SchedulePayload {
       throw new ScheduleValidationError(`weeks[${i}].date must be a real YYYY-MM-DD`);
     }
   }
-  const meets = obj.meets;
-  if (meets !== undefined && !Array.isArray(meets)) {
-    throw new ScheduleValidationError('meets must be an array when present');
-  }
+  const meets = validateMeets(obj.meets);
   return {
     version,
     materialId,
@@ -206,6 +220,61 @@ export function validateSchedule(json: string): SchedulePayload {
     title,
     meetingDayOfWeek,
     weeks,
-    meets: meets as unknown[] | undefined,
+    meets,
   };
+}
+
+/** Field-level validation for the `meets` array. The Phase 3 editor
+ *  writes user customisations through this surface, so each meet has to
+ *  be defended — a malformed `startDate` would silently disable the
+ *  `afterMajorCheckpoint` gate's "most recent past meet" lookup, and
+ *  duplicate `id`s would make stable referencing impossible. */
+function validateMeets(raw: unknown): ValidatedMeet[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new ScheduleValidationError('meets must be an array when present');
+  }
+  const seenIds = new Set<string>();
+  const meets: ValidatedMeet[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const m = raw[i];
+    if (typeof m !== 'object' || m === null) {
+      throw new ScheduleValidationError(`meets[${i}] must be an object`);
+    }
+    const mo = m as Record<string, unknown>;
+    const requireMeetStr = (k: string): string => {
+      const v = mo[k];
+      if (typeof v !== 'string' || v.length === 0) {
+        throw new ScheduleValidationError(`meets[${i}].${k} must be a non-empty string`);
+      }
+      return v;
+    };
+    const id = requireMeetStr('id');
+    if (seenIds.has(id)) {
+      throw new ScheduleValidationError(`meets[${i}].id "${id}" is duplicated`);
+    }
+    seenIds.add(id);
+    const name = requireMeetStr('name');
+    const startDate = requireMeetStr('startDate');
+    if (!isValidIsoDate(startDate)) {
+      throw new ScheduleValidationError(`meets[${i}].startDate must be a real YYYY-MM-DD`);
+    }
+    const endDate = requireMeetStr('endDate');
+    if (!isValidIsoDate(endDate)) {
+      throw new ScheduleValidationError(`meets[${i}].endDate must be a real YYYY-MM-DD`);
+    }
+    if (endDate < startDate) {
+      throw new ScheduleValidationError(`meets[${i}].endDate is before startDate`);
+    }
+    // `location` accepts any string including '' — the bundled schedules
+    // ship "TBD" as a placeholder, and the editor exposes the field as
+    // freely clearable. Missing field falls through to ''.
+    const locRaw = mo.location;
+    if (locRaw !== undefined && typeof locRaw !== 'string') {
+      throw new ScheduleValidationError(`meets[${i}].location must be a string`);
+    }
+    const location = locRaw ?? '';
+    meets.push({ id, name, startDate, endDate, location });
+  }
+  return meets;
 }

--- a/packages/api/src/lib/schedules.ts
+++ b/packages/api/src/lib/schedules.ts
@@ -161,6 +161,31 @@ export interface ValidatedMeet {
   location: string;
 }
 
+/** Field-level validation for `weeks[i].passage` on non-Review weeks.
+ *  `passage: null` is the valid Review-week shape and is gated above
+ *  by the `isReview` check; this helper is only called when the week
+ *  is supposed to carry real content. */
+function validateWeekPassage(i: number, raw: unknown): void {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new ScheduleValidationError(
+      `weeks[${i}].passage must be an object on non-review weeks`,
+    );
+  }
+  const p = raw as Record<string, unknown>;
+  if (typeof p.book !== 'string' || p.book.length === 0) {
+    throw new ScheduleValidationError(`weeks[${i}].passage.book must be a non-empty string`);
+  }
+  for (const f of ['chapter', 'startVerse', 'endVerse'] as const) {
+    const v = p[f];
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 1) {
+      throw new ScheduleValidationError(`weeks[${i}].passage.${f} must be a positive integer`);
+    }
+  }
+  if ((p.endVerse as number) < (p.startVerse as number)) {
+    throw new ScheduleValidationError(`weeks[${i}].passage.endVerse is before startVerse`);
+  }
+}
+
 /** Pull a non-empty string field off a record. Shared by the top-level
  *  schedule fields and the per-meet field-checks — both error formats
  *  differ only in the prefix, so the caller passes a lazy label
@@ -222,6 +247,16 @@ export function validateSchedule(json: string): SchedulePayload {
     const wo = w as Record<string, unknown>;
     if (typeof wo.date !== 'string' || !isValidIsoDate(wo.date)) {
       throw new ScheduleValidationError(`weeks[${i}].date must be a real YYYY-MM-DD`);
+    }
+    // Non-review weeks must carry a usable passage. Without this,
+    // the Phase 3 editor's de-review toggle could save zeroed
+    // placeholder values ({book: '', chapter: 0, startVerse: 0,
+    // endVerse: 0}) that the WASM engine then trips over. The
+    // editor's user flow asks for these fields immediately after
+    // de-review, but a save before they're filled in needs to fail
+    // here rather than silently corrupt the schedule.
+    if (wo.isReview === false || wo.isReview === undefined) {
+      validateWeekPassage(i, wo.passage);
     }
   }
   const meets = validateMeets(obj.meets);


### PR DESCRIPTION
## Summary

Phase 3 of the schedules + per-club settings rework — the schedule editor at `/schedule/<materialId>` (spec: `docs/superpowers/specs/2026-06-14-schedules-and-settings-design.md`). Builds on Phase 1's data model + API and Phase 2's chain UI. Closes the Phase 2 deferral of the "Edit schedule →" link in `/settings/materials`.

9 commits:

- `feat(api): tighten Meet validation` — field-level checks in `validateSchedule`. `id`/`name`/`startDate`/`endDate` required and non-empty; ISO date format with sane month/day ranges; `endDate ≥ startDate`; id uniqueness. `location` accepts empty/missing/"TBD". +5 schedule tests (192 total).
- `feat(web): schedule types + pure helpers` — new `apps/web/src/lib/schedule.ts` with canonical `Schedule` / `ScheduleWeek` / `ScheduleMeet` / `SchedulePassage` / `DayOfWeek` types + pure data-mutating helpers (`applyMeetingDayShift`, `addWeekAt`, `removeWeekAt`, `addMeet`, `updateMeet`, `removeMeet`, `slugifyMeetId`, `cloneSchedule`) + display/arithmetic primitives (`shiftDate`, `formatPassage`, `verseCountsForWeek`, `parseVerseList`, `formatVerseList`). `api.ts` types `getSchedule`/`putSchedule` against the parsed shape; `badges.ts` drops its inline duplicate interfaces.
- `feat(web): /schedule/:materialId route + shell` — View↔Edit mode switch, `saved`/`draft` refs, `JSON.stringify` dirty-check, Save → PUT + re-fetch, Discard → reclone. Nav-away guard via both `onBeforeRouteLeave` (in-app) and `beforeunload` (tab close / refresh / external URL).
- `feat(web): schedule timeline pane + selection` — left pane (desktop) / top stack (mobile): interleaved chronological list of weeks + meets. Weeks sort before meets on date ties. Selection state at the view level routes the detail pane.
- `feat(web): per-week edit pane` — Review-week toggle, passage editor (book/chapter/start/end verse), per-tier comma-text verse inputs with on-blur parsing + normalized re-format, remove-this-week, add-a-week (defaults to last+7 days).
- `feat(web): meets editor` — symmetric meet editor (name, dates, location). Inline endDate < startDate hint. Add-a-meet next to add-a-week. New meets get a `slugifyMeetId`-derived stable id so chain-UI gates referencing the meet survive renames.
- `feat(web): day-shift picker + reset-to-default` — meeting-day picker in edit mode runs `applyMeetingDayShift`. Reset-to-default in view mode hits `DELETE /api/materials/:id/schedule`, ConfirmDialog-gated.
- `feat(web): edit-schedule link in materials card` — Phase 2 deferral closed.
- `chore(web): release 0.4.0` — apps/web 0.3.0 → 0.4.0. No engine/wire-format change; contract crates unchanged.

## Test plan

- [ ] `/schedule/nkjv-cor` loads the bundled schedule, timeline shows 32 weeks + 3 meets interleaved by date
- [ ] Click a week → detail pane shows date, passage, verse lists
- [ ] Click a meet → detail pane shows ⛺ name, date range, location
- [ ] Click "Edit schedule" → controls switch to Save/Discard; day picker appears above the body
- [ ] Edit a verse list (`5, 10, 17` → `5 10 17 a`) → inline error, draft untouched
- [ ] Toggle Review week → passage/verses null out; toggle back → empty skeleton appears
- [ ] Add a week → appended after last, selected, date = last + 7 days
- [ ] Add a meet → blank meet appended, selected, id slugified
- [ ] Change meeting day from Mon to Wed → every week date shifts +2 days; meets unchanged
- [ ] Discard → reverts to saved state, returns to View mode
- [ ] Save → PUT round-trips; saved state updates; back to View mode
- [ ] Reset to default → ConfirmDialog → DELETE + refetch; banner reflects `fallbackToBundled`
- [ ] Navigate away with unsaved changes → confirm prompt fires (both in-app routing and tab close)
- [ ] `/settings/materials` shows "Edit schedule →" link in the per-material card header
- [ ] `pnpm -F @verse-vault/api test` green; `pnpm -F @verse-vault/web exec vue-tsc --noEmit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)