### PR TITLE
fix(web): badge cache leak + signOut drain ordering

### DIFF
--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -435,8 +435,17 @@ export async function signOut(targetProfileId?: string): Promise<void> {
 
   if (activeProfile.value?.profileId === targetId) {
     await registry.setLastActiveProfileId(null)
-    await setActiveProfile(null)
+    // Drain BEFORE detaching the DB handle so the final in-flight
+    // flush can write `testStates` + `deleteQueuedEvents` against
+    // profile A's still-open IDB. With the reverse ordering the
+    // flush's response handler hits `openDb()` → "No active profile",
+    // `Promise.allSettled` swallows the rejection, the local IDB
+    // misses the final batch, and the queue rows linger until the
+    // next sign-in re-sends them (server dedupes by clientEventId,
+    // so it's self-healing — but the staleness window between
+    // sign-out and next sign-in is real).
     await clearProfileCaches()
+    await setActiveProfile(null)
     activeProfile.value = null
     // Reset the load-once flag so the next sign-in re-reads the
     // registry — keeps the "flag true ⟺ registry consulted this

--- a/apps/web/src/composables/useAuth.ts
+++ b/apps/web/src/composables/useAuth.ts
@@ -1,10 +1,19 @@
 import { computed, ref, watch } from 'vue'
 
 import { createAppAuthClient } from '@/lib/authClient'
+import { invalidateScheduleCache } from '@/lib/badges'
 import { clearAllSessions } from '@/lib/engine/engineStore'
 import { migrateLegacyDb } from '@/lib/engine/migrate-legacy'
 import { deleteIdb, profileDbName, setActiveProfile } from '@/lib/engine/persistence'
 import * as registry from '@/lib/engine/registry'
+
+/** Drop every profile-scoped in-memory cache. Called from each
+ *  profile-transition path so module-level caches keyed only by
+ *  `materialId` (not userId) can't leak across profiles — see #100. */
+async function clearProfileCaches(): Promise<void> {
+  await clearAllSessions()
+  invalidateScheduleCache()
+}
 
 // Better Auth's client auto-appends `/api/auth` to baseURL only when the
 // URL has no path component (see `withPath` / `checkHasPath` in
@@ -287,12 +296,12 @@ export async function signInComplete(
   }
 
   // Switch the persistence layer to the new profile's DB before any
-  // migration so the eager open creates all stores. clearAllSessions
+  // migration so the eager open creates all stores. clearProfileCaches
   // is awaited so any in-flight flush or persistLocalGraduation
   // settles against the OLD profile's IDB before the swap — otherwise
   // its response handler writes the old profile's testStates into
   // the new profile's IDB after the swap.
-  await clearAllSessions()
+  await clearProfileCaches()
   await setActiveProfile(user.id)
 
   if (isFirstEverProfile) {
@@ -334,7 +343,7 @@ export async function enterProfile(profileId: string): Promise<EnterResult> {
     // Offline — enter the cached profile anyway.
   }
 
-  await clearAllSessions()
+  await clearProfileCaches()
   await setActiveProfile(profileId)
 
   const touched: registry.ProfileRow = { ...row, lastUsedAt: nowSecs() }
@@ -364,7 +373,7 @@ export async function deleteProfile(profileId: string): Promise<void> {
   }
 
   if (wasActive) {
-    await clearAllSessions()
+    await clearProfileCaches()
     await setActiveProfile(null)
     await registry.setLastActiveProfileId(null)
     activeProfile.value = null
@@ -397,7 +406,7 @@ export async function deleteProfile(profileId: string): Promise<void> {
  *  (this only swaps the persistence-layer handle), so the caller stays
  *  on the same profile. */
 async function resetProfileLocalData(profileId: string): Promise<void> {
-  await clearAllSessions()
+  await clearProfileCaches()
   await setActiveProfile(null)
   await deleteIdb(profileDbName(profileId))
   await setActiveProfile(profileId)
@@ -427,7 +436,7 @@ export async function signOut(targetProfileId?: string): Promise<void> {
   if (activeProfile.value?.profileId === targetId) {
     await registry.setLastActiveProfileId(null)
     await setActiveProfile(null)
-    await clearAllSessions()
+    await clearProfileCaches()
     activeProfile.value = null
     // Reset the load-once flag so the next sign-in re-reads the
     // registry — keeps the "flag true ⟺ registry consulted this

--- a/apps/web/src/lib/badges.ts
+++ b/apps/web/src/lib/badges.ts
@@ -50,13 +50,7 @@ const CLUBS: readonly Club[] = ['club150', 'club300', 'full'] as const
  *  Caches the in-flight promise so concurrent calls (e.g. two
  *  fast back-to-back nav events) share one round-trip rather than
  *  racing two. Exported so callers can invalidate per-material on
- *  schedule writes.
- *
- *  TODO(#100): the cache is keyed by `materialId` only, so a profile
- *  switch leaks the prior profile's schedule into the new profile's
- *  badge count for the same material. Fix: clear on profile switch
- *  inside `useAuth`, or rekey by (userId, materialId). Out of scope
- *  for the Phase 3 PR — see github.com/TommyAmberson/verse-vault/issues/100. */
+ *  schedule writes or per-profile on profile transitions (#100). */
 const scheduleCache = new Map<string, Promise<unknown | null>>()
 
 export function invalidateScheduleCache(materialId?: string): void {


### PR DESCRIPTION
## Summary

Two related fixes to the profile-transition cleanup path in `useAuth.ts`. Both share the same root cause shape — `clearAllSessions`'s documented contract (drain in-flight engine ops BEFORE detaching the active profile) wasn't honoured at every site.

### Commit 1 — `fix(web): clear schedule cache on profile switch` (#100)

The Memorize-tab badge's `scheduleCache` in `lib/badges.ts` is keyed by `materialId` only, so a profile switch left profile A's cached schedule serving profile B's badge count for the same material until the tab closed. Phase 3 made the omission visible — its save/reset paths wired explicit per-material cache invalidation, but the cross-profile case stayed open.

The fix wraps `clearAllSessions()` (engine-store cache drain) and `invalidateScheduleCache()` (badge cache drain) into a new `clearProfileCaches()` helper in `useAuth.ts`. All five profile-transition sites switch to the new helper:

- `signInComplete` — fresh sign-in or profile sign-in
- `enterProfile` — switch to a cached profile
- `deleteProfile` — permanent removal when the deleted profile was active
- `signOut` — soft sign-out of the active profile
- `resetProfileLocalData` — close-then-reopen IDB after a server-side mutation

Badge cache docstring updates to point at the auth-layer guarantee so the contract is documented at both sides.

### Commit 2 — `fix(web): drain sessions before detach on sign-out`

Caught while reviewing commit 1's call-site sweep. The active-profile branch of `signOut` had `setActiveProfile(null)` *before* `clearAllSessions()` (now `clearProfileCaches()`) — the inverse of every other transition site, and a violation of `clearAllSessions`'s docstring contract (`engineStore.ts:611-620`).

In `signOut` specifically the consequence isn't a cross-profile leak (no profile B), but a lost local write: when the final flush's HTTP response lands, `doFlush` at `engineStore.ts:553` calls `await idb.replaceAllTestStates(...)`, which calls `openDb()`, which rejects with "No active profile". `Promise.allSettled` swallows the rejection, the local IDB testStates lag one batch behind the server, and the queued events linger until the next sign-in re-sends them. Self-healing via server-side `clientEventId` dedup — but the staleness window is real, and the asymmetry would have re-bitten future readers.

One-line swap brings signOut in line with the contract.

## Test plan

- [x] `vue-tsc` green
- [ ] CI green (rust / typos / dprint)
- [ ] Manual #100: sign in as user A, open Memorize tab, switch to user B via /profiles. Memorize badge reflects user B's enrolled materials + schedule, not user A's.
- [ ] Manual #signOut: grade a card, then immediately sign out. Sign back in. Confirm the graded card's review state is consistent (server has it; local IDB re-converges via dedupe on first flush).

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)